### PR TITLE
fix(linalg): dispatch direct eigvals values-only

### DIFF
--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -681,7 +681,7 @@ impl TensorLinalgExt for Tensor {
         Ok(self.eigh(backend)?.0)
     }
     fn eigvals<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        Ok(self.eig(backend)?.0)
+        backend.eig_values(self)
     }
     fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
         pinv_owned(self, None, backend)

--- a/crates/tenferro-linalg/tests/integration/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/integration/backend_errors.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use num_complex::{Complex32, Complex64};
 use tenferro_cpu::CpuBackend;
-use tenferro_linalg::LinalgBackend;
+use tenferro_linalg::{LinalgBackend, TensorLinalgExt};
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSessionHost, Buffer, BufferHandle, CompareDir,
     DType, DotGeneralConfig, Error, ErrorKind, GatherConfig, MemoryKind, PadConfig, Placement,
@@ -97,7 +97,10 @@ fn assert_no_panic_backend_download_error<T>(
 
 #[test]
 fn default_svd_read_returns_explicit_backend_boundary_error() {
-    struct DefaultOnlyLinalgBackend;
+    struct DefaultOnlyLinalgBackend {
+        eig_values_result: Option<Tensor>,
+        eig_values_calls: usize,
+    }
 
     macro_rules! panic_backend_methods {
         ($($name:ident($($arg:ident : $argty:ty),*) -> $ret:ty;)+) => {
@@ -208,11 +211,36 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
             eig(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
             solve(a: &Tensor, b: &Tensor) -> tenferro_tensor::Result<Tensor>;
         }
+
+        fn eig_values(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
+            self.eig_values_calls += 1;
+            Ok(self
+                .eig_values_result
+                .take()
+                .expect("eig_values result configured by the test"))
+        }
     }
 
     let input =
         TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0]).unwrap();
-    let mut backend = DefaultOnlyLinalgBackend;
+    let expected_eig_values = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+        )
+        .unwrap(),
+    );
+    let mut backend = DefaultOnlyLinalgBackend {
+        eig_values_result: Some(expected_eig_values),
+        eig_values_calls: 0,
+    };
+
+    let eig_values = Tensor::F64(input.clone()).eigvals(&mut backend).unwrap();
+    assert_eq!(backend.eig_values_calls, 1);
+    assert_eq!(
+        c64_values(&eig_values),
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)]
+    );
 
     let err = backend.lu_factor(&Tensor::F64(input.clone())).unwrap_err();
     assert!(matches!(

--- a/docs/worklogs/2026-07-30-issue-1524-direct-eigvals.md
+++ b/docs/worklogs/2026-07-30-issue-1524-direct-eigvals.md
@@ -1,0 +1,33 @@
+# Direct `eigvals` values-only dispatch
+
+Issue: #1524
+
+## Scope
+
+- Route the owned public `TensorLinalgExt::eigvals` surface through the backend
+  values-only hook.
+- Add a backend-spy regression test that fails if the public surface dispatches
+  to the full eigendecomposition.
+- Measure the exact `cpu/linalg_uncovered/eigvals` public API row at one and
+  four threads.
+
+## Decision
+
+The traced path already dispatches to `LinalgBackend::eig_values`. The owned
+path must use the same values-only backend contract instead of computing and
+discarding eigenvectors through `eig`.
+
+The read surface is unchanged because it has a separate borrowed-input
+contract and no values-only read hook.
+
+## Verification
+
+- Focused backend-spy regression test.
+- `cpu/linalg_uncovered/eigvals`, 3 warmups and 15 samples on an AMD
+  EPYC 7713P:
+  - threads 1, CPU 60: `9.737 ms` before, `7.447 ms` after (`-23.5%`)
+  - threads 4, CPUs 60-63: `11.424 ms` before, `8.507 ms` after (`-25.5%`)
+- The after values match the existing traced values-only path (`7.505 ms` and
+  `8.560 ms`, respectively), resolving the measured layer asymmetry.
+- CPUs 60-63 were 100% idle in the pre-measurement sample.
+- Repository fast check and repository-rules review.


### PR DESCRIPTION
Fixes #1524.

Routes the owned public `eigvals` API through `LinalgBackend::eig_values` instead of computing and discarding eigenvectors. Adds a backend-spy regression test that rejects dispatch to the full `eig` hook.

Benchmark (`cpu/linalg_uncovered/eigvals`, AMD EPYC 7713P, 3 warmups / 15 samples):

| threads | before | after | change | existing trace |
|---:|---:|---:|---:|---:|
| 1 | 9.737 ms | 7.447 ms | -23.5% | 7.505 ms |
| 4 | 11.424 ms | 8.507 ms | -25.5% | 8.560 ms |

CPUs 60-63 were idle before measurement.

Verification:
- focused backend-spy regression test
- `./scripts/check-pr-fast.sh` with focused test and coverage review
- repository rules review: pass, no findings