### PR TITLE
perf(linalg): fuse real sum-of-squares reduction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "1460ab4b5f1720fe5e45bb1eb90844e09d8fd739", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "1460ab4b5f1720fe5e45bb1eb90844e09d8fd739", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "1460ab4b5f1720fe5e45bb1eb90844e09d8fd739", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "1460ab4b5f1720fe5e45bb1eb90844e09d8fd739", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "1460ab4b5f1720fe5e45bb1eb90844e09d8fd739", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "95a607c061e95cc3a698a083dd279283a905f99c", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "95a607c061e95cc3a698a083dd279283a905f99c", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "95a607c061e95cc3a698a083dd279283a905f99c", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "95a607c061e95cc3a698a083dd279283a905f99c", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "95a607c061e95cc3a698a083dd279283a905f99c", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/crates/tenferro-ad/src/eager_backend.rs
+++ b/crates/tenferro-ad/src/eager_backend.rs
@@ -231,6 +231,7 @@ impl TensorStructural for RecordingBackend {
 impl TensorReduction for RecordingBackend {
     delegate_recording_backend_methods! {
         fn reduce_sum(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+        fn reduce_sum_squares_read(input: TensorRead<'_>, axes: &[usize]) -> TensorResult<Tensor>;
         fn reduce_prod(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
         fn reduce_max(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
         fn reduce_min(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
@@ -384,6 +385,7 @@ impl TensorStructural for EagerBackend {
 impl TensorReduction for EagerBackend {
     delegate_tensor_backend_methods! {
         fn reduce_sum(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+        fn reduce_sum_squares_read(input: TensorRead<'_>, axes: &[usize]) -> TensorResult<Tensor>;
         fn reduce_prod(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
         fn reduce_max(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
         fn reduce_min(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;

--- a/crates/tenferro-ad/src/eager_exec.rs
+++ b/crates/tenferro-ad/src/eager_exec.rs
@@ -443,6 +443,9 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
         StdTensorOp::ReduceSum { axes, .. } => {
             vec![exec.reduce_sum_read(inputs[0].clone(), axes)?]
         }
+        StdTensorOp::ReduceSumSquares { axes, .. } => {
+            vec![exec.reduce_sum_squares_read(inputs[0].clone(), axes)?]
+        }
         StdTensorOp::DotGeneral { config, .. } => {
             let (a, b) = promote_binary_reads(exec, inputs[0].clone(), inputs[1].clone(), op)?;
             vec![exec.dot_general_read(a.tensor_read(), b.tensor_read(), config)?]
@@ -703,6 +706,12 @@ fn exec_standard_op_on_tensors<B: TensorBackend>(
             }
             StdTensorOp::Transpose { perm } => vec![exec.transpose(inputs[0], perm)?],
             StdTensorOp::ReduceSum { axes, .. } => vec![exec.reduce_sum(inputs[0], axes)?],
+            StdTensorOp::ReduceSumSquares { axes, .. } => {
+                vec![exec.reduce_sum_squares_read(
+                    tenferro_tensor::TensorRead::from_tensor(inputs[0]),
+                    axes,
+                )?]
+            }
             StdTensorOp::DotGeneral { config, .. } => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
                 vec![exec.dot_general(a.tensor(), b.tensor(), config)?]

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -277,6 +277,29 @@ impl EagerTensor {
         self.unary_op(StdTensorOp::ReduceSum { axes })
     }
 
+    /// Sum elementwise squares over the requested axes.
+    ///
+    /// Each value is squared in its input dtype before reduction. The initial
+    /// supported dtypes are `f32` and `f64`; other dtypes return a typed
+    /// unsupported error. Passing an empty axis slice returns the elementwise
+    /// square without reducing rank.
+    ///
+    /// This operation is useful when the squared sum is needed directly. Use
+    /// the linalg norm APIs when a square root or complex magnitude semantics
+    /// are required.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation error for invalid axes, a typed unsupported
+    /// error for other dtypes, or a typed backend or runtime-state error during
+    /// execution.
+    pub fn reduce_sum_squares(&self, axes: &[usize]) -> Result<Self> {
+        validate_eager_axes("EagerTensor::reduce_sum_squares", self.shape().len(), axes)?;
+        self.unary_op(StdTensorOp::ReduceSumSquares {
+            axes: axes.to_vec(),
+        })
+    }
+
     /// Execute a dot-general contraction eagerly.
     ///
     /// # Examples

--- a/crates/tenferro-ad/src/semantic_transform.rs
+++ b/crates/tenferro-ad/src/semantic_transform.rs
@@ -562,6 +562,12 @@ fn linearize_core(
         | CoreSemanticOp::Reverse { .. } => {
             linearize_unary_core(builder, op.clone(), primal_inputs, tangent_inputs[0])?
         }
+        CoreSemanticOp::ReduceSumSquares { axes } => core_reductions::linearize_sum_squares(
+            builder,
+            primal_inputs[0],
+            tangent_inputs[0],
+            axes,
+        )?,
         CoreSemanticOp::Concatenate { axis, input_count } => {
             linearize_concatenate(builder, primal_inputs, tangent_inputs, *axis, *input_count)?
         }
@@ -805,6 +811,13 @@ fn vjp_core(
             )?;
             primary_cotangent(builder, broadcast, active_inputs, primal_inputs, false)?
         }
+        CoreSemanticOp::ReduceSumSquares { axes } => core_reductions::sum_squares_vjp(
+            builder,
+            primal_inputs[0],
+            cotangent,
+            active_inputs[0],
+            axes,
+        )?,
         CoreSemanticOp::ExtractDiag { axis_a, axis_b } => {
             let embedded = unary_ad_value(
                 builder,

--- a/crates/tenferro-ad/src/semantic_transform/core_reductions.rs
+++ b/crates/tenferro-ad/src/semantic_transform/core_reductions.rs
@@ -1,5 +1,50 @@
 use super::*;
 
+pub(super) fn linearize_sum_squares(
+    builder: &mut SemanticProgramBuilder,
+    input: ProgramValue,
+    tangent: AdValue,
+    axes: &[usize],
+) -> Result<AdValue, SemanticAdTransformError> {
+    let AdValue::Value(tangent) = tangent else {
+        return Ok(AdValue::Absent);
+    };
+    let product = builder.add_op(CoreSemanticOp::Mul, &[input, tangent])?[0];
+    let doubled = builder.add_op(CoreSemanticOp::Add, &[product, product])?[0];
+    Ok(AdValue::Value(
+        builder.add_op(
+            CoreSemanticOp::ReduceSum {
+                axes: axes.to_vec(),
+            },
+            &[doubled],
+        )?[0],
+    ))
+}
+
+pub(super) fn sum_squares_vjp(
+    builder: &mut SemanticProgramBuilder,
+    input: ProgramValue,
+    cotangent: AdValue,
+    active: bool,
+    axes: &[usize],
+) -> Result<Vec<AdValue>, SemanticAdTransformError> {
+    if !active {
+        return Ok(vec![AdValue::Absent]);
+    }
+    let AdValue::Value(cotangent) = cotangent else {
+        return Ok(vec![AdValue::Absent]);
+    };
+    let cotangent = broadcast_reduction_output(builder, cotangent, input, axes)?;
+    let product = builder.add_op(CoreSemanticOp::Mul, &[input, cotangent])?[0];
+    let doubled = builder.add_op(CoreSemanticOp::Add, &[product, product])?[0];
+    Ok(vec![normalize_ad_value(
+        builder,
+        AdValue::Value(doubled),
+        true,
+        input,
+    )?])
+}
+
 pub(super) fn linearize_nonlinear_reduction(
     builder: &mut SemanticProgramBuilder,
     op: &CoreSemanticOp,

--- a/crates/tenferro-ad/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-ad/tests/integration/eager_tensor.rs
@@ -734,6 +734,30 @@ fn eager_x_squared_gradient_matches_finite_difference() {
 }
 
 #[test]
+fn eager_reduce_sum_squares_gradient_matches_finite_difference() {
+    let x_data = vec![1.25, -2.0, 3.5];
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![3], x_data.clone()).unwrap(),
+        test_ctx(),
+    )
+    .unwrap();
+    let loss = x.reduce_sum_squares(&[0]).unwrap();
+    let _cotangents = loss.backward().unwrap();
+    let grad = x.grad().unwrap().unwrap();
+
+    let expected: Vec<f64> = (0..x_data.len())
+        .map(|index| {
+            finite_diff_scalar(
+                |values| values.iter().map(|value| value * value).sum::<f64>(),
+                &x_data,
+                index,
+            )
+        })
+        .collect();
+    assert_close_slice(f64_data(grad.as_ref()), &expected, FD_TOL);
+}
+
+#[test]
 fn eager_repeated_backward_accumulates_across_calls() {
     let x = EagerTensor::requires_grad_in(
         Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),

--- a/crates/tenferro-ad/tests/integration/semantic_transform.rs
+++ b/crates/tenferro-ad/tests/integration/semantic_transform.rs
@@ -450,6 +450,52 @@ fn semantic_core_reshape_and_reduce_sum_transpose_restore_input_shapes() {
 }
 
 #[test]
+fn semantic_core_reduce_sum_squares_jvp_and_vjp_apply_twice_the_input() {
+    let source = unary_core_program(
+        [DimExpr::Const(2), DimExpr::Const(3)],
+        CoreSemanticOp::ReduceSumSquares { axes: vec![0] },
+    );
+    let ad = ad_context();
+
+    let jvp = ad.jvp_program(&source, &[true]).unwrap();
+    let jvp_operations: Vec<_> = jvp.frozen().program.operations().collect();
+    let jvp_suffix = &jvp_operations[jvp_operations.len() - 3..];
+    assert!(matches!(
+        jvp_suffix[0].op(),
+        tenferro_runtime::program::SemanticOpRef::Core(CoreSemanticOp::Mul)
+    ));
+    assert!(matches!(
+        jvp_suffix[1].op(),
+        tenferro_runtime::program::SemanticOpRef::Core(CoreSemanticOp::Add)
+    ));
+    assert!(matches!(
+        jvp_suffix[2].op(),
+        tenferro_runtime::program::SemanticOpRef::Core(
+            CoreSemanticOp::ReduceSum { axes }
+        ) if axes.as_slice() == [0]
+    ));
+
+    let vjp = ad.vjp_program(&source, &[true], &[true]).unwrap();
+    let vjp_operations: Vec<_> = vjp.frozen().program.operations().collect();
+    let vjp_suffix = &vjp_operations[vjp_operations.len() - 3..];
+    assert!(matches!(
+        vjp_suffix[0].op(),
+        tenferro_runtime::program::SemanticOpRef::Core(
+            CoreSemanticOp::BroadcastInDim { shape, dims }
+        ) if shape.as_slice() == [DimExpr::Const(2), DimExpr::Const(3)]
+            && dims.as_slice() == [1]
+    ));
+    assert!(matches!(
+        vjp_suffix[1].op(),
+        tenferro_runtime::program::SemanticOpRef::Core(CoreSemanticOp::Mul)
+    ));
+    assert!(matches!(
+        vjp_suffix[2].op(),
+        tenferro_runtime::program::SemanticOpRef::Core(CoreSemanticOp::Add)
+    ));
+}
+
+#[test]
 fn semantic_core_broadcast_vjp_reduces_inserted_and_singleton_axes() {
     let source = unary_core_program(
         [DimExpr::Const(2), DimExpr::Const(1)],

--- a/crates/tenferro-core-ops/src/catalog.rs
+++ b/crates/tenferro-core-ops/src/catalog.rs
@@ -107,6 +107,7 @@ macro_rules! primitive_ops {
             Log1p, "log1p", Analytic, SameFloatOrComplex, 1, 1, false;
             DotGeneral, "dot_general", Contraction, SameFloatOrComplex, 2, 2, false;
             ReduceSum, "reduce_sum", Reduction, SameNumeric, 1, 1, false;
+            ReduceSumSquares, "reduce_sum_squares", Reduction, SameFloat, 1, 1, false;
             ReduceProd, "reduce_prod", Reduction, SameNumeric, 1, 1, false;
             ReduceMax, "reduce_max", Reduction, SameNumeric, 1, 1, false;
             ReduceMin, "reduce_min", Reduction, SameNumeric, 1, 1, false;
@@ -269,6 +270,9 @@ macro_rules! define_std_tensor_op {
             ReduceSum {
                 axes: Vec<usize>,
             },
+            ReduceSumSquares {
+                axes: Vec<usize>,
+            },
 
             // Elementwise (non-semiring)
             Div,
@@ -389,6 +393,7 @@ macro_rules! define_std_tensor_op {
                     Self::Convert { .. } => $crate::PrimitiveOpKind::Convert,
                     Self::Constant { .. } => $crate::PrimitiveOpKind::Constant,
                     Self::ReduceSum { .. } => $crate::PrimitiveOpKind::ReduceSum,
+                    Self::ReduceSumSquares { .. } => $crate::PrimitiveOpKind::ReduceSumSquares,
                     Self::Div => $crate::PrimitiveOpKind::Div,
                     Self::Rem => $crate::PrimitiveOpKind::Rem,
                     Self::Abs => $crate::PrimitiveOpKind::Abs,
@@ -467,6 +472,9 @@ macro_rules! define_std_tensor_op {
                         bytes: 0.0_f64.to_le_bytes().to_vec(),
                     },
                     $crate::PrimitiveOpKind::ReduceSum => Self::ReduceSum { axes: vec![0] },
+                    $crate::PrimitiveOpKind::ReduceSumSquares => {
+                        Self::ReduceSumSquares { axes: vec![0] }
+                    }
                     $crate::PrimitiveOpKind::Div => Self::Div,
                     $crate::PrimitiveOpKind::Rem => Self::Rem,
                     $crate::PrimitiveOpKind::Abs => Self::Abs,
@@ -693,6 +701,9 @@ macro_rules! define_exec_op {
             ReduceSum {
                 axes: Vec<usize>,
             },
+            ReduceSumSquares {
+                axes: Vec<usize>,
+            },
             ExtractDiag {
                 axis_a: usize,
                 axis_b: usize,
@@ -791,6 +802,7 @@ macro_rules! define_exec_op {
                         $crate::PrimitiveOpKind::DotGeneral
                     }
                     Self::ReduceSum { .. } => $crate::PrimitiveOpKind::ReduceSum,
+                    Self::ReduceSumSquares { .. } => $crate::PrimitiveOpKind::ReduceSumSquares,
                     Self::ExtractDiag { .. } => $crate::PrimitiveOpKind::ExtractDiag,
                     Self::EmbedDiag { .. } => $crate::PrimitiveOpKind::EmbedDiag,
                     Self::Tril { .. } => $crate::PrimitiveOpKind::Tril,
@@ -899,6 +911,9 @@ macro_rules! define_exec_op {
                     }
                     tenferro_ops::std_tensor_op::StdTensorOp::ReduceSum { axes } => {
                         Self::ReduceSum { axes: axes.clone() }
+                    }
+                    tenferro_ops::std_tensor_op::StdTensorOp::ReduceSumSquares { axes } => {
+                        Self::ReduceSumSquares { axes: axes.clone() }
                     }
                     tenferro_ops::std_tensor_op::StdTensorOp::ReduceProd { axes } => {
                         Self::ReduceProd { axes: axes.clone() }
@@ -1033,6 +1048,9 @@ macro_rules! define_exec_op {
                         rhs_batch_dims: vec![],
                     }),
                     $crate::PrimitiveOpKind::ReduceSum => Self::ReduceSum { axes: vec![0] },
+                    $crate::PrimitiveOpKind::ReduceSumSquares => {
+                        Self::ReduceSumSquares { axes: vec![0] }
+                    }
                     $crate::PrimitiveOpKind::ExtractDiag => Self::ExtractDiag {
                         axis_a: 0,
                         axis_b: 1,

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -3012,6 +3012,17 @@ impl TensorReduction for CpuBackend {
         })
     }
 
+    fn reduce_sum_squares_read(
+        &mut self,
+        input: TensorRead<'_>,
+        axes: &[usize],
+    ) -> crate::Result<Tensor> {
+        self.install_with_pool_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            reduction::reduce_sum_squares_read(buffers, input, axes, &exec_context)
+        })
+    }
+
     fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         self.try_install_fresh_with_context(|context| {
             let exec_context = context.strided_exec_context();

--- a/crates/tenferro-cpu/src/capability.rs
+++ b/crates/tenferro-cpu/src/capability.rs
@@ -224,6 +224,8 @@ const CPU_CAPABILITIES: &[OperationCapability] = &[
     same_dtype(PrimitiveOpKind::ReduceSum, DType::I64, N),
     same_dtype(PrimitiveOpKind::ReduceSum, DType::C32, N),
     same_dtype(PrimitiveOpKind::ReduceSum, DType::C64, N),
+    same_dtype(PrimitiveOpKind::ReduceSumSquares, DType::F32, N),
+    same_dtype(PrimitiveOpKind::ReduceSumSquares, DType::F64, N),
     same_dtype(PrimitiveOpKind::ReduceProd, DType::F32, N),
     same_dtype(PrimitiveOpKind::ReduceProd, DType::F64, N),
     same_dtype(PrimitiveOpKind::ReduceProd, DType::I32, N),

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -361,6 +361,17 @@ impl TensorReduction for CpuExecSession<'_> {
         })
     }
 
+    fn reduce_sum_squares_read(
+        &mut self,
+        input: TensorRead<'_>,
+        axes: &[usize],
+    ) -> crate::Result<Tensor> {
+        self.run_native_fresh_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            reduction::reduce_sum_squares_read(buffers, input, axes, &exec_context)
+        })
+    }
+
     fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         self.run_native_fresh_with_context(|context, _| {
             let exec_context = context.strided_exec_context();

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -182,7 +182,7 @@ test_elementwise_wrapper!(sub(lhs: &Tensor, rhs: &Tensor) => sub_with_pool);
 #[cfg(test)]
 pub(crate) use indexing::{dynamic_slice, dynamic_update_slice, gather, pad, scatter};
 #[cfg(test)]
-pub(crate) use reduction::{reduce_max, reduce_min, reduce_prod, reduce_sum};
+pub(crate) use reduction::{reduce_max, reduce_min, reduce_prod, reduce_sum, reduce_sum_squares};
 #[cfg(test)]
 pub(crate) use structural::{
     broadcast_in_dim, embed_diagonal, extract_diagonal, reshape, transpose, tril, triu,

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -8,6 +8,7 @@ use strided_kernel::{
 
 use super::{typed_host_data, typed_view, typed_view_from_view};
 use crate::buffer_pool::BufferPool;
+use crate::elementwise;
 use crate::materialize_tensor_read;
 use tenferro_tensor::{
     DType, Tensor, TensorRank, TensorRead, TensorScalar, TensorView, TypedTensor, TypedTensorView,
@@ -274,6 +275,96 @@ pub(crate) fn reduce_sum_read(
             "reduce_sum",
             exec_context,
         )?)),
+    }
+}
+
+/// # Errors
+///
+/// Returns a typed validation error for invalid axes or zero-length reduced
+/// dimensions, `Unsupported` for non-real floating dtypes, or a typed backend
+/// error while reading storage or executing the strided kernel.
+pub(crate) fn reduce_sum_squares(
+    buffers: &mut BufferPool,
+    input: &Tensor,
+    axes: &[usize],
+    exec_context: &ExecContext,
+) -> crate::Result<Tensor> {
+    if !matches!(input.dtype(), DType::F32 | DType::F64) {
+        return Err(crate::Error::unsupported(
+            "reduce_sum_squares",
+            format!("unsupported dtype {:?}", input.dtype()),
+        ));
+    }
+    validate_axes("reduce_sum_squares", axes, input.shape().len())?;
+    if axes.is_empty() {
+        return elementwise::mul_with_pool(buffers, input, input);
+    }
+
+    match input {
+        Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_erased(
+            t,
+            axes,
+            ReduceOp::SumSquares,
+            "reduce_sum_squares",
+            exec_context,
+        )?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_erased(
+            t,
+            axes,
+            ReduceOp::SumSquares,
+            "reduce_sum_squares",
+            exec_context,
+        )?)),
+        _ => Err(crate::Error::unsupported(
+            "reduce_sum_squares",
+            format!("unsupported dtype {:?}", input.dtype()),
+        )),
+    }
+}
+
+pub(crate) fn reduce_sum_squares_read(
+    buffers: &mut BufferPool,
+    input: TensorRead<'_>,
+    axes: &[usize],
+    exec_context: &ExecContext,
+) -> crate::Result<Tensor> {
+    if !matches!(input.dtype(), DType::F32 | DType::F64) {
+        return Err(crate::Error::unsupported(
+            "reduce_sum_squares",
+            format!("unsupported dtype {:?}", input.dtype()),
+        ));
+    }
+    validate_axes("reduce_sum_squares", axes, input.shape().len())?;
+    if axes.is_empty() {
+        let rhs = input.clone();
+        return elementwise::mul_read_with_pool(buffers, input, rhs);
+    }
+
+    match input {
+        TensorRead::Tensor(input) => {
+            ensure_host_tensor("reduce_sum_squares", input)?;
+            reduce_sum_squares(buffers, input, axes, exec_context)
+        }
+        TensorRead::View(TensorView::F32(t)) => Ok(Tensor::F32(typed_reduce_view_erased(
+            buffers,
+            &t,
+            axes,
+            ReduceOp::SumSquares,
+            "reduce_sum_squares",
+            exec_context,
+        )?)),
+        TensorRead::View(TensorView::F64(t)) => Ok(Tensor::F64(typed_reduce_view_erased(
+            buffers,
+            &t,
+            axes,
+            ReduceOp::SumSquares,
+            "reduce_sum_squares",
+            exec_context,
+        )?)),
+        _ => Err(crate::Error::unsupported(
+            "reduce_sum_squares",
+            format!("unsupported dtype {:?}", input.dtype()),
+        )),
     }
 }
 

--- a/crates/tenferro-cpu/src/runtime_adapter.rs
+++ b/crates/tenferro-cpu/src/runtime_adapter.rs
@@ -289,6 +289,7 @@ fn cpu_operation_kind(op: &CoreSemanticOp) -> Option<CpuPreparedKind> {
         | CoreSemanticOp::Expm1
         | CoreSemanticOp::Log1p => CpuPreparedKind::Elementwise,
         CoreSemanticOp::ReduceSum { .. }
+        | CoreSemanticOp::ReduceSumSquares { .. }
         | CoreSemanticOp::ReduceProd { .. }
         | CoreSemanticOp::ReduceMax { .. }
         | CoreSemanticOp::ReduceMin { .. } => CpuPreparedKind::Reduction,
@@ -440,6 +441,7 @@ fn core_operation_name(op: &CoreSemanticOp) -> &'static str {
         CoreSemanticOp::Convert { .. } => "convert",
         CoreSemanticOp::Constant { .. } => "constant",
         CoreSemanticOp::ReduceSum { .. } => "reduce_sum",
+        CoreSemanticOp::ReduceSumSquares { .. } => "reduce_sum_squares",
         CoreSemanticOp::Div => "div",
         CoreSemanticOp::Rem => "rem",
         CoreSemanticOp::Abs => "abs",

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -13,8 +13,8 @@ use crate::CpuBackendKind;
 use crate::{
     abs, add, broadcast_in_dim, clamp, compare, conj, div, dynamic_slice, dynamic_update_slice,
     embed_diagonal, extract_diagonal, gather, maximum, minimum, mul, neg, pad, pow, reduce_max,
-    reduce_min, reduce_prod, reduce_sum, rem, reshape, scatter, select, sign, transpose, tril,
-    triu, typed_array_uninit_from_pool, CpuBackend, CpuContext, Error,
+    reduce_min, reduce_prod, reduce_sum, reduce_sum_squares, rem, reshape, scatter, select, sign,
+    transpose, tril, triu, typed_array_uninit_from_pool, CpuBackend, CpuContext, Error,
 };
 use tenferro_tensor::backend::{GroupedGemmConfig, GroupedGemmJob};
 #[cfg(feature = "cpu-blas")]

--- a/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
@@ -683,6 +683,67 @@ fn test_reduce_sum() {
 }
 
 #[test]
+fn test_reduce_sum_squares_f32_and_f64() {
+    let f64s =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, -2.0, 3.0, -4.0, 5.0, -6.0]).unwrap();
+    let mut buffers = crate::buffer_pool::BufferPool::new();
+    let f64_rows = reduce_sum_squares(
+        &mut buffers,
+        &f64s,
+        &[0],
+        &strided_kernel::ExecContext::serial(),
+    )
+    .unwrap();
+    assert_eq!(f64_rows.as_slice::<f64>().unwrap(), &[5.0, 25.0, 61.0]);
+
+    let f32s = Tensor::from_vec_col_major(vec![4], vec![1.0_f32, -2.0, 3.0, -4.0]).unwrap();
+    let f32_total = reduce_sum_squares(
+        &mut buffers,
+        &f32s,
+        &[0],
+        &strided_kernel::ExecContext::serial(),
+    )
+    .unwrap();
+    assert_eq!(f32_total.as_slice::<f32>().unwrap(), &[30.0]);
+
+    let mut backend = CpuBackend::new();
+    let f32_squared = backend
+        .reduce_sum_squares_read(TensorRead::from_tensor(&f32s), &[])
+        .unwrap();
+    assert_eq!(
+        f32_squared.as_slice::<f32>().unwrap(),
+        &[1.0, 4.0, 9.0, 16.0]
+    );
+    let f32_squared_owned = reduce_sum_squares(
+        &mut buffers,
+        &f32s,
+        &[],
+        &strided_kernel::ExecContext::serial(),
+    )
+    .unwrap();
+    assert_eq!(
+        f32_squared_owned.as_slice::<f32>().unwrap(),
+        &[1.0, 4.0, 9.0, 16.0]
+    );
+}
+
+#[test]
+fn test_reduce_sum_squares_read_accepts_noncompact_view() {
+    let source =
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, -2.0, 3.0, -4.0, 5.0, -6.0])
+            .unwrap();
+    let transposed = source.as_view().transpose_view([1, 0]).unwrap();
+    let mut backend = CpuBackend::new();
+
+    let output = backend
+        .reduce_sum_squares_read(TensorRead::from_view(TensorView::F64(transposed)), &[0])
+        .unwrap();
+
+    assert_eq!(output.shape(), &[2]);
+    assert_eq!(output.as_slice::<f64>().unwrap(), &[35.0, 56.0]);
+}
+
+#[test]
 fn test_reduce_prod() {
     let t = Tensor::F64(
         TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),

--- a/crates/tenferro-gpu/src/cubecl/capability.rs
+++ b/crates/tenferro-gpu/src/cubecl/capability.rs
@@ -199,6 +199,8 @@ const CUDA_CAPABILITIES: &[OperationCapability] = &[
     same_dtype(PrimitiveOpKind::ReduceSum, DType::I64, N),
     same_dtype(PrimitiveOpKind::ReduceSum, DType::C32, N),
     same_dtype(PrimitiveOpKind::ReduceSum, DType::C64, N),
+    same_dtype(PrimitiveOpKind::ReduceSumSquares, DType::F32, N),
+    same_dtype(PrimitiveOpKind::ReduceSumSquares, DType::F64, N),
     same_dtype(PrimitiveOpKind::ReduceProd, DType::F32, N),
     same_dtype(PrimitiveOpKind::ReduceProd, DType::F64, N),
     same_dtype(PrimitiveOpKind::ReduceProd, DType::I32, N),

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -2074,6 +2074,49 @@ impl CudaBackend {
         })
     }
 
+    fn reduce_sum_squares_float_typed<F: CubeElement + CubeFloat + Clone>(
+        &self,
+        input: &TypedTensor<F>,
+        axes: &[usize],
+    ) -> crate::Result<TypedTensor<F>> {
+        let op = op_name(
+            PrimitiveOpKind::ReduceSumSquares,
+            op_descriptor::GpuLaunchKind::Reduction,
+        )?;
+        ensure_axes_unique(op, "axes", axes, input.shape().len())?;
+        let final_shape = reduction_output_shape(input.shape(), axes);
+        let mut sorted_axes = axes.to_vec();
+        sorted_axes.sort_unstable();
+        let (&first_axis, remaining_axes) = sorted_axes
+            .split_first()
+            .ok_or_else(|| crate::Error::invalid_argument(op, "axes", "axes must not be empty"))?;
+
+        let mut current =
+            self.launch_reduce_axis_typed(input, first_axis, op, |client, input, output| {
+                cubecl_reduce::launch_sum_squares_float::<CubeclCudaRuntime, F>(
+                    client,
+                    input,
+                    output,
+                    first_axis,
+                    ReduceStrategy::Auto,
+                )
+            })?;
+        for &axis in remaining_axes {
+            current =
+                self.launch_reduce_axis_typed(&current, axis, op, |client, input, output| {
+                    cubecl_reduce::launch_sum_float::<CubeclCudaRuntime, F>(
+                        client,
+                        input,
+                        output,
+                        axis,
+                        ReduceStrategy::Auto,
+                    )
+                })?;
+        }
+
+        cubecl_reshape_metadata(current, final_shape, op)
+    }
+
     fn reduce_sum_complex_typed<C: CubeElement + CubeComplex + Clone>(
         &self,
         input: &TypedTensor<C>,
@@ -4832,6 +4875,38 @@ impl TensorReduction for CudaBackend {
             Tensor::Bool(_) => Err(unsupported_dtype(op, input.dtype())),
             Tensor::C32(t) => self.reduce_sum_complex_typed(t, axes).map(Tensor::C32),
             Tensor::C64(t) => self.reduce_sum_complex_typed(t, axes).map(Tensor::C64),
+        }
+    }
+
+    fn reduce_sum_squares_read(
+        &mut self,
+        input: TensorRead<'_>,
+        axes: &[usize],
+    ) -> crate::Result<Tensor> {
+        let op = op_name(
+            PrimitiveOpKind::ReduceSumSquares,
+            op_descriptor::GpuLaunchKind::Reduction,
+        )?;
+        let Some(input) = input.as_tensor() else {
+            return Err(crate::Error::unsupported(
+                op,
+                "CUDA sum-of-squares requires a resident tensor",
+            ));
+        };
+        if axes.is_empty() {
+            return match input {
+                Tensor::F32(_) | Tensor::F64(_) => self.mul(input, input),
+                _ => Err(unsupported_dtype(op, input.dtype())),
+            };
+        }
+        match input {
+            Tensor::F32(t) => self
+                .reduce_sum_squares_float_typed(t, axes)
+                .map(Tensor::F32),
+            Tensor::F64(t) => self
+                .reduce_sum_squares_float_typed(t, axes)
+                .map(Tensor::F64),
+            _ => Err(unsupported_dtype(op, input.dtype())),
         }
     }
 

--- a/crates/tenferro-gpu/src/cubecl/op_descriptor.rs
+++ b/crates/tenferro-gpu/src/cubecl/op_descriptor.rs
@@ -50,6 +50,7 @@ pub(crate) fn gpu_descriptor(kind: PrimitiveOpKind) -> Option<GpuOpDescriptor> {
         PrimitiveOpKind::Select => GpuLaunchKind::SelectBoolFloatInt,
         PrimitiveOpKind::Clamp => GpuLaunchKind::ClampFloat,
         PrimitiveOpKind::ReduceSum
+        | PrimitiveOpKind::ReduceSumSquares
         | PrimitiveOpKind::ReduceProd
         | PrimitiveOpKind::ReduceMax
         | PrimitiveOpKind::ReduceMin => GpuLaunchKind::Reduction,

--- a/crates/tenferro-gpu/src/cubecl/runtime_adapter.rs
+++ b/crates/tenferro-gpu/src/cubecl/runtime_adapter.rs
@@ -300,6 +300,7 @@ fn cuda_operation_kind(op: &CoreSemanticOp) -> Option<CudaPreparedKind> {
         | CoreSemanticOp::Expm1
         | CoreSemanticOp::Log1p => CudaPreparedKind::Elementwise,
         CoreSemanticOp::ReduceSum { .. }
+        | CoreSemanticOp::ReduceSumSquares { .. }
         | CoreSemanticOp::ReduceProd { .. }
         | CoreSemanticOp::ReduceMax { .. }
         | CoreSemanticOp::ReduceMin { .. } => CudaPreparedKind::Reduction,
@@ -452,6 +453,7 @@ fn core_operation_name(op: &CoreSemanticOp) -> &'static str {
         CoreSemanticOp::Convert { .. } => "convert",
         CoreSemanticOp::Constant { .. } => "constant",
         CoreSemanticOp::ReduceSum { .. } => "reduce_sum",
+        CoreSemanticOp::ReduceSumSquares { .. } => "reduce_sum_squares",
         CoreSemanticOp::Div => "div",
         CoreSemanticOp::Rem => "rem",
         CoreSemanticOp::Abs => "abs",
@@ -556,5 +558,22 @@ impl fmt::Display for CudaPreparedKind {
             Self::DotGeneral => "dot_general",
             Self::Layout => "layout",
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sum_squares_routes_through_runtime_reduction_preparation() {
+        assert_eq!(
+            cuda_operation_kind(&CoreSemanticOp::ReduceSumSquares { axes: vec![0] }),
+            Some(CudaPreparedKind::Reduction)
+        );
+        assert_eq!(
+            core_operation_name(&CoreSemanticOp::ReduceSumSquares { axes: vec![0] }),
+            "reduce_sum_squares"
+        );
     }
 }

--- a/crates/tenferro-gpu/src/cubecl/tests/capability_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/capability_tests.rs
@@ -3,7 +3,7 @@ use tenferro_core_ops::{all_primitive_descriptors, PrimitiveOpKind};
 use tenferro_cpu::cpu_capabilities;
 use tenferro_tensor::{
     capability_output_dtype, BackendId, DType, OperationCapability, SupportLevel, Tensor,
-    TensorAnalytic, TensorDot, TensorElementwise, TensorReduction,
+    TensorAnalytic, TensorDot, TensorElementwise, TensorRead, TensorReduction,
 };
 
 use crate::config::CompareDir;
@@ -264,6 +264,11 @@ fn run_supported_case(
         PrimitiveOpKind::ReduceSum => {
             assert_reduction_matches(cpu, gpu, entry, |b, x, axes| b.reduce_sum(x, axes))
         }
+        PrimitiveOpKind::ReduceSumSquares => {
+            assert_reduction_matches(cpu, gpu, entry, |b, x, axes| {
+                b.reduce_sum_squares_read(TensorRead::from_tensor(x), axes)
+            })
+        }
         PrimitiveOpKind::ReduceProd => {
             assert_reduction_matches(cpu, gpu, entry, |b, x, axes| b.reduce_prod(x, axes))
         }
@@ -447,6 +452,9 @@ fn run_cpu_reduction(
 ) -> Tensor {
     match op {
         PrimitiveOpKind::ReduceSum => cpu.reduce_sum(input, axes),
+        PrimitiveOpKind::ReduceSumSquares => {
+            cpu.reduce_sum_squares_read(TensorRead::from_tensor(input), axes)
+        }
         PrimitiveOpKind::ReduceProd => cpu.reduce_prod(input, axes),
         PrimitiveOpKind::ReduceMax => cpu.reduce_max(input, axes),
         PrimitiveOpKind::ReduceMin => cpu.reduce_min(input, axes),

--- a/crates/tenferro-gpu/src/cubecl/tests/reduction_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/reduction_tests.rs
@@ -1,5 +1,5 @@
 // Run with: cargo test --features cuda -- --ignored
-use tenferro_tensor::{DType, TensorReduction};
+use tenferro_tensor::{DType, TensorRead, TensorReduction};
 
 use super::{
     assert_cuda_unsupported_dtype, assert_tensor_close, cpu_backend, download, gpu_backend,
@@ -102,6 +102,62 @@ fn test_cubecl_float_reductions_match_cpu() {
     let gpu_out = gpu.reduce_min(&gpu_input, &[1]).unwrap();
     let actual = download(&gpu, &gpu_out);
     assert_tensor_close(&actual, &expected, 1e-12);
+}
+
+#[test]
+#[ignore]
+fn test_cubecl_sum_squares_matches_cpu_for_multi_axis_and_empty_axes() {
+    let inputs = [
+        tensor_f32(vec![2, 3], vec![1.0, -2.0, 3.0, -4.0, 5.0, -6.0]),
+        tensor_f64(vec![2, 3], vec![1.0, -2.0, 3.0, -4.0, 5.0, -6.0]),
+    ];
+    let mut cpu = cpu_backend();
+    let mut gpu = gpu_backend();
+
+    for input in &inputs {
+        let gpu_input = upload(&gpu, input);
+        for axes in [&[0, 1][..], &[][..]] {
+            let expected = cpu
+                .reduce_sum_squares_read(TensorRead::from_tensor(input), axes)
+                .unwrap();
+            let gpu_output = gpu
+                .reduce_sum_squares_read(TensorRead::from_tensor(&gpu_input), axes)
+                .unwrap();
+            assert_tensor_close(&download(&gpu, &gpu_output), &expected, 1e-5);
+        }
+    }
+
+    let integer = upload(&gpu, &tensor_i32(vec![2], vec![1, 2]));
+    let error = gpu
+        .reduce_sum_squares_read(TensorRead::from_tensor(&integer), &[0])
+        .unwrap_err();
+    assert_cuda_unsupported_dtype(&error, "reduce_sum_squares", DType::I32);
+}
+
+#[test]
+#[ignore]
+fn test_cubecl_sum_squares_does_not_contract_multiply_and_add() {
+    // These values distinguish same-dtype multiply-then-add from FMA.
+    let first = 0.000_442_517_25_f32;
+    let second = 0.684_452_06_f32;
+    let input = tensor_f32(vec![2], vec![first, second]);
+    let expected = first * first + second * second;
+    let contracted = second.mul_add(second, first * first);
+    assert_ne!(expected.to_bits(), contracted.to_bits());
+
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &input);
+    let gpu_output = gpu
+        .reduce_sum_squares_read(TensorRead::from_tensor(&gpu_input), &[0])
+        .unwrap();
+    let actual = download(&gpu, &gpu_output);
+    let crate::Tensor::F32(actual) = actual else {
+        panic!("sum-of-squares output must remain f32");
+    };
+    let actual = actual.as_slice().unwrap()[0];
+
+    assert_eq!(actual.to_bits(), expected.to_bits());
+    assert_ne!(actual.to_bits(), contracted.to_bits());
 }
 
 #[test]

--- a/crates/tenferro-gpu/src/kernels/reduce/kernels.rs
+++ b/crates/tenferro-gpu/src/kernels/reduce/kernels.rs
@@ -56,6 +56,46 @@ reduce_binary_kernel!(reduce_sum_complex, ComplexCore, +);
 reduce_binary_kernel!(reduce_prod_float, Float, *);
 reduce_binary_kernel!(reduce_prod_complex, ComplexCore, *);
 
+#[cube(launch_unchecked)]
+pub(crate) fn reduce_sum_squares_float<F: Float>(
+    input: &Tensor<F>,
+    output: &mut Tensor<F>,
+    axis: usize,
+    output_len: usize,
+) {
+    let output_index = ABSOLUTE_POS as usize;
+    if output_index < output_len {
+        let rank = output.rank();
+        let mut remaining = output_index;
+        let mut input_base_offset = 0usize;
+        let mut output_offset = 0usize;
+
+        for dim in 0..rank {
+            let dim_len = output.shape(dim);
+            let coord = remaining % dim_len;
+            remaining /= dim_len;
+            input_base_offset += coord * input.stride(dim);
+            output_offset += coord * output.stride(dim);
+        }
+
+        let axis_stride = input.stride(axis);
+        let axis_len = input.shape(axis);
+        let first = input[input_base_offset];
+        // `fma(x, x, 0)` rounds the square before the later addition and
+        // prevents NVRTC from contracting that addition with the multiply.
+        let mut acc = fma(first, first, F::new(0.0_f32));
+
+        for reduce_index in 1..axis_len {
+            let input_offset = input_base_offset + reduce_index * axis_stride;
+            let value = input[input_offset];
+            let square = fma(value, value, F::new(0.0_f32));
+            acc += square;
+        }
+
+        output[output_offset] = acc;
+    }
+}
+
 macro_rules! reduce_wrapping_int_kernel {
     ($name:ident, $combine:ident) => {
         #[cube(launch_unchecked)]
@@ -148,6 +188,51 @@ reduce_binary_plane_kernel!(reduce_sum_float_plane, Float, +, plane_sum);
 reduce_binary_plane_kernel!(reduce_sum_complex_plane, ComplexCore, +, plane_sum);
 reduce_binary_plane_kernel!(reduce_prod_float_plane, Float, *, plane_prod);
 reduce_binary_plane_kernel!(reduce_prod_complex_plane, ComplexCore, *, plane_prod);
+
+#[cube(launch_unchecked)]
+pub(crate) fn reduce_sum_squares_float_plane<F: Float>(
+    input: &Tensor<F>,
+    output: &mut Tensor<F>,
+    axis: usize,
+    output_len: usize,
+) {
+    let output_index = CUBE_POS_X as usize;
+    if output_index < output_len {
+        let rank = output.rank();
+        let mut remaining = output_index;
+        let mut input_base_offset = 0usize;
+        let mut output_offset = 0usize;
+
+        for dim in 0..rank {
+            let dim_len = output.shape(dim);
+            let coord = remaining % dim_len;
+            remaining /= dim_len;
+            input_base_offset += coord * input.stride(dim);
+            output_offset += coord * output.stride(dim);
+        }
+
+        let axis_stride = input.stride(axis);
+        let axis_len = input.shape(axis);
+        let plane_width = PLANE_DIM as usize;
+        let mut reduce_index = UNIT_POS as usize;
+        let first = input[input_base_offset + reduce_index * axis_stride];
+        let mut acc = fma(first, first, F::new(0.0_f32));
+
+        reduce_index += plane_width;
+        while reduce_index < axis_len {
+            let input_offset = input_base_offset + reduce_index * axis_stride;
+            let value = input[input_offset];
+            let square = fma(value, value, F::new(0.0_f32));
+            acc += square;
+            reduce_index += plane_width;
+        }
+
+        let reduced = plane_sum(acc);
+        if UNIT_POS == 0 {
+            output[output_offset] = reduced;
+        }
+    }
+}
 
 macro_rules! reduce_wrapping_int_plane_kernel {
     ($name:ident, $combine:ident, $plane_reduce:ident) => {

--- a/crates/tenferro-gpu/src/kernels/reduce/launch.rs
+++ b/crates/tenferro-gpu/src/kernels/reduce/launch.rs
@@ -241,6 +241,50 @@ pub(crate) fn launch_sum_float<R: Runtime, F: Float + CubeElement>(
     Ok(())
 }
 
+/// Launch a floating-point sum-of-squares reduction.
+pub(crate) fn launch_sum_squares_float<R: Runtime, F: Float + CubeElement>(
+    client: &ComputeClient<R>,
+    input: TensorBinding<R>,
+    output: TensorBinding<R>,
+    axis: usize,
+    strategy: ReduceStrategy,
+) -> Result<()> {
+    let problem = validate_launch(&input, &output, axis)?;
+    let launch = resolve_launch_settings(client, problem, strategy)?;
+
+    unsafe {
+        // SAFETY: `validate_launch` proves the input and keepdims output
+        // layouts agree and the reduced axis is non-empty. The resolved launch
+        // covers exactly `problem.reduce_count` guarded output elements.
+        match launch.kind {
+            ResolvedReduceStrategy::Unit => {
+                kernels::reduce_sum_squares_float::launch_unchecked::<F, R>(
+                    client,
+                    launch.cube_count,
+                    launch.cube_dim,
+                    input.into_tensor_arg(),
+                    output.into_tensor_arg(),
+                    launch.axis,
+                    launch.output_len,
+                )
+            }
+            ResolvedReduceStrategy::Plane => {
+                kernels::reduce_sum_squares_float_plane::launch_unchecked::<F, R>(
+                    client,
+                    launch.cube_count,
+                    launch.cube_dim,
+                    input.into_tensor_arg(),
+                    output.into_tensor_arg(),
+                    launch.axis,
+                    launch.output_len,
+                )
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Launch an integer sum reduction.
 pub(crate) fn launch_sum_int<R: Runtime, I: Int + CubeElement>(
     client: &ComputeClient<R>,

--- a/crates/tenferro-gpu/src/kernels/reduce/mod.rs
+++ b/crates/tenferro-gpu/src/kernels/reduce/mod.rs
@@ -17,5 +17,5 @@ mod tests;
 pub(crate) use launch::{
     launch_max_float, launch_max_int, launch_min_float, launch_min_int, launch_prod_complex,
     launch_prod_float, launch_prod_int, launch_sum_complex, launch_sum_float, launch_sum_int,
-    ReduceStrategy,
+    launch_sum_squares_float, ReduceStrategy,
 };

--- a/crates/tenferro-internal-ops/src/ad/registry.rs
+++ b/crates/tenferro-internal-ops/src/ad/registry.rs
@@ -1,6 +1,6 @@
 use crate::ad::PrimitiveRuleBuilder;
 use crate::ad::{ADRuleError, ADRuleKind, ADRuleResult};
-use computegraph::types::{LocalValueId, OperationRole, ValueKey};
+use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_core_ops::PrimitiveOpKind;
 
 use super::context::ShapeGuardContext;
@@ -245,6 +245,11 @@ static PRIMITIVE_AD_RULES: [&'static dyn PrimitiveAdRule; PrimitiveOpKind::COUNT
         kind: PrimitiveOpKind::ReduceSum,
         linearize: linearize_reduce_sum,
         transpose_rule: transpose_reduce_sum,
+    },
+    &FunctionPrimitiveAdRule {
+        kind: PrimitiveOpKind::ReduceSumSquares,
+        linearize: linearize_reduce_sum_squares,
+        transpose_rule: transpose_reduce_sum_squares,
     },
     &FunctionPrimitiveAdRule {
         kind: PrimitiveOpKind::ReduceProd,
@@ -882,6 +887,80 @@ fn transpose_reduce_sum(
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     contraction::transpose_reduce_sum_input(builder, cotangent_out, op, &inputs[0], ctx)
+}
+
+fn linearize_reduce_sum_squares(
+    op: &StdTensorOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    let axes = catalog_payload!(
+        op,
+        ADRuleKind::Jvp,
+        StdTensorOp::ReduceSumSquares { axes } => axes
+    );
+    let square_tangent = semiring::linearize_mul(
+        builder,
+        &[primal_in[0].clone(), primal_in[0].clone()],
+        &[tangent_in[0], tangent_in[0]],
+        ctx,
+    )[0];
+    Ok(contraction::linearize_reduce_sum(
+        builder,
+        &[square_tangent],
+        &StdTensorOp::ReduceSum {
+            axes: axes.to_vec(),
+        },
+        axes,
+    ))
+}
+
+fn transpose_reduce_sum_squares(
+    op: &StdTensorOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[TransposeInputRef<'_>],
+    _mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    let axes = catalog_payload!(
+        op,
+        ADRuleKind::Transpose,
+        StdTensorOp::ReduceSumSquares { axes } => axes
+    );
+    let broadcast = contraction::transpose_reduce_sum_input(
+        builder,
+        cotangent_out,
+        &StdTensorOp::ReduceSum {
+            axes: axes.to_vec(),
+        },
+        &inputs[0],
+        ctx,
+    )?[0];
+    let Some(broadcast) = broadcast else {
+        return Ok(vec![None]);
+    };
+    let product = builder.add_operation(
+        StdTensorOp::Mul,
+        vec![
+            inputs[0].fixed_value("reduce_sum_squares", 0)?,
+            ValueRef::Local(broadcast),
+        ],
+        OperationRole::Linearized {
+            active_mask: vec![false, true],
+        },
+    )[0];
+    let doubled = builder.add_operation(
+        StdTensorOp::Add,
+        vec![ValueRef::Local(product), ValueRef::Local(product)],
+        OperationRole::Linearized {
+            active_mask: vec![true, true],
+        },
+    )[0];
+    Ok(vec![Some(doubled)])
 }
 
 fn linearize_reduce_prod(

--- a/crates/tenferro-internal-ops/src/ad/support.rs
+++ b/crates/tenferro-internal-ops/src/ad/support.rs
@@ -106,6 +106,7 @@ pub static PRIMITIVE_AD_SUPPORT: [PrimitiveAdSupport; PrimitiveOpKind::COUNT] = 
     direct_support!(Log1p),
     direct_support!(DotGeneral),
     direct_support!(ReduceSum),
+    direct_support!(ReduceSumSquares),
     direct_support!(ReduceProd),
     direct_support!(ReduceMax),
     direct_support!(ReduceMin),

--- a/crates/tenferro-internal-ops/src/ad/tests/contraction_tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/contraction_tests.rs
@@ -1,4 +1,4 @@
-use crate::ad::ADRuleKind;
+use crate::ad::{ADRuleKind, PrimitiveTransposeInput};
 use computegraph::graph::GraphBuilder;
 use computegraph::types::{OperationRole, ValueRef};
 use tenferro_tensor::{DType, DotGeneralConfig};
@@ -99,6 +99,41 @@ fn reduction_transposes_accept_upper_bound_input_metadata() {
             "{op:?} transpose should restore the runtime input extent instead of requiring an exact shape"
         );
     }
+}
+
+#[test]
+fn reduce_sum_squares_transpose_uses_retained_primal_not_linear_input() {
+    let linear = super::input_key(300);
+    let primal = super::input_key(301);
+    let mut ctx = ShapeGuardContext::default();
+    ctx.insert_metadata(linear.clone(), super::meta(DType::F64, &[2, 3]));
+    ctx.insert_metadata(primal.clone(), super::meta(DType::F64, &[2, 3]));
+
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let cotangent = builder.add_input(tensor_input(302));
+    crate::ad::transpose_rule(
+        &StdTensorOp::ReduceSumSquares { axes: vec![0] },
+        &mut builder,
+        &[Some(cotangent)],
+        &[PrimitiveTransposeInput::Linear {
+            key: linear.clone(),
+            primal: Some(primal.clone()),
+        }],
+        &OperationRole::Linearized {
+            active_mask: vec![true],
+        },
+        &mut ctx,
+    )
+    .unwrap();
+
+    let graph = builder.build();
+    let product = graph
+        .operations()
+        .iter()
+        .find(|operation| operation.operation == StdTensorOp::Mul)
+        .expect("transpose should multiply the cotangent by the retained primal");
+    assert!(product.inputs.contains(&ValueRef::External(primal)));
+    assert!(!product.inputs.contains(&ValueRef::External(linear)));
 }
 
 #[test]

--- a/crates/tenferro-internal-ops/src/std_tensor_op.rs
+++ b/crates/tenferro-internal-ops/src/std_tensor_op.rs
@@ -181,6 +181,7 @@ impl PartialEq for StdTensorOp {
                 },
             ) => da == db && ba == bb,
             (Self::ReduceSum { axes: a }, Self::ReduceSum { axes: b })
+            | (Self::ReduceSumSquares { axes: a }, Self::ReduceSumSquares { axes: b })
             | (Self::ReduceProd { axes: a }, Self::ReduceProd { axes: b })
             | (Self::ReduceMax { axes: a }, Self::ReduceMax { axes: b })
             | (Self::ReduceMin { axes: a }, Self::ReduceMin { axes: b })
@@ -298,7 +299,7 @@ impl Hash for StdTensorOp {
                 dtype.hash(state);
                 bytes.hash(state);
             }
-            Self::ReduceSum { axes } => {
+            Self::ReduceSum { axes } | Self::ReduceSumSquares { axes } => {
                 axes.hash(state);
             }
             Self::Compare(dir) => dir.hash(state),
@@ -379,6 +380,7 @@ impl GraphOperation for StdTensorOp {
             Self::Reshape { to_shape } => n_inputs_from_dim_exprs(1, &[to_shape]),
             Self::BroadcastInDim { shape, .. } => n_inputs_from_dim_exprs(1, &[shape]),
             Self::ReduceSum { .. }
+            | Self::ReduceSumSquares { .. }
             | Self::ReduceProd { .. }
             | Self::ReduceMax { .. }
             | Self::ReduceMin { .. } => 1,
@@ -421,6 +423,7 @@ impl GraphOperation for StdTensorOp {
             | Self::BroadcastInDim { .. }
             | Self::Convert { .. }
             | Self::ReduceSum { .. }
+            | Self::ReduceSumSquares { .. }
             | Self::Div
             | Self::Rem
             | Self::Abs

--- a/crates/tenferro-linalg/src/eager_composites.rs
+++ b/crates/tenferro-linalg/src/eager_composites.rs
@@ -237,7 +237,7 @@ fn matrix_transpose_perm(rank: usize) -> Vec<usize> {
 }
 
 fn frobenius_norm(abs: &EagerTensor, axes: &[usize]) -> Result<EagerTensor> {
-    abs.mul(abs)?.reduce_sum(Some(axes))?.sqrt()
+    abs.reduce_sum_squares(axes)?.sqrt()
 }
 
 fn p_norm(abs: &EagerTensor, axes: &[usize], p: f64) -> Result<EagerTensor> {

--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -1502,10 +1502,9 @@ fn frobenius_norm<B: LinalgBackend>(
     axes: &[usize],
     backend: &mut B,
 ) -> tenferro_tensor::Result<Tensor> {
-    let squared = backend.with_backend_session(|exec| {
-        exec.mul_read(TensorRead::from_tensor(abs), TensorRead::from_tensor(abs))
+    let sum = backend.with_backend_session(|exec| {
+        exec.reduce_sum_squares_read(TensorRead::from_tensor(abs), axes)
     })?;
-    let sum = reduce_sum(&squared, axes, backend)?;
     backend.with_backend_session(|exec| exec.sqrt_read(TensorRead::from_tensor(&sum)))
 }
 
@@ -1514,9 +1513,7 @@ fn frobenius_norm_read<B: LinalgBackend>(
     axes: &[usize],
     backend: &mut B,
 ) -> tenferro_tensor::Result<Tensor> {
-    let rhs = input.clone();
-    let squared = backend.with_backend_session(|exec| exec.mul_read(input, rhs))?;
-    let sum = reduce_sum(&squared, axes, backend)?;
+    let sum = backend.with_backend_session(|exec| exec.reduce_sum_squares_read(input, axes))?;
     backend.with_backend_session(|exec| exec.sqrt_read(TensorRead::from_tensor(&sum)))
 }
 

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -1639,8 +1639,7 @@ fn matrix_transpose_perm(rank: usize) -> Vec<usize> {
 }
 
 fn frobenius_norm(abs: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
-    let squared = abs.mul(abs)?;
-    squared.reduce_sum(Some(axes))?.sqrt()
+    abs.reduce_sum_squares(axes)?.sqrt()
 }
 
 fn p_norm(abs: &TracedTensor, axes: &[usize], p: f64) -> Result<TracedTensor> {

--- a/crates/tenferro-linalg/tests/integration/linalg_internal_path_contract.rs
+++ b/crates/tenferro-linalg/tests/integration/linalg_internal_path_contract.rs
@@ -90,7 +90,7 @@ fn matrix_norm_uses_singular_values_only_path() {
 }
 
 #[test]
-fn norm_fro_and_p2_norm_square_with_mul_not_generic_pow() {
+fn norm_fro_and_p2_norm_use_fused_backend_hook_without_generic_pow() {
     let eager_source = crate_source("src/eager_composites.rs");
     let eager_frobenius = source_section(
         &eager_source,
@@ -103,8 +103,8 @@ fn norm_fro_and_p2_norm_square_with_mul_not_generic_pow() {
         "fn default_pinv_rtol",
     );
     assert!(
-        !eager_frobenius.contains(".pow("),
-        "eager Frobenius norm should square with mul, not generic pow"
+        eager_frobenius.contains(".reduce_sum_squares(") && !eager_frobenius.contains(".pow("),
+        "eager Frobenius norm should use the fused backend hook, not generic pow"
     );
     assert!(
         eager_p_norm.contains("p == 2.0") && eager_p_norm.contains("frobenius_norm(abs, axes)"),
@@ -123,8 +123,9 @@ fn norm_fro_and_p2_norm_square_with_mul_not_generic_pow() {
         "fn count_nonzero<B: LinalgBackend>",
     );
     assert!(
-        !concrete_frobenius.contains("exec.pow_read"),
-        "concrete Frobenius norm should square with mul_read, not generic pow_read"
+        concrete_frobenius.contains("exec.reduce_sum_squares_read")
+            && !concrete_frobenius.contains("exec.pow_read"),
+        "concrete Frobenius norm should use the fused backend hook, not generic pow_read"
     );
     assert!(
         concrete_p_norm.contains("p == 2.0")
@@ -144,8 +145,8 @@ fn norm_fro_and_p2_norm_square_with_mul_not_generic_pow() {
         "fn reduced_axes_have_zero_extent",
     );
     assert!(
-        !traced_frobenius.contains(".pow("),
-        "traced Frobenius norm should square with mul, not generic pow"
+        traced_frobenius.contains("reduce_sum_squares") && !traced_frobenius.contains(".pow("),
+        "traced Frobenius norm should emit the fused core reduction primitive"
     );
     assert!(
         traced_p_norm.contains("p == 2.0") && traced_p_norm.contains("frobenius_norm(abs, axes)"),

--- a/crates/tenferro-linalg/tests/integration/traced_ad_explicit.rs
+++ b/crates/tenferro-linalg/tests/integration/traced_ad_explicit.rs
@@ -389,6 +389,69 @@ fn complex_svd_values_grad_executes_with_complex_input_dtype() {
 }
 
 #[test]
+fn frobenius_norm_jvp_matches_finite_diff_through_fused_sum_squares() {
+    let ad = ad_context();
+    let data = vec![3.0, 0.1, 0.2, 0.3, 2.0, 0.4];
+    let tangent_data = vec![0.04, -0.03, 0.05, 0.02, -0.06, 0.01];
+    let matrix =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], data.clone())).unwrap();
+    let tangent =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], tangent_data.clone()))
+            .unwrap();
+
+    let norm = matrix.norm(None, Some(&[0, 1]), false).unwrap();
+    assert!(
+        graph_op_debugs(&norm)
+            .iter()
+            .any(|op| op.contains("ReduceSumSquares")),
+        "Frobenius norm should retain the fused semantic primitive"
+    );
+    let jvp = ad.jvp(&norm, &matrix, &tangent).unwrap();
+
+    assert_close_scalar(
+        "Frobenius norm directional JVP",
+        get_f64_data(&eval(&jvp))[0],
+        finite_diff_directional_scalar(
+            |xs| {
+                let input =
+                    TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], xs.to_vec()))
+                        .unwrap();
+                get_f64_data(&eval(&input.norm(None, Some(&[0, 1]), false).unwrap()))[0]
+            },
+            &data,
+            &tangent_data,
+            1.0e-6,
+        ),
+        1.0e-6,
+    );
+}
+
+#[test]
+fn frobenius_norm_grad_matches_finite_diff_through_fused_sum_squares() {
+    let ad = ad_context();
+    let data = vec![3.0, 0.1, 0.2, 0.3, 2.0, 0.4];
+    let matrix =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], data.clone())).unwrap();
+    let norm = matrix.norm(None, Some(&[0, 1]), false).unwrap();
+    let actual = eval(&ad.grad(&norm, &matrix).unwrap());
+
+    for (index, &value) in get_f64_data(&actual).iter().enumerate() {
+        let expected = finite_diff_scalar(
+            |xs| {
+                let input =
+                    TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], xs.to_vec()))
+                        .unwrap();
+                get_f64_data(&eval(&input.norm(None, Some(&[0, 1]), false).unwrap()))[0]
+            },
+            &data,
+            index,
+            1.0e-6,
+        );
+        assert_close_scalar("Frobenius norm gradient", value, expected, 1.0e-6);
+    }
+}
+
+#[test]
 fn spectral_norm_jvp_matches_finite_diff_through_values_only_svd() {
     let ad = ad_context();
     let data = vec![3.0, 0.1, 0.2, 0.3, 2.0, 0.4];

--- a/crates/tenferro-runtime/src/compiler/mod.rs
+++ b/crates/tenferro-runtime/src/compiler/mod.rs
@@ -1001,6 +1001,7 @@ fn conj_commuting_input_indices(
         }
         ExecOp::Negate
         | ExecOp::ReduceSum { .. }
+        | ExecOp::ReduceSumSquares { .. }
         | ExecOp::ReduceProd { .. }
         | ExecOp::Transpose { .. }
         | ExecOp::Reshape { .. }

--- a/crates/tenferro-runtime/src/exec/dispatch.rs
+++ b/crates/tenferro-runtime/src/exec/dispatch.rs
@@ -154,6 +154,7 @@ define_backend_dispatch! {
     PrimitiveOpKind::BroadcastInDim => execute_broadcast_in_dim,
     PrimitiveOpKind::Convert => execute_convert,
     PrimitiveOpKind::ReduceSum => execute_reduce_sum,
+    PrimitiveOpKind::ReduceSumSquares => execute_reduce_sum_squares,
     PrimitiveOpKind::ExtractDiag => execute_extract_diag,
     PrimitiveOpKind::EmbedDiag => execute_embed_diag,
     PrimitiveOpKind::Tril => execute_tril,
@@ -552,6 +553,20 @@ fn execute_reduce_sum(
         return Err(dispatch_mismatch(PrimitiveOpKind::ReduceSum, &inst.op));
     };
     Ok(exec.reduce_sum_read(get_read(slots, &inst.input_slots, 0)?, axes)?)
+}
+
+fn execute_reduce_sum_squares(
+    exec: &mut dyn BackendSession,
+    slots: &[Option<ExecSlot<'_>>],
+    inst: &ExecInstruction,
+) -> Result<Tensor> {
+    let ExecOp::ReduceSumSquares { axes } = &inst.op else {
+        return Err(dispatch_mismatch(
+            PrimitiveOpKind::ReduceSumSquares,
+            &inst.op,
+        ));
+    };
+    Ok(exec.reduce_sum_squares_read(get_read(slots, &inst.input_slots, 0)?, axes)?)
 }
 
 fn execute_extract_diag(

--- a/crates/tenferro-runtime/src/exec/tests.rs
+++ b/crates/tenferro-runtime/src/exec/tests.rs
@@ -341,6 +341,10 @@ fn backend_dispatch_cases() -> Vec<(ExecOp, PrimitiveOpKind)> {
             PrimitiveOpKind::ReduceSum,
         ),
         (
+            ExecOp::ReduceSumSquares { axes: vec![0] },
+            PrimitiveOpKind::ReduceSumSquares,
+        ),
+        (
             ExecOp::ExtractDiag {
                 axis_a: 0,
                 axis_b: 1,

--- a/crates/tenferro-runtime/src/program/identity.rs
+++ b/crates/tenferro-runtime/src/program/identity.rs
@@ -487,6 +487,10 @@ fn encode_core_op(encoder: &mut CanonicalEncoder, op: &CoreSemanticOp) {
             encoder.u8(49);
             encoder.usize_slice(axes);
         }
+        CoreSemanticOp::ReduceSumSquares { axes } => {
+            encoder.u8(50);
+            encoder.usize_slice(axes);
+        }
     }
 }
 

--- a/crates/tenferro-runtime/src/program/op.rs
+++ b/crates/tenferro-runtime/src/program/op.rs
@@ -46,6 +46,9 @@ pub enum CoreSemanticOp {
     ReduceSum {
         axes: Vec<usize>,
     },
+    ReduceSumSquares {
+        axes: Vec<usize>,
+    },
     Div,
     Rem,
     Abs,
@@ -173,6 +176,7 @@ impl TryFrom<&StdTensorOp> for CoreSemanticOp {
                 bytes: bytes.clone(),
             },
             StdTensorOp::ReduceSum { axes } => Self::ReduceSum { axes: axes.clone() },
+            StdTensorOp::ReduceSumSquares { axes } => Self::ReduceSumSquares { axes: axes.clone() },
             StdTensorOp::Div => Self::Div,
             StdTensorOp::Rem => Self::Rem,
             StdTensorOp::Abs => Self::Abs,
@@ -269,6 +273,9 @@ impl From<&CoreSemanticOp> for StdTensorOp {
                 bytes: bytes.clone(),
             },
             CoreSemanticOp::ReduceSum { axes } => Self::ReduceSum { axes: axes.clone() },
+            CoreSemanticOp::ReduceSumSquares { axes } => {
+                Self::ReduceSumSquares { axes: axes.clone() }
+            }
             CoreSemanticOp::Div => Self::Div,
             CoreSemanticOp::Rem => Self::Rem,
             CoreSemanticOp::Abs => Self::Abs,

--- a/crates/tenferro-runtime/src/program/semantic.rs
+++ b/crates/tenferro-runtime/src/program/semantic.rs
@@ -164,6 +164,7 @@ fn core_semantic_op_retained_bytes(op: &CoreSemanticOp) -> Option<usize> {
         }
         CoreSemanticOp::Constant { bytes, .. } => vec_bytes::<u8>(bytes.len()),
         CoreSemanticOp::ReduceSum { axes }
+        | CoreSemanticOp::ReduceSumSquares { axes }
         | CoreSemanticOp::ReduceProd { axes }
         | CoreSemanticOp::ReduceMax { axes }
         | CoreSemanticOp::ReduceMin { axes }

--- a/crates/tenferro-runtime/src/runtime/preparation.rs
+++ b/crates/tenferro-runtime/src/runtime/preparation.rs
@@ -987,6 +987,7 @@ fn required_core_capability(op: &CoreSemanticOp) -> CoreCapabilityKind {
         | CoreSemanticOp::Tril { .. }
         | CoreSemanticOp::Triu { .. } => CoreCapabilityKind::Layout,
         CoreSemanticOp::ReduceSum { .. }
+        | CoreSemanticOp::ReduceSumSquares { .. }
         | CoreSemanticOp::ReduceProd { .. }
         | CoreSemanticOp::ReduceMax { .. }
         | CoreSemanticOp::ReduceMin { .. } => CoreCapabilityKind::Reduction,
@@ -1590,6 +1591,7 @@ fn exec_op_retained_bytes(op: &ExecOp) -> Option<usize> {
             dot_general_config_retained_bytes(config)
         }
         ExecOp::ReduceSum { axes }
+        | ExecOp::ReduceSumSquares { axes }
         | ExecOp::Reverse { axes }
         | ExecOp::ReduceProd { axes }
         | ExecOp::ReduceMax { axes }

--- a/crates/tenferro-runtime/src/shape_infer.rs
+++ b/crates/tenferro-runtime/src/shape_infer.rs
@@ -194,6 +194,7 @@ pub(crate) fn infer_output_dtype_at(
         | StdTensorOp::Reshape { .. }
         | StdTensorOp::BroadcastInDim { .. }
         | StdTensorOp::ReduceSum { .. }
+        | StdTensorOp::ReduceSumSquares { .. }
         | StdTensorOp::ReduceProd { .. }
         | StdTensorOp::ReduceMax { .. }
         | StdTensorOp::ReduceMin { .. }
@@ -305,6 +306,7 @@ pub fn infer_output_shapes(
         StdTensorOp::BroadcastInDim { shape, .. } => vec![shape.clone()],
         StdTensorOp::Constant { .. } => vec![Vec::new()],
         StdTensorOp::ReduceSum { axes, .. }
+        | StdTensorOp::ReduceSumSquares { axes, .. }
         | StdTensorOp::ReduceProd { axes, .. }
         | StdTensorOp::ReduceMax { axes, .. }
         | StdTensorOp::ReduceMin { axes, .. } => {

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -1883,6 +1883,39 @@ impl TracedTensor {
         )
     }
 
+    /// Sum elementwise squares over the requested axes.
+    ///
+    /// Each value is squared in its input dtype before reduction. The initial
+    /// supported dtypes are `f32` and `f64`; other dtypes return a typed
+    /// unsupported error during execution. Passing an empty axis slice returns
+    /// the elementwise square without reducing rank.
+    ///
+    /// This operation is useful when the squared sum is needed directly. Use
+    /// the linalg norm APIs when a square root or complex magnitude semantics
+    /// are required.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation error for invalid axes or a typed
+    /// runtime-state error while registering output metadata.
+    ///
+    /// # Deferred errors
+    ///
+    /// Unsupported dtypes and backend execution failures are reported when the
+    /// compiled graph is executed.
+    pub fn reduce_sum_squares(&self, axes: &[usize]) -> Result<TracedTensor> {
+        let (out_rank, out_shape_hint) =
+            reduction_output_meta(self, axes, "TracedTensor::reduce_sum_squares")?;
+        apply_unary(
+            StdTensorOp::ReduceSumSquares {
+                axes: axes.to_vec(),
+            },
+            self,
+            out_rank,
+            out_shape_hint,
+        )
+    }
+
     /// Reduce by taking the maximum along the given axes.
     ///
     /// Used by tropical (max-plus) compositions: a max-plus reduction over

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -2978,8 +2978,9 @@ pub trait TensorStructural {
 /// Reduction operations.
 ///
 /// Reducing over an axis whose extent is zero returns an error for every
-/// reduction operation. Passing an empty `axes` slice is a no-op and returns the
-/// input values unchanged.
+/// reduction operation. Passing an empty `axes` slice is a no-op for the public
+/// reductions and returns the input values unchanged. Internal mapped
+/// reductions document their own empty-axis semantics.
 ///
 /// # Examples
 ///
@@ -3025,6 +3026,28 @@ pub trait TensorReduction {
                 "backend does not accept borrowed tensor views at this execution boundary",
             )),
         }
+    }
+
+    /// Sum elementwise squares across axes.
+    ///
+    /// This execution hook is used by composite operations that avoid a
+    /// materialized square. Empty axes produce an elementwise square. Backends
+    /// that support this optimized path must override the hook directly.
+    ///
+    /// # Errors
+    ///
+    /// Returns the typed validation, unsupported, runtime-state, or backend
+    /// error produced by multiplication or reduction.
+    #[doc(hidden)]
+    fn reduce_sum_squares_read(
+        &mut self,
+        _input: TensorRead<'_>,
+        _axes: &[usize],
+    ) -> crate::Result<Tensor> {
+        Err(crate::Error::unsupported(
+            "reduce_sum_squares",
+            "backend does not implement fused sum-of-squares reduction",
+        ))
     }
 
     /// # Errors

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -396,6 +396,25 @@ impl TensorReduction for DefaultReadBackend {
     }
 }
 
+#[test]
+fn reduce_sum_squares_default_requires_an_explicit_backend_override() {
+    let input = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
+    let mut backend = DefaultReadBackend::default();
+
+    let error = backend
+        .reduce_sum_squares_read(TensorRead::from_tensor(&input), &[0])
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        crate::Error::Unsupported {
+            op: "reduce_sum_squares",
+            ..
+        }
+    ));
+    assert!(backend.calls.is_empty());
+}
+
 impl TensorIndexing for DefaultReadBackend {
     fn gather(
         &mut self,

--- a/crates/tenferro-xla/src/lowering/program.rs
+++ b/crates/tenferro-xla/src/lowering/program.rs
@@ -238,6 +238,9 @@ fn lower_semantic_operation(
         SemanticOpRef::Core(CoreSemanticOp::ReduceSum { axes }) => {
             lower_reduce_sum(axes, &input_values, &output_ty, emitter)?
         }
+        SemanticOpRef::Core(CoreSemanticOp::ReduceSumSquares { axes }) => {
+            lower_reduce_sum_squares(axes, &input_values, &output_ty, emitter)?
+        }
         SemanticOpRef::Core(CoreSemanticOp::DotGeneral { config }) => {
             lower_dot_general(config, &input_values, &output_ty, emitter)?
         }
@@ -581,6 +584,7 @@ fn semantic_op_name(op: SemanticOpRef<'_>) -> &'static str {
             CoreSemanticOp::Convert { .. } => "Convert",
             CoreSemanticOp::Constant { .. } => "Constant",
             CoreSemanticOp::ReduceSum { .. } => "ReduceSum",
+            CoreSemanticOp::ReduceSumSquares { .. } => "ReduceSumSquares",
             CoreSemanticOp::Div => "Divide",
             CoreSemanticOp::Rem => "Remainder",
             CoreSemanticOp::Abs => "Abs",
@@ -801,6 +805,22 @@ fn lower_reduce_sum(
         name,
         ty: output_ty.clone(),
     })
+}
+
+fn lower_reduce_sum_squares(
+    axes: &[usize],
+    inputs: &[Value],
+    output_ty: &TensorType,
+    emitter: &mut Emitter,
+) -> Result<Value> {
+    require_input_count("reduce_sum_squares", inputs, 1)?;
+    let squared = lower_same_type_binary(
+        "stablehlo.multiply",
+        &[inputs[0].clone(), inputs[0].clone()],
+        &inputs[0].ty,
+        emitter,
+    )?;
+    lower_reduce_sum(axes, &[squared], output_ty, emitter)
 }
 
 fn lower_dot_general(

--- a/crates/tenferro-xla/tests/integration/stablehlo_lowering.rs
+++ b/crates/tenferro-xla/tests/integration/stablehlo_lowering.rs
@@ -24,6 +24,23 @@ fn lowers_elementwise_reduce_and_static_shapes() {
 }
 
 #[test]
+fn lowers_sum_squares_to_multiply_then_reduce() {
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 2).unwrap();
+    let y = x.reduce_sum_squares(&[0]).unwrap();
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(&y, &[(&x, DType::F64, &[2, 3])])
+        .unwrap();
+
+    let module = lower_to_stablehlo(program.program()).unwrap();
+    let text = module.as_str();
+
+    assert!(text.contains("stablehlo.multiply %arg0, %arg0 : tensor<2x3xf64>"));
+    assert!(text.contains("applies stablehlo.add across dimensions = [0]"));
+    assert!(text.contains("-> tensor<3xf64>"));
+}
+
+#[test]
 fn lowers_phase_one_real_elementwise_ops() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
     let unary = x

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -306,6 +306,7 @@ Legend:
 | `log1p` | `F32`, `F64` | `C32`, `C64` | same as input | result Native; read FallbackCopy; write Unsupported; strided Unsupported; accumulation Unsupported |
 | `dot_general` | `F32`, `F64`, `C32`, `C64` | none | same as input | result Native; read Native; write Native; strided Native; accumulation Native |
 | `reduce_sum` | `F32`, `F64`, `I32`, `I64`, `C32`, `C64` | none | same as input | result Native; read FallbackCopy; write Unsupported; strided Unsupported; accumulation Unsupported |
+| `reduce_sum_squares` | `F32`, `F64` | none | same as input | result Native; read FallbackCopy; write Unsupported; strided Unsupported; accumulation Unsupported |
 | `reduce_prod` | `F32`, `F64`, `I32`, `I64`, `C32`, `C64` | none | same as input | result Native; read FallbackCopy; write Unsupported; strided Unsupported; accumulation Unsupported |
 | `reduce_max` | `F32`, `F64`, `I32`, `I64` | none | same as input | result Native; read FallbackCopy; write Unsupported; strided Unsupported; accumulation Unsupported |
 | `reduce_min` | `F32`, `F64`, `I32`, `I64` | none | same as input | result Native; read FallbackCopy; write Unsupported; strided Unsupported; accumulation Unsupported |

--- a/docs/worklogs/2026-07-30-issue-1505-fused-sum-squares.md
+++ b/docs/worklogs/2026-07-30-issue-1505-fused-sum-squares.md
@@ -1,0 +1,119 @@
+# Issue #1505 fused sum-of-squares close-out
+
+## Session summary
+
+The merged pow-to-mul change removed the generic transcendental pass from
+Frobenius norms, but real `f64` still materialized the square before reducing
+it. This change adds a closed `ReduceSumSquares { axes }` core semantic
+primitive and maps the CPU backend to strided-kernel's one-pass
+`ReduceOp::SumSquares`.
+
+The primitive is an execution hook, not a new user-facing norm API. Eager,
+direct, and traced Frobenius paths all use it; `p_norm(..., 2.0)` continues to
+delegate to the Frobenius helper.
+
+## Context read
+
+- tenferro-rs #1505, including the merged step-1 measurements
+- tenferro-rs #1490 benchmark gate policy
+- strided-rs #149 reduction accumulation-order policy
+- strided-rs #167 and merged PR #177
+- `REPOSITORY_RULES.md`, especially explicit execution context, numerical
+  oracle, and benchmark evidence requirements
+
+## Decisions made
+
+- Use a closed semantic primitive rather than compiler-only pattern fusion.
+  Eager execution materializes `Mul` before graph compilation, so an
+  execution-IR rewrite cannot fix the eager row.
+- Treat `reduce_sum_squares` as a supported eager/traced reduction operation,
+  not a hidden sibling-crate helper. Its same-dtype square, dtype support,
+  empty-axis behavior, AD, and backend error contract are documented and
+  tested; the linalg layer consumes that public operation without exposing
+  lower-level graph construction APIs.
+- Keep the hidden backend default explicit: it returns typed unsupported
+  instead of materializing a square. `CpuBackend` and `CpuExecSession`
+  override with strided-kernel and an explicit bounded `ExecContext`.
+- Preserve the previously supported CUDA and XLA surfaces explicitly. CUDA
+  uses a CubeCL map-square reduction kernel on the first reduced axis and
+  ordinary sum kernels on remaining axes. Its generated operation uses
+  `fma(x, x, 0)` as a square-rounding barrier so NVRTC cannot contract the
+  later accumulation into FMA. XLA lowers the primitive to a logical
+  StableHLO multiply feeding reduce, preserving device execution without a
+  host fallback.
+- Restrict the primitive to `f32` and `f64`. Complex Frobenius norm retains
+  the existing complex magnitude pass, whose real output is then consumed by
+  the fused reduction.
+- Define empty axes as elementwise square, matching `ReduceSum(Mul(x, x), [])`.
+  The CPU read hook delegates that case to the existing pooled elementwise
+  multiply implementation.
+- Give both semantic AD and the legacy primitive-rule registry explicit JVP
+  and transpose rules equivalent to `2 * x * tangent` and
+  `2 * x * broadcast(cotangent)`.
+
+## Rejected or deferred alternatives
+
+- Compiler-only `ReduceSum(Mul(x, x))` recognition was rejected because it
+  leaves eager execution materializing the square.
+- Backend history inference and bespoke eager recording were rejected because
+  they introduce hidden state across ownership boundaries.
+- Complex magnitude-square fusion remains deferred; this PR preserves the
+  existing complex `abs` semantics and targets the confirmed real reduction
+  bottleneck.
+
+## Performance evidence
+
+Focused public API subset, full profile, 3 warmups and 15 measured runs. The
+baseline is tenferro-rs `39e96af578f04b19b4be9515b82cacda6e26a281`; the
+candidate uses strided-rs `95a607c061e95cc3a698a083dd279283a905f99c`.
+
+| row | threads | baseline ms | candidate ms | change |
+| --- | ---: | ---: | ---: | ---: |
+| `norm_fro` f64 eager | 1 | 22.568 | 1.002 | -95.6% |
+| `norm_fro` f64 trace | 1 | 5.506 | 1.022 | -81.4% |
+| `norm_fro` c64 eager | 1 | 25.894 | 23.234 | -10.3% |
+| `norm_fro` c64 trace | 1 | 23.029 | 19.763 | -14.2% |
+| `norm_fro` f64 eager | 4 | 10.113 | 1.070 | -89.4% |
+| `norm_fro` f64 trace | 4 | 2.435 | 1.108 | -54.5% |
+| `norm_fro` c64 eager | 4 | 10.337 | 9.531 | -7.8% |
+| `norm_fro` c64 trace | 4 | 6.778 | 5.607 | -17.3% |
+
+The `f64` single-thread eager result is also below the same-run PyTorch
+baseline of 1.205 ms, comfortably satisfying the issue's within-3x
+acceptance. Baseline and candidate were both rerun on CPU 60 for one thread
+and CPUs 60-63 for four threads to avoid a persistent process on CPU 56.
+
+## Verification performed
+
+- CPU fused reduction tests for `f32`, `f64`, empty axes, and non-compact views
+- tensor backend default-hook typed-unsupported test
+- semantic JVP/VJP structure test
+- Frobenius norm directional JVP and gradient finite-difference tests
+- direct eager `reduce_sum_squares` gradient finite-difference oracle
+- direct legacy transpose test distinguishing the linear key from the retained
+  primal key
+- CUDA A100 differential execution for `f32`/`f64`, multi-axis and empty-axis
+  semantics, and integer typed errors
+- CUDA A100 bitwise test with an input that distinguishes multiply-then-add
+  from contracted FMA
+- CUDA runtime-preparation routing test
+- XLA StableHLO multiply-plus-reduce lowering test
+- focused eager, concrete, traced, and AD norm integration tests
+- internal primitive AD registry and catalog coverage tests
+- focused public API benchmark at one and four threads
+- full local oracle replay: 9,585 records, 2,090 supported successes, 2
+  expected errors, 7,493 unsupported records, 56 parallel jobs
+
+## Remaining risks and follow-up work
+
+- Complex Frobenius norm still materializes magnitude before the fused real
+  reduction. Its residual cost is not addressed without separate profile
+  evidence.
+- The XLA preservation lowering expresses multiply followed by reduce in
+  StableHLO. Physical producer/reduction fusion is owned by XLA and is not
+  guaranteed by tenferro's textual lowering; W6's single-pass acceptance and
+  benchmark evidence cover the CPU strided implementation. A custom XLA
+  reduction is separate backend work if physical non-materialization must
+  become a tenferro-level guarantee there.
+- The broader final public API campaign and cross-workload gate verdict remain
+  tracked by #1490.

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "1460ab4b5f1720fe5e45bb1eb90844e09d8fd739"
+        revision = "95a607c061e95cc3a698a083dd279283a905f99c"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
## Summary

- add a closed `ReduceSumSquares` semantic primitive with eager, traced, runtime, AD, CPU, CUDA, and XLA routing
- execute real CPU Frobenius norms through strided-kernel's one-pass `SumSquares` reduction under the explicit pooled `ExecContext`
- preserve CUDA device execution with an A100-tested anti-FMA rounding barrier and preserve XLA through a multiply-then-reduce StableHLO lowering

## Performance

Focused public API benchmark, full profile, 3 warmups / 15 runs. Baseline `39e96af5`; candidate `4faf4cfd`. Both were measured on CPU 60 for t1 and CPUs 60-63 for t4.

| row | threads | baseline ms | candidate ms | change |
| --- | ---: | ---: | ---: | ---: |
| norm_fro f64 eager | 1 | 22.568 | 1.002 | -95.6% |
| norm_fro f64 trace | 1 | 5.506 | 1.022 | -81.4% |
| norm_fro c64 eager | 1 | 25.894 | 23.234 | -10.3% |
| norm_fro c64 trace | 1 | 23.029 | 19.763 | -14.2% |
| norm_fro f64 eager | 4 | 10.113 | 1.070 | -89.4% |
| norm_fro f64 trace | 4 | 2.435 | 1.108 | -54.5% |
| norm_fro c64 eager | 4 | 10.337 | 9.531 | -7.8% |
| norm_fro c64 trace | 4 | 6.778 | 5.607 | -17.3% |

The f64 t1 eager result is below the same-machine PyTorch reference of 1.205 ms and satisfies #1505's within-3x target.

## Verification

- `./scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-linalg --features autodiff --test integration norm'`
- full oracle replay: 9,585 records; 2,090 supported successes; 2 expected errors; 56 jobs
- A100 CUDA differential tests for f32/f64, multi-axis and empty axes
- A100 bitwise test that failed under NVRTC multiply/add contraction before the rounding-barrier fix
- XLA StableHLO lowering tests
- repository rules review passed; independent delta review returned mergeable

Closes #1505
