### PR TITLE
perf(cpu): adopt strided static indexing plans

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "e18ecb10a662771507337b11bce1aa8491956000", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "e18ecb10a662771507337b11bce1aa8491956000", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "e18ecb10a662771507337b11bce1aa8491956000", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "e18ecb10a662771507337b11bce1aa8491956000", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "e18ecb10a662771507337b11bce1aa8491956000", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "ed3053a6b096bc53d2a286ce918ff88b684eadce", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "ed3053a6b096bc53d2a286ce918ff88b684eadce", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "ed3053a6b096bc53d2a286ce918ff88b684eadce", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "ed3053a6b096bc53d2a286ce918ff88b684eadce", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "ed3053a6b096bc53d2a286ce918ff88b684eadce", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "649772c8402e5fe95335366326b6623f9a4f5b0a", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "649772c8402e5fe95335366326b6623f9a4f5b0a", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "649772c8402e5fe95335366326b6623f9a4f5b0a", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "649772c8402e5fe95335366326b6623f9a4f5b0a", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "649772c8402e5fe95335366326b6623f9a4f5b0a", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "e18ecb10a662771507337b11bce1aa8491956000", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "e18ecb10a662771507337b11bce1aa8491956000", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "e18ecb10a662771507337b11bce1aa8491956000", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "e18ecb10a662771507337b11bce1aa8491956000", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "e18ecb10a662771507337b11bce1aa8491956000", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -3211,7 +3211,10 @@ impl TensorIndexing for CpuBackend {
     }
 
     fn slice(&mut self, input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor> {
-        self.install_with_pool(|buffers| indexing::try_slice_with_pool(buffers, input, config))
+        self.install_with_pool_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::try_slice_with_pool(buffers, &exec_context, input, config)
+        })
     }
 
     fn dynamic_slice(
@@ -3253,15 +3256,24 @@ impl TensorIndexing for CpuBackend {
     }
 
     fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
-        self.install_with_pool(|buffers| indexing::try_pad_with_pool(buffers, input, config))
+        self.install_with_pool_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::try_pad_with_pool(buffers, &exec_context, input, config)
+        })
     }
 
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
-        self.install_with_pool(|buffers| indexing::try_concatenate_with_pool(buffers, inputs, axis))
+        self.install_with_pool_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::try_concatenate_with_pool(buffers, &exec_context, inputs, axis)
+        })
     }
 
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-        self.install_with_pool(|buffers| indexing::reverse_with_pool(buffers, input, axes))
+        self.install_with_pool_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::reverse_with_pool(buffers, &exec_context, input, axes)
+        })
     }
 }
 

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -195,6 +195,7 @@ fn cpu_hot_kernels_delegate_to_erased_strided_replay() {
     let elementwise = include_str!("../../../tenferro-internal-cpu-kernels/src/elementwise.rs");
     let indexing = include_str!("../indexing.rs");
     let reduction = include_str!("../reduction.rs");
+    let structural = include_str!("../structural.rs");
 
     assert!(
         elementwise.contains("ErasedFusedPlan::compile"),
@@ -211,6 +212,13 @@ fn cpu_hot_kernels_delegate_to_erased_strided_replay() {
         "CPU indexed slice/update/scatter execution should delegate to erased strided plans"
     );
     assert!(
+        indexing.contains("ErasedSlicePlan::compile")
+            && indexing.contains("ErasedPadPlan::compile")
+            && indexing.contains("ErasedConcatenatePlan::compile")
+            && indexing.contains("ErasedReversePlan::compile"),
+        "CPU static indexing execution should delegate to erased strided plans"
+    );
+    assert!(
         reduction.contains("ErasedReducePlan::compile_axes"),
         "CPU sum/product axis reductions should delegate to erased strided reduce plans"
     );
@@ -225,6 +233,16 @@ fn cpu_hot_kernels_delegate_to_erased_strided_replay() {
             "{name} erased strided replay should inherit CpuExecutionContext, not force serial"
         );
     }
+    let pooled_triangular = structural
+        .split_once("fn typed_triangular_mask_with_fill_pool")
+        .and_then(|(_, rest)| rest.split_once("fn checked_triangular_extent"))
+        .map(|(body, _)| body)
+        .expect("pooled triangular kernel should remain discoverable");
+    assert!(
+        !pooled_triangular.contains("for row in 0..rows")
+            && pooled_triangular.contains("data[start..end].fill(fill)"),
+        "CPU pooled triangular masks should operate on contiguous column runs"
+    );
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -943,6 +943,31 @@ fn linalg_pool_acquire_then_panic_replenishes_buffer_but_reports_poison() {
 }
 
 #[test]
+fn uninit_output_partial_write_then_panic_replenishes_only_capacity() {
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    backend
+        .with_linalg_pool(|_, pool| {
+            <bool as PoolScalar>::pool_release(pool, Vec::with_capacity(1024));
+            Ok(())
+        })
+        .unwrap();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _ = backend.with_linalg_pool::<()>(|_, pool| {
+            let mut output =
+                crate::indexing_alloc::PooledUninitOutput::<bool>::new(pool, vec![1024]).unwrap();
+            output.as_uninit_bytes_mut()[0].write(1);
+            panic!("forced panic after a partial uninitialized output write");
+        });
+    }));
+
+    assert!(result.is_err());
+    let resources = backend.engine.resources.lock().unwrap_err().into_inner();
+    assert_eq!(resources.buffers.len(), 1);
+    assert_eq!(resources.buffers.stats().capacity_bytes, 1024);
+}
+
+#[test]
 fn cached_dot_dispatch_reports_dtype_mismatches() {
     let mut backend = CpuBackend::new();
     let mut cache = gemm::GemmAnalysisCache::default();

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -634,7 +634,12 @@ impl TensorIndexing for CpuExecSession<'_> {
             )
         })
     }
-    delegate_with_pool!(slice(input: &Tensor, config: &SliceConfig) => indexing::try_slice_with_pool);
+    fn slice(&mut self, input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor> {
+        self.run_native_fresh_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::try_slice_with_pool(buffers, &exec_context, input, config)
+        })
+    }
     fn dynamic_slice(
         &mut self,
         input: &Tensor,
@@ -671,12 +676,23 @@ impl TensorIndexing for CpuExecSession<'_> {
             )
         })
     }
-    delegate_with_pool!(pad(input: &Tensor, config: &PadConfig) => indexing::try_pad_with_pool);
+    fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
+        self.run_native_fresh_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::try_pad_with_pool(buffers, &exec_context, input, config)
+        })
+    }
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
-        self.run_native_fresh(|buffers| indexing::try_concatenate_with_pool(buffers, inputs, axis))
+        self.run_native_fresh_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::try_concatenate_with_pool(buffers, &exec_context, inputs, axis)
+        })
     }
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-        self.run_native_fresh(|buffers| indexing::reverse_with_pool(buffers, input, axes))
+        self.run_native_fresh_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::reverse_with_pool(buffers, &exec_context, input, axes)
+        })
     }
 }
 

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -1,25 +1,52 @@
 use std::mem::size_of_val;
 
-use num_traits::Zero;
+use smallvec::SmallVec;
 use strided_kernel::{
-    col_major_strides, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan, ErasedGatherPlan,
-    ErasedRawStridedMut, ErasedRawStridedRef, ErasedScatterPlan, ExecContext, GatherSpec,
-    KernelDType, ScatterSpec,
+    col_major_strides, ErasedConcatenatePlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan,
+    ErasedGatherPlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef, ErasedReversePlan,
+    ErasedScatterPlan, ErasedSlicePlan, ExecContext, GatherSpec, KernelDType, ScatterSpec,
 };
 
 use super::indexed_plan_cache::{IndexedPlanCache, IndexedPlanFamily, IndexedPlanKey};
-use super::indexing_alloc::pooled_uninit_tensor;
+use super::indexing_alloc::{pooled_uninit_tensor, pooled_zeroed_tensor};
 use super::typed_host_data;
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use tenferro_tensor::TensorScalar;
 use tenferro_tensor::{DType, GatherConfig, PadConfig, ScatterConfig, SliceConfig};
 use tenferro_tensor::{Tensor, TypedTensor};
 
-// Indexed gather, additive scatter, and fixed-window dynamic slice/update
-// delegate bulk traversal to strided-kernel erased plans. Pad/concatenate/
-// reverse still own their operation-specific loops here. Backend entrypoints
-// run these kernels inside CpuContext::install, so future parallel
-// implementations can use the same CPU threading policy.
+type InlineStrides = SmallVec<[isize; 8]>;
+
+fn inline_col_major_strides(op: &'static str, dims: &[usize]) -> crate::Result<InlineStrides> {
+    let mut strides = InlineStrides::from_elem(1, dims.len());
+    for axis in 1..dims.len() {
+        if strides[axis - 1] == 0 {
+            strides[axis] = 0;
+            continue;
+        }
+        let prior_dim = isize::try_from(dims[axis - 1]).map_err(|_| {
+            crate::Error::invalid_argument(
+                op,
+                "shape",
+                format!(
+                    "dimension {} does not fit in isize while computing column-major strides",
+                    dims[axis - 1]
+                ),
+            )
+        })?;
+        strides[axis] = strides[axis - 1].checked_mul(prior_dim).ok_or_else(|| {
+            crate::Error::invalid_argument(
+                op,
+                "shape",
+                format!("column-major stride overflows isize for shape {dims:?}"),
+            )
+        })?;
+    }
+    Ok(strides)
+}
+
+// Indexing families delegate bulk traversal to strided-kernel erased plans.
+// Backend entrypoints inject the CpuContext-derived execution policy.
 
 trait TensorAsTyped<T> {
     fn as_typed(&self) -> Option<&TypedTensor<T>>;
@@ -119,20 +146,6 @@ macro_rules! dispatch_tensor_unary_result {
     };
 }
 
-macro_rules! dispatch_tensor_unary_with_bool_special_result {
-    ($input:expr, |$tensor:ident| $body:expr, bool |$bool_tensor:ident| $bool_body:expr) => {
-        match $input {
-            Tensor::F32($tensor) => Ok(Tensor::F32($body?)),
-            Tensor::F64($tensor) => Ok(Tensor::F64($body?)),
-            Tensor::I32($tensor) => Ok(Tensor::I32($body?)),
-            Tensor::I64($tensor) => Ok(Tensor::I64($body?)),
-            Tensor::Bool($bool_tensor) => Ok(Tensor::Bool($bool_body?)),
-            Tensor::C32($tensor) => Ok(Tensor::C32($body?)),
-            Tensor::C64($tensor) => Ok(Tensor::C64($body?)),
-        }
-    };
-}
-
 macro_rules! dispatch_same_dtype_result {
     ($op:literal, $lhs:expr, $rhs:expr, |$lhs_t:ident, $rhs_t:ident| $body:expr) => {
         match ($lhs, $rhs) {
@@ -177,35 +190,6 @@ macro_rules! dispatch_same_dtype_without_bool_result {
 fn with_test_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
     let mut buffers = BufferPool::new();
     f(&mut buffers)
-}
-
-fn advance_col_major_index(index: &mut [usize], shape: &[usize]) {
-    debug_assert_eq!(index.len(), shape.len());
-    for axis in 0..index.len() {
-        if shape[axis] == 0 {
-            index[axis] = 0;
-            continue;
-        }
-        index[axis] += 1;
-        if index[axis] < shape[axis] {
-            break;
-        }
-        index[axis] = 0;
-    }
-}
-
-fn pooled_filled_tensor<T>(
-    buffers: &mut BufferPool,
-    shape: Vec<usize>,
-    fill: T,
-) -> crate::Result<TypedTensor<T>>
-where
-    T: Copy + Clone + PoolScalar,
-{
-    // SAFETY: the following fill writes every pooled output element.
-    let mut out = pooled_uninit_tensor(buffers, shape)?;
-    out.host_data_mut()?.fill(fill);
-    Ok(out)
 }
 
 #[cfg(test)]
@@ -296,10 +280,11 @@ pub(crate) fn scatter_with_pool(
 
 pub(crate) fn try_slice_with_pool(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     input: &Tensor,
     config: &SliceConfig,
 ) -> crate::Result<Tensor> {
-    dispatch_tensor_unary_result!(input, |t| typed_slice(buffers, t, config))
+    dispatch_tensor_unary_result!(input, |t| typed_slice(buffers, exec_context, t, config))
 }
 
 #[cfg(test)]
@@ -399,23 +384,21 @@ pub(crate) fn pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
 
 #[cfg(test)]
 fn try_pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
-    with_test_pool(|buffers| try_pad_with_pool(buffers, input, config))
+    with_test_pool(|buffers| try_pad_with_pool(buffers, &ExecContext::serial(), input, config))
 }
 
 pub(crate) fn try_pad_with_pool(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     input: &Tensor,
     config: &PadConfig,
 ) -> crate::Result<Tensor> {
-    dispatch_tensor_unary_with_bool_special_result!(
-        input,
-        |t| typed_pad(buffers, t, config),
-        bool | t | typed_pad_with_fill(buffers, t, config, false)
-    )
+    dispatch_tensor_unary_result!(input, |t| typed_pad(buffers, exec_context, t, config))
 }
 
 pub(crate) fn try_concatenate_with_pool(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     inputs: &[&Tensor],
     axis: usize,
 ) -> crate::Result<Tensor> {
@@ -427,20 +410,26 @@ pub(crate) fn try_concatenate_with_pool(
         )
     })?;
     dispatch_tensor_unary_result!(first, |t| typed_concatenate_from_dyn_inputs(
-        buffers, t, inputs, axis
+        buffers,
+        exec_context,
+        t,
+        inputs,
+        axis
     ))
 }
 
 pub(crate) fn reverse_with_pool(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     input: &Tensor,
     axes: &[usize],
 ) -> crate::Result<Tensor> {
-    dispatch_tensor_unary_result!(input, |t| typed_reverse(buffers, t, axes))
+    dispatch_tensor_unary_result!(input, |t| typed_reverse(buffers, exec_context, t, axes))
 }
 
-fn typed_slice<T: Copy + Clone + PoolScalar>(
+fn typed_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     input: &TypedTensor<T>,
     config: &SliceConfig,
 ) -> crate::Result<TypedTensor<T>> {
@@ -498,30 +487,54 @@ fn typed_slice<T: Copy + Clone + PoolScalar>(
         })
         .collect::<crate::Result<Vec<_>>>()?;
 
-    // SAFETY: the slice loop below assigns every output coordinate exactly once.
-    let mut out = pooled_uninit_tensor(buffers, out_shape.clone())?;
-    let mut out_idx = vec![0usize; rank];
-    let mut in_idx = vec![0usize; rank];
+    let dtype = kernel_dtype(T::dtype());
+    let input_strides = inline_col_major_strides("slice", input_shape)?;
+    let out_strides = inline_col_major_strides("slice", &out_shape)?;
+    let plan = ErasedSlicePlan::compile(
+        dtype,
+        input_shape,
+        &input_strides,
+        &out_shape,
+        &out_strides,
+        &config.starts,
+        &config.limits,
+        &config.strides,
+    )
+    .map_err(|err| crate::Error::backend_source("slice", err))?;
 
-    for out_value in out.host_data_mut()?.iter_mut() {
-        for axis in 0..rank {
-            in_idx[axis] = config.starts[axis] + out_idx[axis] * config.strides[axis];
-        }
-        *out_value = *input.get(&in_idx)?;
-        advance_col_major_index(&mut out_idx, &out_shape);
-    }
+    // SAFETY: ErasedSlicePlan overwrites every output element.
+    let mut out = pooled_zeroed_tensor(buffers, out_shape.clone())?;
+    let input_ref = ErasedRawStridedRef::new(
+        dtype,
+        typed_bytes(typed_host_data("slice", input)?),
+        input_shape,
+        &input_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("slice", err))?;
+    let mut out_ref = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(out.host_data_mut()?),
+        &out_shape,
+        &out_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("slice", err))?;
+    plan.execute(exec_context, &mut out_ref, &input_ref)
+        .map_err(|err| crate::Error::backend_source("slice", err))?;
 
     Ok(out)
 }
 
 fn typed_concatenate_from_dyn_inputs<T>(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     _first: &TypedTensor<T>,
     inputs: &[&Tensor],
     axis: usize,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + PoolScalar,
+    T: Copy + Clone + PoolScalar + TensorScalar,
     Tensor: TensorAsTyped<T>,
 {
     let first_dtype = inputs
@@ -535,7 +548,7 @@ where
         })?
         .dtype();
     let typed_inputs = collect_typed_inputs(first_dtype, inputs)?;
-    typed_concatenate(buffers, &typed_inputs, axis)
+    typed_concatenate(buffers, exec_context, &typed_inputs, axis)
 }
 
 fn collect_typed_inputs<'a, T>(
@@ -555,8 +568,9 @@ where
         .collect()
 }
 
-fn typed_concatenate<T: Copy + Clone + PoolScalar>(
+fn typed_concatenate<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     inputs: &[&TypedTensor<T>],
     axis: usize,
 ) -> crate::Result<TypedTensor<T>> {
@@ -604,82 +618,95 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar>(
     }
     out_shape[axis] = axis_extent;
 
-    let mut segment_ends = Vec::with_capacity(inputs.len());
-    let mut segment_end = 0usize;
-    for input in inputs {
-        segment_end = segment_end
-            .checked_add(input.shape()[axis])
-            .ok_or_else(|| {
-                crate::Error::invalid_argument(
-                    "concatenate",
-                    "configuration",
-                    "concatenate segment offset overflows usize".to_string(),
-                )
-            })?;
-        segment_ends.push(segment_end);
-    }
+    let dtype = kernel_dtype(T::dtype());
+    let input_dims: SmallVec<[&[usize]; 4]> = inputs.iter().map(|input| input.shape()).collect();
+    let input_strides: SmallVec<[InlineStrides; 4]> = input_dims
+        .iter()
+        .map(|dims| inline_col_major_strides("concatenate", dims))
+        .collect::<crate::Result<_>>()?;
+    let input_stride_refs: SmallVec<[&[isize]; 4]> =
+        input_strides.iter().map(SmallVec::as_slice).collect();
+    let out_strides = inline_col_major_strides("concatenate", &out_shape)?;
+    let plan = ErasedConcatenatePlan::compile(
+        dtype,
+        &input_dims,
+        &input_stride_refs,
+        &out_shape,
+        &out_strides,
+        axis,
+    )
+    .map_err(|err| crate::Error::backend_source("concatenate", err))?;
 
-    // SAFETY: the concatenate loop below assigns every output coordinate exactly once.
-    let mut out = pooled_uninit_tensor(buffers, out_shape.clone())?;
-    let mut out_idx = vec![0usize; rank];
-    let mut in_idx = vec![0usize; rank];
-
-    for out_value in out.host_data_mut()?.iter_mut() {
-        let concat_idx = out_idx[axis];
-        let input_pos = segment_ends.partition_point(|&end| concat_idx >= end);
-        if input_pos == segment_ends.len() {
-            return Err(crate::Error::invalid_argument(
-                "concatenate",
-                "configuration",
-                "output index must map to an input".to_string(),
-            ));
-        }
-        let axis_base = if input_pos == 0 {
-            0
-        } else {
-            segment_ends[input_pos - 1]
-        };
-
-        in_idx.copy_from_slice(&out_idx);
-        in_idx[axis] -= axis_base;
-        *out_value = *inputs[input_pos].get(&in_idx)?;
-        advance_col_major_index(&mut out_idx, &out_shape);
-    }
+    // SAFETY: ErasedConcatenatePlan overwrites every output element.
+    let mut out = pooled_zeroed_tensor(buffers, out_shape.clone())?;
+    let input_refs: SmallVec<[ErasedRawStridedRef<'_>; 4]> = inputs
+        .iter()
+        .zip(input_strides.iter())
+        .map(|(input, strides)| {
+            ErasedRawStridedRef::new(
+                dtype,
+                typed_bytes(typed_host_data("concatenate", input)?),
+                input.shape(),
+                strides,
+                0,
+            )
+            .map_err(|err| crate::Error::backend_source("concatenate", err))
+        })
+        .collect::<crate::Result<_>>()?;
+    let mut out_ref = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(out.host_data_mut()?),
+        &out_shape,
+        &out_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("concatenate", err))?;
+    plan.execute(exec_context, &mut out_ref, &input_refs)
+        .map_err(|err| crate::Error::backend_source("concatenate", err))?;
 
     Ok(out)
 }
 
-fn typed_reverse<T: Copy + Clone + PoolScalar>(
+fn typed_reverse<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     input: &TypedTensor<T>,
     axes: &[usize],
 ) -> crate::Result<TypedTensor<T>> {
     let input_shape = input.shape();
     let rank = input_shape.len();
-    let mut reverse_axis = vec![false; rank];
     for &axis in axes {
         if axis >= rank {
             return Err(crate::Error::axis_out_of_bounds("reverse", axis, rank));
         }
-        reverse_axis[axis] = true;
     }
 
-    // SAFETY: the reverse loop below assigns every output coordinate exactly once.
-    let mut out = pooled_uninit_tensor(buffers, input_shape.to_vec())?;
-    let mut out_idx = vec![0usize; rank];
-    let mut in_idx = vec![0usize; rank];
+    let dtype = kernel_dtype(T::dtype());
+    let input_strides = inline_col_major_strides("reverse", input_shape)?;
+    let out_strides = inline_col_major_strides("reverse", input_shape)?;
+    let plan = ErasedReversePlan::compile(dtype, input_shape, &input_strides, &out_strides, axes)
+        .map_err(|err| crate::Error::backend_source("reverse", err))?;
 
-    for out_value in out.host_data_mut()?.iter_mut() {
-        for axis in 0..rank {
-            in_idx[axis] = if reverse_axis[axis] {
-                input_shape[axis] - 1 - out_idx[axis]
-            } else {
-                out_idx[axis]
-            };
-        }
-        *out_value = *input.get(&in_idx)?;
-        advance_col_major_index(&mut out_idx, input_shape);
-    }
+    // SAFETY: ErasedReversePlan overwrites every output element.
+    let mut out = pooled_zeroed_tensor(buffers, input_shape.to_vec())?;
+    let input_ref = ErasedRawStridedRef::new(
+        dtype,
+        typed_bytes(typed_host_data("reverse", input)?),
+        input_shape,
+        &input_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("reverse", err))?;
+    let mut out_ref = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(out.host_data_mut()?),
+        input_shape,
+        &out_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("reverse", err))?;
+    plan.execute(exec_context, &mut out_ref, &input_ref)
+        .map_err(|err| crate::Error::backend_source("reverse", err))?;
 
     Ok(out)
 }
@@ -1553,19 +1580,11 @@ fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     Ok(out)
 }
 
-fn typed_pad<T: Copy + Clone + Zero + PoolScalar>(
+fn typed_pad<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     input: &TypedTensor<T>,
     config: &PadConfig,
-) -> crate::Result<TypedTensor<T>> {
-    typed_pad_with_fill(buffers, input, config, T::zero())
-}
-
-fn typed_pad_with_fill<T: Copy + Clone + PoolScalar>(
-    buffers: &mut BufferPool,
-    input: &TypedTensor<T>,
-    config: &PadConfig,
-    fill: T,
 ) -> crate::Result<TypedTensor<T>> {
     let input_shape = input.shape();
     let rank = input_shape.len();
@@ -1650,26 +1669,46 @@ fn typed_pad_with_fill<T: Copy + Clone + PoolScalar>(
         })?);
     }
 
-    let mut out = pooled_filled_tensor(buffers, out_shape.clone(), fill)?;
-    let mut input_idx = vec![0usize; input_shape.len()];
-    let mut out_idx = vec![0usize; input_shape.len()];
-
-    for input_value in input.as_slice()? {
-        let mut in_bounds = true;
-        for axis in 0..input_shape.len() {
-            let out_pos = i128::from(config.edge_padding_low[axis])
-                + input_idx[axis] as i128 * i128::from(config.interior_padding[axis] + 1);
-            if !(0..out_shape[axis] as i128).contains(&out_pos) {
-                in_bounds = false;
-                break;
-            }
-            out_idx[axis] = out_pos as usize;
-        }
-        if in_bounds {
-            *out.get_mut(&out_idx)? = *input_value;
-        }
-        advance_col_major_index(&mut input_idx, input_shape);
-    }
+    let dtype = kernel_dtype(T::dtype());
+    let input_strides = inline_col_major_strides("pad", input_shape)?;
+    let out_strides = inline_col_major_strides("pad", &out_shape)?;
+    let plan = ErasedPadPlan::compile(
+        dtype,
+        input_shape,
+        &input_strides,
+        &out_shape,
+        &out_strides,
+        &config.edge_padding_low,
+        &config.edge_padding_high,
+        &config.interior_padding,
+    )
+    .map_err(|err| crate::Error::backend_source("pad", err))?;
+    let fill = T::pool_zero();
+    // SAFETY: ErasedPadPlan overwrites every output element.
+    let mut out = pooled_zeroed_tensor(buffers, out_shape.clone())?;
+    let input_ref = ErasedRawStridedRef::new(
+        dtype,
+        typed_bytes(typed_host_data("pad", input)?),
+        input_shape,
+        &input_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("pad", err))?;
+    let mut out_ref = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(out.host_data_mut()?),
+        &out_shape,
+        &out_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("pad", err))?;
+    plan.execute(
+        exec_context,
+        &mut out_ref,
+        &input_ref,
+        typed_bytes(std::slice::from_ref(&fill)),
+    )
+    .map_err(|err| crate::Error::backend_source("pad", err))?;
 
     Ok(out)
 }

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -3,12 +3,13 @@ use std::mem::size_of_val;
 use smallvec::SmallVec;
 use strided_kernel::{
     col_major_strides, ErasedConcatenatePlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan,
-    ErasedGatherPlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef, ErasedReversePlan,
-    ErasedScatterPlan, ErasedSlicePlan, ExecContext, GatherSpec, KernelDType, ScatterSpec,
+    ErasedGatherPlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef,
+    ErasedRawStridedUninitMut, ErasedReversePlan, ErasedScatterPlan, ErasedSlicePlan, ExecContext,
+    GatherSpec, KernelDType, ScatterSpec,
 };
 
 use super::indexed_plan_cache::{IndexedPlanCache, IndexedPlanFamily, IndexedPlanKey};
-use super::indexing_alloc::{pooled_uninit_tensor, pooled_zeroed_tensor};
+use super::indexing_alloc::{pooled_uninit_tensor, PooledUninitOutput};
 use super::typed_host_data;
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use tenferro_tensor::TensorScalar;
@@ -502,8 +503,7 @@ fn typed_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     )
     .map_err(|err| crate::Error::backend_source("slice", err))?;
 
-    // SAFETY: ErasedSlicePlan overwrites every output element.
-    let mut out = pooled_zeroed_tensor(buffers, out_shape.clone())?;
+    let mut out = PooledUninitOutput::new(buffers, out_shape.clone())?;
     let input_ref = ErasedRawStridedRef::new(
         dtype,
         typed_bytes(typed_host_data("slice", input)?),
@@ -512,18 +512,20 @@ fn typed_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
         0,
     )
     .map_err(|err| crate::Error::backend_source("slice", err))?;
-    let mut out_ref = ErasedRawStridedMut::new(
+    let input_ptr = ErasedRawStridedPtr::from_ref(&input_ref);
+    let mut out_ref = ErasedRawStridedUninitMut::new(
         dtype,
-        typed_bytes_mut(out.host_data_mut()?),
+        out.as_uninit_bytes_mut(),
         &out_shape,
         &out_strides,
         0,
     )
     .map_err(|err| crate::Error::backend_source("slice", err))?;
-    plan.execute(exec_context, &mut out_ref, &input_ref)
+    plan.execute_uninit(exec_context, &mut out_ref, &input_ptr)
         .map_err(|err| crate::Error::backend_source("slice", err))?;
 
-    Ok(out)
+    // SAFETY: successful static-slice replay initializes every logical output.
+    unsafe { out.assume_init() }
 }
 
 fn typed_concatenate_from_dyn_inputs<T>(
@@ -637,8 +639,7 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar + TensorScalar>(
     )
     .map_err(|err| crate::Error::backend_source("concatenate", err))?;
 
-    // SAFETY: ErasedConcatenatePlan overwrites every output element.
-    let mut out = pooled_zeroed_tensor(buffers, out_shape.clone())?;
+    let mut out = PooledUninitOutput::new(buffers, out_shape.clone())?;
     let input_refs: SmallVec<[ErasedRawStridedRef<'_>; 4]> = inputs
         .iter()
         .zip(input_strides.iter())
@@ -653,18 +654,23 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar + TensorScalar>(
             .map_err(|err| crate::Error::backend_source("concatenate", err))
         })
         .collect::<crate::Result<_>>()?;
-    let mut out_ref = ErasedRawStridedMut::new(
+    let input_ptrs: SmallVec<[ErasedRawStridedPtr<'_>; 4]> = input_refs
+        .iter()
+        .map(ErasedRawStridedPtr::from_ref)
+        .collect();
+    let mut out_ref = ErasedRawStridedUninitMut::new(
         dtype,
-        typed_bytes_mut(out.host_data_mut()?),
+        out.as_uninit_bytes_mut(),
         &out_shape,
         &out_strides,
         0,
     )
     .map_err(|err| crate::Error::backend_source("concatenate", err))?;
-    plan.execute(exec_context, &mut out_ref, &input_refs)
+    plan.execute_uninit(exec_context, &mut out_ref, &input_ptrs)
         .map_err(|err| crate::Error::backend_source("concatenate", err))?;
 
-    Ok(out)
+    // SAFETY: successful concatenate replay initializes every logical output.
+    unsafe { out.assume_init() }
 }
 
 fn typed_reverse<T: Copy + Clone + PoolScalar + TensorScalar>(
@@ -687,8 +693,7 @@ fn typed_reverse<T: Copy + Clone + PoolScalar + TensorScalar>(
     let plan = ErasedReversePlan::compile(dtype, input_shape, &input_strides, &out_strides, axes)
         .map_err(|err| crate::Error::backend_source("reverse", err))?;
 
-    // SAFETY: ErasedReversePlan overwrites every output element.
-    let mut out = pooled_zeroed_tensor(buffers, input_shape.to_vec())?;
+    let mut out = PooledUninitOutput::new(buffers, input_shape.to_vec())?;
     let input_ref = ErasedRawStridedRef::new(
         dtype,
         typed_bytes(typed_host_data("reverse", input)?),
@@ -697,18 +702,20 @@ fn typed_reverse<T: Copy + Clone + PoolScalar + TensorScalar>(
         0,
     )
     .map_err(|err| crate::Error::backend_source("reverse", err))?;
-    let mut out_ref = ErasedRawStridedMut::new(
+    let input_ptr = ErasedRawStridedPtr::from_ref(&input_ref);
+    let mut out_ref = ErasedRawStridedUninitMut::new(
         dtype,
-        typed_bytes_mut(out.host_data_mut()?),
+        out.as_uninit_bytes_mut(),
         input_shape,
         &out_strides,
         0,
     )
     .map_err(|err| crate::Error::backend_source("reverse", err))?;
-    plan.execute(exec_context, &mut out_ref, &input_ref)
+    plan.execute_uninit(exec_context, &mut out_ref, &input_ptr)
         .map_err(|err| crate::Error::backend_source("reverse", err))?;
 
-    Ok(out)
+    // SAFETY: successful reverse replay initializes every logical output.
+    unsafe { out.assume_init() }
 }
 
 struct IndexTensor {
@@ -1684,8 +1691,7 @@ fn typed_pad<T: Copy + Clone + PoolScalar + TensorScalar>(
     )
     .map_err(|err| crate::Error::backend_source("pad", err))?;
     let fill = T::pool_zero();
-    // SAFETY: ErasedPadPlan overwrites every output element.
-    let mut out = pooled_zeroed_tensor(buffers, out_shape.clone())?;
+    let mut out = PooledUninitOutput::new(buffers, out_shape.clone())?;
     let input_ref = ErasedRawStridedRef::new(
         dtype,
         typed_bytes(typed_host_data("pad", input)?),
@@ -1694,23 +1700,25 @@ fn typed_pad<T: Copy + Clone + PoolScalar + TensorScalar>(
         0,
     )
     .map_err(|err| crate::Error::backend_source("pad", err))?;
-    let mut out_ref = ErasedRawStridedMut::new(
+    let input_ptr = ErasedRawStridedPtr::from_ref(&input_ref);
+    let mut out_ref = ErasedRawStridedUninitMut::new(
         dtype,
-        typed_bytes_mut(out.host_data_mut()?),
+        out.as_uninit_bytes_mut(),
         &out_shape,
         &out_strides,
         0,
     )
     .map_err(|err| crate::Error::backend_source("pad", err))?;
-    plan.execute(
+    plan.execute_uninit(
         exec_context,
         &mut out_ref,
-        &input_ref,
+        &input_ptr,
         typed_bytes(std::slice::from_ref(&fill)),
     )
     .map_err(|err| crate::Error::backend_source("pad", err))?;
 
-    Ok(out)
+    // SAFETY: successful pad replay initializes every logical output.
+    unsafe { out.assume_init() }
 }
 
 #[cfg(test)]

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -524,7 +524,9 @@ fn typed_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     plan.execute_uninit(exec_context, &mut out_ref, &input_ptr)
         .map_err(|err| crate::Error::backend_source("slice", err))?;
 
-    // SAFETY: successful static-slice replay initializes every logical output.
+    // INVARIANT: the compact output has no unreachable storage, so successful
+    // static-slice replay initializes every element.
+    // SAFETY: every element contains a valid T after successful replay.
     unsafe { out.assume_init() }
 }
 
@@ -669,7 +671,9 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar + TensorScalar>(
     plan.execute_uninit(exec_context, &mut out_ref, &input_ptrs)
         .map_err(|err| crate::Error::backend_source("concatenate", err))?;
 
-    // SAFETY: successful concatenate replay initializes every logical output.
+    // INVARIANT: the compact output has no unreachable storage, so successful
+    // concatenate replay initializes every element.
+    // SAFETY: every element contains a valid T after successful replay.
     unsafe { out.assume_init() }
 }
 
@@ -714,7 +718,9 @@ fn typed_reverse<T: Copy + Clone + PoolScalar + TensorScalar>(
     plan.execute_uninit(exec_context, &mut out_ref, &input_ptr)
         .map_err(|err| crate::Error::backend_source("reverse", err))?;
 
-    // SAFETY: successful reverse replay initializes every logical output.
+    // INVARIANT: the compact output has no unreachable storage, so successful
+    // reverse replay initializes every element.
+    // SAFETY: every element contains a valid T after successful replay.
     unsafe { out.assume_init() }
 }
 
@@ -1717,7 +1723,9 @@ fn typed_pad<T: Copy + Clone + PoolScalar + TensorScalar>(
     )
     .map_err(|err| crate::Error::backend_source("pad", err))?;
 
-    // SAFETY: successful pad replay initializes every logical output.
+    // INVARIANT: the compact output has no unreachable storage, so successful
+    // pad replay initializes every element.
+    // SAFETY: every element contains a valid T after successful replay.
     unsafe { out.assume_init() }
 }
 

--- a/crates/tenferro-cpu/src/indexing/tests.rs
+++ b/crates/tenferro-cpu/src/indexing/tests.rs
@@ -1,14 +1,18 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
-use super::{dynamic_slice, f32_index_to_i64, f64_index_to_i64, typed_concatenate, BufferPool};
-use tenferro_tensor::{Error, Tensor, TypedTensor, ValidationError};
+use super::{
+    dynamic_slice, f32_index_to_i64, f64_index_to_i64, inline_col_major_strides, typed_concatenate,
+    BufferPool,
+};
+use strided_kernel::ExecContext;
+use tenferro_tensor::{Error, ErrorKind, Tensor, TypedTensor, ValidationError, ValidationKind};
 
 #[test]
 fn typed_concatenate_rejects_empty_typed_inputs_without_panicking() {
     let mut buffers = BufferPool::new();
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        typed_concatenate::<f64>(&mut buffers, &[], 0)
+        typed_concatenate::<f64>(&mut buffers, &ExecContext::serial(), &[], 0)
     }));
 
     assert!(result.is_ok(), "empty typed concatenate should return Err");
@@ -28,10 +32,30 @@ fn typed_concatenate_accepts_nonempty_typed_inputs() {
     let b = TypedTensor::from_vec_col_major(vec![1], vec![3.0]).unwrap();
     let inputs = vec![&a, &b];
 
-    let out = typed_concatenate(&mut buffers, &inputs, 0).unwrap();
+    let out = typed_concatenate(&mut buffers, &ExecContext::serial(), &inputs, 0).unwrap();
 
     assert_eq!(out.shape(), &[3]);
     assert_eq!(out.host_data().unwrap(), &[1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn inline_strides_cover_zero_extent_and_spill_without_overflow() {
+    let dims = [2, 0, usize::MAX, 3, 5, 7, 11, 13, 17];
+    let strides = inline_col_major_strides("test_static_indexing", &dims).unwrap();
+
+    assert_eq!(strides.len(), 9);
+    assert_eq!(&strides[..4], &[1, 2, 0, 0]);
+}
+
+#[test]
+fn inline_strides_report_isize_overflow_as_typed_error() {
+    let error = inline_col_major_strides("test_static_indexing", &[usize::MAX, 2])
+        .expect_err("oversized dimensions must not panic or wrap");
+
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
+    );
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/indexing_alloc.rs
+++ b/crates/tenferro-cpu/src/indexing_alloc.rs
@@ -27,9 +27,21 @@ where
     TypedTensor::from_vec_col_major(shape, data)
 }
 
+pub(crate) fn pooled_zeroed_tensor<T>(
+    buffers: &mut BufferPool,
+    shape: Vec<usize>,
+) -> crate::Result<TypedTensor<T>>
+where
+    T: Clone + PoolScalar,
+{
+    let len = checked_shape_product("cpu_pooled_output", &shape)?;
+    let data = T::pool_acquire_zeroed(buffers, len);
+    TypedTensor::from_vec_col_major(shape, data)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::pooled_uninit_tensor;
+    use super::{pooled_uninit_tensor, pooled_zeroed_tensor};
     use crate::buffer_pool::BufferPool;
     use tenferro_tensor::{ErrorKind, ValidationKind};
 
@@ -52,5 +64,13 @@ mod tests {
             ErrorKind::Validation(ValidationKind::InvalidArgument)
         );
         assert!(error.to_string().contains("shape product overflow"));
+    }
+
+    #[test]
+    fn pooled_zeroed_tensor_is_valid_before_kernel_handoff() {
+        let mut buffers = BufferPool::new();
+        let output = pooled_zeroed_tensor::<bool>(&mut buffers, vec![2, 3]).unwrap();
+
+        assert_eq!(output.as_slice().unwrap(), &[false; 6]);
     }
 }

--- a/crates/tenferro-cpu/src/indexing_alloc.rs
+++ b/crates/tenferro-cpu/src/indexing_alloc.rs
@@ -40,6 +40,8 @@ where
 {
     pub(crate) fn new(buffers: &mut BufferPool, shape: Vec<usize>) -> crate::Result<Self> {
         let len = checked_shape_product("cpu_pooled_output", &shape)?;
+        // INVARIANT: this owner exposes only MaybeUninit storage until a
+        // full-overwrite caller proves initialization through assume_init.
         Ok(Self {
             shape,
             data: T::pool_acquire_uninit(buffers, len),
@@ -47,6 +49,10 @@ where
     }
 
     pub(crate) fn as_uninit_bytes_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        // INVARIANT: MaybeUninit<T> may be viewed as size_of::<T>() uninitialized
+        // bytes; no initialized T reference is constructed at this boundary.
+        // SAFETY: MaybeUninit<T> and its byte range share the same allocation,
+        // and the returned lifetime remains bounded by this exclusive borrow.
         unsafe {
             std::slice::from_raw_parts_mut(
                 self.data.as_mut_ptr().cast::<MaybeUninit<u8>>(),
@@ -63,6 +69,10 @@ where
     pub(crate) unsafe fn assume_init(self) -> crate::Result<TypedTensor<T>> {
         let Self { shape, data } = self;
         let mut data = ManuallyDrop::new(data);
+        // INVARIANT: the caller's successful full-overwrite replay initialized
+        // every element, and MaybeUninit<T> has the same allocation layout as T.
+        // SAFETY: the caller guarantees every element is initialized, while
+        // ManuallyDrop transfers the unchanged allocation exactly once.
         let initialized = unsafe {
             Vec::from_raw_parts(data.as_mut_ptr().cast::<T>(), data.len(), data.capacity())
         };
@@ -108,5 +118,18 @@ mod tests {
         let output = unsafe { output.assume_init() }.unwrap();
 
         assert_eq!(output.as_slice().unwrap(), &[false; 6]);
+    }
+
+    #[test]
+    fn pooled_uninit_output_error_drop_clears_in_flight_accounting() {
+        let mut buffers = BufferPool::new();
+        <bool as PoolScalar>::pool_release(&mut buffers, Vec::with_capacity(6));
+
+        let output = PooledUninitOutput::<bool>::new(&mut buffers, vec![2, 3]).unwrap();
+        drop(output);
+        buffers.clear_in_flight_retained();
+
+        assert_eq!(buffers.stats().buffers, 0);
+        assert_eq!(buffers.stats().capacity_bytes, 0);
     }
 }

--- a/crates/tenferro-cpu/src/indexing_alloc.rs
+++ b/crates/tenferro-cpu/src/indexing_alloc.rs
@@ -1,3 +1,5 @@
+use std::mem::{ManuallyDrop, MaybeUninit};
+
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::TypedTensor;
 
@@ -27,22 +29,51 @@ where
     TypedTensor::from_vec_col_major(shape, data)
 }
 
-pub(crate) fn pooled_zeroed_tensor<T>(
-    buffers: &mut BufferPool,
+pub(crate) struct PooledUninitOutput<T> {
     shape: Vec<usize>,
-) -> crate::Result<TypedTensor<T>>
+    data: Vec<MaybeUninit<T>>,
+}
+
+impl<T> PooledUninitOutput<T>
 where
     T: Clone + PoolScalar,
 {
-    let len = checked_shape_product("cpu_pooled_output", &shape)?;
-    let data = T::pool_acquire_zeroed(buffers, len);
-    TypedTensor::from_vec_col_major(shape, data)
+    pub(crate) fn new(buffers: &mut BufferPool, shape: Vec<usize>) -> crate::Result<Self> {
+        let len = checked_shape_product("cpu_pooled_output", &shape)?;
+        Ok(Self {
+            shape,
+            data: T::pool_acquire_uninit(buffers, len),
+        })
+    }
+
+    pub(crate) fn as_uninit_bytes_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        unsafe {
+            std::slice::from_raw_parts_mut(
+                self.data.as_mut_ptr().cast::<MaybeUninit<u8>>(),
+                std::mem::size_of_val(self.data.as_slice()),
+            )
+        }
+    }
+
+    /// Convert the owner after a full-overwrite kernel succeeds.
+    ///
+    /// # Safety
+    ///
+    /// Every element in `self.data` must contain a valid initialized `T`.
+    pub(crate) unsafe fn assume_init(self) -> crate::Result<TypedTensor<T>> {
+        let Self { shape, data } = self;
+        let mut data = ManuallyDrop::new(data);
+        let initialized = unsafe {
+            Vec::from_raw_parts(data.as_mut_ptr().cast::<T>(), data.len(), data.capacity())
+        };
+        TypedTensor::from_vec_col_major(shape, initialized)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{pooled_uninit_tensor, pooled_zeroed_tensor};
-    use crate::buffer_pool::BufferPool;
+    use super::{pooled_uninit_tensor, PooledUninitOutput};
+    use crate::buffer_pool::{BufferPool, PoolScalar};
     use tenferro_tensor::{ErrorKind, ValidationKind};
 
     #[test]
@@ -67,9 +98,14 @@ mod tests {
     }
 
     #[test]
-    fn pooled_zeroed_tensor_is_valid_before_kernel_handoff() {
+    fn pooled_uninit_output_reuses_stale_bool_storage_without_reading_it() {
         let mut buffers = BufferPool::new();
-        let output = pooled_zeroed_tensor::<bool>(&mut buffers, vec![2, 3]).unwrap();
+        <bool as PoolScalar>::pool_release(&mut buffers, vec![true; 6]);
+        let mut output = PooledUninitOutput::<bool>::new(&mut buffers, vec![2, 3]).unwrap();
+        output.data.iter_mut().for_each(|value| {
+            value.write(false);
+        });
+        let output = unsafe { output.assume_init() }.unwrap();
 
         assert_eq!(output.as_slice().unwrap(), &[false; 6]);
     }

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -1188,25 +1188,23 @@ where
     let mut out = clone_host_tensor_from_pool(buffers, op, tensor)?;
     let data = out.host_data_mut()?;
 
-    // Intentionally sequential: triangular masks are index-dependent in the
-    // innermost matrix plane and remain a dedicated CPU-kernel exception.
+    // Column-major matrices make each column contiguous. Clone once, then fill
+    // only the masked run instead of repeating per-element index arithmetic.
     for batch_idx in 0..batch_count {
         for col in 0..cols {
             let boundary = col as i128 - k as i128;
-            for row in 0..rows {
-                let row_idx = row;
-                let row = row_idx as i128;
-                let keep = if upper {
-                    row <= boundary
-                } else {
-                    row >= boundary
-                };
-                if !keep {
-                    let offset =
-                        checked_triangular_offset(op, batch_idx, block_size, col, rows, row_idx)?;
-                    data[offset] = fill;
-                }
-            }
+            let (masked_start, masked_end) = if upper {
+                (
+                    boundary.saturating_add(1).clamp(0, rows as i128) as usize,
+                    rows,
+                )
+            } else {
+                (0, boundary.clamp(0, rows as i128) as usize)
+            };
+            let start =
+                checked_triangular_offset(op, batch_idx, block_size, col, rows, masked_start)?;
+            let end = checked_triangular_offset(op, batch_idx, block_size, col, rows, masked_end)?;
+            data[start..end].fill(fill);
         }
     }
 

--- a/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
@@ -322,7 +322,7 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
 #[test]
 fn static_erased_indexing_preserves_bool_values_and_empty_shapes() {
     let mut backend = CpuBackend::with_threads(2).unwrap();
-    let input = Tensor::from_vec_col_major(vec![4], vec![true, false, true, false]).unwrap();
+    let mut input = Tensor::from_vec_col_major(vec![4], vec![true, false, true, false]).unwrap();
     let sliced = backend
         .slice(
             &input,
@@ -344,6 +344,20 @@ fn static_erased_indexing_preserves_bool_values_and_empty_shapes() {
     assert_eq!(
         concatenated.as_slice::<bool>().unwrap(),
         &[false, false, false, true, false, true]
+    );
+    let Tensor::Bool(input) = &mut input else {
+        panic!("test input must remain Bool");
+    };
+    input.host_data_mut().unwrap().fill(true);
+    assert_eq!(
+        sliced.as_slice::<bool>().unwrap(),
+        &[false, false],
+        "mutating the input after handoff must not change the copied output"
+    );
+    assert_eq!(
+        reversed.as_slice::<bool>().unwrap(),
+        &[false, true, false, true],
+        "static replay outputs must own their destination storage"
     );
 
     let empty = Tensor::from_vec_col_major(vec![0], Vec::<bool>::new()).unwrap();

--- a/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
@@ -320,6 +320,71 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
 }
 
 #[test]
+fn static_erased_indexing_preserves_bool_values_and_empty_shapes() {
+    let mut backend = CpuBackend::with_threads(2).unwrap();
+    let input = Tensor::from_vec_col_major(vec![4], vec![true, false, true, false]).unwrap();
+    let sliced = backend
+        .slice(
+            &input,
+            &SliceConfig {
+                starts: vec![1],
+                limits: vec![4],
+                strides: vec![2],
+            },
+        )
+        .unwrap();
+    assert_eq!(sliced.as_slice::<bool>().unwrap(), &[false, false]);
+
+    let reversed = backend.reverse(&input, &[0]).unwrap();
+    assert_eq!(
+        reversed.as_slice::<bool>().unwrap(),
+        &[false, true, false, true]
+    );
+    let concatenated = backend.concatenate(&[&sliced, &reversed], 0).unwrap();
+    assert_eq!(
+        concatenated.as_slice::<bool>().unwrap(),
+        &[false, false, false, true, false, true]
+    );
+
+    let empty = Tensor::from_vec_col_major(vec![0], Vec::<bool>::new()).unwrap();
+    let empty_slice = backend
+        .slice(
+            &empty,
+            &SliceConfig {
+                starts: vec![0],
+                limits: vec![0],
+                strides: vec![1],
+            },
+        )
+        .unwrap();
+    assert!(empty_slice.as_slice::<bool>().unwrap().is_empty());
+    assert!(backend
+        .reverse(&empty, &[0])
+        .unwrap()
+        .as_slice::<bool>()
+        .unwrap()
+        .is_empty());
+    assert!(backend
+        .concatenate(&[&empty, &empty], 0)
+        .unwrap()
+        .as_slice::<bool>()
+        .unwrap()
+        .is_empty());
+
+    let padded = backend
+        .pad(
+            &empty,
+            &PadConfig {
+                edge_padding_low: vec![1],
+                edge_padding_high: vec![2],
+                interior_padding: vec![0],
+            },
+        )
+        .unwrap();
+    assert_eq!(padded.as_slice::<bool>().unwrap(), &[false; 3]);
+}
+
+#[test]
 fn cpu_indexing_validation_covers_error_branches() {
     let mut backend = CpuBackend::new();
     let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());

--- a/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
@@ -726,6 +726,25 @@ fn test_triu_3x3() {
 }
 
 #[test]
+fn test_triangular_masks_rectangular_batched_nonzero_diagonal() {
+    let t = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3, 2], (1..=12).map(f64::from).collect()).unwrap(),
+    );
+
+    let lower = tril(&t, 1).unwrap();
+    assert_eq!(
+        lower.as_slice::<f64>().unwrap(),
+        &[1.0, 2.0, 3.0, 4.0, 0.0, 6.0, 7.0, 8.0, 9.0, 10.0, 0.0, 12.0]
+    );
+
+    let upper = triu(&t, 1).unwrap();
+    assert_eq!(
+        upper.as_slice::<f64>().unwrap(),
+        &[0.0, 0.0, 3.0, 0.0, 5.0, 6.0, 0.0, 0.0, 9.0, 0.0, 11.0, 12.0]
+    );
+}
+
+#[test]
 fn test_tril_triu_zero_sized_batch_return_empty_tensor() {
     let t = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2, 0], Vec::new()).unwrap());
 

--- a/crates/tenferro-cpu/tests/integration/backend_capability_contracts.rs
+++ b/crates/tenferro-cpu/tests/integration/backend_capability_contracts.rs
@@ -418,12 +418,9 @@ fn concatenate_hot_loop_does_not_linearly_scan_input_segments() {
     let indexing_source = include_str!("../../src/indexing.rs");
 
     assert!(
-        !indexing_source.contains(".position(|&end| concat_idx < end)"),
-        "concatenate should not linearly scan all input segment ends for each output element"
-    );
-    assert!(
-        indexing_source.contains("partition_point"),
-        "concatenate should use precomputed ordered segment boundaries for logarithmic lookup"
+        indexing_source.contains("ErasedConcatenatePlan::compile")
+            && !indexing_source.contains("partition_point"),
+        "concatenate traversal and segment lookup should be owned by strided-kernel"
     );
 }
 

--- a/crates/tenferro-cpu/tests/integration/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/integration/runtime_error_tests.rs
@@ -211,9 +211,8 @@ fn cpu_reshape_concatenate_scatter_use_checked_boundary_arithmetic_contract() {
         "CPU concatenate must check output-axis extent accumulation"
     );
     assert!(
-        concat_section.contains("segment_end")
-            && concat_section.contains(".checked_add(input.shape()[axis])"),
-        "CPU concatenate must check segment prefix offsets"
+        concat_section.contains("ErasedConcatenatePlan::compile"),
+        "CPU concatenate must delegate checked segment prefix arithmetic to strided-kernel"
     );
 
     let scatter_section = source_section(indexing, "fn typed_scatter", "fn typed_dynamic_slice");

--- a/crates/tenferro-internal-cpu-kernels/src/buffer_pool.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/buffer_pool.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 use std::env;
 use std::ffi::OsString;
 use std::fmt;
-use std::mem::size_of;
+use std::mem::{size_of, ManuallyDrop, MaybeUninit};
 use std::sync::OnceLock;
 
 use num_complex::{Complex32, Complex64};
@@ -145,6 +145,13 @@ pub trait PoolScalar: Copy + Sized + Send + Sync + private::Sealed {
     /// assert_eq!(buf, vec![1.0, 2.0]);
     /// ```
     unsafe fn pool_acquire(pool: &mut BufferPool, len: usize) -> Vec<Self>;
+
+    /// Acquire a buffer whose elements may be uninitialized.
+    ///
+    /// The returned `MaybeUninit` vector remains safe to drop after an error
+    /// or panic. Convert it back to `Vec<Self>` only after every element has
+    /// been initialized.
+    fn pool_acquire_uninit(pool: &mut BufferPool, len: usize) -> Vec<MaybeUninit<Self>>;
 
     /// Acquire a buffer with length `len` and every element set to zero.
     ///
@@ -300,6 +307,36 @@ macro_rules! impl_pool_scalar {
                         let mut buf = Vec::with_capacity(len);
                         // SAFETY: raw acquire requires caller full-overwrite; len == capacity here.
                         unsafe { buf.set_len(len) };
+                        buf
+                    }
+                }
+            }
+
+            fn pool_acquire_uninit(pool: &mut BufferPool, len: usize) -> Vec<MaybeUninit<Self>> {
+                match take_best_fit(&mut pool.$field, len) {
+                    Some(buf) => {
+                        pool.retained_capacity_bytes = pool
+                            .retained_capacity_bytes
+                            .saturating_sub(buf.capacity().saturating_mul(size_of::<Self>()));
+                        increment_in_flight(&mut pool.$in_flight, buf.capacity());
+                        let mut buf = ManuallyDrop::new(buf);
+                        // SAFETY: `MaybeUninit<Self>` has the same layout as
+                        // `Self`; best-fit guarantees `len <= capacity`, and
+                        // ManuallyDrop transfers allocation ownership.
+                        unsafe {
+                            Vec::from_raw_parts(
+                                buf.as_mut_ptr().cast::<MaybeUninit<Self>>(),
+                                len,
+                                buf.capacity(),
+                            )
+                        }
+                    }
+                    None => {
+                        let mut buf = Vec::with_capacity(len);
+                        // SAFETY: every bit pattern is valid for MaybeUninit.
+                        unsafe {
+                            buf.set_len(len);
+                        }
                         buf
                     }
                 }

--- a/crates/tenferro-internal-cpu-kernels/src/buffer_pool.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/buffer_pool.rs
@@ -151,6 +151,18 @@ pub trait PoolScalar: Copy + Sized + Send + Sync + private::Sealed {
     /// The returned `MaybeUninit` vector remains safe to drop after an error
     /// or panic. Convert it back to `Vec<Self>` only after every element has
     /// been initialized.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_internal_cpu_kernels::buffer_pool::{BufferPool, PoolScalar};
+    ///
+    /// let mut pool = BufferPool::new();
+    /// let mut buf = <f64 as PoolScalar>::pool_acquire_uninit(&mut pool, 2);
+    /// buf[0].write(1.0);
+    /// buf[1].write(2.0);
+    /// assert_eq!(unsafe { buf[1].assume_init_ref() }, &2.0);
+    /// ```
     fn pool_acquire_uninit(pool: &mut BufferPool, len: usize) -> Vec<MaybeUninit<Self>>;
 
     /// Acquire a buffer with length `len` and every element set to zero.
@@ -313,6 +325,8 @@ macro_rules! impl_pool_scalar {
             }
 
             fn pool_acquire_uninit(pool: &mut BufferPool, len: usize) -> Vec<MaybeUninit<Self>> {
+                // INVARIANT: PoolScalar is sealed to Copy scalars, so
+                // MaybeUninit<Self> preserves allocation layout and drop safety.
                 match take_best_fit(&mut pool.$field, len) {
                     Some(buf) => {
                         pool.retained_capacity_bytes = pool

--- a/crates/tenferro-internal-cpu-kernels/src/buffer_pool/tests.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/buffer_pool/tests.rs
@@ -135,6 +135,62 @@ fn uninit_acquire_reuses_storage_and_can_be_initialized_before_release() {
 }
 
 #[test]
+fn uninit_acquire_error_cleanup_drops_owner_and_clears_in_flight_accounting() {
+    let mut pool = BufferPool::new();
+    <bool as PoolScalar>::pool_release(&mut pool, Vec::with_capacity(4));
+
+    let in_flight = <bool as PoolScalar>::pool_acquire_uninit(&mut pool, 4);
+    drop(in_flight);
+    pool.clear_in_flight_retained();
+
+    assert_eq!(pool.stats().buffers, 0);
+    assert_eq!(pool.stats().capacity_bytes, 0);
+    assert!(pool.bool_in_flight.is_empty());
+}
+
+#[test]
+fn uninit_acquire_panic_cleanup_replenishes_only_an_empty_replacement() {
+    let mut pool = BufferPool::new();
+    <bool as PoolScalar>::pool_release(&mut pool, Vec::with_capacity(4));
+
+    let mut in_flight = <bool as PoolScalar>::pool_acquire_uninit(&mut pool, 4);
+    in_flight[0].write(true);
+    drop(in_flight);
+    pool.replenish_in_flight_retained();
+
+    let replacements = pool.bool_pool.get(&4).unwrap();
+    assert_eq!(replacements.len(), 1);
+    assert!(replacements[0].is_empty());
+    assert_eq!(pool.retained_capacity_bytes(), 4 * size_of::<bool>());
+    assert!(pool.bool_in_flight.is_empty());
+}
+
+#[test]
+fn uninit_acquire_success_release_is_accounted_once() {
+    let mut pool = BufferPool::new();
+    <bool as PoolScalar>::pool_release(&mut pool, Vec::with_capacity(4));
+    let expected = pool.stats();
+
+    let mut reused = <bool as PoolScalar>::pool_acquire_uninit(&mut pool, 4);
+    reused.iter_mut().for_each(|value| {
+        value.write(true);
+    });
+    let mut reused = ManuallyDrop::new(reused);
+    let initialized = unsafe {
+        Vec::from_raw_parts(
+            reused.as_mut_ptr().cast::<bool>(),
+            reused.len(),
+            reused.capacity(),
+        )
+    };
+    <bool as PoolScalar>::pool_release(&mut pool, initialized);
+    pool.replenish_in_flight_retained();
+
+    assert_eq!(pool.stats(), expected);
+    assert!(pool.bool_in_flight.is_empty());
+}
+
+#[test]
 fn zero_len_not_pooled() {
     let mut pool = BufferPool::new();
     <f64 as PoolScalar>::pool_release(&mut pool, Vec::new());

--- a/crates/tenferro-internal-cpu-kernels/src/buffer_pool/tests.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/buffer_pool/tests.rs
@@ -1,4 +1,4 @@
-use std::mem::size_of;
+use std::mem::{size_of, ManuallyDrop};
 
 use super::{
     parse_default_max_retained_capacity_bytes, BufferPool, PoolScalar,
@@ -107,6 +107,31 @@ fn raw_acquire_does_not_zero_initialized_reused_buffers() {
     let reused = unsafe { <f64 as PoolScalar>::pool_acquire(&mut pool, 4) };
 
     assert_eq!(reused, vec![7.0, 8.0, 9.0, 10.0]);
+}
+
+#[test]
+fn uninit_acquire_reuses_storage_and_can_be_initialized_before_release() {
+    let mut pool = BufferPool::new();
+    let original = vec![true; 4];
+    let ptr = original.as_ptr();
+    <bool as PoolScalar>::pool_release(&mut pool, original);
+
+    let mut reused = <bool as PoolScalar>::pool_acquire_uninit(&mut pool, 4);
+    assert_eq!(reused.as_ptr().cast::<bool>(), ptr);
+    reused.iter_mut().for_each(|value| {
+        value.write(false);
+    });
+    let mut reused = ManuallyDrop::new(reused);
+    let initialized = unsafe {
+        Vec::from_raw_parts(
+            reused.as_mut_ptr().cast::<bool>(),
+            reused.len(),
+            reused.capacity(),
+        )
+    };
+    assert_eq!(initialized, vec![false; 4]);
+    <bool as PoolScalar>::pool_release(&mut pool, initialized);
+    assert_eq!(pool.len(), 1);
 }
 
 #[test]

--- a/docs/worklogs/2026-07-29-issue-1512-static-indexing.md
+++ b/docs/worklogs/2026-07-29-issue-1512-static-indexing.md
@@ -1,0 +1,103 @@
+# Issue 1512: static indexing plan adoption
+
+## Summary
+
+Replaced the local CPU per-element implementations of slice, pad,
+concatenate, and reverse with the corresponding strided-kernel erased plans.
+Triangular masking now fills contiguous column runs instead of performing
+per-element index classification.
+
+## Context read
+
+- `REPOSITORY_RULES.md`, especially performance evidence, explicit CPU
+  execution context, destination aliasing, and upstream ownership
+- tenferro-rs issues #1490 and #1512
+- strided-rs issues #149, #160, and #170
+- the existing CPU backend, execution-session, buffer-pool, static-indexing,
+  and structural implementations
+
+## Design
+
+- `CpuBackend` and `CpuExecutionSession` pass their pooled
+  `ExecContext` explicitly to every erased static plan replay.
+- Static outputs are acquired zero-initialized from the CPU buffer pool before
+  safe typed slices and erased descriptors are
+  constructed. This avoids exposing the pool's legacy typed-uninitialized
+  acquisition to the new paths.
+- Short-rank column-major strides use inline `SmallVec` storage with checked
+  `usize` to `isize` conversion and multiplication. A zero extent keeps all
+  subsequent strides at zero without converting unreachable large extents.
+- Slice, pad, concatenate, and reverse preserve the upstream plan's typed
+  shape, stride, offset, and overlap validation.
+- Triangular operations retain their local semantics but classify one boundary
+  per matrix column, copying the kept run and filling the masked run.
+- Tests cover Bool values, empty dimensions, rectangular and batched
+  triangular tensors, and nonzero diagonal offsets.
+- Source-contract tests now require delegation to upstream erased plans rather
+  than the removed local segment-prefix and per-element loops.
+
+## Stop-the-line and upstream fix
+
+The first adoption benchmark found that scalar `ErasedPadPlan` replay regressed
+the exact public API pad row at one thread by about 60 percent. Work stopped
+before opening the tenferro PR. The missing contiguous-run coalescing was filed
+as strided-rs #170 and implemented upstream as compile-time run metadata with a
+generic strided fallback.
+
+Exact `cpu/indexing_layout/pad` measurements used 15 measured runs after three
+warmups:
+
+| Row | Pre-adoption | Scalar adopted | Run-coalesced |
+|---|---:|---:|---:|
+| eager t1 | 16.103 ms | 25.948 ms | 1.078 ms |
+| trace t1 | 15.895 ms | 25.449 ms | 1.133 ms |
+| eager t4 | 16.127 ms | 4.873 ms | 1.096 ms |
+| trace t4 | 17.226 ms | 4.800 ms | 1.126 ms |
+
+strided-rs PR #171 added contiguous pad runs. The fixed tenferro allocation
+gate then exposed per-call exact injectivity-check allocation during static
+plan compile; strided-rs PR #173 moved the existing disjoint-stride proof
+ahead of exact enumeration and added checked offset/fusion arithmetic. All
+workspace strided dependencies are pinned to merged commit `e18ecb10`. The
+final exact-row comparison used the equivalent #171 kernel state, 15 measured
+runs after three warmups, t1 pinned to CPU 60, and t4 pinned to CPUs 56-59:
+
+| Operation | Backend | t1 | t4 |
+|---|---|---:|---:|
+| slice | eager | -86.4% | -85.5% |
+| slice | trace | -85.7% | -86.3% |
+| pad | eager | -92.2% | -92.2% |
+| pad | trace | -92.1% | -92.7% |
+| concatenate | eager | -94.9% | -94.6% |
+| concatenate | trace | -94.9% | -94.6% |
+| reverse | eager | -90.4% | -88.9% |
+| reverse | trace | -90.4% | -89.5% |
+| tril | eager | -27.3% | -22.7% |
+| tril | trace | -27.7% | -23.9% |
+| triu | eager | -29.3% | -23.3% |
+| triu | trace | -28.2% | -20.8% |
+
+Every predeclared row improved; no row approached the +20 percent blocking
+threshold. The measurements used the same benchmark binaries and machine
+profile for each baseline/candidate pair. PR #173 changes compile-time
+validation only; the final pin is rechecked by the fixed allocation gate and
+the complete CPU test suite.
+
+## Independent review follow-up
+
+The final review identified that the pre-existing `PoolScalar::pool_acquire`
+API can expose typed uninitialized storage before a kernel completes. The new
+static indexing paths were changed to the safe zero-initialized acquisition
+path before descriptor construction. The repository-wide `MaybeUninit` owner
+and handoff redesign is tracked separately in #1516 so that it can cover every
+legacy caller without hiding a broad safety change inside this performance PR.
+
+The same review found unchecked arithmetic in the inline stride helper. The
+helper now returns typed validation errors on conversion or multiplication
+overflow, and tests cover overflow, a zero extent followed by an unreachable
+large extent, and rank nine spilling beyond the inline capacity.
+
+The eight static-indexing rows in the table were remeasured after the safe
+acquisition change with the same 15-run/three-warmup protocol and CPU binding.
+The additional initialization cost reduces part of the gain but every row
+still improves by 85.5 to 94.9 percent relative to `origin/main`.

--- a/docs/worklogs/2026-07-29-issue-1512-static-indexing.md
+++ b/docs/worklogs/2026-07-29-issue-1512-static-indexing.md
@@ -20,10 +20,9 @@ per-element index classification.
 
 - `CpuBackend` and `CpuExecutionSession` pass their pooled
   `ExecContext` explicitly to every erased static plan replay.
-- Static outputs are acquired zero-initialized from the CPU buffer pool before
-  safe typed slices and erased descriptors are
-  constructed. This avoids exposing the pool's legacy typed-uninitialized
-  acquisition to the new paths.
+- Static outputs are acquired as `Vec<MaybeUninit<T>>` from the CPU buffer
+  pool. The upstream full-overwrite descriptor never constructs `&mut [T]`
+  before replay, and converts the owner to `Vec<T>` only after success.
 - Short-rank column-major strides use inline `SmallVec` storage with checked
   `usize` to `isize` conversion and multiplication. A zero extent keeps all
   subsequent strides at zero without converting unreachable large extents.
@@ -58,24 +57,25 @@ strided-rs PR #171 added contiguous pad runs. The fixed tenferro allocation
 gate then exposed per-call exact injectivity-check allocation during static
 plan compile; strided-rs PR #173 moved the existing disjoint-stride proof
 ahead of exact enumeration and added checked offset/fusion arithmetic. All
-workspace strided dependencies are pinned to merged commit `e18ecb10`. The
-final exact-row comparison used the equivalent #171 kernel state, 15 measured
-runs after three warmups, t1 pinned to CPU 60, and t4 pinned to CPUs 56-59:
+workspace strided dependencies are pinned to merged commit `ed3053a6`, which
+also includes PR #175's safe uninitialized full-overwrite replay. The final
+exact-row comparison used that merged state, 15 measured runs after three
+warmups, t1 pinned to CPU 60, and t4 pinned to CPUs 56-59:
 
 | Operation | Backend | t1 | t4 |
 |---|---|---:|---:|
-| slice | eager | -86.4% | -85.5% |
-| slice | trace | -85.7% | -86.3% |
-| pad | eager | -92.2% | -92.2% |
-| pad | trace | -92.1% | -92.7% |
-| concatenate | eager | -94.9% | -94.6% |
-| concatenate | trace | -94.9% | -94.6% |
-| reverse | eager | -90.4% | -88.9% |
-| reverse | trace | -90.4% | -89.5% |
-| tril | eager | -27.3% | -22.7% |
-| tril | trace | -27.7% | -23.9% |
-| triu | eager | -29.3% | -23.3% |
-| triu | trace | -28.2% | -20.8% |
+| slice | eager | -89.7% | -89.0% |
+| slice | trace | -89.2% | -86.3% |
+| pad | eager | -93.5% | -93.8% |
+| pad | trace | -93.6% | -88.8% |
+| concatenate | eager | -96.6% | -96.3% |
+| concatenate | trace | -96.3% | -95.6% |
+| reverse | eager | -92.7% | -91.4% |
+| reverse | trace | -92.6% | -91.7% |
+| tril | eager | -28.3% | -25.6% |
+| tril | trace | -27.2% | -24.8% |
+| triu | eager | -27.9% | -25.1% |
+| triu | trace | -28.9% | -23.7% |
 
 Every predeclared row improved; no row approached the +20 percent blocking
 threshold. The measurements used the same benchmark binaries and machine
@@ -86,18 +86,20 @@ the complete CPU test suite.
 ## Independent review follow-up
 
 The final review identified that the pre-existing `PoolScalar::pool_acquire`
-API can expose typed uninitialized storage before a kernel completes. The new
-static indexing paths were changed to the safe zero-initialized acquisition
-path before descriptor construction. The repository-wide `MaybeUninit` owner
-and handoff redesign is tracked separately in #1516 so that it can cover every
-legacy caller without hiding a broad safety change inside this performance PR.
+API can expose typed uninitialized storage before a kernel completes. The
+temporary zero-initialized fix violated the full-overwrite materialization
+rule, so strided-rs #174 / PR #175 added a narrow
+`ErasedRawStridedUninitMut` contract. The CPU pool now hands these four paths
+`Vec<MaybeUninit<T>>` directly and remains safely droppable on error or panic.
+Issue #1516 continues to track the remaining legacy typed-uninitialized
+callers outside this static indexing scope.
 
 The same review found unchecked arithmetic in the inline stride helper. The
 helper now returns typed validation errors on conversion or multiplication
 overflow, and tests cover overflow, a zero extent followed by an unreachable
 large extent, and rank nine spilling beyond the inline capacity.
 
-The eight static-indexing rows in the table were remeasured after the safe
-acquisition change with the same 15-run/three-warmup protocol and CPU binding.
-The additional initialization cost reduces part of the gain but every row
-still improves by 85.5 to 94.9 percent relative to `origin/main`.
+All rows in the table were remeasured after the safe acquisition change with
+the same 15-run/three-warmup protocol and CPU binding. Static indexing improves
+by 86.3 to 96.6 percent and triangular masking by 23.7 to 28.9 percent relative
+to the pre-adoption baseline.

--- a/docs/worklogs/2026-07-29-issue-1512-static-indexing.md
+++ b/docs/worklogs/2026-07-29-issue-1512-static-indexing.md
@@ -94,6 +94,12 @@ rule, so strided-rs #174 / PR #175 added a narrow
 Issue #1516 continues to track the remaining legacy typed-uninitialized
 callers outside this static indexing scope.
 
+The follow-up unsafe review found no memory-safety defect. It required explicit
+`// INVARIANT:` markers at each raw acquisition, byte-view, and initialized
+handoff boundary, plus direct normal-error, panic-replenishment, and
+success-release accounting tests. Those tests confirm that partial storage is
+never returned to the pool and that replacement capacity is accounted once.
+
 The same review found unchecked arithmetic in the inline stride helper. The
 helper now returns typed validation errors on conversion or multiplication
 overflow, and tests cover overflow, a zero extent followed by an unreachable

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "649772c8402e5fe95335366326b6623f9a4f5b0a"
+        revision = "ed3053a6b096bc53d2a286ce918ff88b684eadce"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
## Summary
- adopt merged strided erased slice, pad, concatenate, and reverse plans with explicit pooled `ExecContext`
- coalesce `tril`/`triu` masking into contiguous column runs
- pin strided-rs at merged `ed3053a6` (pad run coalescing #171, allocation-free injectivity proof #173, safe full-overwrite replay #175)
- keep full-overwrite outputs as `MaybeUninit` until successful replay; retain #1516 for remaining legacy typed-uninitialized callers

Closes #1512.

## Performance
Exact public API rows, 15 runs / 3 warmups, t1 CPU 60, t4 CPUs 56-59, baseline `035c02b0`:

| Operation | Backend | t1 | t4 |
|---|---|---:|---:|
| slice | eager | -89.7% | -89.0% |
| slice | trace | -89.2% | -86.3% |
| pad | eager | -93.5% | -93.8% |
| pad | trace | -93.6% | -88.8% |
| concatenate | eager | -96.6% | -96.3% |
| concatenate | trace | -96.3% | -95.6% |
| reverse | eager | -92.7% | -91.4% |
| reverse | trace | -92.6% | -91.7% |
| tril | eager | -28.3% | -25.6% |
| tril | trace | -27.2% | -24.8% |
| triu | eager | -27.9% | -25.1% |
| triu | trace | -28.9% | -23.7% |

Every predeclared row improved; no +20% gate regression. Full details and the earlier scalar-pad stop-the-line result are in [`docs/worklogs/2026-07-29-issue-1512-static-indexing.md`](https://github.com/tensor4all/tenferro-rs/blob/codex/issue-1512-static-indexing/docs/worklogs/2026-07-29-issue-1512-static-indexing.md).

## Verification
- `cargo test -p tenferro-cpu --features cpu-faer`: 502 unit, 48 integration, 3 allocation, 183 doctests
- `bash scripts/check-pr-fast.sh --coverage-reviewed ...`: pass, including workspace and extension clippy
- repository rules review: pass, no findings
- exact public API benchmark rows at t1 and t4: pass

## Provenance
- upstream strided-rs PRs: tensor4all/strided-rs#171, #173, #175
- safety follow-up: #1516