### PR TITLE
Execute explicit location-aware transfer nodes

### DIFF
--- a/crates/tenferro-runtime/src/lib.rs
+++ b/crates/tenferro-runtime/src/lib.rs
@@ -92,7 +92,8 @@ pub use runtime::{
     RuntimeCacheError, RuntimeCacheOwner, RuntimeCacheStats, RuntimeConfigBuilder,
     RuntimeConfigError, RuntimeConfigSnapshot, RuntimeEpoch, RuntimeId, RuntimeReconfiguration,
     RuntimeReconfigureError, RuntimeStateError, SpecializationError, SpecializationProjection,
-    SpecializationRequirements, StorageClass, TransferProvider, TransferRequest, UnsupportedReason,
+    SpecializationRequirements, StorageClass, TransferError, TransferProvider, TransferRequest,
+    UnsupportedReason,
 };
 #[doc(hidden)]
 pub use shape_constraint::ShapeGuard;

--- a/crates/tenferro-runtime/src/runtime/error.rs
+++ b/crates/tenferro-runtime/src/runtime/error.rs
@@ -729,6 +729,12 @@ pub enum PrepareError {
         /// Placement constraint that could not be satisfied.
         constraint: ProgramPlacementConstraint,
     },
+    /// A resolved placement references an engine absent from its preparation snapshot.
+    #[error("resolved engine {engine_id:?} is unavailable in the preparation snapshot")]
+    ResolvedEngineUnavailable {
+        /// Engine referenced by the resolved placement.
+        engine_id: EngineId,
+    },
     /// No provider supports this operation under the requested constraints.
     #[error("operation is unsupported: {reason}")]
     Unsupported {

--- a/crates/tenferro-runtime/src/runtime/execution.rs
+++ b/crates/tenferro-runtime/src/runtime/execution.rs
@@ -1046,9 +1046,9 @@ impl PreparedOperationExecution {
     }
 }
 
-struct LocatedExecSlot<'input> {
-    location: ExecutionLocation,
-    value: ExecSlot<'input>,
+pub(crate) struct LocatedExecSlot<'input> {
+    pub(crate) location: ExecutionLocation,
+    pub(crate) value: ExecSlot<'input>,
 }
 
 fn stage_instruction_inputs<'input>(
@@ -1077,7 +1077,7 @@ fn stage_instruction_inputs<'input>(
     Ok(())
 }
 
-fn retain_instruction_results<'input>(
+pub(crate) fn retain_instruction_results<'input>(
     instruction: &ExecInstruction,
     location: &ExecutionLocation,
     located: &mut [Vec<LocatedExecSlot<'input>>],
@@ -1372,57 +1372,19 @@ mod tests {
         BackendSessionHost, DType, Tensor, TensorBackend, TensorRead, TypedTensor,
     };
 
-    use crate::exec::{ExecInstruction, ExecOp, ExecProgram, ExecSlot};
-    use crate::runtime::schedule::ExecutionLocation;
+    use crate::exec::{ExecInstruction, ExecOp, ExecProgram};
     use crate::runtime::{
-        EngineId, ErasedExecutionContext, EventDomainId, ExecutionContextIdentity, HardwareClassId,
+        EngineId, ErasedExecutionContext, ExecutionContextIdentity, HardwareClassId,
         InputSignature, PreparedOperation, PreparedOperationBinding, PreparedOperationExecutor,
         PreparedOperationPlan, RegistrationIdentity, RuntimeEpoch, RuntimeId,
-        SpecializationProjection, SpecializationRequirements, StorageClass,
+        SpecializationProjection, SpecializationRequirements,
     };
     use crate::{Error, ErrorPhase, ExtensionCacheStore, Result};
 
-    use super::{
-        retain_instruction_results, ErasedTensorBackendExecutor, LocatedExecSlot,
-        TensorBackendExecutor,
-    };
+    use super::{ErasedTensorBackendExecutor, TensorBackendExecutor};
 
     const LOCK_PROBE_FAMILY: &str = "runtime.lock-probe.v1";
     const REENTRANT_PROBE_FAMILY: &str = "runtime.reentrant-probe.v1";
-
-    #[test]
-    fn result_retention_preserves_output_that_reuses_last_input_slot() {
-        let location = ExecutionLocation::new(
-            EngineId::new("tenferro-test.same-slot-engine").expect("engine id"),
-            EventDomainId::runtime_created_for_test(1),
-            StorageClass::new("tenferro-test.same-slot-storage").expect("storage class"),
-        );
-        let instruction = ExecInstruction {
-            op: ExecOp::Negate,
-            semantic_operation_index: None,
-            input_slots: vec![0],
-            output_slots: vec![0],
-            dtype: DType::F64,
-            output_shapes: Default::default(),
-            output_extents: Default::default(),
-            last_use: vec![true],
-        };
-        let output =
-            Tensor::from_vec_col_major(vec![2], vec![-1.0_f64, -2.0]).expect("output tensor");
-        let mut staged = vec![Some(ExecSlot::Owned(output))];
-        let mut located: Vec<Vec<LocatedExecSlot<'_>>> = vec![Vec::new()];
-
-        retain_instruction_results(&instruction, &location, &mut located, &mut staged)
-            .expect("retain output");
-
-        assert!(staged[0].is_none());
-        assert_eq!(located[0].len(), 1);
-        assert_eq!(located[0][0].location, location);
-        let ExecSlot::Owned(output) = &located[0][0].value else {
-            panic!("same-slot output must remain owned");
-        };
-        assert_eq!(output.as_slice::<f64>().expect("f64 output"), &[-1.0, -2.0]);
-    }
 
     #[derive(Clone, Debug)]
     struct LockProbeOp;

--- a/crates/tenferro-runtime/src/runtime/execution.rs
+++ b/crates/tenferro-runtime/src/runtime/execution.rs
@@ -19,11 +19,13 @@ use crate::exec::{
 };
 use crate::extension_cache::{ExtensionCacheSelector, ExtensionCacheStore};
 use crate::graph::CompiledGraph;
-use crate::runtime::schedule::{ScheduledGraph, ScheduledNode};
+use crate::runtime::schedule::{
+    ExecutionLocation, ScheduledGraph, ScheduledNode, ScheduledTransfer,
+};
 use crate::runtime::{
     CacheOwnerError, CacheStats, InputSignature, PrepareError, PrepareOptions,
-    PreparedOperationPlan, Runtime, RuntimeCacheOwner, StorageClass, TransferProvider,
-    TransferRequest,
+    PreparedOperationPlan, Runtime, RuntimeCacheOwner, StorageClass, TransferError,
+    TransferProvider, TransferRequest,
 };
 use crate::{Error, Result};
 
@@ -594,7 +596,7 @@ fn cache_stats_from_tensor_stats(stats: tenferro_tensor::CacheStats) -> CacheSta
 #[derive(Debug)]
 struct PreparedExecutionEngines {
     root: Arc<dyn ErasedTensorBackendExecutor>,
-    root_storage_class: StorageClass,
+    root_location: ExecutionLocation,
     operations: Box<[PreparedOperationExecution]>,
     transfers: BTreeMap<(StorageClass, StorageClass), Arc<dyn TransferProvider>>,
 }
@@ -602,7 +604,7 @@ struct PreparedExecutionEngines {
 #[derive(Debug)]
 struct PreparedOperationExecution {
     executor: Arc<dyn ErasedTensorBackendExecutor>,
-    storage_class: StorageClass,
+    location: ExecutionLocation,
 }
 
 pub(super) fn run_compiled(
@@ -751,6 +753,21 @@ fn execution_engines(
         ));
     }
     let storage_class = root.resolved_placement().storage_class();
+    let root_engine = snapshot.engine(root.engine_id()).ok_or_else(|| {
+        Error::runtime_state(
+            "Runtime::run_compiled",
+            ErrorPhase::Execution,
+            format!(
+                "prepared root engine {:?} is no longer registered",
+                root.engine_id()
+            ),
+        )
+    })?;
+    let root_location = ExecutionLocation::new(
+        root.engine_id().clone(),
+        root_engine.event_domain_id(),
+        storage_class.clone(),
+    );
     let root_executor = execution_engine_from_snapshot(&snapshot, root.engine_id())?;
     let operation_placements = root.operation_placements();
     if operation_placements.len() != prepared.operations().len() {
@@ -786,12 +803,16 @@ fn execution_engines(
         }
         operation_executors.push(PreparedOperationExecution {
             executor: execution_engine_from_snapshot(&snapshot, engine_id)?,
-            storage_class: placement.storage_class().clone(),
+            location: ExecutionLocation::new(
+                engine_id.clone(),
+                engine.event_domain_id(),
+                placement.storage_class().clone(),
+            ),
         });
     }
     Ok(PreparedExecutionEngines {
         root: root_executor,
-        root_storage_class: storage_class.clone(),
+        root_location,
         operations: operation_executors.into_boxed_slice(),
         transfers: snapshot.transfers_for_execution(),
     })
@@ -884,59 +905,73 @@ fn execute_scheduled_slots<'input>(
     } else {
         Vec::new()
     };
-    let mut slots = Vec::new();
-    let mut slot_storage = vec![None; program.n_slots];
+    let mut staged = Vec::new();
+    let mut located = (0..program.n_slots)
+        .map(|_| Vec::new())
+        .collect::<Vec<Vec<LocatedExecSlot<'input>>>>();
     let result = (|| {
-        crate::exec::initialize_exec_slots_in(program, inputs, &mut slots)?;
+        crate::exec::initialize_exec_slots_in(program, inputs, &mut staged)?;
         for &slot in &program.input_slots {
-            if let Some(storage) = slot_storage.get_mut(slot) {
-                *storage = Some(execution.root_storage_class.clone());
-            }
+            let value = staged
+                .get_mut(slot)
+                .and_then(Option::take)
+                .ok_or(tenferro_tensor::Error::MissingValue { slot })?;
+            located[slot].push(LocatedExecSlot {
+                location: execution.root_location.clone(),
+                value,
+            });
         }
-        if schedule.nodes().len() != program.instructions.len() {
-            return Err(Error::runtime_state(
-                "Runtime::run_compiled",
-                ErrorPhase::Execution,
-                format!(
-                    "scheduled graph has {} nodes for {} execution instructions",
-                    schedule.nodes().len(),
-                    program.instructions.len()
-                ),
-            ));
-        }
-        for (instruction_index, node) in schedule.nodes().iter().enumerate() {
+        for node in schedule.nodes() {
             match node {
-                ScheduledNode::Operation(_) => {
-                    let instruction = &program.instructions[instruction_index];
+                ScheduledNode::Operation(operation_node) => {
+                    let instruction_index = operation_node.instruction_index();
+                    let instruction =
+                        program.instructions.get(instruction_index).ok_or_else(|| {
+                            Error::runtime_state(
+                                "Runtime::run_compiled",
+                                ErrorPhase::Execution,
+                                format!(
+                                    "scheduled operation references instruction \
+                                     {instruction_index}, but the execution program has {} \
+                                     instructions",
+                                    program.instructions.len()
+                                ),
+                            )
+                        })?;
                     let operation = instruction_execution(execution, instruction)?;
-                    ensure_instruction_inputs_in_storage(
-                        execution,
+                    if operation.location() != operation_node.location() {
+                        return Err(Error::runtime_state(
+                            "Runtime::run_compiled",
+                            ErrorPhase::Execution,
+                            format!(
+                                "scheduled instruction {instruction_index} location does not \
+                                 match its prepared executor"
+                            ),
+                        ));
+                    }
+                    stage_instruction_inputs(
                         instruction,
-                        operation.storage_class(),
-                        &mut slots,
-                        &mut slot_storage,
+                        operation.location(),
+                        &mut located,
+                        &mut staged,
                     )?;
                     operation.executor().execute_slot_instruction(
                         instruction_index,
                         instruction,
                         operations,
-                        &mut slots,
+                        &mut staged,
                         output_mode,
                         &terminal_slots,
                     )?;
-                    for &slot in &instruction.output_slots {
-                        if let Some(storage) = slot_storage.get_mut(slot) {
-                            *storage = Some(operation.storage_class().clone());
-                        }
-                    }
-                    clear_last_use_storage(instruction, &mut slot_storage);
+                    retain_instruction_results(
+                        instruction,
+                        operation.location(),
+                        &mut located,
+                        &mut staged,
+                    )?;
                 }
-                ScheduledNode::Transfer(_) => {
-                    return Err(Error::runtime_state(
-                        "Runtime::run_compiled",
-                        ErrorPhase::Execution,
-                        "transfer node execution is not implemented before U3",
-                    ));
+                ScheduledNode::Transfer(transfer) => {
+                    execute_scheduled_transfer(execution, transfer, &mut located)?;
                 }
                 ScheduledNode::Collective(_) => {
                     return Err(Error::runtime_state(
@@ -948,13 +983,16 @@ fn execute_scheduled_slots<'input>(
                 ScheduledNode::Barrier(_) => {}
             }
         }
-        Ok(())
+        collect_located_outputs(program, &mut located)
     })();
-    if let Err(error) = result {
-        slots.clear();
-        return Err(error);
+    match result {
+        Ok(slots) => Ok(slots),
+        Err(error) => {
+            staged.clear();
+            located.clear();
+            Err(error)
+        }
     }
-    Ok(slots)
 }
 
 fn instruction_execution<'a>(
@@ -964,7 +1002,7 @@ fn instruction_execution<'a>(
     let Some(operation_index) = instruction.semantic_operation_index else {
         return Ok(InstructionExecution {
             executor: &execution.root,
-            storage_class: &execution.root_storage_class,
+            location: &execution.root_location,
         });
     };
     let operation = execution.operations.get(operation_index).ok_or_else(|| {
@@ -979,13 +1017,13 @@ fn instruction_execution<'a>(
         })?;
     Ok(InstructionExecution {
         executor: operation.executor(),
-        storage_class: operation.storage_class(),
+        location: operation.location(),
     })
 }
 
 struct InstructionExecution<'a> {
     executor: &'a Arc<dyn ErasedTensorBackendExecutor>,
-    storage_class: &'a StorageClass,
+    location: &'a ExecutionLocation,
 }
 
 impl InstructionExecution<'_> {
@@ -993,8 +1031,8 @@ impl InstructionExecution<'_> {
         self.executor
     }
 
-    fn storage_class(&self) -> &StorageClass {
-        self.storage_class
+    fn location(&self) -> &ExecutionLocation {
+        self.location
     }
 }
 
@@ -1003,75 +1041,172 @@ impl PreparedOperationExecution {
         &self.executor
     }
 
-    fn storage_class(&self) -> &StorageClass {
-        &self.storage_class
+    fn location(&self) -> &ExecutionLocation {
+        &self.location
     }
 }
 
-fn ensure_instruction_inputs_in_storage<'input>(
-    execution: &PreparedExecutionEngines,
+struct LocatedExecSlot<'input> {
+    location: ExecutionLocation,
+    value: ExecSlot<'input>,
+}
+
+fn stage_instruction_inputs<'input>(
     instruction: &ExecInstruction,
-    destination: &StorageClass,
-    slots: &mut [Option<ExecSlot<'input>>],
-    slot_storage: &mut [Option<StorageClass>],
+    location: &ExecutionLocation,
+    located: &mut [Vec<LocatedExecSlot<'input>>],
+    staged: &mut [Option<ExecSlot<'input>>],
 ) -> Result<()> {
     for &slot in &instruction.input_slots {
-        ensure_slot_in_storage(execution, slot, destination, slots, slot_storage)?;
-    }
-    Ok(())
-}
-
-fn ensure_slot_in_storage<'input>(
-    execution: &PreparedExecutionEngines,
-    slot: usize,
-    destination: &StorageClass,
-    slots: &mut [Option<ExecSlot<'input>>],
-    slot_storage: &mut [Option<StorageClass>],
-) -> Result<()> {
-    let source = slot_storage
-        .get(slot)
-        .and_then(Option::as_ref)
-        .ok_or_else(|| tenferro_tensor::Error::MissingValue { slot })?;
-    if source == destination {
-        return Ok(());
-    }
-    let provider = execution
-        .transfers
-        .get(&(source.clone(), destination.clone()))
-        .ok_or_else(|| {
-            Error::runtime_state(
-                "Runtime::run_compiled",
-                ErrorPhase::Execution,
-                format!(
-                    "no transfer provider registered from {:?} to {:?}",
-                    source.as_str(),
-                    destination.as_str()
-                ),
-            )
-        })?;
-    let transferred = {
-        let value = slots
+        if staged
             .get(slot)
-            .and_then(Option::as_ref)
-            .ok_or_else(|| tenferro_tensor::Error::MissingValue { slot })?;
-        provider.transfer(TransferRequest::new(source, destination, value.as_read()))?
-    };
-    slots[slot] = Some(ExecSlot::Owned(transferred));
-    slot_storage[slot] = Some(destination.clone());
+            .ok_or(tenferro_tensor::Error::MissingValue { slot })?
+            .is_some()
+        {
+            continue;
+        }
+        let values = located
+            .get_mut(slot)
+            .ok_or(tenferro_tensor::Error::MissingValue { slot })?;
+        let value_index = values
+            .iter()
+            .position(|value| &value.location == location)
+            .ok_or(tenferro_tensor::Error::MissingValue { slot })?;
+        staged[slot] = Some(values.swap_remove(value_index).value);
+    }
     Ok(())
 }
 
-fn clear_last_use_storage(
+fn retain_instruction_results<'input>(
     instruction: &ExecInstruction,
-    slot_storage: &mut [Option<StorageClass>],
-) {
-    for (index, &slot) in instruction.input_slots.iter().enumerate() {
-        if instruction.last_use.get(index).copied().unwrap_or(false) {
-            if let Some(storage) = slot_storage.get_mut(slot) {
-                *storage = None;
+    location: &ExecutionLocation,
+    located: &mut [Vec<LocatedExecSlot<'input>>],
+    staged: &mut [Option<ExecSlot<'input>>],
+) -> Result<()> {
+    for &slot in &instruction.input_slots {
+        let is_output = instruction.output_slots.contains(&slot);
+        let is_last_use = instruction
+            .input_slots
+            .iter()
+            .enumerate()
+            .any(|(index, &candidate)| {
+                candidate == slot && instruction.last_use.get(index).copied().unwrap_or(false)
+            });
+        if is_last_use {
+            located[slot].clear();
+            if !is_output {
+                staged[slot].take();
+            }
+        } else if !is_output {
+            if let Some(value) = staged[slot].take() {
+                located[slot].push(LocatedExecSlot {
+                    location: location.clone(),
+                    value,
+                });
             }
         }
     }
+
+    for &slot in &instruction.output_slots {
+        let value = staged
+            .get_mut(slot)
+            .and_then(Option::take)
+            .ok_or(tenferro_tensor::Error::MissingValue { slot })?;
+        let values = located
+            .get_mut(slot)
+            .ok_or(tenferro_tensor::Error::MissingValue { slot })?;
+        values.clear();
+        values.push(LocatedExecSlot {
+            location: location.clone(),
+            value,
+        });
+    }
+    Ok(())
+}
+
+fn execute_scheduled_transfer<'input>(
+    execution: &PreparedExecutionEngines,
+    transfer: &ScheduledTransfer,
+    located: &mut [Vec<LocatedExecSlot<'input>>],
+) -> Result<()> {
+    let source = transfer.source_location();
+    let destination = transfer.destination_location();
+    let provider = execution
+        .transfers
+        .get(&(
+            source.storage_class().clone(),
+            destination.storage_class().clone(),
+        ))
+        .ok_or_else(|| {
+            Error::runtime_state_source(
+                "Runtime::run_compiled",
+                ErrorPhase::Execution,
+                TransferError::MissingProvider {
+                    source_engine_id: source.engine_id().clone(),
+                    source_event_domain_id: source.event_domain_id(),
+                    source_storage_class: source.storage_class().clone(),
+                    destination_engine_id: destination.engine_id().clone(),
+                    destination_event_domain_id: destination.event_domain_id(),
+                    destination_storage_class: destination.storage_class().clone(),
+                },
+            )
+        })?;
+    let values =
+        located
+            .get_mut(transfer.value_slot())
+            .ok_or(tenferro_tensor::Error::MissingValue {
+                slot: transfer.value_slot(),
+            })?;
+    if values.iter().any(|value| &value.location == destination) {
+        return Err(Error::runtime_state(
+            "Runtime::run_compiled",
+            ErrorPhase::Execution,
+            format!(
+                "scheduled transfer destination already contains value slot {}",
+                transfer.value_slot()
+            ),
+        ));
+    }
+    let transferred = {
+        let source_value = values
+            .iter()
+            .find(|value| &value.location == source)
+            .ok_or(tenferro_tensor::Error::MissingValue {
+                slot: transfer.value_slot(),
+            })?;
+        provider.transfer(TransferRequest::new(
+            source,
+            destination,
+            source_value.value.as_read(),
+        ))?
+    };
+    values.push(LocatedExecSlot {
+        location: destination.clone(),
+        value: ExecSlot::Owned(transferred),
+    });
+    Ok(())
+}
+
+fn collect_located_outputs<'input>(
+    program: &ExecProgram,
+    located: &mut [Vec<LocatedExecSlot<'input>>],
+) -> Result<Vec<Option<ExecSlot<'input>>>> {
+    let mut outputs = (0..program.n_slots).map(|_| None).collect::<Vec<_>>();
+    for &slot in &program.output_slots {
+        if outputs[slot].is_some() {
+            continue;
+        }
+        let values = located
+            .get_mut(slot)
+            .ok_or(tenferro_tensor::Error::MissingValue { slot })?;
+        let value = values
+            .pop()
+            .ok_or(tenferro_tensor::Error::MissingValue { slot })?;
+        values.clear();
+        outputs[slot] = Some(value.value);
+    }
+    located.iter_mut().for_each(Vec::clear);
+    Ok(outputs)
 }
 
 fn input_signature(inputs: &[&Tensor]) -> Result<InputSignature> {
@@ -1237,19 +1372,57 @@ mod tests {
         BackendSessionHost, DType, Tensor, TensorBackend, TensorRead, TypedTensor,
     };
 
-    use crate::exec::{ExecInstruction, ExecOp, ExecProgram};
+    use crate::exec::{ExecInstruction, ExecOp, ExecProgram, ExecSlot};
+    use crate::runtime::schedule::ExecutionLocation;
     use crate::runtime::{
-        EngineId, ErasedExecutionContext, ExecutionContextIdentity, HardwareClassId,
+        EngineId, ErasedExecutionContext, EventDomainId, ExecutionContextIdentity, HardwareClassId,
         InputSignature, PreparedOperation, PreparedOperationBinding, PreparedOperationExecutor,
         PreparedOperationPlan, RegistrationIdentity, RuntimeEpoch, RuntimeId,
-        SpecializationProjection, SpecializationRequirements,
+        SpecializationProjection, SpecializationRequirements, StorageClass,
     };
     use crate::{Error, ErrorPhase, ExtensionCacheStore, Result};
 
-    use super::{ErasedTensorBackendExecutor, TensorBackendExecutor};
+    use super::{
+        retain_instruction_results, ErasedTensorBackendExecutor, LocatedExecSlot,
+        TensorBackendExecutor,
+    };
 
     const LOCK_PROBE_FAMILY: &str = "runtime.lock-probe.v1";
     const REENTRANT_PROBE_FAMILY: &str = "runtime.reentrant-probe.v1";
+
+    #[test]
+    fn result_retention_preserves_output_that_reuses_last_input_slot() {
+        let location = ExecutionLocation::new(
+            EngineId::new("tenferro-test.same-slot-engine").expect("engine id"),
+            EventDomainId::runtime_created_for_test(1),
+            StorageClass::new("tenferro-test.same-slot-storage").expect("storage class"),
+        );
+        let instruction = ExecInstruction {
+            op: ExecOp::Negate,
+            semantic_operation_index: None,
+            input_slots: vec![0],
+            output_slots: vec![0],
+            dtype: DType::F64,
+            output_shapes: Default::default(),
+            output_extents: Default::default(),
+            last_use: vec![true],
+        };
+        let output =
+            Tensor::from_vec_col_major(vec![2], vec![-1.0_f64, -2.0]).expect("output tensor");
+        let mut staged = vec![Some(ExecSlot::Owned(output))];
+        let mut located: Vec<Vec<LocatedExecSlot<'_>>> = vec![Vec::new()];
+
+        retain_instruction_results(&instruction, &location, &mut located, &mut staged)
+            .expect("retain output");
+
+        assert!(staged[0].is_none());
+        assert_eq!(located[0].len(), 1);
+        assert_eq!(located[0][0].location, location);
+        let ExecSlot::Owned(output) = &located[0][0].value else {
+            panic!("same-slot output must remain owned");
+        };
+        assert_eq!(output.as_slice::<f64>().expect("f64 output"), &[-1.0, -2.0]);
+    }
 
     #[derive(Clone, Debug)]
     struct LockProbeOp;

--- a/crates/tenferro-runtime/src/runtime/mod.rs
+++ b/crates/tenferro-runtime/src/runtime/mod.rs
@@ -60,7 +60,7 @@ pub use specialization::{
     PlacementProjection, PlacementSpecialization, SpecializationProjection,
     SpecializationRequirements,
 };
-pub use transfer::{TransferProvider, TransferRequest};
+pub use transfer::{TransferError, TransferProvider, TransferRequest};
 
 #[cfg(test)]
 mod tests;

--- a/crates/tenferro-runtime/src/runtime/preparation.rs
+++ b/crates/tenferro-runtime/src/runtime/preparation.rs
@@ -21,7 +21,7 @@ use super::cache::{
     CacheLookup, CacheProduced, PreparedCacheKey, PreparedValue, RuntimeCacheSet, SharedRetention,
 };
 use super::extension::ExtensionFamilyId;
-use super::schedule::ScheduledGraph;
+use super::schedule::{ExecutionLocation, ScheduleBuildError, ScheduledGraph};
 use super::{
     CoreCapabilityKind, CorePrepareContext, DotGeneralPreparation, DotGeneralPrepareRequest,
     ElementwisePrepareRequest, ElementwiseRuntime, EngineId, ExecutionContextIdentity,
@@ -198,9 +198,15 @@ impl PreparedProgramRoot {
         identity: Arc<PreparedRootIdentity>,
         staging: Arc<ExecProgram>,
         extension_planning: Arc<[Arc<dyn ExtensionPlanningConfig>]>,
-    ) -> Self {
+        root_location: ExecutionLocation,
+        operation_locations: &[ExecutionLocation],
+    ) -> Result<Self, ScheduleBuildError> {
         let semantic = Arc::clone(&identity.semantic);
-        let schedule = Arc::new(ScheduledGraph::from_exec_program(&staging));
+        let schedule = Arc::new(ScheduledGraph::from_exec_program(
+            &staging,
+            root_location,
+            operation_locations,
+        )?);
         let logical_retained_bytes = prepared_program_root_retained_bytes(
             &identity,
             &semantic,
@@ -208,14 +214,14 @@ impl PreparedProgramRoot {
             &schedule,
             &extension_planning,
         );
-        Self {
+        Ok(Self {
             identity,
             semantic,
             staging,
             schedule,
             extension_planning,
             logical_retained_bytes,
-        }
+        })
     }
 
     fn shared_retention(self: &Arc<Self>) -> SharedRetention<Self> {
@@ -365,6 +371,8 @@ impl PreparedValue for PreparedProgram {
 struct PreparationContext {
     root_identity: Arc<PreparedRootIdentity>,
     operation_dispatch: Arc<[OperationDispatch]>,
+    root_location: ExecutionLocation,
+    operation_locations: Arc<[ExecutionLocation]>,
     extension_planning: Arc<[Arc<dyn ExtensionPlanningConfig>]>,
 }
 
@@ -607,6 +615,20 @@ fn candidate_storage_classes(
     }
 }
 
+fn execution_location(
+    snapshot: &super::RuntimeConfigSnapshot,
+    placement: &ResolvedProgramPlacement,
+) -> ExecutionLocation {
+    let engine = snapshot
+        .engine(placement.engine_id())
+        .expect("resolved placement must reference its source snapshot");
+    ExecutionLocation::new(
+        placement.engine_id().clone(),
+        engine.event_domain_id(),
+        placement.storage_class().clone(),
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_operation_dispatch(
     runtime: &Runtime,
@@ -691,6 +713,11 @@ fn build_operation_dispatch(
         };
     let planning_key = ResolvedPlanningKey::from_config(&primary_planning);
 
+    let root_location = execution_location(snapshot, &primary_resolved_placement);
+    let operation_locations = placements
+        .iter()
+        .map(|placement| execution_location(snapshot, placement))
+        .collect::<Arc<[_]>>();
     let root_identity = Arc::new(PreparedRootIdentity {
         semantic_fingerprint: frozen.program.semantic_fingerprint(),
         semantic: Arc::clone(&frozen.program),
@@ -712,6 +739,8 @@ fn build_operation_dispatch(
     Ok(Some(PreparationContext {
         root_identity,
         operation_dispatch: dispatch.into(),
+        root_location,
+        operation_locations,
         extension_planning: extension_planning.into(),
     }))
 }
@@ -759,6 +788,11 @@ fn build_cross_storage_operation_dispatch(
     };
     let planning_key = ResolvedPlanningKey::from_config(&primary.planning);
     let primary_binding = primary.binding.clone();
+    let root_location = execution_location(snapshot, &primary.resolved_placement);
+    let operation_locations = placements
+        .iter()
+        .map(|placement| execution_location(snapshot, placement))
+        .collect::<Arc<[_]>>();
     let root_identity = Arc::new(PreparedRootIdentity {
         semantic_fingerprint: frozen.program.semantic_fingerprint(),
         semantic: Arc::clone(&frozen.program),
@@ -780,6 +814,8 @@ fn build_cross_storage_operation_dispatch(
     Ok(Some(PreparationContext {
         root_identity,
         operation_dispatch: dispatch.into(),
+        root_location,
+        operation_locations,
         extension_planning: extension_planning.into(),
     }))
 }
@@ -1084,11 +1120,19 @@ fn root_for_key(
             })
         },
     )?;
-    Ok(Arc::new(PreparedProgramRoot::new(
+    PreparedProgramRoot::new(
         identity,
         Arc::new(staging),
         Arc::clone(&context.extension_planning),
-    )))
+        context.root_location.clone(),
+        &context.operation_locations,
+    )
+    .map(Arc::new)
+    .map_err(|source| {
+        Arc::new(PrepareError::Engine {
+            source: Arc::new(source),
+        })
+    })
 }
 
 fn prepare_operation(

--- a/crates/tenferro-runtime/src/runtime/preparation.rs
+++ b/crates/tenferro-runtime/src/runtime/preparation.rs
@@ -615,18 +615,20 @@ fn candidate_storage_classes(
     }
 }
 
-fn execution_location(
+pub(crate) fn execution_location(
     snapshot: &super::RuntimeConfigSnapshot,
     placement: &ResolvedProgramPlacement,
-) -> ExecutionLocation {
-    let engine = snapshot
-        .engine(placement.engine_id())
-        .expect("resolved placement must reference its source snapshot");
-    ExecutionLocation::new(
+) -> PreparedProgramResult<ExecutionLocation> {
+    let engine = snapshot.engine(placement.engine_id()).ok_or_else(|| {
+        Arc::new(PrepareError::ResolvedEngineUnavailable {
+            engine_id: placement.engine_id().clone(),
+        })
+    })?;
+    Ok(ExecutionLocation::new(
         placement.engine_id().clone(),
         engine.event_domain_id(),
         placement.storage_class().clone(),
-    )
+    ))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -713,11 +715,12 @@ fn build_operation_dispatch(
         };
     let planning_key = ResolvedPlanningKey::from_config(&primary_planning);
 
-    let root_location = execution_location(snapshot, &primary_resolved_placement);
-    let operation_locations = placements
+    let root_location = execution_location(snapshot, &primary_resolved_placement)?;
+    let operation_locations: Arc<[_]> = placements
         .iter()
         .map(|placement| execution_location(snapshot, placement))
-        .collect::<Arc<[_]>>();
+        .collect::<PreparedProgramResult<Vec<_>>>()?
+        .into();
     let root_identity = Arc::new(PreparedRootIdentity {
         semantic_fingerprint: frozen.program.semantic_fingerprint(),
         semantic: Arc::clone(&frozen.program),
@@ -788,11 +791,12 @@ fn build_cross_storage_operation_dispatch(
     };
     let planning_key = ResolvedPlanningKey::from_config(&primary.planning);
     let primary_binding = primary.binding.clone();
-    let root_location = execution_location(snapshot, &primary.resolved_placement);
-    let operation_locations = placements
+    let root_location = execution_location(snapshot, &primary.resolved_placement)?;
+    let operation_locations: Arc<[_]> = placements
         .iter()
         .map(|placement| execution_location(snapshot, placement))
-        .collect::<Arc<[_]>>();
+        .collect::<PreparedProgramResult<Vec<_>>>()?
+        .into();
     let root_identity = Arc::new(PreparedRootIdentity {
         semantic_fingerprint: frozen.program.semantic_fingerprint(),
         semantic: Arc::clone(&frozen.program),

--- a/crates/tenferro-runtime/src/runtime/schedule.rs
+++ b/crates/tenferro-runtime/src/runtime/schedule.rs
@@ -320,11 +320,15 @@ impl ScheduledBarrier {
 pub(crate) enum ScheduledNode {
     Operation(ScheduledOperation),
     Transfer(ScheduledTransfer),
+    // INVARIANT: collective nodes remain representation-only until the
+    // explicitly deferred collective scheduler work lands.
     #[allow(
         dead_code,
         reason = "collective scheduling remains representation-only in this scoped change"
     )]
     Collective(ScheduledCollective),
+    // INVARIANT: barrier nodes remain representation-only until the explicitly
+    // deferred asynchronous event scheduler work lands.
     #[allow(
         dead_code,
         reason = "barrier scheduling remains representation-only in this scoped change"

--- a/crates/tenferro-runtime/src/runtime/schedule.rs
+++ b/crates/tenferro-runtime/src/runtime/schedule.rs
@@ -1,27 +1,22 @@
 //! Runtime-owned scheduled graph boundary.
 //!
-//! Phase 5 keeps this representation crate-private. Later phases attach native
+//! This representation remains crate-private. Later phases attach native
 //! GPU/XLA dispatch and asynchronous completion to the same node families.
 
-#![allow(
-    dead_code,
-    reason = "Phase 5 establishes schedule metadata consumed incrementally by later phases"
-)]
-
+#[cfg(test)]
 use std::error::Error as StdError;
+#[cfg(test)]
 use std::fmt;
 
 use crate::error::ErrorPhase;
 use crate::exec::ExecProgram;
-use crate::Error;
+use crate::{EngineId, Error, StorageClass};
 
 /// Opaque runtime event-domain identifier.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct EventDomainId(u32);
 
 impl EventDomainId {
-    pub(crate) const CPU_BLOCKING: Self = Self(0);
-
     pub(crate) fn runtime_allocated(value: u32) -> Self {
         Self(value)
     }
@@ -29,6 +24,48 @@ impl EventDomainId {
     #[cfg(test)]
     pub(crate) fn runtime_created_for_test(value: u32) -> Self {
         Self(value)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct ExecutionLocation {
+    engine_id: EngineId,
+    event_domain_id: EventDomainId,
+    storage_class: StorageClass,
+}
+
+impl ExecutionLocation {
+    pub(crate) fn new(
+        engine_id: EngineId,
+        event_domain_id: EventDomainId,
+        storage_class: StorageClass,
+    ) -> Self {
+        Self {
+            engine_id,
+            event_domain_id,
+            storage_class,
+        }
+    }
+
+    pub(crate) fn engine_id(&self) -> &EngineId {
+        &self.engine_id
+    }
+
+    pub(crate) fn event_domain_id(&self) -> EventDomainId {
+        self.event_domain_id
+    }
+
+    pub(crate) fn storage_class(&self) -> &StorageClass {
+        &self.storage_class
+    }
+
+    #[cfg(test)]
+    fn for_test(domain: EventDomainId) -> Self {
+        Self::new(
+            EngineId::new("tenferro-test.schedule-engine").expect("test engine id"),
+            domain,
+            StorageClass::new("tenferro-test.schedule-storage").expect("test storage class"),
+        )
     }
 }
 
@@ -60,6 +97,10 @@ impl EventDependency {
     pub(crate) fn domain(&self) -> EventDomainId {
         self.domain
     }
+
+    fn from_completion(completion: EventCompletion) -> Self {
+        Self::new(completion.domain, completion.slot, completion.generation)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -85,6 +126,8 @@ impl EventCompletion {
 
 #[derive(Clone, Debug)]
 pub(crate) struct ScheduledOperation {
+    instruction_index: usize,
+    location: ExecutionLocation,
     input_values: Box<[usize]>,
     output_values: Box<[usize]>,
     completion: EventCompletion,
@@ -92,11 +135,15 @@ pub(crate) struct ScheduledOperation {
 
 impl ScheduledOperation {
     pub(crate) fn new(
+        instruction_index: usize,
+        location: ExecutionLocation,
         input_values: impl Into<Box<[usize]>>,
         output_values: impl Into<Box<[usize]>>,
         completion: EventCompletion,
     ) -> Self {
         Self {
+            instruction_index,
+            location,
             input_values: input_values.into(),
             output_values: output_values.into(),
             completion,
@@ -105,7 +152,21 @@ impl ScheduledOperation {
 
     #[cfg(test)]
     pub(crate) fn for_test(domain: EventDomainId) -> Self {
-        Self::new([], [], EventCompletion::new(domain, EventSlotId::new(0), 0))
+        Self::new(
+            0,
+            ExecutionLocation::for_test(domain),
+            [],
+            [],
+            EventCompletion::new(domain, EventSlotId::new(0), 0),
+        )
+    }
+
+    pub(crate) fn instruction_index(&self) -> usize {
+        self.instruction_index
+    }
+
+    pub(crate) fn location(&self) -> &ExecutionLocation {
+        &self.location
     }
 
     pub(crate) fn completion(&self) -> EventCompletion {
@@ -126,22 +187,25 @@ impl ScheduledOperation {
 
 #[derive(Clone, Debug)]
 pub(crate) struct ScheduledTransfer {
-    source_event_domain: EventDomainId,
-    destination_event_domain: EventDomainId,
+    value_slot: usize,
+    source_location: ExecutionLocation,
+    destination_location: ExecutionLocation,
     dependencies: Box<[EventDependency]>,
     completion: EventCompletion,
 }
 
 impl ScheduledTransfer {
     pub(crate) fn new(
-        source_event_domain: EventDomainId,
-        destination_event_domain: EventDomainId,
+        value_slot: usize,
+        source_location: ExecutionLocation,
+        destination_location: ExecutionLocation,
         dependencies: impl Into<Box<[EventDependency]>>,
         completion: EventCompletion,
     ) -> Self {
         Self {
-            source_event_domain,
-            destination_event_domain,
+            value_slot,
+            source_location,
+            destination_location,
             dependencies: dependencies.into(),
             completion,
         }
@@ -152,9 +216,12 @@ impl ScheduledTransfer {
         source_event_domain: EventDomainId,
         destination_event_domain: EventDomainId,
     ) -> Self {
+        let source_location = ExecutionLocation::for_test(source_event_domain);
+        let destination_location = ExecutionLocation::for_test(destination_event_domain);
         Self::new(
-            source_event_domain,
-            destination_event_domain,
+            0,
+            source_location,
+            destination_location,
             [EventDependency::new(
                 source_event_domain,
                 EventSlotId::new(0),
@@ -164,12 +231,26 @@ impl ScheduledTransfer {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn source_event_domain(&self) -> EventDomainId {
-        self.source_event_domain
+        self.source_location.event_domain_id()
     }
 
+    #[cfg(test)]
     pub(crate) fn destination_event_domain(&self) -> EventDomainId {
-        self.destination_event_domain
+        self.destination_location.event_domain_id()
+    }
+
+    pub(crate) fn value_slot(&self) -> usize {
+        self.value_slot
+    }
+
+    pub(crate) fn source_location(&self) -> &ExecutionLocation {
+        &self.source_location
+    }
+
+    pub(crate) fn destination_location(&self) -> &ExecutionLocation {
+        &self.destination_location
     }
 
     pub(crate) fn dependencies(&self) -> &[EventDependency] {
@@ -191,7 +272,6 @@ impl ScheduledTransfer {
 pub(crate) struct ScheduledCollective {
     dependencies: Box<[EventDependency]>,
     completion: EventCompletion,
-    supported: bool,
 }
 
 impl ScheduledCollective {
@@ -199,8 +279,11 @@ impl ScheduledCollective {
     pub(crate) fn unsupported_for_test() -> Self {
         Self {
             dependencies: Box::new([]),
-            completion: EventCompletion::new(EventDomainId::CPU_BLOCKING, EventSlotId::new(0), 0),
-            supported: false,
+            completion: EventCompletion::new(
+                EventDomainId::runtime_created_for_test(0),
+                EventSlotId::new(0),
+                0,
+            ),
         }
     }
 
@@ -237,11 +320,20 @@ impl ScheduledBarrier {
 pub(crate) enum ScheduledNode {
     Operation(ScheduledOperation),
     Transfer(ScheduledTransfer),
+    #[allow(
+        dead_code,
+        reason = "collective scheduling remains representation-only in this scoped change"
+    )]
     Collective(ScheduledCollective),
+    #[allow(
+        dead_code,
+        reason = "barrier scheduling remains representation-only in this scoped change"
+    )]
     Barrier(ScheduledBarrier),
 }
 
 impl ScheduledNode {
+    #[cfg(test)]
     pub(crate) fn completion(&self) -> EventCompletion {
         match self {
             Self::Operation(node) => node.completion(),
@@ -261,74 +353,126 @@ impl ScheduledNode {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-pub(crate) struct BufferPlan {
-    value_count: usize,
-    output_slots: Box<[usize]>,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(crate) struct RunAdmissionSummary {
-    node_count: usize,
-    value_count: usize,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(crate) struct NodeAdmissionSummary {
-    input_count: usize,
-    output_count: usize,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct ScheduleSegment {
-    node_range: std::ops::Range<usize>,
-    event_domain: EventDomainId,
-}
-
 #[derive(Clone, Debug)]
 pub(crate) struct ScheduledGraph {
     nodes: Box<[ScheduledNode]>,
     input_slots: Box<[usize]>,
     output_slots: Box<[usize]>,
     value_count: usize,
-    buffer_plan: BufferPlan,
-    segments: Box<[ScheduleSegment]>,
 }
 
 impl ScheduledGraph {
-    pub(crate) fn from_exec_program(program: &ExecProgram) -> Self {
-        let nodes = program
-            .instructions
-            .iter()
-            .enumerate()
-            .map(|(index, instruction)| {
-                ScheduledNode::Operation(ScheduledOperation::new(
-                    instruction.input_slots.clone(),
-                    instruction.output_slots.clone(),
-                    EventCompletion::new(
-                        EventDomainId::CPU_BLOCKING,
-                        EventSlotId::new(index as u32),
-                        0,
-                    ),
-                ))
-            })
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
-        let node_count = nodes.len();
-        Self {
-            nodes,
+    pub(crate) fn from_exec_program(
+        program: &ExecProgram,
+        root_location: ExecutionLocation,
+        operation_locations: &[ExecutionLocation],
+    ) -> Result<Self, ScheduleBuildError> {
+        let mut nodes = Vec::with_capacity(program.instructions.len());
+        let mut available = vec![Vec::<AvailableValue>::new(); program.n_slots];
+        for &slot in &program.input_slots {
+            let values =
+                available
+                    .get_mut(slot)
+                    .ok_or(ScheduleBuildError::ValueSlotOutOfBounds {
+                        slot,
+                        value_count: program.n_slots,
+                    })?;
+            values.push(AvailableValue {
+                location: root_location.clone(),
+                completion: None,
+            });
+        }
+
+        for (instruction_index, instruction) in program.instructions.iter().enumerate() {
+            let location = match instruction.semantic_operation_index {
+                Some(operation_index) => operation_locations.get(operation_index).cloned().ok_or(
+                    ScheduleBuildError::MissingOperationLocation {
+                        instruction_index,
+                        operation_index,
+                    },
+                )?,
+                None => root_location.clone(),
+            };
+
+            for &slot in &instruction.input_slots {
+                let values =
+                    available
+                        .get(slot)
+                        .ok_or(ScheduleBuildError::ValueSlotOutOfBounds {
+                            slot,
+                            value_count: program.n_slots,
+                        })?;
+                if values.iter().any(|value| value.location == location) {
+                    continue;
+                }
+                let source =
+                    values
+                        .first()
+                        .cloned()
+                        .ok_or(ScheduleBuildError::ValueUnavailable {
+                            instruction_index,
+                            slot,
+                        })?;
+                let completion = event_completion(&nodes, location.event_domain_id())?;
+                let dependencies = source
+                    .completion
+                    .map(EventDependency::from_completion)
+                    .into_iter()
+                    .collect::<Vec<_>>();
+                nodes.push(ScheduledNode::Transfer(ScheduledTransfer::new(
+                    slot,
+                    source.location,
+                    location.clone(),
+                    dependencies,
+                    completion,
+                )));
+                available[slot].push(AvailableValue {
+                    location: location.clone(),
+                    completion: Some(completion),
+                });
+            }
+
+            let completion = event_completion(&nodes, location.event_domain_id())?;
+            nodes.push(ScheduledNode::Operation(ScheduledOperation::new(
+                instruction_index,
+                location.clone(),
+                instruction.input_slots.clone(),
+                instruction.output_slots.clone(),
+                completion,
+            )));
+
+            for (input_index, &slot) in instruction.input_slots.iter().enumerate() {
+                if instruction
+                    .last_use
+                    .get(input_index)
+                    .copied()
+                    .unwrap_or(false)
+                {
+                    available[slot].clear();
+                }
+            }
+            for &slot in &instruction.output_slots {
+                let values =
+                    available
+                        .get_mut(slot)
+                        .ok_or(ScheduleBuildError::ValueSlotOutOfBounds {
+                            slot,
+                            value_count: program.n_slots,
+                        })?;
+                values.clear();
+                values.push(AvailableValue {
+                    location: location.clone(),
+                    completion: Some(completion),
+                });
+            }
+        }
+
+        Ok(Self {
+            nodes: nodes.into_boxed_slice(),
             input_slots: program.input_slots.clone().into_boxed_slice(),
             output_slots: program.output_slots.clone().into_boxed_slice(),
             value_count: program.n_slots,
-            buffer_plan: BufferPlan {
-                value_count: program.n_slots,
-                output_slots: program.output_slots.clone().into_boxed_slice(),
-            },
-            segments: Box::new([ScheduleSegment {
-                node_range: 0..node_count,
-                event_domain: EventDomainId::CPU_BLOCKING,
-            }]),
-        }
+        })
     }
 
     #[cfg(test)]
@@ -339,25 +483,44 @@ impl ScheduledGraph {
             input_slots: Box::new([]),
             output_slots: Box::new([]),
             value_count,
-            buffer_plan: BufferPlan::default(),
-            segments: Box::new([]),
         }
     }
 
     pub(crate) fn validate(&self) -> Result<(), ScheduleValidationError> {
         for (index, node) in self.nodes.iter().enumerate() {
             match node {
-                ScheduledNode::Transfer(transfer) => {
-                    if transfer.source_event_domain == transfer.destination_event_domain {
-                        return Err(ScheduleValidationError::TransferSameEventDomain { index });
-                    }
-                    if transfer.dependencies.is_empty() {
-                        return Err(ScheduleValidationError::MissingDependency { index });
+                ScheduledNode::Operation(operation) => {
+                    if operation.completion().domain() != operation.location().event_domain_id() {
+                        return Err(ScheduleValidationError::CompletionEventDomainMismatch {
+                            index,
+                        });
                     }
                 }
-                ScheduledNode::Collective(_)
-                | ScheduledNode::Operation(_)
-                | ScheduledNode::Barrier(_) => {}
+                ScheduledNode::Transfer(transfer) => {
+                    if transfer.source_location == transfer.destination_location {
+                        return Err(ScheduleValidationError::TransferSameLocation { index });
+                    }
+                    if transfer.completion().domain()
+                        != transfer.destination_location().event_domain_id()
+                    {
+                        return Err(ScheduleValidationError::CompletionEventDomainMismatch {
+                            index,
+                        });
+                    }
+                    if transfer.dependencies().iter().any(|dependency| {
+                        dependency.domain() != transfer.source_location().event_domain_id()
+                    }) {
+                        return Err(ScheduleValidationError::DependencyEventDomainMismatch {
+                            index,
+                        });
+                    }
+                }
+                ScheduledNode::Collective(collective) => {
+                    let _ = collective.completion().domain();
+                }
+                ScheduledNode::Barrier(barrier) => {
+                    let _ = barrier.completion().domain();
+                }
             }
         }
         Ok(())
@@ -369,6 +532,7 @@ impl ScheduledGraph {
         })
     }
 
+    #[cfg(test)]
     pub(crate) fn contains_collective(&self) -> bool {
         self.nodes
             .iter()
@@ -397,14 +561,6 @@ impl ScheduledGraph {
                 .len()
                 .checked_mul(std::mem::size_of::<usize>())?,
             self.value_count.checked_mul(std::mem::size_of::<usize>())?,
-            std::mem::size_of::<BufferPlan>(),
-            self.buffer_plan
-                .output_slots
-                .len()
-                .checked_mul(std::mem::size_of::<usize>())?,
-            self.segments
-                .len()
-                .checked_mul(std::mem::size_of::<ScheduleSegment>())?,
         ])
     }
 
@@ -432,17 +588,42 @@ impl ScheduledGraph {
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ScheduleValidationError {
-    #[error("transfer node {index} uses the same source and destination event domain")]
-    TransferSameEventDomain { index: usize },
-    #[error("schedule node {index} has no event dependency")]
-    MissingDependency { index: usize },
+    #[error("transfer node {index} uses the same source and destination location")]
+    TransferSameLocation { index: usize },
+    #[error("schedule node {index} completion uses the wrong event domain")]
+    CompletionEventDomainMismatch { index: usize },
+    #[error("schedule node {index} dependency uses the wrong event domain")]
+    DependencyEventDomainMismatch { index: usize },
 }
 
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ScheduleBuildError {
+    #[error(
+        "instruction {instruction_index} references semantic operation {operation_index}, \
+         but that operation has no execution location"
+    )]
+    MissingOperationLocation {
+        instruction_index: usize,
+        operation_index: usize,
+    },
+    #[error("instruction {instruction_index} requires unavailable value slot {slot}")]
+    ValueUnavailable {
+        instruction_index: usize,
+        slot: usize,
+    },
+    #[error("value slot {slot} is outside schedule value count {value_count}")]
+    ValueSlotOutOfBounds { slot: usize, value_count: usize },
+    #[error("scheduled node count exceeds the event-slot identity space")]
+    EventSlotExhausted,
+}
+
+#[cfg(test)]
 #[derive(Debug)]
 pub(crate) enum ScheduleExecutionError {
     UnsupportedCollective,
 }
 
+#[cfg(test)]
 impl fmt::Display for ScheduleExecutionError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -451,10 +632,25 @@ impl fmt::Display for ScheduleExecutionError {
     }
 }
 
+#[cfg(test)]
 impl StdError for ScheduleExecutionError {}
 
 fn checked_sum(values: impl IntoIterator<Item = usize>) -> Option<usize> {
     values
         .into_iter()
         .try_fold(0usize, |sum, value| sum.checked_add(value))
+}
+
+#[derive(Clone)]
+struct AvailableValue {
+    location: ExecutionLocation,
+    completion: Option<EventCompletion>,
+}
+
+fn event_completion(
+    nodes: &[ScheduledNode],
+    domain: EventDomainId,
+) -> Result<EventCompletion, ScheduleBuildError> {
+    let slot = u32::try_from(nodes.len()).map_err(|_| ScheduleBuildError::EventSlotExhausted)?;
+    Ok(EventCompletion::new(domain, EventSlotId::new(slot), 0))
 }

--- a/crates/tenferro-runtime/src/runtime/tests/execution.rs
+++ b/crates/tenferro-runtime/src/runtime/tests/execution.rs
@@ -1,0 +1,39 @@
+use tenferro_tensor::{DType, Tensor};
+
+use crate::exec::{ExecInstruction, ExecOp, ExecSlot};
+use crate::runtime::execution::{retain_instruction_results, LocatedExecSlot};
+use crate::runtime::schedule::ExecutionLocation;
+use crate::runtime::{EngineId, EventDomainId, StorageClass};
+
+#[test]
+fn result_retention_preserves_output_that_reuses_last_input_slot() {
+    let location = ExecutionLocation::new(
+        EngineId::new("tenferro-test.same-slot-engine").expect("engine id"),
+        EventDomainId::runtime_created_for_test(1),
+        StorageClass::new("tenferro-test.same-slot-storage").expect("storage class"),
+    );
+    let instruction = ExecInstruction {
+        op: ExecOp::Negate,
+        semantic_operation_index: None,
+        input_slots: vec![0],
+        output_slots: vec![0],
+        dtype: DType::F64,
+        output_shapes: Default::default(),
+        output_extents: Default::default(),
+        last_use: vec![true],
+    };
+    let output = Tensor::from_vec_col_major(vec![2], vec![-1.0_f64, -2.0]).expect("output tensor");
+    let mut staged = vec![Some(ExecSlot::Owned(output))];
+    let mut located: Vec<Vec<LocatedExecSlot<'_>>> = vec![Vec::new()];
+
+    retain_instruction_results(&instruction, &location, &mut located, &mut staged)
+        .expect("retain output");
+
+    assert!(staged[0].is_none());
+    assert_eq!(located[0].len(), 1);
+    assert_eq!(located[0][0].location, location);
+    let ExecSlot::Owned(output) = &located[0][0].value else {
+        panic!("same-slot output must remain owned");
+    };
+    assert_eq!(output.as_slice::<f64>().expect("f64 output"), &[-1.0, -2.0]);
+}

--- a/crates/tenferro-runtime/src/runtime/tests/mod.rs
+++ b/crates/tenferro-runtime/src/runtime/tests/mod.rs
@@ -1,6 +1,7 @@
 mod cache;
 mod cache_owner;
 mod capability;
+mod execution;
 mod extension;
 mod identity;
 mod policy;

--- a/crates/tenferro-runtime/src/runtime/tests/preparation.rs
+++ b/crates/tenferro-runtime/src/runtime/tests/preparation.rs
@@ -22,6 +22,27 @@ use crate::runtime::{
 
 const TEST_EXTENSION_FAMILY: &str = "tenferro.test.identity-extension.v1";
 
+#[test]
+fn missing_resolved_engine_returns_typed_prepare_error() {
+    let runtime = Runtime::builder().build().expect("empty runtime");
+    let snapshot = runtime.snapshot().expect("runtime snapshot");
+    let engine_id = EngineId::new("tenferro-test.missing-resolved-engine").expect("test engine id");
+    let placement = ResolvedProgramPlacement::new(
+        engine_id.clone(),
+        StorageClass::new("tenferro-test.missing-resolved-storage").expect("test storage class"),
+    );
+
+    let error = crate::runtime::preparation::execution_location(&snapshot, &placement)
+        .expect_err("missing engine must fail");
+
+    assert!(matches!(
+        error.as_ref(),
+        PrepareError::ResolvedEngineUnavailable {
+            engine_id: actual
+        } if actual == &engine_id
+    ));
+}
+
 #[derive(Clone, Debug)]
 enum ProviderAction {
     Prepared { retained_bytes: usize },

--- a/crates/tenferro-runtime/src/runtime/tests/schedule.rs
+++ b/crates/tenferro-runtime/src/runtime/tests/schedule.rs
@@ -1,7 +1,92 @@
 use super::super::schedule::{
-    EventDomainId, ScheduledCollective, ScheduledGraph, ScheduledNode, ScheduledOperation,
-    ScheduledTransfer,
+    EventDomainId, ExecutionLocation, ScheduledCollective, ScheduledGraph, ScheduledNode,
+    ScheduledOperation, ScheduledTransfer,
 };
+use super::super::{EngineId, StorageClass};
+use crate::exec::{ExecInstruction, ExecOp, ExecProgram};
+use crate::DType;
+
+fn location(engine: &str, domain: u32, storage: &str) -> ExecutionLocation {
+    ExecutionLocation::new(
+        EngineId::new(engine).expect("engine id"),
+        EventDomainId::runtime_created_for_test(domain),
+        StorageClass::new(storage).expect("storage class"),
+    )
+}
+
+fn instruction(
+    semantic_operation_index: usize,
+    input_slot: usize,
+    output_slot: usize,
+    last_use: bool,
+) -> ExecInstruction {
+    ExecInstruction {
+        op: ExecOp::Negate,
+        semantic_operation_index: Some(semantic_operation_index),
+        input_slots: vec![input_slot],
+        output_slots: vec![output_slot],
+        dtype: DType::F64,
+        output_shapes: Default::default(),
+        output_extents: Default::default(),
+        last_use: vec![last_use],
+    }
+}
+
+#[test]
+fn schedule_emits_location_transfer_and_retains_source_for_split_use() {
+    let source = location(
+        "tenferro-test.engine.source",
+        1,
+        "tenferro-test.storage.shared",
+    );
+    let destination = location(
+        "tenferro-test.engine.destination",
+        2,
+        "tenferro-test.storage.shared",
+    );
+    let program = ExecProgram {
+        instructions: vec![
+            instruction(0, 0, 1, true),
+            instruction(1, 1, 2, false),
+            instruction(2, 1, 3, true),
+        ],
+        input_slots: vec![0],
+        output_slots: vec![2, 3],
+        n_slots: 4,
+        shape_guards: Vec::new(),
+    };
+
+    let graph = ScheduledGraph::from_exec_program(
+        &program,
+        source.clone(),
+        &[source.clone(), destination.clone(), source.clone()],
+    )
+    .expect("schedule");
+
+    assert_eq!(graph.nodes_for_test().len(), 4);
+    assert!(matches!(
+        &graph.nodes_for_test()[0],
+        ScheduledNode::Operation(operation)
+            if operation.instruction_index() == 0 && operation.location() == &source
+    ));
+    assert!(matches!(
+        &graph.nodes_for_test()[1],
+        ScheduledNode::Transfer(transfer)
+            if transfer.value_slot() == 1
+                && transfer.source_location() == &source
+                && transfer.destination_location() == &destination
+    ));
+    assert!(matches!(
+        &graph.nodes_for_test()[2],
+        ScheduledNode::Operation(operation)
+            if operation.instruction_index() == 1 && operation.location() == &destination
+    ));
+    assert!(matches!(
+        &graph.nodes_for_test()[3],
+        ScheduledNode::Operation(operation)
+            if operation.instruction_index() == 2 && operation.location() == &source
+    ));
+}
 
 #[test]
 fn transfer_node_bridges_distinct_event_domains() {

--- a/crates/tenferro-runtime/src/runtime/transfer.rs
+++ b/crates/tenferro-runtime/src/runtime/transfer.rs
@@ -43,31 +43,95 @@ impl<'a> TransferRequest<'a> {
     }
 
     /// Return the source engine for this transfer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::{EngineId, TransferRequest};
+    ///
+    /// # fn inspect(request: TransferRequest<'_>) {
+    /// let source: &EngineId = request.source_engine_id();
+    /// assert!(!source.as_str().is_empty());
+    /// # }
+    /// ```
     pub fn source_engine_id(&self) -> &'a EngineId {
         self.source_location.engine_id()
     }
 
     /// Return the source event domain for this transfer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::{EventDomainId, TransferRequest};
+    ///
+    /// # fn inspect(request: TransferRequest<'_>) {
+    /// let _: EventDomainId = request.source_event_domain_id();
+    /// # }
+    /// ```
     pub fn source_event_domain_id(&self) -> EventDomainId {
         self.source_location.event_domain_id()
     }
 
     /// Return the source storage class for this transfer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::{StorageClass, TransferRequest};
+    ///
+    /// # fn inspect(request: TransferRequest<'_>) {
+    /// let source: &StorageClass = request.source_storage_class();
+    /// assert!(!source.as_str().is_empty());
+    /// # }
+    /// ```
     pub fn source_storage_class(&self) -> &'a StorageClass {
         self.source_location.storage_class()
     }
 
     /// Return the destination engine for this transfer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::{EngineId, TransferRequest};
+    ///
+    /// # fn inspect(request: TransferRequest<'_>) {
+    /// let destination: &EngineId = request.destination_engine_id();
+    /// assert!(!destination.as_str().is_empty());
+    /// # }
+    /// ```
     pub fn destination_engine_id(&self) -> &'a EngineId {
         self.destination_location.engine_id()
     }
 
     /// Return the destination event domain for this transfer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::{EventDomainId, TransferRequest};
+    ///
+    /// # fn inspect(request: TransferRequest<'_>) {
+    /// let _: EventDomainId = request.destination_event_domain_id();
+    /// # }
+    /// ```
     pub fn destination_event_domain_id(&self) -> EventDomainId {
         self.destination_location.event_domain_id()
     }
 
     /// Return the destination storage class for this transfer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::{StorageClass, TransferRequest};
+    ///
+    /// # fn inspect(request: TransferRequest<'_>) {
+    /// let destination: &StorageClass = request.destination_storage_class();
+    /// assert!(!destination.as_str().is_empty());
+    /// # }
+    /// ```
     pub fn destination_storage_class(&self) -> &'a StorageClass {
         self.destination_location.storage_class()
     }
@@ -79,6 +143,16 @@ impl<'a> TransferRequest<'a> {
 }
 
 /// Typed runtime transfer setup failure.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_runtime::TransferError;
+///
+/// fn is_missing_provider(error: &TransferError) -> bool {
+///     matches!(error, TransferError::MissingProvider { .. })
+/// }
+/// ```
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum TransferError {

--- a/crates/tenferro-runtime/src/runtime/transfer.rs
+++ b/crates/tenferro-runtime/src/runtime/transfer.rs
@@ -2,11 +2,16 @@ use std::fmt;
 
 use tenferro_tensor::{Tensor, TensorRead};
 
-use super::StorageClass;
+use super::schedule::{EventDomainId, ExecutionLocation};
+use super::{EngineId, StorageClass};
 
-/// Runtime-owned transfer provider between two registered storage classes.
+/// Runtime-owned transfer provider between two execution locations.
+///
+/// Providers remain registered by source and destination storage class. Each
+/// request also identifies the concrete engines and event domains at its
+/// endpoints.
 pub trait TransferProvider: fmt::Debug + Send + Sync + 'static {
-    /// Transfer one tensor read into the destination storage class.
+    /// Transfer one tensor read into the destination execution location.
     ///
     /// # Errors
     ///
@@ -19,36 +24,84 @@ pub trait TransferProvider: fmt::Debug + Send + Sync + 'static {
 
 /// Borrowed request passed to a [`TransferProvider`].
 pub struct TransferRequest<'a> {
-    source_storage_class: &'a StorageClass,
-    destination_storage_class: &'a StorageClass,
+    source_location: &'a ExecutionLocation,
+    destination_location: &'a ExecutionLocation,
     input: TensorRead<'a>,
 }
 
 impl<'a> TransferRequest<'a> {
     pub(crate) fn new(
-        source_storage_class: &'a StorageClass,
-        destination_storage_class: &'a StorageClass,
+        source_location: &'a ExecutionLocation,
+        destination_location: &'a ExecutionLocation,
         input: TensorRead<'a>,
     ) -> Self {
         Self {
-            source_storage_class,
-            destination_storage_class,
+            source_location,
+            destination_location,
             input,
         }
     }
 
+    /// Return the source engine for this transfer.
+    pub fn source_engine_id(&self) -> &'a EngineId {
+        self.source_location.engine_id()
+    }
+
+    /// Return the source event domain for this transfer.
+    pub fn source_event_domain_id(&self) -> EventDomainId {
+        self.source_location.event_domain_id()
+    }
+
     /// Return the source storage class for this transfer.
     pub fn source_storage_class(&self) -> &'a StorageClass {
-        self.source_storage_class
+        self.source_location.storage_class()
+    }
+
+    /// Return the destination engine for this transfer.
+    pub fn destination_engine_id(&self) -> &'a EngineId {
+        self.destination_location.engine_id()
+    }
+
+    /// Return the destination event domain for this transfer.
+    pub fn destination_event_domain_id(&self) -> EventDomainId {
+        self.destination_location.event_domain_id()
     }
 
     /// Return the destination storage class for this transfer.
     pub fn destination_storage_class(&self) -> &'a StorageClass {
-        self.destination_storage_class
+        self.destination_location.storage_class()
     }
 
     /// Return the tensor read that must be transferred.
     pub fn input(&self) -> &TensorRead<'a> {
         &self.input
     }
+}
+
+/// Typed runtime transfer setup failure.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum TransferError {
+    /// No provider was registered for the storage-class pair required by two
+    /// concrete execution locations.
+    #[error(
+        "no transfer provider registered from {source_storage_class:?} on \
+         {source_engine_id:?}/{source_event_domain_id:?} to \
+         {destination_storage_class:?} on \
+         {destination_engine_id:?}/{destination_event_domain_id:?}"
+    )]
+    MissingProvider {
+        /// Source engine.
+        source_engine_id: EngineId,
+        /// Source event domain.
+        source_event_domain_id: EventDomainId,
+        /// Source storage class.
+        source_storage_class: StorageClass,
+        /// Destination engine.
+        destination_engine_id: EngineId,
+        /// Destination event domain.
+        destination_event_domain_id: EventDomainId,
+        /// Destination storage class.
+        destination_storage_class: StorageClass,
+    },
 }

--- a/crates/tenferro-runtime/tests/integration/runtime_execution.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_execution.rs
@@ -29,6 +29,7 @@ const CPU_ENGINE_ID: &str = "tenferro-cpu.default.v1";
 const CPU_HARDWARE_CLASS_ID: &str = "tenferro-cpu.host.v1";
 const CPU_STORAGE_CLASS_ID: &str = "tenferro-cpu.host.v1";
 const COUNTING_EXTENSION_FAMILY: &str = "tenferro-test.counting-extension.v1";
+const DOWNSTREAM_COUNTING_EXTENSION_FAMILY: &str = "tenferro-test.downstream-counting-extension.v1";
 
 fn cpu_registration(
     backend: &CpuBackend,
@@ -207,17 +208,24 @@ impl BackendBuffer<f64> for DropTrackedBuffer {
 }
 
 #[derive(Clone, Debug)]
-struct CountingExtensionOp;
+struct CountingExtensionOp {
+    family_id: &'static str,
+}
 
 impl ExtensionOp for CountingExtensionOp {
     fn family_id(&self) -> &'static str {
-        COUNTING_EXTENSION_FAMILY
+        self.family_id
     }
 
-    fn payload_hash(&self, _hasher: &mut dyn Hasher) {}
+    fn payload_hash(&self, hasher: &mut dyn Hasher) {
+        hasher.write(self.family_id.as_bytes());
+    }
 
     fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
-        other.as_any().downcast_ref::<Self>().is_some()
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| self.family_id == other.family_id)
     }
 
     fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
@@ -253,11 +261,13 @@ impl ExtensionOp for CountingExtensionOp {
 }
 
 #[derive(Debug)]
-struct CountingExtensionConfig;
+struct CountingExtensionConfig {
+    family_id: &'static str,
+}
 
 impl ExtensionPlanningConfig for CountingExtensionConfig {
     fn family_id(&self) -> &'static str {
-        COUNTING_EXTENSION_FAMILY
+        self.family_id
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -265,11 +275,14 @@ impl ExtensionPlanningConfig for CountingExtensionConfig {
     }
 
     fn payload_hash(&self, state: &mut dyn Hasher) {
-        state.write_u8(0);
+        state.write(self.family_id.as_bytes());
     }
 
     fn payload_eq(&self, other: &dyn ExtensionPlanningConfig) -> bool {
-        other.as_any().downcast_ref::<Self>().is_some()
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| self.family_id == other.family_id)
     }
 
     fn retained_bytes(&self) -> usize {
@@ -279,13 +292,14 @@ impl ExtensionPlanningConfig for CountingExtensionConfig {
 
 #[derive(Debug)]
 struct CountingExtensionEngine {
+    family_id: &'static str,
     engine_id: EngineId,
     counters: Arc<ExtensionCounters>,
 }
 
 impl ExtensionEngine for CountingExtensionEngine {
     fn family_id(&self) -> &'static str {
-        COUNTING_EXTENSION_FAMILY
+        self.family_id
     }
 
     fn engine_id(&self) -> &EngineId {
@@ -300,7 +314,7 @@ impl ExtensionEngine for CountingExtensionEngine {
         &self,
         request: ExtensionPrepareRequest<'_>,
     ) -> Result<PrepareCapability, PrepareError> {
-        assert_eq!(request.operation().family_id(), COUNTING_EXTENSION_FAMILY);
+        assert_eq!(request.operation().family_id(), self.family_id);
         assert_eq!(request.binding().engine_id(), &self.engine_id);
         self.counters.prepare.fetch_add(1, Ordering::SeqCst);
         let prepared = Arc::new(CountingPreparedOperation {
@@ -379,6 +393,7 @@ impl PreparedOperationExecutor for CountingPreparedOperation {
 #[derive(Debug)]
 struct CountingExtensionModule {
     module_id: ExtensionModuleId,
+    family_id: &'static str,
     engine_id: EngineId,
     counters: Arc<ExtensionCounters>,
 }
@@ -393,11 +408,16 @@ impl ExtensionModule for CountingExtensionModule {
         registrar: &mut ExtensionModuleRegistrar<'_>,
     ) -> Result<(), ExtensionModuleError> {
         registrar.register_engine(Arc::new(CountingExtensionEngine {
+            family_id: self.family_id,
             engine_id: self.engine_id.clone(),
             counters: Arc::clone(&self.counters),
         }))?;
-        registrar
-            .register_planning_config(self.engine_id.clone(), Arc::new(CountingExtensionConfig))
+        registrar.register_planning_config(
+            self.engine_id.clone(),
+            Arc::new(CountingExtensionConfig {
+                family_id: self.family_id,
+            }),
+        )
     }
 }
 
@@ -410,6 +430,7 @@ fn runtime_with_counting_extension(
     builder.install_extension_module(Arc::new(CountingExtensionModule {
         module_id: ExtensionModuleId::new("tenferro-test.counting-extension.module")
             .map_err(RuntimeConfigError::from)?,
+        family_id: COUNTING_EXTENSION_FAMILY,
         engine_id: EngineId::new(CPU_ENGINE_ID).map_err(RuntimeConfigError::from)?,
         counters,
     }))?;
@@ -544,9 +565,14 @@ fn runtime_run_compiled_executes_extension_prepared_operation() -> Result<(), Bo
     let counters = Arc::new(ExtensionCounters::default());
     let runtime = runtime_with_counting_extension(&backend, Arc::clone(&counters))?;
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
-    let y = tenferro_runtime::extension::apply(Arc::new(CountingExtensionOp), &[&x])?
-        .pop()
-        .expect("extension has one output");
+    let y = tenferro_runtime::extension::apply(
+        Arc::new(CountingExtensionOp {
+            family_id: COUNTING_EXTENSION_FAMILY,
+        }),
+        &[&x],
+    )?
+    .pop()
+    .expect("extension has one output");
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])?;
     let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0])?;
@@ -603,6 +629,7 @@ fn runtime_run_compiled_dispatches_same_storage_extension_on_selected_engine(
     builder.install_extension_module(Arc::new(CountingExtensionModule {
         module_id: ExtensionModuleId::new("tenferro-test.counting-extension.per-op-module")
             .map_err(RuntimeConfigError::from)?,
+        family_id: COUNTING_EXTENSION_FAMILY,
         engine_id: EngineId::new(extension_engine_id).map_err(RuntimeConfigError::from)?,
         counters: Arc::clone(&counters),
     }))?;
@@ -619,9 +646,14 @@ fn runtime_run_compiled_dispatches_same_storage_extension_on_selected_engine(
 
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
     let sum = (&x + &x)?;
-    let y = tenferro_runtime::extension::apply(Arc::new(CountingExtensionOp), &[&sum])?
-        .pop()
-        .expect("extension has one output");
+    let y = tenferro_runtime::extension::apply(
+        Arc::new(CountingExtensionOp {
+            family_id: COUNTING_EXTENSION_FAMILY,
+        }),
+        &[&sum],
+    )?
+    .pop()
+    .expect("extension has one output");
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])?;
     let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0])?;
@@ -694,6 +726,7 @@ fn runtime_run_compiled_transfers_between_storage_classes_on_scheduled_path(
     builder.install_extension_module(Arc::new(CountingExtensionModule {
         module_id: ExtensionModuleId::new("tenferro-test.counting-extension.transfer-module")
             .map_err(RuntimeConfigError::from)?,
+        family_id: COUNTING_EXTENSION_FAMILY,
         engine_id: EngineId::new(extension_engine_id).map_err(RuntimeConfigError::from)?,
         counters: Arc::clone(&counters),
     }))?;
@@ -711,9 +744,14 @@ fn runtime_run_compiled_transfers_between_storage_classes_on_scheduled_path(
 
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
     let sum = (&x + &x)?;
-    let y = tenferro_runtime::extension::apply(Arc::new(CountingExtensionOp), &[&sum])?
-        .pop()
-        .expect("extension has one output");
+    let y = tenferro_runtime::extension::apply(
+        Arc::new(CountingExtensionOp {
+            family_id: COUNTING_EXTENSION_FAMILY,
+        }),
+        &[&sum],
+    )?
+    .pop()
+    .expect("extension has one output");
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])?;
     let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0])?;
@@ -789,6 +827,7 @@ fn runtime_run_compiled_split_use_retains_source_and_destination_values(
     builder.install_extension_module(Arc::new(CountingExtensionModule {
         module_id: ExtensionModuleId::new("tenferro-test.counting-extension.split-module")
             .map_err(RuntimeConfigError::from)?,
+        family_id: COUNTING_EXTENSION_FAMILY,
         engine_id: EngineId::new(extension_engine_id).map_err(RuntimeConfigError::from)?,
         counters: Arc::clone(&counters),
     }))?;
@@ -796,9 +835,14 @@ fn runtime_run_compiled_split_use_retains_source_and_destination_values(
 
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
     let sum = (&x + &x)?;
-    let extension = tenferro_runtime::extension::apply(Arc::new(CountingExtensionOp), &[&sum])?
-        .pop()
-        .expect("extension has one output");
+    let extension = tenferro_runtime::extension::apply(
+        Arc::new(CountingExtensionOp {
+            family_id: COUNTING_EXTENSION_FAMILY,
+        }),
+        &[&sum],
+    )?
+    .pop()
+    .expect("extension has one output");
     let y = (&extension + &sum)?;
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])?;
@@ -823,8 +867,9 @@ fn transfer_failure_skips_downstream_execution_and_releases_located_values(
     let core_backend = CpuBackend::new();
     let extension_backend = CpuBackend::new();
     let drops = Arc::new(AtomicUsize::new(0));
-    let counters = Arc::new(ExtensionCounters::default());
-    *counters
+    let upstream_counters = Arc::new(ExtensionCounters::default());
+    let downstream_counters = Arc::new(ExtensionCounters::default());
+    *upstream_counters
         .tracked_output_drops
         .lock()
         .expect("tracked output lock") = Some(Arc::clone(&drops));
@@ -866,17 +911,39 @@ fn transfer_failure_skips_downstream_execution_and_releases_located_values(
             "tenferro-test.counting-extension.transfer-failure-module",
         )
         .map_err(RuntimeConfigError::from)?,
+        family_id: COUNTING_EXTENSION_FAMILY,
         engine_id: EngineId::new(extension_engine_id).map_err(RuntimeConfigError::from)?,
-        counters: Arc::clone(&counters),
+        counters: Arc::clone(&upstream_counters),
+    }))?;
+    builder.install_extension_module(Arc::new(CountingExtensionModule {
+        module_id: ExtensionModuleId::new(
+            "tenferro-test.downstream-counting-extension.transfer-failure-module",
+        )
+        .map_err(RuntimeConfigError::from)?,
+        family_id: DOWNSTREAM_COUNTING_EXTENSION_FAMILY,
+        engine_id: EngineId::new(core_engine_id).map_err(RuntimeConfigError::from)?,
+        counters: Arc::clone(&downstream_counters),
     }))?;
     let runtime = builder.build()?;
 
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
     let sum = (&x + &x)?;
-    let extension = tenferro_runtime::extension::apply(Arc::new(CountingExtensionOp), &[&sum])?
-        .pop()
-        .expect("extension has one output");
-    let y = (&extension + &sum)?;
+    let extension = tenferro_runtime::extension::apply(
+        Arc::new(CountingExtensionOp {
+            family_id: COUNTING_EXTENSION_FAMILY,
+        }),
+        &[&sum],
+    )?
+    .pop()
+    .expect("extension has one output");
+    let y = tenferro_runtime::extension::apply(
+        Arc::new(CountingExtensionOp {
+            family_id: DOWNSTREAM_COUNTING_EXTENSION_FAMILY,
+        }),
+        &[&extension],
+    )?
+    .pop()
+    .expect("downstream extension has one output");
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])?;
     let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0])?;
@@ -886,7 +953,12 @@ fn transfer_failure_skips_downstream_execution_and_releases_located_values(
     assert!(error.to_string().contains("intentional transfer failure"));
     assert_eq!(forward.calls(), 1);
     assert_eq!(failing.calls.load(Ordering::SeqCst), 1);
-    assert_eq!(counters.execute.load(Ordering::SeqCst), 1);
+    assert_eq!(upstream_counters.execute.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        downstream_counters.execute.load(Ordering::SeqCst),
+        0,
+        "the downstream operation must not execute after its input transfer fails"
+    );
     assert_eq!(
         drops.load(Ordering::SeqCst),
         1,
@@ -924,6 +996,7 @@ fn runtime_run_compiled_reports_missing_transfer_provider_for_cross_storage(
     builder.install_extension_module(Arc::new(CountingExtensionModule {
         module_id: ExtensionModuleId::new("tenferro-test.counting-extension.no-transfer-module")
             .map_err(RuntimeConfigError::from)?,
+        family_id: COUNTING_EXTENSION_FAMILY,
         engine_id: EngineId::new(extension_engine_id).map_err(RuntimeConfigError::from)?,
         counters: Arc::clone(&counters),
     }))?;
@@ -940,9 +1013,14 @@ fn runtime_run_compiled_reports_missing_transfer_provider_for_cross_storage(
 
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
     let sum = (&x + &x)?;
-    let y = tenferro_runtime::extension::apply(Arc::new(CountingExtensionOp), &[&sum])?
-        .pop()
-        .expect("extension has one output");
+    let y = tenferro_runtime::extension::apply(
+        Arc::new(CountingExtensionOp {
+            family_id: COUNTING_EXTENSION_FAMILY,
+        }),
+        &[&sum],
+    )?
+    .pop()
+    .expect("extension has one output");
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])?;
     let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0])?;

--- a/crates/tenferro-runtime/tests/integration/runtime_execution.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_execution.rs
@@ -11,16 +11,19 @@ use tenferro_ops::{
 };
 use tenferro_runtime::{
     CoreCapabilityBundle, DType, DotGeneralPreparation, ElementwiseRuntime, EngineId,
-    EngineRegistration, ErasedExecutionContext, Error, ErrorPhase, ExecutionContextIdentity,
-    ExtensionCacheStore, ExtensionEngine, ExtensionModule, ExtensionModuleError, ExtensionModuleId,
-    ExtensionModuleRegistrar, ExtensionPlanningConfig, ExtensionPrepareRequest, GraphCompiler,
-    HardwareClassId, IndexingRuntime, LayoutRuntime, PrepareCapability, PrepareError,
-    PreparedOperation, PreparedOperationBinding, PreparedOperationExecutor, PreparedOperationPlan,
-    ReductionRuntime, Runtime, RuntimeCacheOwner, RuntimeConfigError, SpecializationProjection,
-    StorageClass, TracedTensor, TransferProvider, TransferRequest,
+    EngineRegistration, ErasedExecutionContext, Error, ErrorPhase, EventDomainId,
+    ExecutionContextIdentity, ExtensionCacheStore, ExtensionEngine, ExtensionModule,
+    ExtensionModuleError, ExtensionModuleId, ExtensionModuleRegistrar, ExtensionPlanningConfig,
+    ExtensionPrepareRequest, GraphCompiler, HardwareClassId, IndexingRuntime, LayoutRuntime,
+    PrepareCapability, PrepareError, PreparedOperation, PreparedOperationBinding,
+    PreparedOperationExecutor, PreparedOperationPlan, ReductionRuntime, RegistrationKey, Runtime,
+    RuntimeCacheOwner, RuntimeConfigError, SpecializationProjection, StorageClass, TracedTensor,
+    TransferError, TransferProvider, TransferRequest,
 };
-use tenferro_tensor::{AllocationDomainId, SharedTensorAllocationDomain};
-use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+use tenferro_tensor::{
+    AllocationDomainId, BackendBuffer, BackendSessionHost, Buffer, Placement,
+    SharedTensorAllocationDomain, Tensor, TensorRead, TypedTensor,
+};
 
 const CPU_ENGINE_ID: &str = "tenferro-cpu.default.v1";
 const CPU_HARDWARE_CLASS_ID: &str = "tenferro-cpu.host.v1";
@@ -77,6 +80,7 @@ struct ExtensionCounters {
     prepare: AtomicUsize,
     execute: AtomicUsize,
     last_execute_domain: Mutex<Option<AllocationDomainId>>,
+    tracked_output_drops: Mutex<Option<Arc<AtomicUsize>>>,
 }
 
 #[derive(Debug)]
@@ -100,6 +104,17 @@ struct RecordingTransferProvider {
     source: StorageClass,
     destination: StorageClass,
     calls: AtomicUsize,
+    requests: Mutex<Vec<RecordedTransferRequest>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RecordedTransferRequest {
+    source_engine_id: EngineId,
+    source_event_domain_id: EventDomainId,
+    source_storage_class: StorageClass,
+    destination_engine_id: EngineId,
+    destination_event_domain_id: EventDomainId,
+    destination_storage_class: StorageClass,
 }
 
 impl RecordingTransferProvider {
@@ -108,11 +123,16 @@ impl RecordingTransferProvider {
             source,
             destination,
             calls: AtomicUsize::new(0),
+            requests: Mutex::new(Vec::new()),
         }
     }
 
     fn calls(&self) -> usize {
         self.calls.load(Ordering::SeqCst)
+    }
+
+    fn requests(&self) -> Vec<RecordedTransferRequest> {
+        self.requests.lock().expect("request lock").clone()
     }
 }
 
@@ -120,12 +140,69 @@ impl TransferProvider for RecordingTransferProvider {
     fn transfer(&self, request: TransferRequest<'_>) -> tenferro_runtime::Result<Tensor> {
         assert_eq!(request.source_storage_class(), &self.source);
         assert_eq!(request.destination_storage_class(), &self.destination);
+        self.requests
+            .lock()
+            .expect("request lock")
+            .push(RecordedTransferRequest {
+                source_engine_id: request.source_engine_id().clone(),
+                source_event_domain_id: request.source_event_domain_id(),
+                source_storage_class: request.source_storage_class().clone(),
+                destination_engine_id: request.destination_engine_id().clone(),
+                destination_event_domain_id: request.destination_event_domain_id(),
+                destination_storage_class: request.destination_storage_class().clone(),
+            });
         self.calls.fetch_add(1, Ordering::SeqCst);
         request
             .input()
             .as_tensor()
             .cloned()
             .ok_or_else(|| Error::Internal("test transfer expected an owned tensor".into()))
+    }
+}
+
+#[derive(Debug)]
+struct FailingTransferProvider {
+    calls: AtomicUsize,
+}
+
+impl TransferProvider for FailingTransferProvider {
+    fn transfer(&self, _request: TransferRequest<'_>) -> tenferro_runtime::Result<Tensor> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err(Error::runtime_state_source(
+            "FailingTransferProvider::transfer",
+            ErrorPhase::Execution,
+            TestTransferFailure,
+        ))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("intentional transfer failure")]
+struct TestTransferFailure;
+
+#[derive(Debug)]
+struct DropTrackedBuffer {
+    len: usize,
+    drops: Arc<AtomicUsize>,
+}
+
+impl Drop for DropTrackedBuffer {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+impl BackendBuffer<f64> for DropTrackedBuffer {
+    fn backend_family(&self) -> &'static str {
+        "tenferro-test.drop-tracked"
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
@@ -276,6 +353,23 @@ impl PreparedOperationExecutor for CountingPreparedOperation {
             .last_execute_domain
             .lock()
             .expect("domain lock") = backend.allocation_domain();
+        if let Some(drops) = self
+            .counters
+            .tracked_output_drops
+            .lock()
+            .expect("tracked output lock")
+            .clone()
+        {
+            let shape = inputs[0].shape().to_vec();
+            let len = shape.iter().product();
+            let buffer = Buffer::Backend(Arc::new(DropTrackedBuffer { len, drops }));
+            return Ok(vec![TypedTensor::<f64>::from_buffer_col_major(
+                shape,
+                buffer,
+                Placement::default(),
+            )?
+            .into()]);
+        }
         Ok(vec![backend.with_backend_session(|session| {
             session.to_contiguous_read(inputs[0].clone())
         })?])
@@ -404,6 +498,47 @@ fn cpu_registration_with_storage_id(
 }
 
 #[test]
+fn transfer_provider_registration_is_idempotent_and_rejects_conflicts(
+) -> Result<(), Box<dyn StdError>> {
+    let source = StorageClass::new("tenferro-test.storage.registry-source")?;
+    let destination = StorageClass::new("tenferro-test.storage.registry-destination")?;
+    let provider: Arc<dyn TransferProvider> = Arc::new(RecordingTransferProvider::new(
+        source.clone(),
+        destination.clone(),
+    ));
+    let conflicting: Arc<dyn TransferProvider> = Arc::new(RecordingTransferProvider::new(
+        source.clone(),
+        destination.clone(),
+    ));
+    let mut builder = Runtime::builder();
+
+    builder.register_transfer_provider(
+        source.clone(),
+        destination.clone(),
+        Arc::clone(&provider),
+    )?;
+    builder.register_transfer_provider(
+        source.clone(),
+        destination.clone(),
+        Arc::clone(&provider),
+    )?;
+    let error = builder
+        .register_transfer_provider(source.clone(), destination.clone(), conflicting)
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        RuntimeConfigError::ConflictingRegistration {
+            key: RegistrationKey::TransferProvider {
+                source: actual_source,
+                destination: actual_destination,
+            },
+        } if actual_source == source && actual_destination == destination
+    ));
+    Ok(())
+}
+
+#[test]
 fn runtime_run_compiled_executes_extension_prepared_operation() -> Result<(), Box<dyn StdError>> {
     let backend = CpuBackend::new();
     let counters = Arc::new(ExtensionCounters::default());
@@ -443,12 +578,18 @@ fn runtime_run_compiled_dispatches_same_storage_extension_on_selected_engine(
     let extension_backend =
         CpuBackend::new().with_allocation_domain(Arc::new(TestAllocationDomain(extension_domain)));
     let counters = Arc::new(ExtensionCounters::default());
+    let core_engine_id = "tenferro-test.core-engine.v1";
     let extension_engine_id = "tenferro-test.extension-engine.v1";
+    let storage = StorageClass::new(CPU_STORAGE_CLASS_ID)?;
+    let transfer = Arc::new(RecordingTransferProvider::new(
+        storage.clone(),
+        storage.clone(),
+    ));
 
     let mut builder = Runtime::builder();
     builder.register_engine(cpu_registration_with_id(
         &core_backend,
-        "tenferro-test.core-engine.v1",
+        core_engine_id,
         true,
         true,
     )?)?;
@@ -458,6 +599,7 @@ fn runtime_run_compiled_dispatches_same_storage_extension_on_selected_engine(
         false,
         true,
     )?)?;
+    builder.register_transfer_provider(storage.clone(), storage.clone(), transfer.clone())?;
     builder.install_extension_module(Arc::new(CountingExtensionModule {
         module_id: ExtensionModuleId::new("tenferro-test.counting-extension.per-op-module")
             .map_err(RuntimeConfigError::from)?,
@@ -465,6 +607,15 @@ fn runtime_run_compiled_dispatches_same_storage_extension_on_selected_engine(
         counters: Arc::clone(&counters),
     }))?;
     let runtime = builder.build()?;
+    let snapshot = runtime.snapshot()?;
+    let source_event_domain = snapshot
+        .engine(&EngineId::new(core_engine_id)?)
+        .expect("source engine")
+        .event_domain_id();
+    let destination_event_domain = snapshot
+        .engine(&EngineId::new(extension_engine_id)?)
+        .expect("destination engine")
+        .event_domain_id();
 
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
     let sum = (&x + &x)?;
@@ -480,6 +631,18 @@ fn runtime_run_compiled_dispatches_same_storage_extension_on_selected_engine(
     assert_eq!(output[0].as_slice::<f64>()?, &[6.0, 10.0]);
     assert_eq!(counters.prepare.load(Ordering::SeqCst), 1);
     assert_eq!(counters.execute.load(Ordering::SeqCst), 1);
+    assert_eq!(transfer.calls(), 1);
+    assert_eq!(
+        transfer.requests(),
+        vec![RecordedTransferRequest {
+            source_engine_id: EngineId::new(core_engine_id)?,
+            source_event_domain_id: source_event_domain,
+            source_storage_class: storage.clone(),
+            destination_engine_id: EngineId::new(extension_engine_id)?,
+            destination_event_domain_id: destination_event_domain,
+            destination_storage_class: storage,
+        }]
+    );
     assert_eq!(
         *counters.last_execute_domain.lock().expect("domain lock"),
         Some(extension_domain),
@@ -559,12 +722,176 @@ fn runtime_run_compiled_transfers_between_storage_classes_on_scheduled_path(
 
     assert_eq!(output[0].as_slice::<f64>()?, &[6.0, 10.0]);
     assert_eq!(transfer.calls(), 1);
+    assert_eq!(
+        transfer.requests(),
+        vec![RecordedTransferRequest {
+            source_engine_id: EngineId::new(core_engine_id)?,
+            source_event_domain_id: source_event_domain,
+            source_storage_class: source_storage,
+            destination_engine_id: EngineId::new(extension_engine_id)?,
+            destination_event_domain_id: destination_event_domain,
+            destination_storage_class: destination_storage,
+        }]
+    );
     assert_eq!(counters.execute.load(Ordering::SeqCst), 1);
     assert_eq!(
         *counters.last_execute_domain.lock().expect("domain lock"),
         Some(extension_domain)
     );
 
+    Ok(())
+}
+
+#[test]
+fn runtime_run_compiled_split_use_retains_source_and_destination_values(
+) -> Result<(), Box<dyn StdError>> {
+    let core_backend = CpuBackend::new();
+    let extension_backend = CpuBackend::new();
+    let counters = Arc::new(ExtensionCounters::default());
+    let core_engine_id = "tenferro-test.core-split-source.v1";
+    let extension_engine_id = "tenferro-test.extension-split-destination.v1";
+    let source_storage = StorageClass::new(CPU_STORAGE_CLASS_ID)?;
+    let destination_storage = StorageClass::new("tenferro-test.storage.split-destination.v1")?;
+    let forward = Arc::new(RecordingTransferProvider::new(
+        source_storage.clone(),
+        destination_storage.clone(),
+    ));
+    let reverse = Arc::new(RecordingTransferProvider::new(
+        destination_storage.clone(),
+        source_storage.clone(),
+    ));
+
+    let mut builder = Runtime::builder();
+    builder.register_engine(cpu_registration_with_storage_id(
+        &core_backend,
+        core_engine_id,
+        source_storage.as_str(),
+        true,
+        true,
+    )?)?;
+    builder.register_engine(cpu_registration_with_storage_id(
+        &extension_backend,
+        extension_engine_id,
+        destination_storage.as_str(),
+        false,
+        true,
+    )?)?;
+    builder.register_transfer_provider(
+        source_storage.clone(),
+        destination_storage.clone(),
+        forward.clone(),
+    )?;
+    builder.register_transfer_provider(
+        destination_storage.clone(),
+        source_storage,
+        reverse.clone(),
+    )?;
+    builder.install_extension_module(Arc::new(CountingExtensionModule {
+        module_id: ExtensionModuleId::new("tenferro-test.counting-extension.split-module")
+            .map_err(RuntimeConfigError::from)?,
+        engine_id: EngineId::new(extension_engine_id).map_err(RuntimeConfigError::from)?,
+        counters: Arc::clone(&counters),
+    }))?;
+    let runtime = builder.build()?;
+
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
+    let sum = (&x + &x)?;
+    let extension = tenferro_runtime::extension::apply(Arc::new(CountingExtensionOp), &[&sum])?
+        .pop()
+        .expect("extension has one output");
+    let y = (&extension + &sum)?;
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])?;
+    let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0])?;
+
+    let output = runtime.run_compiled(&program, &[&input])?;
+
+    assert_eq!(output[0].as_slice::<f64>()?, &[12.0, 20.0]);
+    assert_eq!(forward.calls(), 1);
+    assert_eq!(
+        reverse.calls(),
+        1,
+        "the source-side sum must remain available after its split transfer"
+    );
+    assert_eq!(counters.execute.load(Ordering::SeqCst), 1);
+    Ok(())
+}
+
+#[test]
+fn transfer_failure_skips_downstream_execution_and_releases_located_values(
+) -> Result<(), Box<dyn StdError>> {
+    let core_backend = CpuBackend::new();
+    let extension_backend = CpuBackend::new();
+    let drops = Arc::new(AtomicUsize::new(0));
+    let counters = Arc::new(ExtensionCounters::default());
+    *counters
+        .tracked_output_drops
+        .lock()
+        .expect("tracked output lock") = Some(Arc::clone(&drops));
+    let core_engine_id = "tenferro-test.core-transfer-failure.v1";
+    let extension_engine_id = "tenferro-test.extension-transfer-failure.v1";
+    let source_storage = StorageClass::new(CPU_STORAGE_CLASS_ID)?;
+    let destination_storage = StorageClass::new("tenferro-test.storage.failure-destination.v1")?;
+    let forward = Arc::new(RecordingTransferProvider::new(
+        source_storage.clone(),
+        destination_storage.clone(),
+    ));
+    let failing = Arc::new(FailingTransferProvider {
+        calls: AtomicUsize::new(0),
+    });
+
+    let mut builder = Runtime::builder();
+    builder.register_engine(cpu_registration_with_storage_id(
+        &core_backend,
+        core_engine_id,
+        source_storage.as_str(),
+        true,
+        true,
+    )?)?;
+    builder.register_engine(cpu_registration_with_storage_id(
+        &extension_backend,
+        extension_engine_id,
+        destination_storage.as_str(),
+        false,
+        true,
+    )?)?;
+    builder.register_transfer_provider(
+        source_storage.clone(),
+        destination_storage.clone(),
+        forward.clone(),
+    )?;
+    builder.register_transfer_provider(destination_storage, source_storage, failing.clone())?;
+    builder.install_extension_module(Arc::new(CountingExtensionModule {
+        module_id: ExtensionModuleId::new(
+            "tenferro-test.counting-extension.transfer-failure-module",
+        )
+        .map_err(RuntimeConfigError::from)?,
+        engine_id: EngineId::new(extension_engine_id).map_err(RuntimeConfigError::from)?,
+        counters: Arc::clone(&counters),
+    }))?;
+    let runtime = builder.build()?;
+
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
+    let sum = (&x + &x)?;
+    let extension = tenferro_runtime::extension::apply(Arc::new(CountingExtensionOp), &[&sum])?
+        .pop()
+        .expect("extension has one output");
+    let y = (&extension + &sum)?;
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])?;
+    let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0])?;
+
+    let error = runtime.run_compiled(&program, &[&input]).unwrap_err();
+
+    assert!(error.to_string().contains("intentional transfer failure"));
+    assert_eq!(forward.calls(), 1);
+    assert_eq!(failing.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(counters.execute.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        drops.load(Ordering::SeqCst),
+        1,
+        "the extension output retained at its source location must be released on failure"
+    );
     Ok(())
 }
 
@@ -576,6 +903,7 @@ fn runtime_run_compiled_reports_missing_transfer_provider_for_cross_storage(
     let counters = Arc::new(ExtensionCounters::default());
     let core_engine_id = "tenferro-test.core-missing-transfer-source.v1";
     let extension_engine_id = "tenferro-test.extension-missing-transfer-destination.v1";
+    let source_storage = StorageClass::new(CPU_STORAGE_CLASS_ID)?;
     let destination_storage = StorageClass::new("tenferro-test.storage.missing-destination.v1")?;
 
     let mut builder = Runtime::builder();
@@ -597,9 +925,18 @@ fn runtime_run_compiled_reports_missing_transfer_provider_for_cross_storage(
         module_id: ExtensionModuleId::new("tenferro-test.counting-extension.no-transfer-module")
             .map_err(RuntimeConfigError::from)?,
         engine_id: EngineId::new(extension_engine_id).map_err(RuntimeConfigError::from)?,
-        counters,
+        counters: Arc::clone(&counters),
     }))?;
     let runtime = builder.build()?;
+    let snapshot = runtime.snapshot()?;
+    let source_event_domain = snapshot
+        .engine(&EngineId::new(core_engine_id)?)
+        .expect("source engine")
+        .event_domain_id();
+    let destination_event_domain = snapshot
+        .engine(&EngineId::new(extension_engine_id)?)
+        .expect("destination engine")
+        .event_domain_id();
 
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
     let sum = (&x + &x)?;
@@ -613,6 +950,27 @@ fn runtime_run_compiled_reports_missing_transfer_provider_for_cross_storage(
     let error = runtime.run_compiled(&program, &[&input]).unwrap_err();
 
     assert!(error.to_string().contains("no transfer provider"));
+    let transfer_error = error
+        .source()
+        .and_then(|source| source.downcast_ref::<TransferError>())
+        .expect("typed transfer error source");
+    assert!(matches!(
+        transfer_error,
+        TransferError::MissingProvider {
+            source_engine_id,
+            source_event_domain_id: actual_source_event_domain,
+            source_storage_class,
+            destination_engine_id,
+            destination_event_domain_id: actual_destination_event_domain,
+            destination_storage_class,
+        } if source_engine_id == &EngineId::new(core_engine_id)?
+            && *actual_source_event_domain == source_event_domain
+            && source_storage_class == &source_storage
+            && destination_engine_id == &EngineId::new(extension_engine_id)?
+            && *actual_destination_event_domain == destination_event_domain
+            && destination_storage_class == &destination_storage
+    ));
+    assert_eq!(counters.execute.load(Ordering::SeqCst), 0);
 
     Ok(())
 }

--- a/docs/worklogs/2026-07-29-issue-1471-explicit-transfers.md
+++ b/docs/worklogs/2026-07-29-issue-1471-explicit-transfers.md
@@ -1,0 +1,88 @@
+# Issue 1471 Explicit Transfers
+
+## Session Summary
+
+Implemented split PR 1 from issue
+[#1471](https://github.com/tensor4all/tenferro-rs/issues/1471): synchronous
+production execution now consumes explicit scheduled transfer nodes and retains
+tensor values by execution location. The transfer-provider registry remains
+keyed by source and destination storage class.
+
+## Context Read
+
+- Workspace and repository `AGENTS.md`, workspace `CODING_RULES.md`, and
+  `REPOSITORY_RULES.md`.
+- Issue #1471, including the split proposal in comment `5115212328`.
+- Shared Tensor4all repository, Rust, performance, documentation, and test
+  rules.
+- Runtime preparation, schedule generation, prepared execution, transfer
+  registration, and existing integration-test paths after refreshing the local
+  CodeGraph index.
+
+## Decisions Made
+
+- Added a crate-private execution location identity containing engine ID,
+  runtime event-domain ID, and storage class. Event-domain identity is required
+  because CUDA and WebGPU can share a storage-class identifier while remaining
+  distinct execution locations.
+- Kept provider lookup keyed by `(source storage class, destination storage
+  class)`. `TransferRequest` now exposes the concrete engine and event-domain
+  endpoints in addition to those storage classes.
+- Generated `ScheduledTransfer` nodes whenever an instruction needs a value at
+  a location where no copy exists. Storage-class equality alone does not avoid
+  a transfer.
+- Added an explicit execution-instruction index to every scheduled operation.
+  Production execution no longer equates schedule-node position with
+  instruction position.
+- Stored each execution slot as zero or more location-tagged copies. A transfer
+  adds a destination copy without removing the source; global last use clears
+  every retained copy.
+- Preserved the existing executor ABI by staging only the copy for the current
+  operation into a temporary slot vector, then returning live inputs and
+  outputs to the location-aware store.
+- Added a public typed `TransferError::MissingProvider` source while preserving
+  the existing runtime-state error category.
+- Removed inline `ensure_slot_in_storage` transfer execution and the stale
+  module-wide `dead_code` allowance from `schedule.rs`.
+
+## TDD
+
+- RED: the schedule test failed because execution locations, explicit
+  instruction indices, and value-bearing transfer nodes did not exist.
+- RED: integration tests failed because transfer requests lacked engine/event
+  endpoints and no typed missing-provider error existed.
+- GREEN: schedule generation emits one same-storage/different-location transfer
+  for a split-use program and reuses the retained source copy for the later
+  source-side operation.
+- GREEN: `Runtime::run_compiled` executes scheduled transfers for cross-storage
+  and same-storage location changes.
+- GREEN: a split-use graph performs one forward and one reverse transfer,
+  proving that the first transfer does not destroy the source copy.
+- GREEN: an intentional transfer failure skips the downstream operation and
+  drops a tracked source-location backend value.
+- GREEN: identical transfer-provider registration is idempotent, while a
+  different provider at the same class-pair key returns the typed conflict.
+
+## Deferred Scope
+
+- Submit/event schedulers and asynchronous completion.
+- CUDA and WebGPU transfer adapters.
+- Collectives, distributed tensors, and real multi-GPU execution.
+- Any change to transfer-provider registry keying.
+
+## Documentation Impact
+
+The scheduling model remains crate-private. Public documentation changes are
+limited to the additive `TransferRequest` endpoint accessors and
+`TransferError`; no user guide or migration guide change is required.
+
+## Verification
+
+- `cargo test -p tenferro-runtime runtime::tests::schedule:: --lib`
+- `cargo test -p tenferro-runtime --test integration runtime_execution::`
+- `cargo test -p tenferro-runtime`: passed across library, integration, and
+  doctest targets.
+- `cargo fmt --all --check`: passed.
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p
+  tenferro-runtime --test integration runtime_execution::'`: passed, including
+  workspace and extension clippy with warnings denied.

--- a/docs/worklogs/2026-07-29-issue-1471-explicit-transfers.md
+++ b/docs/worklogs/2026-07-29-issue-1471-explicit-transfers.md
@@ -59,9 +59,23 @@ keyed by source and destination storage class.
 - GREEN: a split-use graph performs one forward and one reverse transfer,
   proving that the first transfer does not destroy the source copy.
 - GREEN: an intentional transfer failure skips the downstream operation and
-  drops a tracked source-location backend value.
+  drops a tracked source-location backend value. A separate downstream
+  extension family records an explicit zero execution count after the failed
+  transfer.
 - GREEN: identical transfer-provider registration is idempotent, while a
   different provider at the same class-pair key returns the typed conflict.
+
+## Specification Review Follow-up
+
+The initial specification review returned `NOT_APPROVED`. The follow-up:
+
+- places an independently counted extension operation downstream of the
+  intentional transfer failure and asserts its execution count remains zero;
+- replaces the preparation-path `expect()` used to resolve execution locations
+  with `PrepareError::ResolvedEngineUnavailable`, propagated through both
+  same-storage and cross-storage dispatch construction; and
+- adds runnable `# Examples` to all public transfer endpoint accessors and
+  `TransferError`.
 
 ## Deferred Scope
 
@@ -82,7 +96,15 @@ limited to the additive `TransferRequest` endpoint accessors and
 - `cargo test -p tenferro-runtime --test integration runtime_execution::`
 - `cargo test -p tenferro-runtime`: passed across library, integration, and
   doctest targets.
+- `cargo test -p tenferro-runtime
+  runtime::preparation::execution_location_tests::missing_resolved_engine_returns_typed_prepare_error
+  --lib`
 - `cargo fmt --all --check`: passed.
 - `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p
   tenferro-runtime --test integration runtime_execution::'`: passed, including
   workspace and extension clippy with warnings denied.
+- The fast check was rerun after rebasing onto `origin/main` at `96c9e1c4`
+  with both the runtime execution module and typed preparation error test; it
+  passed.
+- `python3 scripts/repository-rules-review.py --base origin/main --worktree`:
+  passed. Follow-up unit tests are organized under `src/runtime/tests/`.


### PR DESCRIPTION
## Summary

- execute `ScheduledTransfer` nodes in the production runtime path
- retain values per execution location and preserve source copies across transfers
- expose location-bearing transfer requests and typed missing-provider failures
- cover same-storage/different-location routing, failure cleanup, and downstream suppression

This is split PR 1/5 for #1471. Submit scheduling, native event adapters, CUDA/WebGPU adapters, collectives, and distributed tensors remain deferred.

## Worklog

- [`docs/worklogs/2026-07-29-issue-1471-explicit-transfers.md`](docs/worklogs/2026-07-29-issue-1471-explicit-transfers.md)

## Verification

- `cargo test -p tenferro-runtime`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-runtime transfer_failure_skips_downstream_execution_and_releases_located_values'`\n- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-w7-pr1.json`\n- independent specification re-review: approved at `fa7ed7af`, followed only by invariant-marker documentation required by repository review\n