### PR TITLE
perf(cpu): cache erased indexed plans

### DIFF
--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -65,6 +65,7 @@ cblas-src = { workspace = true, optional = true }
 blas-src = { workspace = true, optional = true }
 lapack = { workspace = true, optional = true }
 lapack-src = { workspace = true, optional = true }
+lru.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -14,6 +14,9 @@ use crate::arbiter::{
 use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
 use crate::dot_runtime::{CpuProviderBundle, CpuProviderBundleInstallError};
 use crate::engine::{CpuEngine, EngineResources};
+use crate::indexed_plan_cache::{
+    IndexedPlanCache, IndexedPlanCacheLimits, DEFAULT_INDEXED_PLAN_CACHE_LIMITS,
+};
 use crate::placement::{
     resolve_placement, resolve_placement_with_affinity, CpuEngineConstructionError,
     ResolvedCpuExecution,
@@ -798,6 +801,7 @@ struct CpuBackendState {
     arbiter: ResourceArbiter,
     kind: CpuBackendKind,
     buffer_limit: AtomicUsize,
+    indexed_plan_cache_limits: Mutex<IndexedPlanCacheLimits>,
 }
 
 impl CpuBackendState {
@@ -806,6 +810,17 @@ impl CpuBackendState {
         placement: &ResolvedCpuPlacement,
         requested: CpuPlacement,
     ) -> Result<Arc<CpuEngine>, CpuPlacementError> {
+        // INVARIANT: cache configuration is the outermost lock for lazy engine
+        // creation and limit updates. The shared order is configuration,
+        // registry, then engine resources.
+        let cache_configuration = self.indexed_plan_cache_limits.lock().map_err(|_| {
+            CpuPlacementError::InternalState {
+                requested,
+                backend: self.kind,
+                message: "CPU indexed-plan cache configuration lock is poisoned",
+            }
+        })?;
+        let cache_limits = *cache_configuration;
         let CpuEngineRegistry::ManagedLazy(registry) = &self.engines else {
             return Err(CpuPlacementError::InternalState {
                 requested,
@@ -844,6 +859,7 @@ impl CpuBackendState {
                         }
                     })?,
                 );
+                self.configure_new_indexed_plan_cache(&engine, requested, cache_limits)?;
                 engines.insert(*id, Arc::clone(&engine));
                 Ok(engine)
             }
@@ -873,10 +889,30 @@ impl CpuBackendState {
                         }
                     })?,
                 );
+                self.configure_new_indexed_plan_cache(&engine, requested, cache_limits)?;
                 let _ = registry.all_allowed.set(Arc::clone(&engine));
                 Ok(engine)
             }
         }
+    }
+
+    fn configure_new_indexed_plan_cache(
+        &self,
+        engine: &CpuEngine,
+        requested: CpuPlacement,
+        limits: IndexedPlanCacheLimits,
+    ) -> Result<(), CpuPlacementError> {
+        let mut resources =
+            engine
+                .resources
+                .lock()
+                .map_err(|_| CpuPlacementError::InternalState {
+                    requested,
+                    backend: self.kind,
+                    message: "new CPU engine indexed-plan cache lock is poisoned",
+                })?;
+        resources.indexed_plan_cache.set_limits(limits);
+        Ok(())
     }
 
     fn managed_base_engine(
@@ -959,6 +995,15 @@ fn lock_engine_resources<'a>(
         .resources
         .lock()
         .map_err(|_| poisoned_cpu_lock(op, "CPU engine resources"))
+}
+
+fn saturating_add_tensor_cache_stats(total: &mut CacheStats, value: CacheStats) {
+    total.entries = total.entries.saturating_add(value.entries);
+    total.retained_bytes = total.retained_bytes.saturating_add(value.retained_bytes);
+    total.hits = total.hits.saturating_add(value.hits);
+    total.misses = total.misses.saturating_add(value.misses);
+    total.evictions = total.evictions.saturating_add(value.evictions);
+    total.clears = total.clears.saturating_add(value.clears);
 }
 
 /// A cheap cloneable handle to shared CPU execution coordination.
@@ -1085,6 +1130,7 @@ impl CpuBackend {
                     arbiter: ResourceArbiter::global(),
                     kind,
                     buffer_limit: AtomicUsize::new(max_retained_capacity_bytes),
+                    indexed_plan_cache_limits: Mutex::new(DEFAULT_INDEXED_PLAN_CACHE_LIMITS),
                 }),
                 requested: CpuPlacement::Auto,
                 resolved,
@@ -1151,6 +1197,7 @@ impl CpuBackend {
                 arbiter: ResourceArbiter::global(),
                 kind,
                 buffer_limit: AtomicUsize::new(max_retained_capacity_bytes),
+                indexed_plan_cache_limits: Mutex::new(DEFAULT_INDEXED_PLAN_CACHE_LIMITS),
             }),
             requested: CpuPlacement::Auto,
             resolved,
@@ -1437,6 +1484,7 @@ impl CpuBackend {
                 arbiter,
                 kind,
                 buffer_limit: AtomicUsize::new(buffer_limit),
+                indexed_plan_cache_limits: Mutex::new(DEFAULT_INDEXED_PLAN_CACHE_LIMITS),
             }),
             requested: CpuPlacement::Auto,
             resolved,
@@ -2058,6 +2106,144 @@ impl CpuBackend {
         })
     }
 
+    /// Return the limits applied to each CPU engine's indexed-plan cache.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let backend = CpuBackend::new();
+    /// assert!(backend.indexed_plan_cache_limits()?.max_entries() > 0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] when the shared cache
+    /// configuration lock is poisoned.
+    pub fn indexed_plan_cache_limits(&self) -> crate::Result<IndexedPlanCacheLimits> {
+        self.shared
+            .indexed_plan_cache_limits
+            .lock()
+            .map(|limits| *limits)
+            .map_err(|_| {
+                poisoned_cpu_lock(
+                    "CpuBackend::indexed_plan_cache_limits",
+                    "CPU indexed-plan cache configuration",
+                )
+            })
+    }
+
+    /// Update indexed-plan cache limits for current and future CPU engines.
+    ///
+    /// Shrinking either bound evicts least-recently-used plans immediately. A
+    /// zero entry or byte bound disables retention.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuBackend, IndexedPlanCacheLimits};
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// backend.set_indexed_plan_cache_limits(IndexedPlanCacheLimits::new(8, 4096))?;
+    /// assert_eq!(backend.indexed_plan_cache_limits()?.max_entries(), 8);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] without changing the configured
+    /// limits when an engine registry or resource lock is poisoned.
+    pub fn set_indexed_plan_cache_limits(
+        &mut self,
+        limits: IndexedPlanCacheLimits,
+    ) -> crate::Result<()> {
+        // INVARIANT: keep the configuration guard while snapshotting the
+        // registry and updating every initialized engine. Lazy creation takes
+        // the same guard before any registry or resource lock.
+        let mut configured_limits = self.shared.indexed_plan_cache_limits.lock().map_err(|_| {
+            poisoned_cpu_lock(
+                "CpuBackend::set_indexed_plan_cache_limits",
+                "CPU indexed-plan cache configuration",
+            )
+        })?;
+        let engines = self
+            .shared
+            .initialized_engines("CpuBackend::set_indexed_plan_cache_limits")?;
+        let mut resources = engines
+            .iter()
+            .map(|engine| {
+                lock_engine_resources(engine, "CpuBackend::set_indexed_plan_cache_limits")
+            })
+            .collect::<crate::Result<Vec<_>>>()?;
+        *configured_limits = limits;
+        for resource in &mut resources {
+            resource.indexed_plan_cache.set_limits(limits);
+        }
+        Ok(())
+    }
+
+    /// Snapshot aggregate indexed-plan cache statistics across initialized CPU engines.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let backend = CpuBackend::new();
+    /// assert_eq!(backend.indexed_plan_cache_stats()?.entries, 0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] when an engine registry or
+    /// resource lock is poisoned.
+    pub fn indexed_plan_cache_stats(&self) -> crate::Result<CacheStats> {
+        self.shared
+            .initialized_engines("CpuBackend::indexed_plan_cache_stats")?
+            .iter()
+            .try_fold(CacheStats::default(), |mut total, engine| {
+                let stats = lock_engine_resources(engine, "CpuBackend::indexed_plan_cache_stats")?
+                    .indexed_plan_cache
+                    .stats();
+                saturating_add_tensor_cache_stats(&mut total, stats);
+                Ok(total)
+            })
+    }
+
+    /// Clear indexed traversal plans retained by all initialized CPU engines.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// backend.clear_indexed_plan_cache()?;
+    /// assert_eq!(backend.indexed_plan_cache_stats()?.entries, 0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] without clearing any engine when
+    /// an engine registry or resource lock is poisoned.
+    pub fn clear_indexed_plan_cache(&mut self) -> crate::Result<()> {
+        let engines = self
+            .shared
+            .initialized_engines("CpuBackend::clear_indexed_plan_cache")?;
+        let mut resources = engines
+            .iter()
+            .map(|engine| lock_engine_resources(engine, "CpuBackend::clear_indexed_plan_cache"))
+            .collect::<crate::Result<Vec<_>>>()?;
+        for resource in &mut resources {
+            resource.indexed_plan_cache.clear();
+        }
+        Ok(())
+    }
+
     /// Current CPU buffer-pool retention limit in bytes.
     ///
     /// # Examples
@@ -2162,13 +2348,20 @@ impl CpuBackend {
         let resources = lock_engine_resources(&self.engine, "CpuBackend::runtime_cache_stats")?;
         let buffers = resources.buffers.cache_stats();
         let gemm = tenferro_tensor::RuntimeCacheControl::stats(&resources.gemm_analysis_cache);
+        let indexed = resources.indexed_plan_cache.stats();
         Ok(tenferro_runtime::runtime::CacheStats {
-            entries: buffers.entries.saturating_add(gemm.entries),
-            retained_bytes: buffers.retained_bytes.saturating_add(gemm.retained_bytes),
-            hits: 0,
-            misses: 0,
-            evictions: 0,
-            clears: 0,
+            entries: buffers
+                .entries
+                .saturating_add(gemm.entries)
+                .saturating_add(indexed.entries),
+            retained_bytes: buffers
+                .retained_bytes
+                .saturating_add(gemm.retained_bytes)
+                .saturating_add(indexed.retained_bytes),
+            hits: indexed.hits,
+            misses: indexed.misses,
+            evictions: indexed.evictions,
+            clears: indexed.clears,
         })
     }
 
@@ -2177,6 +2370,7 @@ impl CpuBackend {
             lock_engine_resources(&self.engine, "CpuBackend::clear_runtime_caches")?;
         resources.buffers.clear();
         tenferro_tensor::RuntimeCacheControl::clear(&mut resources.gemm_analysis_cache);
+        resources.indexed_plan_cache.clear();
         Ok(())
     }
 
@@ -2298,6 +2492,36 @@ impl CpuBackend {
             .map_err(|error| crate::Error::backend_source("CPU tensor execution", error))?
     }
 
+    fn install_with_indexed_pool_context_unmarked<R: Send>(
+        &mut self,
+        op: impl FnOnce(
+                &CpuExecutionContext<'_>,
+                &mut BufferPool,
+                &mut IndexedPlanCache,
+            ) -> crate::Result<R>
+            + Send,
+    ) -> crate::Result<R> {
+        let owner = inherited_or_new_execution_owner();
+        let permit = self.acquire_execution_permit(owner);
+        let entry = CpuOperationEntry::new(self.engine.domain(), &permit);
+        let mode = entry.preferred_engine_mode();
+        entry
+            .enter(mode, |context| {
+                context.with_native_parallelism(|| {
+                    self.with_execution_resources(&permit, |resources| {
+                        let EngineResources {
+                            buffers,
+                            indexed_plan_cache,
+                            ..
+                        } = resources;
+                        let mut buffers = BufferPoolLoan::new(buffers);
+                        op(context, buffers.get_mut(), indexed_plan_cache)
+                    })
+                })
+            })
+            .map_err(|error| crate::Error::backend_source("CPU tensor execution", error))?
+    }
+
     fn install_with_pool<R: FreshCpuOutput + Send>(
         &mut self,
         op: impl FnOnce(&mut BufferPool) -> crate::Result<R> + Send,
@@ -2314,6 +2538,21 @@ impl CpuBackend {
     ) -> crate::Result<R> {
         let domain = self.engine.domain().id();
         let mut output = self.install_with_pool_context_unmarked(op)?;
+        output.tag_fresh(domain);
+        Ok(output)
+    }
+
+    fn install_with_indexed_pool_context<R: FreshCpuOutput + Send>(
+        &mut self,
+        op: impl FnOnce(
+                &CpuExecutionContext<'_>,
+                &mut BufferPool,
+                &mut IndexedPlanCache,
+            ) -> crate::Result<R>
+            + Send,
+    ) -> crate::Result<R> {
+        let domain = self.engine.domain().id();
+        let mut output = self.install_with_indexed_pool_context_unmarked(op)?;
         output.tag_fresh(domain);
         Ok(output)
     }
@@ -2937,9 +3176,16 @@ impl TensorIndexing for CpuBackend {
         start_indices: &Tensor,
         config: &GatherConfig,
     ) -> crate::Result<Tensor> {
-        self.install_with_pool_context(|context, buffers| {
+        self.install_with_indexed_pool_context(|context, buffers, cache| {
             let exec_context = context.strided_exec_context();
-            indexing::gather_with_pool(buffers, &exec_context, operand, start_indices, config)
+            indexing::gather_with_pool(
+                buffers,
+                cache,
+                &exec_context,
+                operand,
+                start_indices,
+                config,
+            )
         })
     }
 
@@ -2950,10 +3196,11 @@ impl TensorIndexing for CpuBackend {
         updates: &Tensor,
         config: &ScatterConfig,
     ) -> crate::Result<Tensor> {
-        self.install_with_pool_context(|context, buffers| {
+        self.install_with_indexed_pool_context(|context, buffers, cache| {
             let exec_context = context.strided_exec_context();
             indexing::scatter_with_pool(
                 buffers,
+                cache,
                 &exec_context,
                 operand,
                 scatter_indices,
@@ -2973,9 +3220,16 @@ impl TensorIndexing for CpuBackend {
         starts: &Tensor,
         slice_sizes: &[usize],
     ) -> crate::Result<Tensor> {
-        self.install_with_pool_context(|context, buffers| {
+        self.install_with_indexed_pool_context(|context, buffers, cache| {
             let exec_context = context.strided_exec_context();
-            indexing::dynamic_slice_with_pool(buffers, &exec_context, input, starts, slice_sizes)
+            indexing::dynamic_slice_with_pool(
+                buffers,
+                cache,
+                &exec_context,
+                input,
+                starts,
+                slice_sizes,
+            )
         })
     }
 
@@ -2985,10 +3239,11 @@ impl TensorIndexing for CpuBackend {
         update: &Tensor,
         starts: &Tensor,
     ) -> crate::Result<Tensor> {
-        self.install_with_pool_context(|context, buffers| {
+        self.install_with_indexed_pool_context(|context, buffers, cache| {
             let exec_context = context.strided_exec_context();
             indexing::dynamic_update_slice_with_pool(
                 buffers,
+                cache,
                 &exec_context,
                 operand,
                 update,
@@ -3090,6 +3345,7 @@ impl CpuBackend {
                     entered,
                     buffers: buffers.get_mut(),
                     gemm_analysis_cache: cache,
+                    indexed_plan_cache: &mut resources.indexed_plan_cache,
                     providers: &providers,
                 };
                 record_cpu_session_profile(

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -42,6 +42,24 @@ fn cpu_tensor_kernel_parallel_features_are_wired() {
 }
 
 #[test]
+fn indexed_plan_cache_configuration_poison_is_typed() {
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    let shared = Arc::clone(&backend.shared);
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        let _guard = shared.indexed_plan_cache_limits.lock().unwrap();
+        panic!("poison indexed-plan cache configuration");
+    }));
+    assert!(panic.is_err());
+
+    let error = backend.indexed_plan_cache_limits().unwrap_err();
+    assert_eq!(error.kind(), crate::ErrorKind::RuntimeState);
+    let error = backend
+        .set_indexed_plan_cache_limits(IndexedPlanCacheLimits::new(1, 1))
+        .unwrap_err();
+    assert_eq!(error.kind(), crate::ErrorKind::RuntimeState);
+}
+
+#[test]
 fn provider_context_source_cannot_reenter_or_bypass_the_executor_boundary() {
     let provider = include_str!("../provider.rs");
     let dot_runtime = include_str!("../dot_runtime.rs");

--- a/crates/tenferro-cpu/src/engine.rs
+++ b/crates/tenferro-cpu/src/engine.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::buffer_pool::BufferPool;
 use crate::gemm::GemmAnalysisCache;
+use crate::indexed_plan_cache::IndexedPlanCache;
 use crate::resource_domain::CpuResourceDomain;
 use crate::{
     CpuContext, CpuContextError, CpuDomainExecutor, CpuDomainId, CpuDomainOwnership,
@@ -13,6 +14,7 @@ use crate::{
 pub(crate) struct EngineResources {
     pub(crate) buffers: BufferPool,
     pub(crate) gemm_analysis_cache: GemmAnalysisCache,
+    pub(crate) indexed_plan_cache: IndexedPlanCache,
 }
 
 impl EngineResources {
@@ -20,6 +22,7 @@ impl EngineResources {
         Self {
             buffers: BufferPool::with_max_retained_capacity_bytes(buffer_limit),
             gemm_analysis_cache: GemmAnalysisCache::default(),
+            indexed_plan_cache: IndexedPlanCache::default(),
         }
     }
 }

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -13,6 +13,7 @@ use tenferro_tensor::{
 use super::backend::{
     elementwise_read_into_fallback_with_pool, reclaim_typed, tag_fresh_output, FreshCpuOutput,
 };
+use super::indexed_plan_cache::IndexedPlanCache;
 use super::provider::{CpuExecutionContext, CpuOperationEntry};
 use super::CpuProviderBundle;
 use super::{
@@ -25,6 +26,7 @@ pub(crate) struct CpuExecSession<'a> {
     pub(crate) entered: Option<CpuExecutionContext<'a>>,
     pub(crate) buffers: &'a mut BufferPool,
     pub(crate) gemm_analysis_cache: &'a mut gemm::GemmAnalysisCache,
+    pub(crate) indexed_plan_cache: &'a mut IndexedPlanCache,
     pub(crate) providers: &'a CpuProviderBundle,
 }
 
@@ -136,6 +138,36 @@ impl CpuExecSession<'_> {
             .enter(mode, |context| {
                 context.with_native_parallelism(|| {
                     let mut output = op(context, buffers)?;
+                    output.tag_fresh(context.domain_id());
+                    Ok(output)
+                })
+            })
+            .map_err(|error| crate::Error::backend_source("CPU native execution", error))?
+    }
+
+    fn run_native_fresh_with_indexed_context<R: FreshCpuOutput + Send>(
+        &mut self,
+        op: impl FnOnce(
+                &CpuExecutionContext<'_>,
+                &mut BufferPool,
+                &mut IndexedPlanCache,
+            ) -> crate::Result<R>
+            + Send,
+    ) -> crate::Result<R> {
+        let buffers = &mut *self.buffers;
+        let indexed_plan_cache = &mut *self.indexed_plan_cache;
+        if let Some(context) = self.entered {
+            return context.with_native_parallelism(|| {
+                let mut output = op(&context, buffers, indexed_plan_cache)?;
+                output.tag_fresh(context.domain_id());
+                Ok(output)
+            });
+        }
+        let mode = self.entry.preferred_engine_mode();
+        self.entry
+            .enter(mode, |context| {
+                context.with_native_parallelism(|| {
+                    let mut output = op(context, buffers, indexed_plan_cache)?;
                     output.tag_fresh(context.domain_id());
                     Ok(output)
                 })
@@ -570,9 +602,16 @@ impl TensorIndexing for CpuExecSession<'_> {
         start_indices: &Tensor,
         config: &GatherConfig,
     ) -> crate::Result<Tensor> {
-        self.run_native_fresh_with_context(|context, buffers| {
+        self.run_native_fresh_with_indexed_context(|context, buffers, cache| {
             let exec_context = context.strided_exec_context();
-            indexing::gather_with_pool(buffers, &exec_context, operand, start_indices, config)
+            indexing::gather_with_pool(
+                buffers,
+                cache,
+                &exec_context,
+                operand,
+                start_indices,
+                config,
+            )
         })
     }
     fn scatter(
@@ -582,9 +621,17 @@ impl TensorIndexing for CpuExecSession<'_> {
         updates: &Tensor,
         config: &ScatterConfig,
     ) -> crate::Result<Tensor> {
-        self.run_native_fresh_with_context(|context, buffers| {
+        self.run_native_fresh_with_indexed_context(|context, buffers, cache| {
             let exec_context = context.strided_exec_context();
-            indexing::scatter_with_pool(buffers, &exec_context, operand, indices, updates, config)
+            indexing::scatter_with_pool(
+                buffers,
+                cache,
+                &exec_context,
+                operand,
+                indices,
+                updates,
+                config,
+            )
         })
     }
     delegate_with_pool!(slice(input: &Tensor, config: &SliceConfig) => indexing::try_slice_with_pool);
@@ -594,9 +641,16 @@ impl TensorIndexing for CpuExecSession<'_> {
         starts: &Tensor,
         slice_sizes: &[usize],
     ) -> crate::Result<Tensor> {
-        self.run_native_fresh_with_context(|context, buffers| {
+        self.run_native_fresh_with_indexed_context(|context, buffers, cache| {
             let exec_context = context.strided_exec_context();
-            indexing::dynamic_slice_with_pool(buffers, &exec_context, input, starts, slice_sizes)
+            indexing::dynamic_slice_with_pool(
+                buffers,
+                cache,
+                &exec_context,
+                input,
+                starts,
+                slice_sizes,
+            )
         })
     }
     fn dynamic_update_slice(
@@ -605,10 +659,11 @@ impl TensorIndexing for CpuExecSession<'_> {
         update: &Tensor,
         starts: &Tensor,
     ) -> crate::Result<Tensor> {
-        self.run_native_fresh_with_context(|context, buffers| {
+        self.run_native_fresh_with_indexed_context(|context, buffers, cache| {
             let exec_context = context.strided_exec_context();
             indexing::dynamic_update_slice_with_pool(
                 buffers,
+                cache,
                 &exec_context,
                 operand,
                 update,

--- a/crates/tenferro-cpu/src/exec_session/tests.rs
+++ b/crates/tenferro-cpu/src/exec_session/tests.rs
@@ -6,6 +6,7 @@ fn native_operation_enters_the_selected_rayon_executor() {
     let fixture = execution_context_fixture(2);
     let mut buffers = BufferPool::new();
     let mut gemm_analysis_cache = gemm::GemmAnalysisCache::default();
+    let mut indexed_plan_cache = crate::indexed_plan_cache::IndexedPlanCache::default();
     let kind = crate::CpuBackendKind::default_compiled();
     let providers = CpuProviderBundle::standard(kind, kind == crate::CpuBackendKind::Blas);
     let mut session = CpuExecSession {
@@ -13,6 +14,7 @@ fn native_operation_enters_the_selected_rayon_executor() {
         entered: None,
         buffers: &mut buffers,
         gemm_analysis_cache: &mut gemm_analysis_cache,
+        indexed_plan_cache: &mut indexed_plan_cache,
         providers: &providers,
     };
 

--- a/crates/tenferro-cpu/src/indexed_plan_cache.rs
+++ b/crates/tenferro-cpu/src/indexed_plan_cache.rs
@@ -1,0 +1,362 @@
+use std::mem::{size_of, size_of_val};
+use std::sync::Arc;
+
+use lru::LruCache;
+use smallvec::{Array, SmallVec};
+use strided_kernel::{
+    ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan, ErasedGatherPlan, ErasedScatterPlan,
+    KernelDType,
+};
+use tenferro_tensor::CacheStats;
+
+/// Limits for the CPU indexed-plan cache.
+///
+/// A zero entry or byte limit disables retention. Limits apply independently
+/// to each initialized CPU execution engine.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::IndexedPlanCacheLimits;
+///
+/// let limits = IndexedPlanCacheLimits::new(32, 1024 * 1024);
+/// assert_eq!(limits.max_entries(), 32);
+/// assert_eq!(limits.max_retained_bytes(), 1024 * 1024);
+/// ```
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IndexedPlanCacheLimits {
+    max_entries: usize,
+    max_retained_bytes: usize,
+}
+
+impl IndexedPlanCacheLimits {
+    /// Construct indexed-plan cache limits.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::IndexedPlanCacheLimits;
+    ///
+    /// let limits = IndexedPlanCacheLimits::new(8, 4096);
+    /// assert_eq!(limits.max_entries(), 8);
+    /// ```
+    pub const fn new(max_entries: usize, max_retained_bytes: usize) -> Self {
+        Self {
+            max_entries,
+            max_retained_bytes,
+        }
+    }
+
+    /// Maximum retained plan count per CPU execution engine.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::IndexedPlanCacheLimits;
+    ///
+    /// assert_eq!(IndexedPlanCacheLimits::new(8, 4096).max_entries(), 8);
+    /// ```
+    pub const fn max_entries(self) -> usize {
+        self.max_entries
+    }
+
+    /// Maximum logical retained bytes per CPU execution engine.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::IndexedPlanCacheLimits;
+    ///
+    /// assert_eq!(
+    ///     IndexedPlanCacheLimits::new(8, 4096).max_retained_bytes(),
+    ///     4096
+    /// );
+    /// ```
+    pub const fn max_retained_bytes(self) -> usize {
+        self.max_retained_bytes
+    }
+}
+
+pub(crate) const DEFAULT_INDEXED_PLAN_CACHE_LIMITS: IndexedPlanCacheLimits =
+    IndexedPlanCacheLimits::new(256, 8 * 1024 * 1024);
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum IndexedPlanFamily {
+    Gather,
+    Scatter,
+    DynamicSlice,
+    DynamicUpdateSlice,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct IndexedPlanKey {
+    family: IndexedPlanFamily,
+    dtype: KernelDType,
+    index_dtype: KernelDType,
+    dims: SmallVec<[SmallVec<[usize; 8]>; 4]>,
+    strides: SmallVec<[SmallVec<[isize; 8]>; 4]>,
+    config: SmallVec<[SmallVec<[usize; 8]>; 5]>,
+}
+
+impl IndexedPlanKey {
+    pub(crate) fn from_slices(
+        family: IndexedPlanFamily,
+        dtype: KernelDType,
+        index_dtype: KernelDType,
+        dims: &[&[usize]],
+        strides: &[&[isize]],
+        config: &[&[usize]],
+    ) -> Self {
+        Self {
+            family,
+            dtype,
+            index_dtype,
+            dims: dims
+                .iter()
+                .map(|values| values.iter().copied().collect())
+                .collect(),
+            strides: strides
+                .iter()
+                .map(|values| values.iter().copied().collect())
+                .collect(),
+            config: config
+                .iter()
+                .map(|values| values.iter().copied().collect())
+                .collect(),
+        }
+    }
+
+    fn retained_bytes(&self) -> usize {
+        nested_smallvec_retained_bytes(&self.dims)
+            .saturating_add(nested_smallvec_retained_bytes(&self.strides))
+            .saturating_add(nested_smallvec_retained_bytes(&self.config))
+    }
+
+    fn logical_payload_bytes(&self) -> usize {
+        nested_smallvec_logical_bytes(&self.dims)
+            .saturating_add(nested_smallvec_logical_bytes(&self.strides))
+            .saturating_add(nested_smallvec_logical_bytes(&self.config))
+    }
+}
+
+fn smallvec_retained_bytes<A: Array>(values: &SmallVec<A>) -> usize {
+    if values.spilled() {
+        values.capacity().saturating_mul(size_of::<A::Item>())
+    } else {
+        0
+    }
+}
+
+fn nested_smallvec_retained_bytes<A, B>(values: &SmallVec<A>) -> usize
+where
+    A: Array<Item = SmallVec<B>>,
+    B: Array,
+{
+    smallvec_retained_bytes(values).saturating_add(
+        values
+            .iter()
+            .map(smallvec_retained_bytes)
+            .fold(0usize, usize::saturating_add),
+    )
+}
+
+fn nested_smallvec_logical_bytes<A, B>(values: &SmallVec<A>) -> usize
+where
+    A: Array<Item = SmallVec<B>>,
+    B: Array,
+{
+    values.iter().fold(0usize, |total, inner| {
+        total.saturating_add(inner.len().saturating_mul(size_of::<B::Item>()))
+    })
+}
+
+#[derive(Clone, Debug)]
+enum IndexedPlan {
+    Gather(Arc<ErasedGatherPlan>),
+    Scatter(Arc<ErasedScatterPlan>),
+    DynamicSlice(Arc<ErasedDynamicSlicePlan>),
+    DynamicUpdateSlice(Arc<ErasedDynamicUpdateSlicePlan>),
+}
+
+#[derive(Debug)]
+struct IndexedPlanCacheEntry {
+    plan: IndexedPlan,
+    retained_bytes: usize,
+}
+
+/// Engine-owned cache for compile-once indexed traversal plans.
+///
+/// Each [`crate::engine::EngineResources`] value owns one cache for the
+/// lifetime of its CPU execution engine. The bounded default retains at most
+/// 256 plans and 8 MiB of logical plan/key payload. Entries are keyed by the
+/// complete family, dtype, index dtype, layout, and operation configuration,
+/// and least-recently-used entries are evicted when either bound is exceeded.
+///
+/// [`crate::CpuBackend`] exposes cache-specific limits, clear, and aggregate
+/// stats methods. Its [`tenferro_runtime::runtime::RuntimeCacheOwner`]
+/// implementation also includes this cache in runtime aggregate stats/clear.
+#[derive(Debug)]
+pub(crate) struct IndexedPlanCache {
+    entries: LruCache<IndexedPlanKey, IndexedPlanCacheEntry>,
+    limits: IndexedPlanCacheLimits,
+    retained_bytes: usize,
+    hits: u64,
+    misses: u64,
+    evictions: u64,
+    clears: u64,
+}
+
+impl Default for IndexedPlanCache {
+    fn default() -> Self {
+        Self::new(DEFAULT_INDEXED_PLAN_CACHE_LIMITS)
+    }
+}
+
+impl IndexedPlanCache {
+    pub(crate) fn new(limits: IndexedPlanCacheLimits) -> Self {
+        Self {
+            entries: LruCache::unbounded(),
+            limits,
+            retained_bytes: 0,
+            hits: 0,
+            misses: 0,
+            evictions: 0,
+            clears: 0,
+        }
+    }
+
+    pub(crate) fn set_limits(&mut self, limits: IndexedPlanCacheLimits) {
+        self.limits = limits;
+        self.evict_to_limits();
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.entries.clear();
+        self.retained_bytes = 0;
+        self.clears = self.clears.saturating_add(1);
+    }
+
+    pub(crate) fn stats(&self) -> CacheStats {
+        CacheStats {
+            entries: self.entries.len(),
+            retained_bytes: self.retained_bytes,
+            hits: self.hits,
+            misses: self.misses,
+            evictions: self.evictions,
+            clears: self.clears,
+        }
+    }
+
+    pub(crate) fn gather<E>(
+        &mut self,
+        key: IndexedPlanKey,
+        compile: impl FnOnce() -> Result<ErasedGatherPlan, E>,
+    ) -> Result<Arc<ErasedGatherPlan>, E> {
+        if let Some(IndexedPlan::Gather(plan)) = self.lookup(&key) {
+            return Ok(plan);
+        }
+        let plan = Arc::new(compile()?);
+        self.insert(key, IndexedPlan::Gather(Arc::clone(&plan)));
+        Ok(plan)
+    }
+
+    pub(crate) fn scatter<E>(
+        &mut self,
+        key: IndexedPlanKey,
+        compile: impl FnOnce() -> Result<ErasedScatterPlan, E>,
+    ) -> Result<Arc<ErasedScatterPlan>, E> {
+        if let Some(IndexedPlan::Scatter(plan)) = self.lookup(&key) {
+            return Ok(plan);
+        }
+        let plan = Arc::new(compile()?);
+        self.insert(key, IndexedPlan::Scatter(Arc::clone(&plan)));
+        Ok(plan)
+    }
+
+    pub(crate) fn dynamic_slice<E>(
+        &mut self,
+        key: IndexedPlanKey,
+        compile: impl FnOnce() -> Result<ErasedDynamicSlicePlan, E>,
+    ) -> Result<Arc<ErasedDynamicSlicePlan>, E> {
+        if let Some(IndexedPlan::DynamicSlice(plan)) = self.lookup(&key) {
+            return Ok(plan);
+        }
+        let plan = Arc::new(compile()?);
+        self.insert(key, IndexedPlan::DynamicSlice(Arc::clone(&plan)));
+        Ok(plan)
+    }
+
+    pub(crate) fn dynamic_update_slice<E>(
+        &mut self,
+        key: IndexedPlanKey,
+        compile: impl FnOnce() -> Result<ErasedDynamicUpdateSlicePlan, E>,
+    ) -> Result<Arc<ErasedDynamicUpdateSlicePlan>, E> {
+        if let Some(IndexedPlan::DynamicUpdateSlice(plan)) = self.lookup(&key) {
+            return Ok(plan);
+        }
+        let plan = Arc::new(compile()?);
+        self.insert(key, IndexedPlan::DynamicUpdateSlice(Arc::clone(&plan)));
+        Ok(plan)
+    }
+
+    fn lookup(&mut self, key: &IndexedPlanKey) -> Option<IndexedPlan> {
+        let Some(entry) = self.entries.get(key) else {
+            self.misses = self.misses.saturating_add(1);
+            return None;
+        };
+        self.hits = self.hits.saturating_add(1);
+        Some(entry.plan.clone())
+    }
+
+    fn insert(&mut self, key: IndexedPlanKey, plan: IndexedPlan) {
+        if self.limits.max_entries == 0 || self.limits.max_retained_bytes == 0 {
+            return;
+        }
+        let retained_bytes = indexed_plan_retained_bytes(&key, &plan);
+        if retained_bytes > self.limits.max_retained_bytes {
+            return;
+        }
+        let entry = IndexedPlanCacheEntry {
+            plan,
+            retained_bytes,
+        };
+        if let Some(replaced) = self.entries.put(key, entry) {
+            self.retained_bytes = self.retained_bytes.saturating_sub(replaced.retained_bytes);
+        }
+        self.retained_bytes = self.retained_bytes.saturating_add(retained_bytes);
+        self.evict_to_limits();
+    }
+
+    fn evict_to_limits(&mut self) {
+        while self.entries.len() > self.limits.max_entries
+            || self.retained_bytes > self.limits.max_retained_bytes
+        {
+            let Some((_key, entry)) = self.entries.pop_lru() else {
+                break;
+            };
+            self.retained_bytes = self.retained_bytes.saturating_sub(entry.retained_bytes);
+            self.evictions = self.evictions.saturating_add(1);
+        }
+    }
+}
+
+fn indexed_plan_retained_bytes(key: &IndexedPlanKey, plan: &IndexedPlan) -> usize {
+    let plan_header = match plan {
+        IndexedPlan::Gather(plan) => size_of_val(plan.as_ref()),
+        IndexedPlan::Scatter(plan) => size_of_val(plan.as_ref()),
+        IndexedPlan::DynamicSlice(plan) => size_of_val(plan.as_ref()),
+        IndexedPlan::DynamicUpdateSlice(plan) => size_of_val(plan.as_ref()),
+    };
+    // INVARIANT: erased indexed plans clone the key's layout/config vectors
+    // and may derive additional axis vectors. Charge twice the logical key
+    // payload in addition to any spilled key capacity so inline SmallVec keys
+    // still account for the upstream plan's heap-owned Vec payload.
+    size_of::<IndexedPlanCacheEntry>()
+        .saturating_add(size_of::<IndexedPlanKey>())
+        .saturating_add(plan_header)
+        .saturating_add(key.retained_bytes())
+        .saturating_add(key.logical_payload_bytes().saturating_mul(2))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tenferro-cpu/src/indexed_plan_cache/tests.rs
+++ b/crates/tenferro-cpu/src/indexed_plan_cache/tests.rs
@@ -1,0 +1,141 @@
+use super::*;
+use strided_kernel::ErasedDynamicSlicePlan;
+
+fn key(size: usize) -> IndexedPlanKey {
+    IndexedPlanKey::from_slices(
+        IndexedPlanFamily::DynamicSlice,
+        KernelDType::F64,
+        KernelDType::I64,
+        &[&[size], &[1], &[size]],
+        &[&[1], &[1], &[1]],
+        &[&[size]],
+    )
+}
+
+fn plan(size: usize) -> ErasedDynamicSlicePlan {
+    ErasedDynamicSlicePlan::compile(
+        KernelDType::F64,
+        KernelDType::I64,
+        &[size],
+        &[1],
+        &[1],
+        &[1],
+        &[size],
+        &[1],
+        &[size],
+    )
+    .expect("valid test plan")
+}
+
+#[test]
+fn key_distinguishes_family_layout_and_config_boundaries() {
+    let base = key(8);
+    let different_layout = key(16);
+    let different_family = IndexedPlanKey::from_slices(
+        IndexedPlanFamily::Gather,
+        KernelDType::F64,
+        KernelDType::I64,
+        &[&[8], &[1], &[8]],
+        &[&[1], &[1], &[1]],
+        &[&[8]],
+    );
+    let different_config_boundary = IndexedPlanKey::from_slices(
+        IndexedPlanFamily::DynamicSlice,
+        KernelDType::F64,
+        KernelDType::I64,
+        &[&[8], &[1], &[8]],
+        &[&[1], &[1], &[1]],
+        &[&[], &[8]],
+    );
+
+    assert_ne!(base, different_layout);
+    assert_ne!(base, different_family);
+    assert_ne!(base, different_config_boundary);
+}
+
+#[test]
+fn repeated_key_compiles_once_and_reports_hit() {
+    let mut cache = IndexedPlanCache::new(IndexedPlanCacheLimits::new(4, usize::MAX));
+    let mut compiles = 0;
+
+    for _ in 0..2 {
+        cache
+            .dynamic_slice(key(8), || {
+                compiles += 1;
+                Ok::<_, std::convert::Infallible>(plan(8))
+            })
+            .expect("cache lookup");
+    }
+
+    assert_eq!(compiles, 1);
+    assert_eq!(cache.stats().entries, 1);
+    assert_eq!(cache.stats().hits, 1);
+    assert_eq!(cache.stats().misses, 1);
+    assert!(cache.stats().retained_bytes > 0);
+}
+
+#[test]
+fn entry_limit_evicts_least_recently_used_plan() {
+    let mut cache = IndexedPlanCache::new(IndexedPlanCacheLimits::new(2, usize::MAX));
+    for size in [4, 8] {
+        cache
+            .dynamic_slice(key(size), || Ok::<_, std::convert::Infallible>(plan(size)))
+            .expect("insert plan");
+    }
+    cache
+        .dynamic_slice(key(4), || Ok::<_, std::convert::Infallible>(plan(4)))
+        .expect("touch first plan");
+    cache
+        .dynamic_slice(key(16), || Ok::<_, std::convert::Infallible>(plan(16)))
+        .expect("insert third plan");
+
+    let misses_before = cache.stats().misses;
+    cache
+        .dynamic_slice(key(8), || Ok::<_, std::convert::Infallible>(plan(8)))
+        .expect("recompile evicted plan");
+
+    assert_eq!(cache.stats().entries, 2);
+    assert_eq!(cache.stats().evictions, 2);
+    assert_eq!(cache.stats().misses, misses_before + 1);
+}
+
+#[test]
+fn byte_limit_and_clear_are_accounted() {
+    let mut cache = IndexedPlanCache::new(IndexedPlanCacheLimits::new(8, usize::MAX));
+    cache
+        .dynamic_slice(key(8), || Ok::<_, std::convert::Infallible>(plan(8)))
+        .expect("insert plan");
+    let one_entry_bytes = cache.stats().retained_bytes;
+    cache.set_limits(IndexedPlanCacheLimits::new(8, one_entry_bytes - 1));
+
+    assert_eq!(cache.stats().entries, 0);
+    assert_eq!(cache.stats().retained_bytes, 0);
+    assert_eq!(cache.stats().evictions, 1);
+
+    cache.clear();
+    assert_eq!(cache.stats().clears, 1);
+}
+
+#[test]
+fn retained_bytes_charge_inline_and_spilled_plan_payloads() {
+    let inline = key(8);
+    assert_eq!(inline.retained_bytes(), 0);
+    assert!(inline.logical_payload_bytes() > 0);
+
+    let rank = 12;
+    let dims = vec![2usize; rank];
+    let strides = vec![1isize; rank];
+    let spilled = IndexedPlanKey::from_slices(
+        IndexedPlanFamily::DynamicSlice,
+        KernelDType::F64,
+        KernelDType::I64,
+        &[&dims, &[1], &dims],
+        &[&strides, &[1], &strides],
+        &[&dims],
+    );
+    assert!(spilled.retained_bytes() > 0);
+    assert!(
+        spilled.logical_payload_bytes() > inline.logical_payload_bytes(),
+        "higher-rank plans must carry a larger logical retention charge"
+    );
+}

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -7,6 +7,7 @@ use strided_kernel::{
     KernelDType, ScatterSpec,
 };
 
+use super::indexed_plan_cache::{IndexedPlanCache, IndexedPlanFamily, IndexedPlanKey};
 use super::indexing_alloc::pooled_uninit_tensor;
 use super::typed_host_data;
 use crate::buffer_pool::{BufferPool, PoolScalar};
@@ -91,6 +92,17 @@ fn scatter_spec(config: &ScatterConfig) -> ScatterSpec {
         scatter_dims_to_operand_dims: config.scatter_dims_to_operand_dims.clone(),
         index_vector_dim: config.index_vector_dim,
     }
+}
+
+fn indexed_plan_key(
+    family: IndexedPlanFamily,
+    dtype: KernelDType,
+    index_dtype: KernelDType,
+    dims: &[&[usize]],
+    strides: &[&[isize]],
+    config: &[&[usize]],
+) -> IndexedPlanKey {
+    IndexedPlanKey::from_slices(family, dtype, index_dtype, dims, strides, config)
 }
 
 macro_rules! dispatch_tensor_unary_result {
@@ -203,8 +215,10 @@ pub(crate) fn gather(
     config: &GatherConfig,
 ) -> crate::Result<Tensor> {
     with_test_pool(|buffers| {
+        let mut cache = IndexedPlanCache::default();
         gather_with_pool(
             buffers,
+            &mut cache,
             &ExecContext::serial(),
             operand,
             start_indices,
@@ -215,6 +229,7 @@ pub(crate) fn gather(
 
 pub(crate) fn gather_with_pool(
     buffers: &mut BufferPool,
+    cache: &mut IndexedPlanCache,
     exec_context: &ExecContext,
     operand: &Tensor,
     start_indices: &Tensor,
@@ -223,6 +238,7 @@ pub(crate) fn gather_with_pool(
     let start_indices = try_index_tensor(start_indices)?;
     dispatch_tensor_unary_result!(operand, |t| typed_gather(
         buffers,
+        cache,
         exec_context,
         t,
         &start_indices,
@@ -238,8 +254,10 @@ pub(crate) fn scatter(
     config: &ScatterConfig,
 ) -> crate::Result<Tensor> {
     with_test_pool(|buffers| {
+        let mut cache = IndexedPlanCache::default();
         scatter_with_pool(
             buffers,
+            &mut cache,
             &ExecContext::serial(),
             operand,
             scatter_indices,
@@ -251,6 +269,7 @@ pub(crate) fn scatter(
 
 pub(crate) fn scatter_with_pool(
     buffers: &mut BufferPool,
+    cache: &mut IndexedPlanCache,
     exec_context: &ExecContext,
     operand: &Tensor,
     scatter_indices: &Tensor,
@@ -263,7 +282,15 @@ pub(crate) fn scatter_with_pool(
         operand,
         updates,
         "Bool data tensors are not supported by additive scatter",
-        |op, upd| typed_scatter(buffers, exec_context, op, &scatter_indices, upd, config)
+        |op, upd| typed_scatter(
+            buffers,
+            cache,
+            exec_context,
+            op,
+            &scatter_indices,
+            upd,
+            config
+        )
     )
 }
 
@@ -282,12 +309,21 @@ pub(crate) fn dynamic_slice(
     slice_sizes: &[usize],
 ) -> crate::Result<Tensor> {
     with_test_pool(|buffers| {
-        dynamic_slice_with_pool(buffers, &ExecContext::serial(), input, starts, slice_sizes)
+        let mut cache = IndexedPlanCache::default();
+        dynamic_slice_with_pool(
+            buffers,
+            &mut cache,
+            &ExecContext::serial(),
+            input,
+            starts,
+            slice_sizes,
+        )
     })
 }
 
 pub(crate) fn dynamic_slice_with_pool(
     buffers: &mut BufferPool,
+    cache: &mut IndexedPlanCache,
     exec_context: &ExecContext,
     input: &Tensor,
     starts: &Tensor,
@@ -296,6 +332,7 @@ pub(crate) fn dynamic_slice_with_pool(
     let starts = try_index_tensor(starts)?;
     dispatch_tensor_unary_result!(input, |t| typed_dynamic_slice(
         buffers,
+        cache,
         exec_context,
         t,
         &starts,
@@ -329,12 +366,21 @@ pub(crate) fn dynamic_update_slice(
     starts: &Tensor,
 ) -> crate::Result<Tensor> {
     with_test_pool(|buffers| {
-        dynamic_update_slice_with_pool(buffers, &ExecContext::serial(), operand, update, starts)
+        let mut cache = IndexedPlanCache::default();
+        dynamic_update_slice_with_pool(
+            buffers,
+            &mut cache,
+            &ExecContext::serial(),
+            operand,
+            update,
+            starts,
+        )
     })
 }
 
 pub(crate) fn dynamic_update_slice_with_pool(
     buffers: &mut BufferPool,
+    cache: &mut IndexedPlanCache,
     exec_context: &ExecContext,
     operand: &Tensor,
     update: &Tensor,
@@ -342,7 +388,7 @@ pub(crate) fn dynamic_update_slice_with_pool(
 ) -> crate::Result<Tensor> {
     let starts = try_index_tensor(starts)?;
     dispatch_same_dtype_result!("dynamic_update_slice", operand, update, |op, upd| {
-        typed_dynamic_update_slice(buffers, exec_context, op, upd, &starts)
+        typed_dynamic_update_slice(buffers, cache, exec_context, op, upd, &starts)
     })
 }
 
@@ -794,6 +840,7 @@ fn operand_window_dims(rank: usize, collapsed_or_inserted: &[usize]) -> Vec<usiz
 
 fn typed_gather<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
+    cache: &mut IndexedPlanCache,
     exec_context: &ExecContext,
     operand: &TypedTensor<T>,
     start_indices: &IndexTensor,
@@ -942,18 +989,36 @@ fn typed_gather<T: Copy + Clone + PoolScalar + TensorScalar>(
     let operand_strides = col_major_strides(operand_shape);
     let index_strides = col_major_strides(&start_indices.shape);
     let out_strides = col_major_strides(&out_shape);
-    let plan = ErasedGatherPlan::compile(
+    let index_dtype = KernelDType::I64;
+    let key = indexed_plan_key(
+        IndexedPlanFamily::Gather,
         dtype,
-        KernelDType::I64,
-        operand_shape,
-        &operand_strides,
-        &start_indices.shape,
-        &index_strides,
-        &out_shape,
-        &out_strides,
-        gather_spec(config),
-    )
-    .map_err(|err| crate::Error::backend_source("gather", err))?;
+        index_dtype,
+        &[operand_shape, &start_indices.shape, &out_shape],
+        &[&operand_strides, &index_strides, &out_strides],
+        &[
+            &config.offset_dims,
+            &config.collapsed_slice_dims,
+            &config.start_index_map,
+            std::slice::from_ref(&config.index_vector_dim),
+            &config.slice_sizes,
+        ],
+    );
+    let plan = cache
+        .gather(key, || {
+            ErasedGatherPlan::compile(
+                dtype,
+                index_dtype,
+                operand_shape,
+                &operand_strides,
+                &start_indices.shape,
+                &index_strides,
+                &out_shape,
+                &out_strides,
+                gather_spec(config),
+            )
+        })
+        .map_err(|err| crate::Error::backend_source("gather", err))?;
 
     let operand_ref = ErasedRawStridedRef::new(
         dtype,
@@ -964,7 +1029,7 @@ fn typed_gather<T: Copy + Clone + PoolScalar + TensorScalar>(
     )
     .map_err(|err| crate::Error::backend_source("gather", err))?;
     let index_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
+        index_dtype,
         typed_bytes(&start_indices.values),
         &start_indices.shape,
         &index_strides,
@@ -987,6 +1052,7 @@ fn typed_gather<T: Copy + Clone + PoolScalar + TensorScalar>(
 
 fn typed_scatter<T>(
     buffers: &mut BufferPool,
+    cache: &mut IndexedPlanCache,
     exec_context: &ExecContext,
     operand: &TypedTensor<T>,
     scatter_indices: &IndexTensor,
@@ -1161,20 +1227,46 @@ where
     let index_strides = col_major_strides(&scatter_indices.shape);
     let update_strides = col_major_strides(updates_shape);
     let out_strides = col_major_strides(operand_shape);
-    let plan = ErasedScatterPlan::compile(
+    let key = indexed_plan_key(
+        IndexedPlanFamily::Scatter,
         dtype,
         index_dtype,
-        operand_shape,
-        &operand_strides,
-        &scatter_indices.shape,
-        &index_strides,
-        updates_shape,
-        &update_strides,
-        operand_shape,
-        &out_strides,
-        scatter_spec(config),
-    )
-    .map_err(|err| crate::Error::backend_source("scatter", err))?;
+        &[
+            operand_shape,
+            &scatter_indices.shape,
+            updates_shape,
+            operand_shape,
+        ],
+        &[
+            &operand_strides,
+            &index_strides,
+            &update_strides,
+            &out_strides,
+        ],
+        &[
+            &config.update_window_dims,
+            &config.inserted_window_dims,
+            &config.scatter_dims_to_operand_dims,
+            std::slice::from_ref(&config.index_vector_dim),
+        ],
+    );
+    let plan = cache
+        .scatter(key, || {
+            ErasedScatterPlan::compile(
+                dtype,
+                index_dtype,
+                operand_shape,
+                &operand_strides,
+                &scatter_indices.shape,
+                &index_strides,
+                updates_shape,
+                &update_strides,
+                operand_shape,
+                &out_strides,
+                scatter_spec(config),
+            )
+        })
+        .map_err(|err| crate::Error::backend_source("scatter", err))?;
 
     // INVARIANT: ErasedScatterPlan first copies the full operand into `out`,
     // then applies every additive update.
@@ -1225,6 +1317,7 @@ where
 
 fn typed_dynamic_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
+    cache: &mut IndexedPlanCache,
     exec_context: &ExecContext,
     input: &TypedTensor<T>,
     starts: &IndexTensor,
@@ -1271,18 +1364,30 @@ fn typed_dynamic_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     let input_strides = col_major_strides(input_shape);
     let start_strides = col_major_strides(&starts.shape);
     let out_strides = col_major_strides(&out_shape);
-    let plan = ErasedDynamicSlicePlan::compile(
+    let index_dtype = KernelDType::I64;
+    let key = indexed_plan_key(
+        IndexedPlanFamily::DynamicSlice,
         dtype,
-        KernelDType::I64,
-        input_shape,
-        &input_strides,
-        &starts.shape,
-        &start_strides,
-        &out_shape,
-        &out_strides,
-        slice_sizes,
-    )
-    .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
+        index_dtype,
+        &[input_shape, &starts.shape, &out_shape],
+        &[&input_strides, &start_strides, &out_strides],
+        &[slice_sizes],
+    );
+    let plan = cache
+        .dynamic_slice(key, || {
+            ErasedDynamicSlicePlan::compile(
+                dtype,
+                index_dtype,
+                input_shape,
+                &input_strides,
+                &starts.shape,
+                &start_strides,
+                &out_shape,
+                &out_strides,
+                slice_sizes,
+            )
+        })
+        .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
     // INVARIANT: ErasedDynamicSlicePlan writes every output coordinate exactly once.
     let mut out = pooled_uninit_tensor(buffers, out_shape.clone())?;
     if T::dtype() == DType::Bool {
@@ -1297,7 +1402,7 @@ fn typed_dynamic_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     )
     .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
     let start_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
+        index_dtype,
         typed_bytes(&starts.values),
         &starts.shape,
         &start_strides,
@@ -1320,6 +1425,7 @@ fn typed_dynamic_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
 
 fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
+    cache: &mut IndexedPlanCache,
     exec_context: &ExecContext,
     operand: &TypedTensor<T>,
     update: &TypedTensor<T>,
@@ -1367,19 +1473,36 @@ fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     let start_strides = col_major_strides(&starts.shape);
     let update_strides = col_major_strides(update_shape);
     let out_strides = col_major_strides(operand_shape);
-    let plan = ErasedDynamicUpdateSlicePlan::compile(
+    let index_dtype = KernelDType::I64;
+    let key = indexed_plan_key(
+        IndexedPlanFamily::DynamicUpdateSlice,
         dtype,
-        KernelDType::I64,
-        operand_shape,
-        &operand_strides,
-        &starts.shape,
-        &start_strides,
-        update_shape,
-        &update_strides,
-        operand_shape,
-        &out_strides,
-    )
-    .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
+        index_dtype,
+        &[operand_shape, &starts.shape, update_shape, operand_shape],
+        &[
+            &operand_strides,
+            &start_strides,
+            &update_strides,
+            &out_strides,
+        ],
+        &[],
+    );
+    let plan = cache
+        .dynamic_update_slice(key, || {
+            ErasedDynamicUpdateSlicePlan::compile(
+                dtype,
+                index_dtype,
+                operand_shape,
+                &operand_strides,
+                &starts.shape,
+                &start_strides,
+                update_shape,
+                &update_strides,
+                operand_shape,
+                &out_strides,
+            )
+        })
+        .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
     // INVARIANT: ErasedDynamicUpdateSlicePlan copies the full operand into
     // `out` before overwriting the update window.
     let mut out = pooled_uninit_tensor(buffers, operand_shape.to_vec())?;
@@ -1403,7 +1526,7 @@ fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     )
     .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
     let start_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
+        index_dtype,
         typed_bytes(&starts.values),
         &starts.shape,
         &start_strides,

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -68,6 +68,7 @@ pub(crate) use tenferro_internal_cpu_kernels::elementwise;
 mod engine;
 mod exec_session;
 mod gemm;
+mod indexed_plan_cache;
 mod indexing;
 mod indexing_alloc;
 #[cfg(feature = "provider-inject")]
@@ -120,6 +121,7 @@ pub use dot_runtime::{
     CpuProviderBundle, CpuProviderBundleBuildError, CpuProviderBundleBuilder,
     CpuProviderBundleInstallError, CpuProviderSlot, GeneralContractionPolicy,
 };
+pub use indexed_plan_cache::IndexedPlanCacheLimits;
 pub use placement::{
     CpuEngineConstructionError, CpuPlacement, CpuPlacementError, CpuPlacementGuarantee,
     ResolvedCpuPlacement,

--- a/crates/tenferro-cpu/src/runtime_adapter/tests.rs
+++ b/crates/tenferro-cpu/src/runtime_adapter/tests.rs
@@ -10,7 +10,8 @@ use tenferro_runtime::{
     SpecializationRequirements,
 };
 use tenferro_tensor::{
-    GatherConfig, PadConfig, Placement, ScatterConfig, ShapeVec, SliceConfig, StrideVec,
+    GatherConfig, PadConfig, Placement, ScatterConfig, ShapeVec, SliceConfig, StrideVec, Tensor,
+    TensorIndexing,
 };
 
 use super::{
@@ -150,7 +151,7 @@ fn cpu_runtime_adapter_has_only_the_six_runtime_trait_impls_on_cpu_backend() {
 
 #[test]
 fn cpu_backend_cache_owner_hooks_report_and_clear_current_engine_caches() {
-    let backend = CpuBackend::new();
+    let mut backend = CpuBackend::with_threads(1).expect("backend");
 
     let stats = RuntimeCacheOwner::cache_stats(&backend).expect("cache stats");
     assert_eq!(stats.entries, 0);
@@ -159,7 +160,33 @@ fn cpu_backend_cache_owner_hooks_report_and_clear_current_engine_caches() {
     assert_eq!(stats.misses, 0);
     assert_eq!(stats.evictions, 0);
     assert_eq!(stats.clears, 0);
+
+    let operand = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).expect("operand");
+    let indices = Tensor::from_vec_col_major(vec![2, 1], vec![0_i64, 2]).expect("indices");
+    let config = GatherConfig {
+        offset_dims: vec![],
+        collapsed_slice_dims: vec![0],
+        start_index_map: vec![0],
+        index_vector_dim: 1,
+        slice_sizes: vec![1],
+    };
+    backend
+        .gather(&operand, &indices, &config)
+        .expect("compile gather plan");
+    backend
+        .gather(&operand, &indices, &config)
+        .expect("reuse gather plan");
+    let populated = RuntimeCacheOwner::cache_stats(&backend).expect("populated cache stats");
+    assert_eq!(populated.entries, 1);
+    assert!(populated.retained_bytes > 0);
+    assert_eq!(populated.hits, 1);
+    assert_eq!(populated.misses, 1);
+
     RuntimeCacheOwner::clear_caches(&backend).expect("clear caches");
+    let cleared = RuntimeCacheOwner::cache_stats(&backend).expect("cleared cache stats");
+    assert_eq!(cleared.entries, 0);
+    assert_eq!(cleared.retained_bytes, 0);
+    assert_eq!(cleared.clears, 1);
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
@@ -735,3 +735,110 @@ fn test_backend_gather_scatter_dynamic_slice_dispatch() {
     assert_eq!(get_f64(&ds, &[0, 0]), 11.0);
     assert_eq!(get_f64(&ds, &[1, 1]), 16.0);
 }
+
+#[test]
+fn indexed_plan_cache_reuses_public_gather_plan_and_obeys_controls() {
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    let operand = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![5], vec![10.0, 20.0, 30.0, 40.0, 50.0]).unwrap(),
+    );
+    let indices = Tensor::from_vec_col_major(vec![3, 1], vec![0_i64, 2, 4]).unwrap();
+    let config = simple_gather_config();
+
+    backend.gather(&operand, &indices, &config).unwrap();
+    let after_compile = backend.indexed_plan_cache_stats().unwrap();
+    assert_eq!(after_compile.entries, 1);
+    assert_eq!(after_compile.hits, 0);
+    assert_eq!(after_compile.misses, 1);
+    assert!(after_compile.retained_bytes > 0);
+
+    backend.gather(&operand, &indices, &config).unwrap();
+    let scatter_operand = Tensor::F64(TypedTensor::zeros(vec![5]).unwrap());
+    let updates =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap());
+    let scatter_config = ScatterConfig {
+        update_window_dims: vec![],
+        inserted_window_dims: vec![0],
+        scatter_dims_to_operand_dims: vec![0],
+        index_vector_dim: 1,
+    };
+    let starts = Tensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap();
+    let update = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![7.0, 8.0]).unwrap());
+    for _ in 0..2 {
+        backend
+            .scatter(&scatter_operand, &indices, &updates, &scatter_config)
+            .unwrap();
+        backend.dynamic_slice(&operand, &starts, &[2]).unwrap();
+        backend
+            .dynamic_update_slice(&operand, &update, &starts)
+            .unwrap();
+    }
+
+    let after_replay = backend.indexed_plan_cache_stats().unwrap();
+    assert_eq!(after_replay.entries, 4);
+    assert_eq!(after_replay.hits, 4);
+    assert_eq!(after_replay.misses, 4);
+
+    backend
+        .set_indexed_plan_cache_limits(crate::IndexedPlanCacheLimits::new(0, 0))
+        .unwrap();
+    assert_eq!(backend.indexed_plan_cache_stats().unwrap().entries, 0);
+    backend.clear_indexed_plan_cache().unwrap();
+    assert_eq!(backend.indexed_plan_cache_stats().unwrap().clears, 1);
+}
+
+#[test]
+fn indexed_plan_cache_reuses_gather_plan_through_exec_session() {
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    let operand = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![5], vec![10.0, 20.0, 30.0, 40.0, 50.0]).unwrap(),
+    );
+    let indices = Tensor::from_vec_col_major(vec![3, 1], vec![0_i64, 2, 4]).unwrap();
+    let config = simple_gather_config();
+
+    backend
+        .with_backend_session(|session| {
+            session.gather(&operand, &indices, &config)?;
+            session.gather(&operand, &indices, &config)?;
+            Ok::<(), crate::Error>(())
+        })
+        .unwrap();
+
+    let stats = backend.indexed_plan_cache_stats().unwrap();
+    assert_eq!(stats.entries, 1);
+    assert_eq!(stats.misses, 1);
+    assert_eq!(stats.hits, 1);
+}
+
+#[test]
+fn indexed_plan_cache_limit_snapshots_remain_coherent_across_clones() {
+    let backend = CpuBackend::with_threads(1).unwrap();
+    let mut writer = backend.clone();
+    let reader = backend.clone();
+    let start = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let writer_start = std::sync::Arc::clone(&start);
+
+    let update = std::thread::spawn(move || {
+        writer_start.wait();
+        for index in 0..2_000 {
+            let limits = if index % 2 == 0 {
+                crate::IndexedPlanCacheLimits::new(11, 1_111)
+            } else {
+                crate::IndexedPlanCacheLimits::new(22, 2_222)
+            };
+            writer.set_indexed_plan_cache_limits(limits).unwrap();
+        }
+    });
+
+    start.wait();
+    for _ in 0..2_000 {
+        let limits = reader.indexed_plan_cache_limits().unwrap();
+        assert!(
+            limits == crate::IndexedPlanCacheLimits::new(11, 1_111)
+                || limits == crate::IndexedPlanCacheLimits::new(22, 2_222)
+                || limits == crate::IndexedPlanCacheLimits::new(256, 8 * 1024 * 1024),
+            "cache limit readers must never observe a mixed configuration"
+        );
+    }
+    update.join().unwrap();
+}

--- a/docs/worklogs/2026-07-29-issue-1511-indexed-plan-cache.md
+++ b/docs/worklogs/2026-07-29-issue-1511-indexed-plan-cache.md
@@ -1,0 +1,95 @@
+# Issue 1511: CPU indexed-plan cache
+
+## Summary
+
+Added an engine-owned bounded cache for the strided erased gather, additive
+scatter, dynamic-slice, and dynamic-update-slice plans used by public eager and
+traced CPU execution.
+
+## Context read
+
+- `REPOSITORY_RULES.md`, especially cache ownership, CPU threading, benchmark
+  protocol, and public API documentation
+- tenferro-rs issues #1490 and #1511
+- strided-rs issue #149 and the merged erased indexed-plan implementations
+- `tenferro-cpu` engine resources, backend sessions, runtime cache-owner
+  adapter, buffer-pool controls, GEMM analysis cache, and indexed adapters
+
+## Design
+
+- Owner and lifetime: one cache in each `CpuEngine::EngineResources`, shared by
+  clones of the owning `CpuBackend` for that engine's lifetime.
+- Bounds: 256 entries and 8 MiB logical retained payload per engine by default.
+  Either zero bound disables retention.
+- Key: family, value dtype, index dtype, all operand/index/update/output
+  dimensions and strides, and the complete operation configuration.
+- Lookup allocation: rank/config metadata uses nested `SmallVec` values, so
+  normal rank-at-most-eight calls do not allocate a temporary heap key.
+- Values: compiled erased plans are retained behind `Arc`; replay clones only
+  the `Arc`, not the plan metadata.
+- Eviction: the repository-standard `lru` implementation, enforced in constant
+  time for both entry and retained-byte bounds.
+- Accounting: key and plan headers, spilled key capacity, and a conservative
+  logical charge for the upstream plan's cloned/derived vectors. Tests cover
+  inline and spilled-rank keys. Stats include hits, misses, evictions, clears,
+  entries, and retained bytes.
+- Controls: `CpuBackend` exposes cache-specific limits, aggregate stats, and
+  clear methods. Existing `RuntimeCacheOwner` stats and clear include the
+  current engine's indexed cache. Updated limits are inherited by lazily
+  created managed engines. A single configuration lock serializes limit
+  updates with lazy engine creation, so readers and new engines cannot observe
+  mixed entry/byte bounds.
+
+No process-global or thread-local cache was introduced. Additive scatter replay
+remains serial as required by strided-rs #164.
+
+## Verification and performance
+
+Focused correctness tests cover all four public backend families sharing the
+cache, compile-once reuse through direct and execution-session paths,
+family/config keys, LRU eviction, byte eviction, coherent limit snapshots
+across clones, inline/spilled retention charges, clear/configure controls, and
+runtime cache-owner aggregation.
+
+The benchmark source was `tenferro-benchmark`'s public API suite with
+`PUBLICATION_GATE_PROFILE=full`, rows
+`gather,scatter,dynamic_slice,dynamic_update_slice`, and thread counts 1 and 4.
+The baseline was tenferro commit `60837e8f`; the candidate used this worktree.
+Two complete counterbalanced orders were run because three warmups did not
+remove a reproducible first-binary/cold-worker bias from the first t4 eager
+gather row. The comparison statistic below is the geometric mean of the two
+candidate/baseline ratios:
+
+| Row | t1 | t4 |
+|---|---:|---:|
+| gather eager | +2.7% | -0.1% |
+| gather trace | +2.1% | +0.7% |
+| scatter eager | +1.1% | +1.0% |
+| scatter trace | -0.8% | +0.2% |
+| dynamic_slice eager | -0.6% | -0.1% |
+| dynamic_slice trace | +10.3% | -0.2% |
+| dynamic_update_slice eager | +0.9% | -2.3% |
+
+All rows remained below the predeclared +20% blocking threshold. An earlier
+run was classified `INCONCLUSIVE` after a competing release compile was
+discovered during measurement; none of its values were promoted. The final
+reviewed implementation was remeasured with t1 pinned to CPU 60 and t4 pinned
+to CPUs 56-59 because three unrelated Julia processes were active elsewhere
+on the 64-core host. Both baseline/candidate orders are retained. The t1
+dynamic-slice trace row remained the noisiest result (+15.0% and +5.7% in the
+two orders); the matching eager and t4 trace rows did not regress.
+
+A same-binary alternating attribution probe measured t4 gather at 1.288 ms
+with retention enabled and 1.300 ms with retention disabled. Plan compilation
+therefore does not explain the remaining order-of-magnitude public API gap.
+Source inspection attributes the residual to execute-time coordinate decode
+and checked per-element offset reconstruction in the upstream erased indexed
+plans. That kernel work is intentionally refiled in strided-rs rather than
+being optimized inside the tenferro adapter.
+
+## Deferred
+
+- Contiguous-run/rank-one and general indexed execute-loop optimization belongs
+  to strided-rs and requires its own benchmark-backed PR.
+- Static slice/pad/concatenate/reverse and row-run triangular work remain in
+  tenferro-rs #1512.


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [x] Implementation of accepted issue

## Related issue

Closes #1511
Refs tensor4all/strided-rs#169

## Summary

- add a bounded `CpuEngine`-owned cache for erased gather, additive-scatter, dynamic-slice, and dynamic-update-slice plans
- key every family by value/index dtype, dimensions, strides, and complete operation config; retain plans behind `Arc` with entry/byte LRU bounds
- expose configure, clear, retained-byte, and aggregate stats through `CpuBackend` and the runtime cache-owner surface
- serialize limit changes with lazy engine creation using one coherent configuration snapshot
- preserve explicit `ExecContext` threading and expected-serial additive-scatter replay

## Performance

Public API full-profile focused rows were measured at threads 1 and 4 in two complete counterbalanced orders. Because unrelated Julia processes were active, t1 was pinned to CPU 60 and t4 to CPUs 56-59. The table is the geometric mean of candidate/baseline ratios:

| Row | t1 | t4 |
|---|---:|---:|
| gather eager | +2.7% | -0.1% |
| gather trace | +2.1% | +0.7% |
| scatter eager | +1.1% | +1.0% |
| scatter trace | -0.8% | +0.2% |
| dynamic_slice eager | -0.6% | -0.1% |
| dynamic_slice trace | +10.3% | -0.2% |
| dynamic_update_slice eager | +0.9% | -2.3% |

All rows remain below the predeclared +20% gate. A same-binary alternating probe measured gather t4 at 1.288 ms cached versus 1.300 ms uncached, so residual execute-time coordinate decode is filed upstream as tensor4all/strided-rs#169 rather than optimized here.

## Work log

[`docs/worklogs/2026-07-29-issue-1511-indexed-plan-cache.md`](docs/worklogs/2026-07-29-issue-1511-indexed-plan-cache.md)

## Verification

- `cargo fmt --all -- --check`
- `./scripts/check-pr-fast.sh --coverage-reviewed --test ...`
- `cargo test -p tenferro-cpu --no-default-features --features cpu-faer` (496 unit, 48 integration, 183 doctests)
- `cargo llvm-cov --package tenferro-cpu --no-default-features --features cpu-faer --lib` (new cache module 95.0%; indexing 90.4%)
- `python3 scripts/repository-rules-review.py --base origin/main --head 4000351b --worktree`
- focused public API full-profile t1/t4 benchmark, counterbalanced and CPU-pinned

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] The linked issue has been accepted by maintainers.
- [x] I added and linked the required work log.
