### PR TITLE
chore: adopt strided reduction kernels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "ed3053a6b096bc53d2a286ce918ff88b684eadce", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "ed3053a6b096bc53d2a286ce918ff88b684eadce", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "ed3053a6b096bc53d2a286ce918ff88b684eadce", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "ed3053a6b096bc53d2a286ce918ff88b684eadce", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "ed3053a6b096bc53d2a286ce918ff88b684eadce", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "1460ab4b5f1720fe5e45bb1eb90844e09d8fd739", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "1460ab4b5f1720fe5e45bb1eb90844e09d8fd739", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "1460ab4b5f1720fe5e45bb1eb90844e09d8fd739", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "1460ab4b5f1720fe5e45bb1eb90844e09d8fd739", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "1460ab4b5f1720fe5e45bb1eb90844e09d8fd739", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/docs/worklogs/2026-07-30-strided-reduction-adoption.md
+++ b/docs/worklogs/2026-07-30-strided-reduction-adoption.md
@@ -59,6 +59,9 @@ that reference, and the worst baseline-relative change is +2.7 percent.
   no records by filter.
 - The repository-rules review is run against the committed adoption diff
   before the PR is opened.
+- The CI build-artifact source-contract test is advanced with the pin so it
+  continues to require one exact merged revision across all five strided
+  workspace dependencies.
 
 ## Remaining Work
 

--- a/docs/worklogs/2026-07-30-strided-reduction-adoption.md
+++ b/docs/worklogs/2026-07-30-strided-reduction-adoption.md
@@ -1,0 +1,68 @@
+# Strided Reduction Kernel Adoption
+
+## Summary
+
+Advanced every workspace strided-rs dependency from `ed3053a6` to merged
+commit `1460ab4b`. The new upstream kernel gives compact full sum and product
+reductions a fixed multi-accumulator implementation while preserving
+tenferro's explicit CPU `ExecContext` threading boundary.
+
+## Context Read
+
+- tenferro-rs issues #1490 and #1505
+- strided-rs issues #149 and #167
+- strided-rs PR #176 and its accumulation-order policy comments
+- `AGENTS.md`, `REPOSITORY_RULES.md`, and the shared tensor4all Rust,
+  performance, numerical, documentation, and test rules
+- the root-facade oracle replay harness and nightly workflow
+
+## Design And Numerical Contract
+
+- The adoption changes only the merged dependency pin. CPU reduction replay
+  already passes the backend-owned bounded `ExecContext`; no ambient Rayon
+  state is introduced.
+- Compact full reductions now use upstream's documented fixed association.
+  `ExecContext::serial()` and `ExecContext::max_threads(1)` select the same
+  serial algorithm.
+- Floating reassociation may change roundoff, signed zero, NaN details, and
+  intermediate overflow or underflow classification. Arithmetic remains in
+  the input dtype, fixed-context reproducibility remains required, and no
+  tenferro oracle tolerance or benchmark threshold is changed.
+- Noncompact and axis reductions retain their existing traversal in this
+  adoption. Fused sum-of-squares remains the separate #1505 close-out step.
+
+## Performance Evidence
+
+The focused public API benchmark used the full profile with 15 measured runs
+after three warmups. The f64 `8192x4096` rows were pinned to CPU 60 for one
+thread and CPUs 56-59 for four threads.
+
+| Row | Baseline t1 | Candidate t1 | Baseline t4 | Candidate t4 |
+| --- | ---: | ---: | ---: | ---: |
+| sum eager | 28.207 ms | 10.163 ms | 8.040 ms | 7.583 ms |
+| sum trace | 28.332 ms | 10.210 ms | 7.652 ms | 7.398 ms |
+| product eager | 28.308 ms | 10.162 ms | 8.443 ms | 7.459 ms |
+| product trace | 28.315 ms | 10.236 ms | 8.098 ms | 8.314 ms |
+
+Same-machine PyTorch measured 10.130/10.133 ms at one thread and
+5.894/5.856 ms at four threads for sum/product. The candidate is within 2x of
+that reference, and the worst baseline-relative change is +2.7 percent.
+
+## Verification
+
+- The upstream PR passed strided-rs workspace tests, documentation, formatting,
+  and the 53-file coverage policy on Linux CI, plus the macOS test job.
+- tenferro's fast-check passed with the focused CPU reduction tests.
+- The full root-facade linalg oracle replay used 56 workers and passed all
+  2,090 supported-success records plus both expected-error records. It
+  classified 7,493 of 9,585 records as intentionally unsupported and skipped
+  no records by filter.
+- The repository-rules review is run against the committed adoption diff
+  before the PR is opened.
+
+## Remaining Work
+
+- #1505 owns the fused single-pass sum-of-squares implementation and its
+  `norm_fro` acceptance measurement.
+- The final full public API campaign and cross-row gate verdict remain under
+  #1490.

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "ed3053a6b096bc53d2a286ce918ff88b684eadce"
+        revision = "1460ab4b5f1720fe5e45bb1eb90844e09d8fd739"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
## Summary
- advance all workspace strided-rs dependencies to merged reduction-kernel commit `1460ab4b`
- retain the existing backend-owned explicit `ExecContext` wiring
- record the association contract, focused public API evidence, and oracle result

Upstream: tensor4all/strided-rs#176. Follow-up for fused sum-of-squares: #1505. Final campaign: #1490.

Worklog: [`docs/worklogs/2026-07-30-strided-reduction-adoption.md`](docs/worklogs/2026-07-30-strided-reduction-adoption.md)

## Performance
Full-profile focused rows, 15 runs / 3 warmups, f64 `8192x4096`:

| row | baseline t1 ms | candidate t1 ms | baseline t4 ms | candidate t4 ms |
|---|---:|---:|---:|---:|
| sum eager | 28.207 | 10.163 | 8.040 | 7.583 |
| sum trace | 28.332 | 10.210 | 7.652 | 7.398 |
| product eager | 28.308 | 10.162 | 8.443 | 7.459 |
| product trace | 28.315 | 10.236 | 8.098 | 8.314 |

Same-machine PyTorch is 10.130/10.133 ms at t1 and 5.894/5.856 ms at t4. No +20% gate breach; worst baseline-relative row is +2.7%.

## Verification
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-cpu test_reduce'`
- `RUN_ORACLE_REPLAY=1 ORACLE_REPLAY_JOBS=56 ... oracle_replays_supported_db_cases_when_requested`: 2,090 supported + 2 expected-error passed; 0 filtered
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD ...`: pass, no findings
