### PR TITLE
feat(runtime): define event-domain execution contract

### DIFF
--- a/crates/tenferro-cpu/src/runtime_adapter.rs
+++ b/crates/tenferro-cpu/src/runtime_adapter.rs
@@ -3,6 +3,7 @@ use std::mem::{size_of, size_of_val};
 use std::sync::Arc;
 
 use tenferro_runtime::program::{CoreSemanticOp, SemanticOpRef, SemanticOperationView};
+use tenferro_runtime::runtime::ImmediateEventDomainDriver;
 use tenferro_runtime::{
     CacheOwnerError, CoreCapabilityBundle, CoreCapabilityKind, CorePrepareContext,
     DotGeneralPreparation, DotGeneralPrepareRequest, ElementwisePrepareRequest, ElementwiseRuntime,
@@ -88,6 +89,7 @@ pub fn runtime_engine_registration(
     )
     .map(|registration| {
         registration
+            .with_event_domain_driver(Arc::new(ImmediateEventDomainDriver::new()))
             .with_cache_owner(cache_owner)
             .with_tensor_backend_executor(execution_backend)
             .with_input_signature_validator(move |placement, family, domain, candidate| {

--- a/crates/tenferro-runtime/src/runtime/engine_registration.rs
+++ b/crates/tenferro-runtime/src/runtime/engine_registration.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 
 use super::{
     execution, CoreCapabilityBundle, EngineId, EventDomainDriver, ExecutionContextIdentity,
-    HardwareClassId, ImmediateEventDomainDriver, InputSignatureEntry, RuntimeCacheOwner,
-    RuntimeConfigError, StorageClass,
+    HardwareClassId, InputSignatureEntry, RuntimeCacheOwner, RuntimeConfigError, StorageClass,
 };
 use tenferro_tensor::{AllocationDomainId, Placement, TensorBackend, TensorRead};
 
@@ -50,7 +49,7 @@ pub struct EngineRegistration {
     storage_classes: Arc<[StorageClass]>,
     default_storage_class: StorageClass,
     capabilities: CoreCapabilityBundle,
-    event_domain_driver: Arc<dyn EventDomainDriver>,
+    event_domain_driver: Option<Arc<dyn EventDomainDriver>>,
     pub(super) cache_owner: Option<Arc<dyn RuntimeCacheOwner>>,
     pub(super) execution_engine: Option<Arc<dyn execution::ErasedTensorBackendExecutor>>,
     input_placement_validator: Option<Arc<InputPlacementValidator>>,
@@ -93,7 +92,7 @@ impl EngineRegistration {
             storage_classes,
             default_storage_class,
             capabilities,
-            event_domain_driver: Arc::new(ImmediateEventDomainDriver::new()),
+            event_domain_driver: None,
             cache_owner: None,
             execution_engine: None,
             input_placement_validator: None,
@@ -162,7 +161,7 @@ impl EngineRegistration {
     /// # }
     /// ```
     pub fn with_event_domain_driver(mut self, driver: Arc<dyn EventDomainDriver>) -> Self {
-        self.event_domain_driver = driver;
+        self.event_domain_driver = Some(driver);
         self
     }
 
@@ -473,8 +472,9 @@ impl EngineRegistration {
         self.execution_engine.is_some()
     }
 
-    pub(super) fn event_domain_driver(&self) -> &Arc<dyn EventDomainDriver> {
-        &self.event_domain_driver
+    #[cfg(test)]
+    pub(crate) fn event_domain_driver(&self) -> Option<&Arc<dyn EventDomainDriver>> {
+        self.event_domain_driver.as_ref()
     }
 
     pub(super) fn candidate_identical(&self, other: &Self) -> bool {
@@ -493,7 +493,7 @@ impl fmt::Debug for EngineRegistration {
             .field("storage_class_count", &self.storage_classes.len())
             .field("default_storage_class", &self.default_storage_class)
             .field("capabilities", &self.capabilities)
-            .field("event_domain_driver", &self.event_domain_driver)
+            .field("event_domain_driver", &self.event_domain_driver.is_some())
             .field("cache_owner", &self.cache_owner.is_some())
             .field("execution_engine", &self.has_execution_engine())
             .field(

--- a/crates/tenferro-runtime/src/runtime/engine_registration.rs
+++ b/crates/tenferro-runtime/src/runtime/engine_registration.rs
@@ -2,8 +2,9 @@ use std::fmt;
 use std::sync::Arc;
 
 use super::{
-    execution, CoreCapabilityBundle, EngineId, ExecutionContextIdentity, HardwareClassId,
-    InputSignatureEntry, RuntimeCacheOwner, RuntimeConfigError, StorageClass,
+    execution, CoreCapabilityBundle, EngineId, EventDomainDriver, ExecutionContextIdentity,
+    HardwareClassId, ImmediateEventDomainDriver, InputSignatureEntry, RuntimeCacheOwner,
+    RuntimeConfigError, StorageClass,
 };
 use tenferro_tensor::{AllocationDomainId, Placement, TensorBackend, TensorRead};
 
@@ -49,6 +50,7 @@ pub struct EngineRegistration {
     storage_classes: Arc<[StorageClass]>,
     default_storage_class: StorageClass,
     capabilities: CoreCapabilityBundle,
+    event_domain_driver: Arc<dyn EventDomainDriver>,
     pub(super) cache_owner: Option<Arc<dyn RuntimeCacheOwner>>,
     pub(super) execution_engine: Option<Arc<dyn execution::ErasedTensorBackendExecutor>>,
     input_placement_validator: Option<Arc<InputPlacementValidator>>,
@@ -91,6 +93,7 @@ impl EngineRegistration {
             storage_classes,
             default_storage_class,
             capabilities,
+            event_domain_driver: Arc::new(ImmediateEventDomainDriver::new()),
             cache_owner: None,
             execution_engine: None,
             input_placement_validator: None,
@@ -129,6 +132,38 @@ impl EngineRegistration {
     /// Return direct core capability slots.
     pub fn capabilities(&self) -> &CoreCapabilityBundle {
         &self.capabilities
+    }
+
+    /// Attach the driver that owns this engine's per-run event-domain state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::sync::Arc;
+    /// use tenferro_runtime::runtime::ImmediateEventDomainDriver;
+    /// use tenferro_runtime::{
+    ///     CoreCapabilityBundle, EngineId, EngineRegistration, ExecutionContextIdentity,
+    ///     HardwareClassId, StorageClass,
+    /// };
+    ///
+    /// let storage = StorageClass::new("tenferro.storage.host")?;
+    /// let registration = EngineRegistration::new(
+    ///     EngineId::new("tenferro.cpu")?,
+    ///     ExecutionContextIdentity::of::<()>(),
+    ///     HardwareClassId::new("tenferro.cpu.host")?,
+    ///     Arc::from([storage.clone()]),
+    ///     storage,
+    ///     CoreCapabilityBundle::default(),
+    /// )?
+    /// .with_event_domain_driver(Arc::new(ImmediateEventDomainDriver::new()));
+    /// assert_eq!(registration.engine_id().as_str(), "tenferro.cpu");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_event_domain_driver(mut self, driver: Arc<dyn EventDomainDriver>) -> Self {
+        self.event_domain_driver = driver;
+        self
     }
 
     /// Attach a runtime cache owner to this registration.
@@ -438,6 +473,10 @@ impl EngineRegistration {
         self.execution_engine.is_some()
     }
 
+    pub(super) fn event_domain_driver(&self) -> &Arc<dyn EventDomainDriver> {
+        &self.event_domain_driver
+    }
+
     pub(super) fn candidate_identical(&self, other: &Self) -> bool {
         self.engine_id == other.engine_id
             && Arc::ptr_eq(&self.candidate_token, &other.candidate_token)
@@ -454,6 +493,7 @@ impl fmt::Debug for EngineRegistration {
             .field("storage_class_count", &self.storage_classes.len())
             .field("default_storage_class", &self.default_storage_class)
             .field("capabilities", &self.capabilities)
+            .field("event_domain_driver", &self.event_domain_driver)
             .field("cache_owner", &self.cache_owner.is_some())
             .field("execution_engine", &self.has_execution_engine())
             .field(

--- a/crates/tenferro-runtime/src/runtime/event_domain.rs
+++ b/crates/tenferro-runtime/src/runtime/event_domain.rs
@@ -6,6 +6,17 @@ use std::sync::Arc;
 pub trait EventToken: fmt::Debug + Send + Sync + 'static {
     /// Return the token as [`Any`] for driver-specific inspection.
     fn as_any(&self) -> &dyn Any;
+
+    /// Wait on the host until this completion becomes ready.
+    ///
+    /// Native drivers should encode same-backend dependencies in their queue or
+    /// stream. They use this fallback for foreign token types that cannot be
+    /// represented as a native dependency.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed backend or runtime error when completion fails.
+    fn wait(&self) -> crate::Result<()>;
 }
 
 /// Per-execution state owned by one event domain.
@@ -16,6 +27,10 @@ pub trait EventDomainRun: fmt::Debug + Send {
     ///
     /// Returns a typed runtime error when a dependency is incompatible with
     /// this domain or when the launch fails.
+    ///
+    /// The implementation must invoke `launch` exactly once before returning,
+    /// without holding a driver lock. The closure submits work to the native
+    /// queue; it does not wait for that work to complete.
     fn enqueue(
         &mut self,
         dependencies: &[Arc<dyn EventToken>],
@@ -27,6 +42,9 @@ pub trait EventDomainRun: fmt::Debug + Send {
     /// # Errors
     ///
     /// Returns the first domain completion failure.
+    ///
+    /// Draining observes already-progressing work. It must not require another
+    /// event domain's `drain` call to start that work.
     fn drain(&mut self) -> crate::Result<()>;
 }
 
@@ -47,6 +65,10 @@ pub struct ReadyEventToken;
 impl EventToken for ReadyEventToken {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn wait(&self) -> crate::Result<()> {
+        Ok(())
     }
 }
 
@@ -74,9 +96,12 @@ struct ImmediateEventDomainRun;
 impl EventDomainRun for ImmediateEventDomainRun {
     fn enqueue(
         &mut self,
-        _dependencies: &[Arc<dyn EventToken>],
+        dependencies: &[Arc<dyn EventToken>],
         launch: &mut dyn FnMut() -> crate::Result<()>,
     ) -> crate::Result<Arc<dyn EventToken>> {
+        for dependency in dependencies {
+            dependency.wait()?;
+        }
         launch()?;
         Ok(Arc::new(ReadyEventToken))
     }

--- a/crates/tenferro-runtime/src/runtime/event_domain.rs
+++ b/crates/tenferro-runtime/src/runtime/event_domain.rs
@@ -3,8 +3,53 @@ use std::fmt;
 use std::sync::Arc;
 
 /// Opaque completion token produced by one event-domain run.
+///
+/// `wait` is repeatable and safe to call concurrently. A schedule may fan one
+/// completion out to multiple foreign event domains, so implementations must
+/// not consume the token on the first wait.
+///
+/// # Examples
+///
+/// ```
+/// use std::any::Any;
+/// use tenferro_runtime::runtime::EventToken;
+///
+/// #[derive(Debug)]
+/// struct Ready;
+///
+/// impl EventToken for Ready {
+///     fn as_any(&self) -> &dyn Any {
+///         self
+///     }
+///
+///     fn wait(&self) -> tenferro_runtime::Result<()> {
+///         Ok(())
+///     }
+/// }
+///
+/// let token = Ready;
+/// token.wait()?;
+/// token.wait()?;
+/// assert!(token.as_any().is::<Ready>());
+/// # Ok::<(), tenferro_runtime::Error>(())
+/// ```
 pub trait EventToken: fmt::Debug + Send + Sync + 'static {
     /// Return the token as [`Any`] for driver-specific inspection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::runtime::{
+    ///     EventDomainDriver, ImmediateEventDomainDriver,
+    /// };
+    ///
+    /// let driver = ImmediateEventDomainDriver::new();
+    /// let mut run = driver.begin_run()?;
+    /// let mut launch = || Ok(());
+    /// let token = run.enqueue(&[], &mut launch)?;
+    /// let _opaque = token.as_any();
+    /// # Ok::<(), tenferro_runtime::Error>(())
+    /// ```
     fn as_any(&self) -> &dyn Any;
 
     /// Wait on the host until this completion becomes ready.
@@ -15,22 +60,77 @@ pub trait EventToken: fmt::Debug + Send + Sync + 'static {
     ///
     /// # Errors
     ///
-    /// Returns a typed backend or runtime error when completion fails.
+    /// Returns a typed backend or runtime error when the native completion
+    /// reports failure, or when a foreign completion token cannot be waited on.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::runtime::{
+    ///     EventDomainDriver, ImmediateEventDomainDriver,
+    /// };
+    ///
+    /// let driver = ImmediateEventDomainDriver::new();
+    /// let mut run = driver.begin_run()?;
+    /// let mut launch = || Ok(());
+    /// run.enqueue(&[], &mut launch)?.wait()?;
+    /// # Ok::<(), tenferro_runtime::Error>(())
+    /// ```
     fn wait(&self) -> crate::Result<()>;
 }
 
 /// Per-execution state owned by one event domain.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_runtime::runtime::{
+///     EventDomainDriver, EventDomainRun, ImmediateEventDomainDriver,
+/// };
+///
+/// fn submit(run: &mut dyn EventDomainRun) -> tenferro_runtime::Result<()> {
+///     let mut launch = || Ok(());
+///     run.enqueue(&[], &mut launch)?;
+///     run.drain()
+/// }
+///
+/// let driver = ImmediateEventDomainDriver::new();
+/// let mut run = driver.begin_run()?;
+/// submit(run.as_mut())?;
+/// # Ok::<(), tenferro_runtime::Error>(())
+/// ```
 pub trait EventDomainRun: fmt::Debug + Send {
     /// Enqueue one launch after its dependency tokens.
     ///
     /// # Errors
     ///
-    /// Returns a typed runtime error when a dependency is incompatible with
-    /// this domain or when the launch fails.
+    /// Returns a typed runtime error when a dependency token is incompatible
+    /// with this domain, native queue submission fails, or `launch` returns an
+    /// error.
     ///
-    /// The implementation must invoke `launch` exactly once before returning,
-    /// without holding a driver lock. The closure submits work to the native
-    /// queue; it does not wait for that work to complete.
+    /// The implementation must not invoke `launch` when dependency admission
+    /// or waiting fails. After dependencies are admitted, it invokes `launch`
+    /// exactly once without holding a driver lock. The closure submits work to
+    /// the native queue; it does not wait for that work to complete.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::runtime::{
+    ///     EventDomainDriver, ImmediateEventDomainDriver,
+    /// };
+    ///
+    /// let driver = ImmediateEventDomainDriver::new();
+    /// let mut run = driver.begin_run()?;
+    /// let mut launched = false;
+    /// let mut launch = || {
+    ///     launched = true;
+    ///     Ok(())
+    /// };
+    /// run.enqueue(&[], &mut launch)?;
+    /// assert!(launched);
+    /// # Ok::<(), tenferro_runtime::Error>(())
+    /// ```
     fn enqueue(
         &mut self,
         dependencies: &[Arc<dyn EventToken>],
@@ -41,26 +141,72 @@ pub trait EventDomainRun: fmt::Debug + Send {
     ///
     /// # Errors
     ///
-    /// Returns the first domain completion failure.
+    /// Returns the first driver-defined typed error, such as
+    /// [`crate::Error::Internal`], when a queued completion reports failure or
+    /// the native queue cannot be synchronized.
     ///
     /// Draining observes already-progressing work. It must not require another
     /// event domain's `drain` call to start that work.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::runtime::{
+    ///     EventDomainDriver, ImmediateEventDomainDriver,
+    /// };
+    ///
+    /// let driver = ImmediateEventDomainDriver::new();
+    /// let mut run = driver.begin_run()?;
+    /// run.drain()?;
+    /// # Ok::<(), tenferro_runtime::Error>(())
+    /// ```
     fn drain(&mut self) -> crate::Result<()>;
 }
 
 /// Runtime-owned factory for per-execution event-domain state.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_runtime::runtime::{
+///     EventDomainDriver, ImmediateEventDomainDriver,
+/// };
+///
+/// let driver = ImmediateEventDomainDriver::new();
+/// let mut run = driver.begin_run()?;
+/// let mut launch = || Ok(());
+/// let completion = run.enqueue(&[], &mut launch)?;
+/// completion.wait()?;
+/// run.drain()?;
+/// # Ok::<(), tenferro_runtime::Error>(())
+/// ```
 pub trait EventDomainDriver: fmt::Debug + Send + Sync + 'static {
     /// Begin one isolated execution run.
     ///
     /// # Errors
     ///
-    /// Returns a typed runtime error when the domain cannot admit a new run.
+    /// Returns a driver-defined typed error, such as [`crate::Error::Internal`],
+    /// when native queue, stream, or per-run event-state allocation fails, or
+    /// when the domain cannot admit a new run.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::runtime::{
+    ///     EventDomainDriver, ImmediateEventDomainDriver,
+    /// };
+    ///
+    /// let driver = ImmediateEventDomainDriver::new();
+    /// let mut run = driver.begin_run()?;
+    /// run.drain()?;
+    /// # Ok::<(), tenferro_runtime::Error>(())
+    /// ```
     fn begin_run(&self) -> crate::Result<Box<dyn EventDomainRun>>;
 }
 
 /// Completion token returned by the blocking immediate domain.
 #[derive(Debug)]
-pub struct ReadyEventToken;
+struct ReadyEventToken;
 
 impl EventToken for ReadyEventToken {
     fn as_any(&self) -> &dyn Any {
@@ -73,11 +219,31 @@ impl EventToken for ReadyEventToken {
 }
 
 /// Blocking event-domain driver used by synchronous CPU engines.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_runtime::runtime::{
+///     EventDomainDriver, ImmediateEventDomainDriver,
+/// };
+///
+/// let driver = ImmediateEventDomainDriver::new();
+/// driver.begin_run()?.drain()?;
+/// # Ok::<(), tenferro_runtime::Error>(())
+/// ```
 #[derive(Clone, Copy, Debug, Default)]
 pub struct ImmediateEventDomainDriver;
 
 impl ImmediateEventDomainDriver {
     /// Construct a blocking immediate driver.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::runtime::ImmediateEventDomainDriver;
+    ///
+    /// let _driver = ImmediateEventDomainDriver::new();
+    /// ```
     #[must_use]
     pub const fn new() -> Self {
         Self

--- a/crates/tenferro-runtime/src/runtime/event_domain.rs
+++ b/crates/tenferro-runtime/src/runtime/event_domain.rs
@@ -1,0 +1,87 @@
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+/// Opaque completion token produced by one event-domain run.
+pub trait EventToken: fmt::Debug + Send + Sync + 'static {
+    /// Return the token as [`Any`] for driver-specific inspection.
+    fn as_any(&self) -> &dyn Any;
+}
+
+/// Per-execution state owned by one event domain.
+pub trait EventDomainRun: fmt::Debug + Send {
+    /// Enqueue one launch after its dependency tokens.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed runtime error when a dependency is incompatible with
+    /// this domain or when the launch fails.
+    fn enqueue(
+        &mut self,
+        dependencies: &[Arc<dyn EventToken>],
+        launch: &mut dyn FnMut() -> crate::Result<()>,
+    ) -> crate::Result<Arc<dyn EventToken>>;
+
+    /// Wait for all work already enqueued in this run.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first domain completion failure.
+    fn drain(&mut self) -> crate::Result<()>;
+}
+
+/// Runtime-owned factory for per-execution event-domain state.
+pub trait EventDomainDriver: fmt::Debug + Send + Sync + 'static {
+    /// Begin one isolated execution run.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed runtime error when the domain cannot admit a new run.
+    fn begin_run(&self) -> crate::Result<Box<dyn EventDomainRun>>;
+}
+
+/// Completion token returned by the blocking immediate domain.
+#[derive(Debug)]
+pub struct ReadyEventToken;
+
+impl EventToken for ReadyEventToken {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Blocking event-domain driver used by synchronous CPU engines.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ImmediateEventDomainDriver;
+
+impl ImmediateEventDomainDriver {
+    /// Construct a blocking immediate driver.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl EventDomainDriver for ImmediateEventDomainDriver {
+    fn begin_run(&self) -> crate::Result<Box<dyn EventDomainRun>> {
+        Ok(Box::new(ImmediateEventDomainRun))
+    }
+}
+
+#[derive(Debug)]
+struct ImmediateEventDomainRun;
+
+impl EventDomainRun for ImmediateEventDomainRun {
+    fn enqueue(
+        &mut self,
+        _dependencies: &[Arc<dyn EventToken>],
+        launch: &mut dyn FnMut() -> crate::Result<()>,
+    ) -> crate::Result<Arc<dyn EventToken>> {
+        launch()?;
+        Ok(Arc::new(ReadyEventToken))
+    }
+
+    fn drain(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/tenferro-runtime/src/runtime/mod.rs
+++ b/crates/tenferro-runtime/src/runtime/mod.rs
@@ -38,9 +38,7 @@ pub use error::{
     PrepareError, ProviderContractError, RankRequirement, RegistrationKey, RuntimeConfigError,
     RuntimeReconfigureError, SpecializationError, SubmissionError,
 };
-pub use event_domain::{
-    EventDomainDriver, EventDomainRun, EventToken, ImmediateEventDomainDriver, ReadyEventToken,
-};
+pub use event_domain::{EventDomainDriver, EventDomainRun, EventToken, ImmediateEventDomainDriver};
 pub use execution::{ExecutionHandle, PreparedCompiledGraph};
 pub use extension::{ExtensionModule, ExtensionModuleId, ExtensionModuleRegistrar};
 pub use extension_provider::{ExtensionEngine, ExtensionPlanningConfig, ExtensionPrepareRequest};

--- a/crates/tenferro-runtime/src/runtime/mod.rs
+++ b/crates/tenferro-runtime/src/runtime/mod.rs
@@ -3,6 +3,7 @@ mod cache_owner;
 mod capability;
 mod engine_registration;
 mod error;
+mod event_domain;
 mod execution;
 mod extension;
 mod extension_provider;
@@ -36,6 +37,9 @@ pub use error::{
     InputSignatureError, InputSpecializationRequirementsError, PlacementConstraintError,
     PrepareError, ProviderContractError, RankRequirement, RegistrationKey, RuntimeConfigError,
     RuntimeReconfigureError, SpecializationError, SubmissionError,
+};
+pub use event_domain::{
+    EventDomainDriver, EventDomainRun, EventToken, ImmediateEventDomainDriver, ReadyEventToken,
 };
 pub use execution::{ExecutionHandle, PreparedCompiledGraph};
 pub use extension::{ExtensionModule, ExtensionModuleId, ExtensionModuleRegistrar};

--- a/crates/tenferro-runtime/src/runtime/schedule.rs
+++ b/crates/tenferro-runtime/src/runtime/schedule.rs
@@ -598,7 +598,9 @@ impl ScheduledGraph {
             {
                 return Err(ScheduleValidationError::DependencyNotPriorCompletion { index });
             }
-            known_completions.insert(EventDependency::from_completion(node.completion()));
+            if !known_completions.insert(EventDependency::from_completion(node.completion())) {
+                return Err(ScheduleValidationError::DuplicateCompletion { index });
+            }
         }
         Ok(())
     }
@@ -673,6 +675,8 @@ pub(crate) enum ScheduleValidationError {
     DependencyEventDomainMismatch { index: usize },
     #[error("schedule node {index} dependency does not refer to a prior completion")]
     DependencyNotPriorCompletion { index: usize },
+    #[error("schedule node {index} reuses a prior completion identity")]
+    DuplicateCompletion { index: usize },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/tenferro-runtime/src/runtime/schedule.rs
+++ b/crates/tenferro-runtime/src/runtime/schedule.rs
@@ -3,7 +3,7 @@
 //! This representation remains crate-private. Later phases attach native
 //! GPU/XLA dispatch and asynchronous completion to the same node families.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 #[cfg(test)]
 use std::error::Error as StdError;
 #[cfg(test)]
@@ -133,6 +133,7 @@ pub(crate) struct ScheduledOperation {
     location: ExecutionLocation,
     input_values: Box<[usize]>,
     output_values: Box<[usize]>,
+    dependencies: Box<[EventDependency]>,
     completion: EventCompletion,
 }
 
@@ -142,6 +143,7 @@ impl ScheduledOperation {
         location: ExecutionLocation,
         input_values: impl Into<Box<[usize]>>,
         output_values: impl Into<Box<[usize]>>,
+        dependencies: impl Into<Box<[EventDependency]>>,
         completion: EventCompletion,
     ) -> Self {
         Self {
@@ -149,6 +151,7 @@ impl ScheduledOperation {
             location,
             input_values: input_values.into(),
             output_values: output_values.into(),
+            dependencies: dependencies.into(),
             completion,
         }
     }
@@ -158,6 +161,7 @@ impl ScheduledOperation {
         Self::new(
             0,
             ExecutionLocation::for_test(domain),
+            [],
             [],
             [],
             EventCompletion::new(domain, EventSlotId::new(0), 0),
@@ -172,6 +176,10 @@ impl ScheduledOperation {
         &self.location
     }
 
+    pub(crate) fn dependencies(&self) -> &[EventDependency] {
+        &self.dependencies
+    }
+
     pub(crate) fn completion(&self) -> EventCompletion {
         self.completion
     }
@@ -184,6 +192,9 @@ impl ScheduledOperation {
             self.output_values
                 .len()
                 .checked_mul(std::mem::size_of::<usize>())?,
+            self.dependencies
+                .len()
+                .checked_mul(std::mem::size_of::<EventDependency>())?,
         ])
     }
 }
@@ -294,6 +305,10 @@ impl ScheduledCollective {
         self.completion
     }
 
+    fn dependencies(&self) -> &[EventDependency] {
+        &self.dependencies
+    }
+
     fn retained_bytes(&self) -> Option<usize> {
         self.dependencies
             .len()
@@ -308,6 +323,10 @@ pub(crate) struct ScheduledBarrier {
 }
 
 impl ScheduledBarrier {
+    fn dependencies(&self) -> &[EventDependency] {
+        &self.dependencies
+    }
+
     pub(crate) fn completion(&self) -> EventCompletion {
         self.completion
     }
@@ -340,13 +359,21 @@ pub(crate) enum ScheduledNode {
 }
 
 impl ScheduledNode {
-    #[cfg(test)]
     pub(crate) fn completion(&self) -> EventCompletion {
         match self {
             Self::Operation(node) => node.completion(),
             Self::Transfer(node) => node.completion(),
             Self::Collective(node) => node.completion(),
             Self::Barrier(node) => node.completion(),
+        }
+    }
+
+    pub(crate) fn dependencies(&self) -> &[EventDependency] {
+        match self {
+            Self::Operation(node) => node.dependencies(),
+            Self::Transfer(node) => node.dependencies(),
+            Self::Collective(node) => node.dependencies(),
+            Self::Barrier(node) => node.dependencies(),
         }
     }
 
@@ -466,12 +493,19 @@ impl ScheduledGraph {
                 });
             }
 
+            let dependencies = operation_dependencies(
+                &available,
+                instruction_index,
+                &instruction.input_slots,
+                &location,
+            )?;
             let completion = event_completion(&nodes, location.event_domain_id())?;
             nodes.push(ScheduledNode::Operation(ScheduledOperation::new(
                 instruction_index,
                 location.clone(),
                 instruction.input_slots.clone(),
                 instruction.output_slots.clone(),
+                dependencies,
                 completion,
             )));
 
@@ -521,6 +555,7 @@ impl ScheduledGraph {
     }
 
     pub(crate) fn validate(&self) -> Result<(), ScheduleValidationError> {
+        let mut known_completions = HashSet::with_capacity(self.nodes.len());
         for (index, node) in self.nodes.iter().enumerate() {
             match node {
                 ScheduledNode::Operation(operation) => {
@@ -556,6 +591,14 @@ impl ScheduledGraph {
                     let _ = barrier.completion().domain();
                 }
             }
+            if node
+                .dependencies()
+                .iter()
+                .any(|dependency| !known_completions.contains(dependency))
+            {
+                return Err(ScheduleValidationError::DependencyNotPriorCompletion { index });
+            }
+            known_completions.insert(EventDependency::from_completion(node.completion()));
         }
         Ok(())
     }
@@ -628,6 +671,8 @@ pub(crate) enum ScheduleValidationError {
     CompletionEventDomainMismatch { index: usize },
     #[error("schedule node {index} dependency uses the wrong event domain")]
     DependencyEventDomainMismatch { index: usize },
+    #[error("schedule node {index} dependency does not refer to a prior completion")]
+    DependencyNotPriorCompletion { index: usize },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -691,6 +736,38 @@ fn checked_sum(values: impl IntoIterator<Item = usize>) -> Option<usize> {
 struct AvailableValue {
     location: ExecutionLocation,
     completion: Option<EventCompletion>,
+}
+
+fn operation_dependencies(
+    available: &[Vec<AvailableValue>],
+    instruction_index: usize,
+    input_slots: &[usize],
+    location: &ExecutionLocation,
+) -> Result<Vec<EventDependency>, ScheduleBuildError> {
+    let mut dependencies = Vec::with_capacity(input_slots.len());
+    let mut seen = HashSet::with_capacity(input_slots.len());
+    for &slot in input_slots {
+        let values = available
+            .get(slot)
+            .ok_or(ScheduleBuildError::ValueSlotOutOfBounds {
+                slot,
+                value_count: available.len(),
+            })?;
+        let value = values
+            .iter()
+            .find(|value| &value.location == location)
+            .ok_or(ScheduleBuildError::ValueUnavailable {
+                instruction_index,
+                slot,
+            })?;
+        if let Some(completion) = value.completion {
+            let dependency = EventDependency::from_completion(completion);
+            if seen.insert(dependency) {
+                dependencies.push(dependency);
+            }
+        }
+    }
+    Ok(dependencies)
 }
 
 fn event_completion(

--- a/crates/tenferro-runtime/src/runtime/snapshot.rs
+++ b/crates/tenferro-runtime/src/runtime/snapshot.rs
@@ -21,11 +21,11 @@ use super::extension::{
 use super::preparation::{PreparedEntryKey, PreparedProgram, PreparedProgramResult};
 use super::schedule::EventDomainId;
 use super::{
-    CacheOwnerId, CoreCapabilityBundle, EngineId, EngineRegistration, ExecutionContextIdentity,
-    ExecutionPolicy, ExtensionModule, ExtensionModuleError, ExtensionModuleId, HardwareClassId,
-    InputSignature, PrepareOptions, RegistrationIdentity, RegistrationKey, RuntimeCacheError,
-    RuntimeCacheStats, RuntimeConfigError, RuntimeEpoch, RuntimeId, RuntimeReconfigureError,
-    RuntimeStateError, StorageClass, TransferProvider,
+    CacheOwnerId, CoreCapabilityBundle, EngineId, EngineRegistration, EventDomainDriver,
+    ExecutionContextIdentity, ExecutionPolicy, ExtensionModule, ExtensionModuleError,
+    ExtensionModuleId, HardwareClassId, InputSignature, PrepareOptions, RegistrationIdentity,
+    RegistrationKey, RuntimeCacheError, RuntimeCacheStats, RuntimeConfigError, RuntimeEpoch,
+    RuntimeId, RuntimeReconfigureError, RuntimeStateError, StorageClass, TransferProvider,
 };
 
 static NEXT_RUNTIME_ID: AtomicU64 = AtomicU64::new(1);
@@ -1130,6 +1130,22 @@ impl<'a> EngineSnapshotView<'a> {
     /// Return this engine's runtime event domain.
     pub fn event_domain_id(&self) -> EventDomainId {
         self.slot.event_domain_id
+    }
+
+    /// Return the driver that owns this engine's per-run event-domain state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_runtime::{EngineSnapshotView, Result};
+    ///
+    /// fn begin_and_drain(view: &EngineSnapshotView<'_>) -> Result<()> {
+    ///     let mut run = view.event_domain_driver().begin_run()?;
+    ///     run.drain()
+    /// }
+    /// ```
+    pub fn event_domain_driver(&self) -> &'a Arc<dyn EventDomainDriver> {
+        self.slot.registration.event_domain_driver()
     }
 
     /// Return the hardware class for this slot.

--- a/crates/tenferro-runtime/src/runtime/snapshot.rs
+++ b/crates/tenferro-runtime/src/runtime/snapshot.rs
@@ -21,11 +21,11 @@ use super::extension::{
 use super::preparation::{PreparedEntryKey, PreparedProgram, PreparedProgramResult};
 use super::schedule::EventDomainId;
 use super::{
-    CacheOwnerId, CoreCapabilityBundle, EngineId, EngineRegistration, EventDomainDriver,
-    ExecutionContextIdentity, ExecutionPolicy, ExtensionModule, ExtensionModuleError,
-    ExtensionModuleId, HardwareClassId, InputSignature, PrepareOptions, RegistrationIdentity,
-    RegistrationKey, RuntimeCacheError, RuntimeCacheStats, RuntimeConfigError, RuntimeEpoch,
-    RuntimeId, RuntimeReconfigureError, RuntimeStateError, StorageClass, TransferProvider,
+    CacheOwnerId, CoreCapabilityBundle, EngineId, EngineRegistration, ExecutionContextIdentity,
+    ExecutionPolicy, ExtensionModule, ExtensionModuleError, ExtensionModuleId, HardwareClassId,
+    InputSignature, PrepareOptions, RegistrationIdentity, RegistrationKey, RuntimeCacheError,
+    RuntimeCacheStats, RuntimeConfigError, RuntimeEpoch, RuntimeId, RuntimeReconfigureError,
+    RuntimeStateError, StorageClass, TransferProvider,
 };
 
 static NEXT_RUNTIME_ID: AtomicU64 = AtomicU64::new(1);
@@ -1132,19 +1132,9 @@ impl<'a> EngineSnapshotView<'a> {
         self.slot.event_domain_id
     }
 
-    /// Return the driver that owns this engine's per-run event-domain state.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_runtime::{EngineSnapshotView, Result};
-    ///
-    /// fn begin_and_drain(view: &EngineSnapshotView<'_>) -> Result<()> {
-    ///     let mut run = view.event_domain_driver().begin_run()?;
-    ///     run.drain()
-    /// }
-    /// ```
-    pub fn event_domain_driver(&self) -> &'a Arc<dyn EventDomainDriver> {
+    // Scheduler activation will make this production-visible inside the runtime.
+    #[cfg(test)]
+    pub(crate) fn event_domain_driver(&self) -> Option<&'a Arc<dyn super::EventDomainDriver>> {
         self.slot.registration.event_domain_driver()
     }
 

--- a/crates/tenferro-runtime/src/runtime/tests/schedule.rs
+++ b/crates/tenferro-runtime/src/runtime/tests/schedule.rs
@@ -1,6 +1,6 @@
 use super::super::schedule::{
-    EventDomainId, ExecutionLocation, ScheduledCollective, ScheduledGraph, ScheduledNode,
-    ScheduledOperation, ScheduledTransfer, TransferReachability,
+    EventDependency, EventDomainId, EventSlotId, ExecutionLocation, ScheduledCollective,
+    ScheduledGraph, ScheduledNode, ScheduledOperation, ScheduledTransfer, TransferReachability,
 };
 use super::super::{EngineId, StorageClass};
 use crate::exec::{ExecInstruction, ExecOp, ExecProgram};
@@ -84,7 +84,14 @@ fn schedule_emits_location_transfer_and_retains_source_for_split_use() {
     assert!(matches!(
         &graph.nodes_for_test()[2],
         ScheduledNode::Operation(operation)
-            if operation.instruction_index() == 1 && operation.location() == &destination
+            if operation.instruction_index() == 1
+                && operation.location() == &destination
+                && operation.dependencies()
+                    == [EventDependency::new(
+                        destination.event_domain_id(),
+                        EventSlotId::new(1),
+                        0,
+                    )]
     ));
     assert!(matches!(
         &graph.nodes_for_test()[3],
@@ -144,6 +151,121 @@ fn schedule_uses_a_copy_with_a_direct_route_to_the_destination() {
     assert_eq!(transfers.len(), 2);
     assert_eq!(transfers[1].source_location(), &reachable);
     assert_eq!(transfers[1].destination_location(), &destination);
+}
+
+#[test]
+fn operation_dependencies_follow_input_order_and_are_deduplicated() {
+    let execution = location(
+        "tenferro-test.engine.execution",
+        1,
+        "tenferro-test.storage.execution",
+    );
+    let program = ExecProgram {
+        instructions: vec![
+            instruction(0, 0, 1, false),
+            instruction(1, 0, 2, true),
+            ExecInstruction {
+                op: ExecOp::Negate,
+                semantic_operation_index: Some(2),
+                input_slots: vec![2, 1, 2],
+                output_slots: vec![3],
+                dtype: DType::F64,
+                output_shapes: Default::default(),
+                output_extents: Default::default(),
+                last_use: vec![true, true, true],
+            },
+        ],
+        input_slots: vec![0],
+        output_slots: vec![3],
+        n_slots: 4,
+        shape_guards: Vec::new(),
+    };
+
+    let graph = ScheduledGraph::from_exec_program(
+        &program,
+        execution.clone(),
+        std::slice::from_ref(&execution),
+        &[execution.clone(), execution.clone(), execution.clone()],
+        &TransferReachability::new(),
+    )
+    .expect("schedule");
+    let ScheduledNode::Operation(operation) = &graph.nodes_for_test()[2] else {
+        panic!("third node should be an operation");
+    };
+
+    assert_eq!(
+        operation.dependencies(),
+        &[
+            EventDependency::new(
+                EventDomainId::runtime_created_for_test(1),
+                EventSlotId::new(1),
+                0,
+            ),
+            EventDependency::new(
+                EventDomainId::runtime_created_for_test(1),
+                EventSlotId::new(0),
+                0,
+            ),
+        ]
+    );
+}
+
+#[test]
+fn schedule_validation_rejects_dependency_without_prior_completion() {
+    let source = EventDomainId::runtime_created_for_test(1);
+    let destination = EventDomainId::runtime_created_for_test(2);
+    let source_location = location(
+        "tenferro-test.engine.source",
+        1,
+        "tenferro-test.storage.source",
+    );
+    let destination_location = location(
+        "tenferro-test.engine.destination",
+        2,
+        "tenferro-test.storage.destination",
+    );
+    let graph = ScheduledGraph::for_test(vec![ScheduledNode::Transfer(ScheduledTransfer::new(
+        0,
+        source_location,
+        destination_location,
+        [EventDependency::new(source, EventSlotId::new(99), 0)],
+        super::super::schedule::EventCompletion::new(destination, EventSlotId::new(0), 0),
+    ))]);
+
+    assert!(graph.validate().is_err());
+}
+
+#[test]
+fn retained_bytes_include_operation_dependencies() {
+    let execution = location(
+        "tenferro-test.engine.execution",
+        1,
+        "tenferro-test.storage.execution",
+    );
+    let program = ExecProgram {
+        instructions: vec![instruction(0, 0, 1, true), instruction(1, 1, 2, true)],
+        input_slots: vec![0],
+        output_slots: vec![2],
+        n_slots: 3,
+        shape_guards: Vec::new(),
+    };
+    let graph = ScheduledGraph::from_exec_program(
+        &program,
+        execution.clone(),
+        std::slice::from_ref(&execution),
+        &[execution.clone(), execution.clone()],
+        &TransferReachability::new(),
+    )
+    .expect("schedule");
+    let expected = std::mem::size_of::<ScheduledGraph>()
+        + 2 * std::mem::size_of::<ScheduledNode>()
+        + 4 * std::mem::size_of::<usize>()
+        + std::mem::size_of::<EventDependency>()
+        + std::mem::size_of::<usize>()
+        + std::mem::size_of::<usize>()
+        + 3 * std::mem::size_of::<usize>();
+
+    assert_eq!(graph.retained_bytes(), Some(expected));
 }
 
 #[test]

--- a/crates/tenferro-runtime/src/runtime/tests/schedule.rs
+++ b/crates/tenferro-runtime/src/runtime/tests/schedule.rs
@@ -236,6 +236,20 @@ fn schedule_validation_rejects_dependency_without_prior_completion() {
 }
 
 #[test]
+fn schedule_validation_rejects_duplicate_completion_identity() {
+    let domain = EventDomainId::runtime_created_for_test(1);
+    let graph = ScheduledGraph::for_test(vec![
+        ScheduledNode::Operation(ScheduledOperation::for_test(domain)),
+        ScheduledNode::Operation(ScheduledOperation::for_test(domain)),
+    ]);
+
+    assert!(matches!(
+        graph.validate(),
+        Err(super::super::schedule::ScheduleValidationError::DuplicateCompletion { index: 1 })
+    ));
+}
+
+#[test]
 fn retained_bytes_include_operation_dependencies() {
     let execution = location(
         "tenferro-test.engine.execution",
@@ -304,7 +318,18 @@ fn mock_transfer_does_not_reuse_source_event_domain_as_destination_completion() 
     let graph = ScheduledGraph::for_test(vec![
         ScheduledNode::Operation(ScheduledOperation::for_test(source)),
         ScheduledNode::Transfer(ScheduledTransfer::for_test(source, destination)),
-        ScheduledNode::Operation(ScheduledOperation::for_test(destination)),
+        ScheduledNode::Operation(ScheduledOperation::new(
+            1,
+            location(
+                "tenferro-test.engine.destination",
+                8,
+                "tenferro-test.storage.destination",
+            ),
+            [],
+            [],
+            [EventDependency::new(destination, EventSlotId::new(0), 0)],
+            super::super::schedule::EventCompletion::new(destination, EventSlotId::new(1), 0),
+        )),
     ]);
 
     let transfer = graph

--- a/crates/tenferro-runtime/src/runtime/tests/snapshot.rs
+++ b/crates/tenferro-runtime/src/runtime/tests/snapshot.rs
@@ -75,6 +75,36 @@ fn single_identity(runtime: &Runtime, engine_name: &str) -> RegistrationIdentity
 }
 
 #[test]
+fn engine_registration_has_no_implicit_event_domain_driver() {
+    let registration = registration("tenferro.engine.no-event-driver", 1).unwrap();
+    assert!(registration.event_domain_driver().is_none());
+}
+
+#[test]
+fn custom_event_domain_driver_survives_snapshot_freeze() -> Result<(), Box<dyn StdError>> {
+    let driver: Arc<dyn EventDomainDriver> = Arc::new(ImmediateEventDomainDriver::new());
+    let weak_driver = Arc::downgrade(&driver);
+    let registration = registration("tenferro.engine.event-driver", 1)?
+        .with_event_domain_driver(Arc::clone(&driver));
+    let mut builder = Runtime::builder();
+    builder.register_engine(registration)?;
+    let runtime = builder.build()?;
+    drop(driver);
+
+    let snapshot = runtime.snapshot()?;
+    let frozen = snapshot
+        .engine(&engine_id("tenferro.engine.event-driver"))
+        .expect("engine slot")
+        .event_domain_driver()
+        .expect("explicit event-domain driver");
+    assert!(Arc::ptr_eq(
+        frozen,
+        &weak_driver.upgrade().expect("snapshot retains driver")
+    ));
+    Ok(())
+}
+
+#[test]
 fn fresh_builds_have_distinct_runtime_and_registration_identities() -> Result<(), Box<dyn StdError>>
 {
     let first = runtime_with("tenferro.engine.same", 1)?;

--- a/crates/tenferro-runtime/tests/integration.rs
+++ b/crates/tenferro-runtime/tests/integration.rs
@@ -2,6 +2,8 @@
 mod public_surface_contract;
 #[path = "integration/runtime_error_api.rs"]
 mod runtime_error_api;
+#[path = "integration/runtime_event_domains.rs"]
+mod runtime_event_domains;
 #[path = "integration/runtime_execution.rs"]
 mod runtime_execution;
 #[path = "integration/runtime_foundations.rs"]

--- a/crates/tenferro-runtime/tests/integration/runtime_event_domains.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_event_domains.rs
@@ -1,0 +1,23 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tenferro_runtime::runtime::{EventDomainDriver, ImmediateEventDomainDriver};
+
+#[test]
+fn immediate_event_domain_launches_once_and_drains() -> Result<(), Box<dyn std::error::Error>> {
+    let driver = ImmediateEventDomainDriver::new();
+    let mut run = driver.begin_run()?;
+    let launches = AtomicUsize::new(0);
+    let mut launch = || {
+        launches.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    };
+
+    let completion = run.enqueue(&[], &mut launch)?;
+    assert!(completion
+        .as_any()
+        .is::<tenferro_runtime::runtime::ReadyEventToken>());
+    run.drain()?;
+
+    assert_eq!(launches.load(Ordering::SeqCst), 1);
+    Ok(())
+}

--- a/crates/tenferro-runtime/tests/integration/runtime_event_domains.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_event_domains.rs
@@ -18,6 +18,21 @@ impl EventToken for CountingToken {
     }
 }
 
+#[derive(Debug)]
+struct FailingToken;
+
+impl EventToken for FailingToken {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn wait(&self) -> tenferro_runtime::Result<()> {
+        Err(tenferro_runtime::Error::Internal(
+            "dependency failed".to_owned(),
+        ))
+    }
+}
+
 #[test]
 fn immediate_event_domain_launches_once_and_drains() -> Result<(), Box<dyn std::error::Error>> {
     let driver = ImmediateEventDomainDriver::new();
@@ -52,4 +67,38 @@ fn immediate_event_domain_waits_for_foreign_dependencies_before_launch(
 
     assert_eq!(waits.load(Ordering::SeqCst), 1);
     Ok(())
+}
+
+#[test]
+fn immediate_completion_supports_concurrent_repeated_waits(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let driver = ImmediateEventDomainDriver::new();
+    let mut run = driver.begin_run()?;
+    let mut launch = || Ok(());
+    let completion = run.enqueue(&[], &mut launch)?;
+
+    let first = Arc::clone(&completion);
+    let second = Arc::clone(&completion);
+    let first_wait = std::thread::spawn(move || first.wait());
+    let second_wait = std::thread::spawn(move || second.wait());
+
+    first_wait.join().unwrap()?;
+    second_wait.join().unwrap()?;
+    completion.wait()?;
+    Ok(())
+}
+
+#[test]
+fn immediate_event_domain_does_not_launch_after_dependency_failure() {
+    let driver = ImmediateEventDomainDriver::new();
+    let mut run = driver.begin_run().unwrap();
+    let launches = AtomicUsize::new(0);
+    let dependency: Arc<dyn EventToken> = Arc::new(FailingToken);
+    let mut launch = || {
+        launches.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    };
+
+    assert!(run.enqueue(&[dependency], &mut launch).is_err());
+    assert_eq!(launches.load(Ordering::SeqCst), 0);
 }

--- a/crates/tenferro-runtime/tests/integration/runtime_event_domains.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_event_domains.rs
@@ -1,6 +1,22 @@
+use std::any::Any;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
-use tenferro_runtime::runtime::{EventDomainDriver, ImmediateEventDomainDriver};
+use tenferro_runtime::runtime::{EventDomainDriver, EventToken, ImmediateEventDomainDriver};
+
+#[derive(Debug)]
+struct CountingToken(Arc<AtomicUsize>);
+
+impl EventToken for CountingToken {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn wait(&self) -> tenferro_runtime::Result<()> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
 
 #[test]
 fn immediate_event_domain_launches_once_and_drains() -> Result<(), Box<dyn std::error::Error>> {
@@ -13,11 +29,27 @@ fn immediate_event_domain_launches_once_and_drains() -> Result<(), Box<dyn std::
     };
 
     let completion = run.enqueue(&[], &mut launch)?;
-    assert!(completion
-        .as_any()
-        .is::<tenferro_runtime::runtime::ReadyEventToken>());
+    completion.wait()?;
     run.drain()?;
 
     assert_eq!(launches.load(Ordering::SeqCst), 1);
+    Ok(())
+}
+
+#[test]
+fn immediate_event_domain_waits_for_foreign_dependencies_before_launch(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let driver = ImmediateEventDomainDriver::new();
+    let mut run = driver.begin_run()?;
+    let waits = Arc::new(AtomicUsize::new(0));
+    let dependency: Arc<dyn EventToken> = Arc::new(CountingToken(Arc::clone(&waits)));
+    let mut launch = || {
+        assert_eq!(waits.load(Ordering::SeqCst), 1);
+        Ok(())
+    };
+
+    run.enqueue(&[dependency], &mut launch)?;
+
+    assert_eq!(waits.load(Ordering::SeqCst), 1);
     Ok(())
 }

--- a/crates/tenferro-runtime/tests/integration/runtime_foundations.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_foundations.rs
@@ -92,6 +92,68 @@ mod identity {
     }
 }
 
+mod event_domain_driver_ownership {
+    use std::fmt;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use tenferro_runtime::runtime::{
+        EventDomainDriver, EventDomainRun, ImmediateEventDomainDriver,
+    };
+    use tenferro_runtime::{
+        CoreCapabilityBundle, EngineId, EngineRegistration, ExecutionContextIdentity,
+        HardwareClassId, Runtime, StorageClass,
+    };
+
+    struct CountingEventDomainDriver {
+        begin_count: Arc<AtomicUsize>,
+    }
+
+    impl fmt::Debug for CountingEventDomainDriver {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter
+                .debug_struct("CountingEventDomainDriver")
+                .finish_non_exhaustive()
+        }
+    }
+
+    impl EventDomainDriver for CountingEventDomainDriver {
+        fn begin_run(&self) -> tenferro_runtime::Result<Box<dyn EventDomainRun>> {
+            self.begin_count.fetch_add(1, Ordering::SeqCst);
+            ImmediateEventDomainDriver::new().begin_run()
+        }
+    }
+
+    #[test]
+    fn custom_event_domain_driver_survives_freeze_and_begins_snapshot_run() {
+        let begin_count = Arc::new(AtomicUsize::new(0));
+        let storage = StorageClass::new("tenferro.storage.host").unwrap();
+        let engine_id = EngineId::new("tenferro.cpu.event-domain-test").unwrap();
+        let registration = EngineRegistration::new(
+            engine_id.clone(),
+            ExecutionContextIdentity::of::<()>(),
+            HardwareClassId::new("tenferro.cpu.host").unwrap(),
+            Arc::from([storage.clone()]),
+            storage,
+            CoreCapabilityBundle::default(),
+        )
+        .unwrap()
+        .with_event_domain_driver(Arc::new(CountingEventDomainDriver {
+            begin_count: Arc::clone(&begin_count),
+        }));
+        let mut builder = Runtime::builder();
+        builder.register_engine(registration).unwrap();
+        let runtime = builder.build().unwrap();
+
+        let snapshot = runtime.snapshot().unwrap();
+        let engine = snapshot.engine(&engine_id).unwrap();
+        let mut run = engine.event_domain_driver().begin_run().unwrap();
+        run.drain().unwrap();
+
+        assert_eq!(begin_count.load(Ordering::SeqCst), 1);
+    }
+}
+
 mod policy {
     use std::fmt::Debug;
 

--- a/crates/tenferro-runtime/tests/integration/runtime_foundations.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_foundations.rs
@@ -92,68 +92,6 @@ mod identity {
     }
 }
 
-mod event_domain_driver_ownership {
-    use std::fmt;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
-
-    use tenferro_runtime::runtime::{
-        EventDomainDriver, EventDomainRun, ImmediateEventDomainDriver,
-    };
-    use tenferro_runtime::{
-        CoreCapabilityBundle, EngineId, EngineRegistration, ExecutionContextIdentity,
-        HardwareClassId, Runtime, StorageClass,
-    };
-
-    struct CountingEventDomainDriver {
-        begin_count: Arc<AtomicUsize>,
-    }
-
-    impl fmt::Debug for CountingEventDomainDriver {
-        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter
-                .debug_struct("CountingEventDomainDriver")
-                .finish_non_exhaustive()
-        }
-    }
-
-    impl EventDomainDriver for CountingEventDomainDriver {
-        fn begin_run(&self) -> tenferro_runtime::Result<Box<dyn EventDomainRun>> {
-            self.begin_count.fetch_add(1, Ordering::SeqCst);
-            ImmediateEventDomainDriver::new().begin_run()
-        }
-    }
-
-    #[test]
-    fn custom_event_domain_driver_survives_freeze_and_begins_snapshot_run() {
-        let begin_count = Arc::new(AtomicUsize::new(0));
-        let storage = StorageClass::new("tenferro.storage.host").unwrap();
-        let engine_id = EngineId::new("tenferro.cpu.event-domain-test").unwrap();
-        let registration = EngineRegistration::new(
-            engine_id.clone(),
-            ExecutionContextIdentity::of::<()>(),
-            HardwareClassId::new("tenferro.cpu.host").unwrap(),
-            Arc::from([storage.clone()]),
-            storage,
-            CoreCapabilityBundle::default(),
-        )
-        .unwrap()
-        .with_event_domain_driver(Arc::new(CountingEventDomainDriver {
-            begin_count: Arc::clone(&begin_count),
-        }));
-        let mut builder = Runtime::builder();
-        builder.register_engine(registration).unwrap();
-        let runtime = builder.build().unwrap();
-
-        let snapshot = runtime.snapshot().unwrap();
-        let engine = snapshot.engine(&engine_id).unwrap();
-        let mut run = engine.event_domain_driver().begin_run().unwrap();
-        run.drain().unwrap();
-
-        assert_eq!(begin_count.load(Ordering::SeqCst), 1);
-    }
-}
-
 mod policy {
     use std::fmt::Debug;
 

--- a/docs/worklogs/2026-07-30-issue-1471-event-domain-scheduler.md
+++ b/docs/worklogs/2026-07-30-issue-1471-event-domain-scheduler.md
@@ -1,88 +1,90 @@
-# Worklog: #1471 Event-Domain Scheduler
+# Worklog: #1471 Event-Domain Contract
 
 ## Scope
 
-Implement the backend-neutral event-domain scheduler after the production
-transfer and submission-admission PRs. This PR covers runtime scheduling and
-deterministic fake domains only. CUDA and WebGPU adapters remain separate.
+This PR defines the backend-neutral event-domain contract required by the
+production scheduler. It also attaches deterministic dependency and completion
+metadata to scheduled nodes and retains explicitly registered drivers in
+immutable runtime snapshots.
 
-## Design
+This PR does not execute scheduled nodes through event domains. Production
+activation, native CUDA/WebGPU adapters, fail-fast draining, and asynchronous
+buffer retirement remain follow-up PRs under #1471.
 
-Each frozen engine owns an `EventDomainDriver`. A driver creates a per-run
-`EventDomainRun` that accepts dependency tokens and a one-shot launch closure,
-enqueues the launch in its native domain, and returns an opaque completion
-token. The immediate driver invokes the closure synchronously and returns a
-ready token, preserving the current CPU behavior.
+## Implemented Contract
 
-The scheduler stores completion tokens by the schedule's event point. Before
-enqueuing a node it resolves all declared dependencies and passes their tokens
-to the destination domain run. Independent nodes therefore enqueue without a
-host wait. The domain adapter, rather than the scheduler, decides whether a
-dependency becomes a native stream wait, queue dependency, or immediate host
-completion.
+`EventDomainDriver` creates per-execution `EventDomainRun` state. A run admits a
+submission closure after its dependency tokens and returns an opaque
+`EventToken`. Tokens support repeatable, concurrent host waits because one
+completion may fan out to multiple foreign event domains.
 
-On the first enqueue or launch error, the scheduler stops admitting new nodes.
-It drains every started domain in ascending event-domain ID order and returns
-the first error. Drain errors after an earlier failure are retained as
-secondary diagnostics rather than replacing the original cause. No scheduler
-mutex is held while calling an engine, transfer provider, or domain driver.
+The blocking `ImmediateEventDomainDriver` waits dependencies before invoking
+the closure and returns an already-ready token. CPU registration opts into this
+driver explicitly. `EngineRegistration::new` leaves the driver absent so CUDA
+or WebGPU registration cannot silently inherit synchronous completion
+semantics.
 
-Logical last-use remains unchanged, but slots removed at last use move into a
-per-run retired-value owner. They are dropped only after every started domain
-has drained. This separates logical reuse from physical buffer lifetime and
-prevents asynchronous work from observing freed storage.
+Drivers are retained by `EngineRegistration`, then by the immutable runtime
+snapshot. Driver lookup remains runtime-internal; external callers cannot start
+runs outside scheduler admission.
 
-`EventToken::wait` is the typed host fallback for dependencies that a native
-driver cannot encode directly. Native drivers should downcast same-backend
-tokens and encode stream or queue waits; only foreign token types use the host
-fallback. The immediate CPU driver waits every dependency before launch.
+`ScheduledGraph::validate` rejects dependencies that do not name prior
+completions and rejects duplicate completion identities. Operation and transfer
+nodes carry deterministic, deduplicated dependency metadata.
 
-The borrowed launch closure is submission-only: a driver calls it exactly once
-before `enqueue` returns, without holding a driver lock. Fake domains may delay
-their completion token, but they do not retain and execute the Rust closure on
-another thread. `drain` observes work that is already progressing and must not
-depend on another domain's `drain` call to start progress.
+## Activation Requirements
 
-## Review Boundary
+The production activation stack must:
 
-This work is split into a contract PR and a production-activation stack. The
-contract PR defines drivers/tokens, freezes driver ownership in engine
-snapshots, and attaches schedule dependencies. It does not activate the
-production scheduler.
+- reject a scheduled engine that has no explicit event-domain driver;
+- install native CUDA and WebGPU drivers before enabling their scheduled
+  execution paths;
+- keep same-backend dependencies as native stream or queue waits and use
+  `EventToken::wait` only for foreign-domain fallback;
+- stop admitting nodes after the first enqueue or launch error;
+- drain every started domain in canonical event-domain order without holding a
+  runtime, driver, backend, or provider lock;
+- drain during panic unwinding before releasing retired values;
+- retain logically dead buffers until all started domains have drained;
+- exercise transfer ordering, failure cleanup, fanout waits, and lock ordering
+  with two logical CPU-backed devices.
 
-Production activation is blocked until CUDA and WebGPU registrations install
-explicit drivers. `ImmediateEventDomainDriver` is valid only for synchronous
-engines; silently applying it to an asynchronous GPU engine would publish a
-ready token before device work completes. The activation stack must also drain
-started domains during panic unwinding before retired buffers are released.
+## TDD Record
 
-## TDD Order
+RED:
 
-1. Schedule operations carry deterministic, deduplicated producer
-   dependencies and reject unknown or forward event references.
-2. Immediate domains preserve existing execution behavior.
-3. A delayed fake domain proves transfer completion precedes its consumer
-   while independent nodes enqueue before the final drain.
-4. A failing fake domain proves first-error fail-fast and draining of
-   previously started work.
-5. Retired-value probes prove buffers outlive the completion that consumes
-   them.
-6. Opposing engine order proves canonical drain order and callback execution
-   without runtime lock inversion.
+- an engine registration inherited an immediate driver without opting in;
+- schedule validation accepted duplicate completion identities;
+- the immediate-domain contract did not test repeated waits or dependency
+  failure before launch.
+
+GREEN:
+
+- registrations represent driver absence explicitly and CPU registration adds
+  the immediate driver;
+- snapshot tests retain an explicitly registered driver;
+- repeated/concurrent waits and dependency-failure launch suppression are
+  covered;
+- duplicate completion identities are rejected.
 
 ## Explicit Non-Goals
 
-- CUDA events, streams, peer transfer, or host-staging policy.
+- Production dispatch through `EventDomainRun`.
+- CUDA events or streams.
 - WebGPU submission-index or queue-future integration.
 - Collectives, distributed tensors, real two-card CI, event-slot recycling, or
   cancellation.
 
 ## Verification
 
-Pending implementation. Required before PR:
-
-- focused schedule tests with recorded RED and GREEN results;
-- runtime event-domain integration tests;
-- complete `tenferro-runtime` tests and doctests;
-- CUDA/WebGPU feature checks to preserve adapter compilation;
-- repository fast check and repository-rules review.
+- `cargo test -p tenferro-runtime --lib`: 349 passed.
+- `cargo test -p tenferro-runtime --test integration runtime_event_domains`:
+  4 passed.
+- `cargo test -p tenferro-runtime --doc`: 382 passed.
+- `cargo check -p tenferro-runtime`: passed.
+- `cargo check -p tenferro-cpu`: passed.
+- `scripts/check-pr-fast.sh --coverage-reviewed` with the focused runtime
+  commands: passed, including workspace and extension clippy checks.
+- `scripts/repository-rules-review.py`: passed with no findings.
+- Independent contract review: architecture and correctness findings resolved;
+  public per-item doctests added in response to the final documentation review.

--- a/docs/worklogs/2026-07-30-issue-1471-event-domain-scheduler.md
+++ b/docs/worklogs/2026-07-30-issue-1471-event-domain-scheduler.md
@@ -32,6 +32,30 @@ per-run retired-value owner. They are dropped only after every started domain
 has drained. This separates logical reuse from physical buffer lifetime and
 prevents asynchronous work from observing freed storage.
 
+`EventToken::wait` is the typed host fallback for dependencies that a native
+driver cannot encode directly. Native drivers should downcast same-backend
+tokens and encode stream or queue waits; only foreign token types use the host
+fallback. The immediate CPU driver waits every dependency before launch.
+
+The borrowed launch closure is submission-only: a driver calls it exactly once
+before `enqueue` returns, without holding a driver lock. Fake domains may delay
+their completion token, but they do not retain and execute the Rust closure on
+another thread. `drain` observes work that is already progressing and must not
+depend on another domain's `drain` call to start progress.
+
+## Review Boundary
+
+This work is split into a contract PR and a production-activation stack. The
+contract PR defines drivers/tokens, freezes driver ownership in engine
+snapshots, and attaches schedule dependencies. It does not activate the
+production scheduler.
+
+Production activation is blocked until CUDA and WebGPU registrations install
+explicit drivers. `ImmediateEventDomainDriver` is valid only for synchronous
+engines; silently applying it to an asynchronous GPU engine would publish a
+ready token before device work completes. The activation stack must also drain
+started domains during panic unwinding before retired buffers are released.
+
 ## TDD Order
 
 1. Schedule operations carry deterministic, deduplicated producer

--- a/docs/worklogs/2026-07-30-issue-1471-event-domain-scheduler.md
+++ b/docs/worklogs/2026-07-30-issue-1471-event-domain-scheduler.md
@@ -1,0 +1,64 @@
+# Worklog: #1471 Event-Domain Scheduler
+
+## Scope
+
+Implement the backend-neutral event-domain scheduler after the production
+transfer and submission-admission PRs. This PR covers runtime scheduling and
+deterministic fake domains only. CUDA and WebGPU adapters remain separate.
+
+## Design
+
+Each frozen engine owns an `EventDomainDriver`. A driver creates a per-run
+`EventDomainRun` that accepts dependency tokens and a one-shot launch closure,
+enqueues the launch in its native domain, and returns an opaque completion
+token. The immediate driver invokes the closure synchronously and returns a
+ready token, preserving the current CPU behavior.
+
+The scheduler stores completion tokens by the schedule's event point. Before
+enqueuing a node it resolves all declared dependencies and passes their tokens
+to the destination domain run. Independent nodes therefore enqueue without a
+host wait. The domain adapter, rather than the scheduler, decides whether a
+dependency becomes a native stream wait, queue dependency, or immediate host
+completion.
+
+On the first enqueue or launch error, the scheduler stops admitting new nodes.
+It drains every started domain in ascending event-domain ID order and returns
+the first error. Drain errors after an earlier failure are retained as
+secondary diagnostics rather than replacing the original cause. No scheduler
+mutex is held while calling an engine, transfer provider, or domain driver.
+
+Logical last-use remains unchanged, but slots removed at last use move into a
+per-run retired-value owner. They are dropped only after every started domain
+has drained. This separates logical reuse from physical buffer lifetime and
+prevents asynchronous work from observing freed storage.
+
+## TDD Order
+
+1. Schedule operations carry deterministic, deduplicated producer
+   dependencies and reject unknown or forward event references.
+2. Immediate domains preserve existing execution behavior.
+3. A delayed fake domain proves transfer completion precedes its consumer
+   while independent nodes enqueue before the final drain.
+4. A failing fake domain proves first-error fail-fast and draining of
+   previously started work.
+5. Retired-value probes prove buffers outlive the completion that consumes
+   them.
+6. Opposing engine order proves canonical drain order and callback execution
+   without runtime lock inversion.
+
+## Explicit Non-Goals
+
+- CUDA events, streams, peer transfer, or host-staging policy.
+- WebGPU submission-index or queue-future integration.
+- Collectives, distributed tensors, real two-card CI, event-slot recycling, or
+  cancellation.
+
+## Verification
+
+Pending implementation. Required before PR:
+
+- focused schedule tests with recorded RED and GREEN results;
+- runtime event-domain integration tests;
+- complete `tenferro-runtime` tests and doctests;
+- CUDA/WebGPU feature checks to preserve adapter compilation;
+- repository fast check and repository-rules review.


### PR DESCRIPTION
Part of #1471.

This is the contract/ownership PR from the split recorded on #1471. It does not activate scheduled execution through event domains.

## Scope

- attach deterministic dependencies and unique completions to scheduled nodes;
- define repeatable/concurrent `EventToken`, per-run `EventDomainRun`, and driver contracts;
- represent missing drivers explicitly and retain explicitly registered drivers in frozen snapshots;
- install the blocking immediate driver only from CPU registration;
- keep driver lookup runtime-internal until production activation;
- reject duplicate completion identities;
- add runnable examples and focused ownership/fanout/failure tests.

CUDA/WebGPU native adapters, production activation, panic-safe draining, and retired-buffer lifetime remain subsequent PRs under #1471.

## Verification

- `cargo test -p tenferro-runtime --lib`: 349 passed
- `cargo test -p tenferro-runtime --test integration runtime_event_domains`: 4 passed
- `cargo test -p tenferro-runtime --doc`: 382 passed
- `cargo check -p tenferro-runtime`: passed
- `cargo check -p tenferro-cpu`: passed
- `scripts/check-pr-fast.sh --coverage-reviewed ...`: passed
- repository rules review: passed, no findings
- independent contract review: no remaining blockers
