### PR TITLE
perf(cpu): use fixed comparison dispatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "95a607c061e95cc3a698a083dd279283a905f99c", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "95a607c061e95cc3a698a083dd279283a905f99c", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "95a607c061e95cc3a698a083dd279283a905f99c", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "95a607c061e95cc3a698a083dd279283a905f99c", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "95a607c061e95cc3a698a083dd279283a905f99c", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "fa312f9ef3766163540869ee8fb6be3e7199a3e0", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "fa312f9ef3766163540869ee8fb6be3e7199a3e0", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "fa312f9ef3766163540869ee8fb6be3e7199a3e0", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "fa312f9ef3766163540869ee8fb6be3e7199a3e0", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "fa312f9ef3766163540869ee8fb6be3e7199a3e0", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 use num_complex::Complex;
 use num_traits::{One, Zero};
 use strided_kernel::{
-    batched_outer_product_into, broadcast_mul_into, map_into, mul_into, reduce, zip_map2_into,
-    zip_map3_into, ErasedFusedPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext,
-    FusedInst, FusedOp, FusedPlan, KernelDType, StridedArray, StridedView,
+    batched_outer_product_into, broadcast_mul_into, compare_into, map_into, mul_into, reduce,
+    zip_map2_into, zip_map3_into, CompareOp, ErasedFusedPlan, ErasedRawStridedMut,
+    ErasedRawStridedRef, ExecContext, FusedInst, FusedOp, FusedPlan, KernelDType, StridedArray,
+    StridedView,
 };
 
 use crate::buffer_pool::{BufferPool, PoolScalar};
@@ -1511,6 +1512,43 @@ where
         f,
     )
     .map_err(|err| crate::Error::backend_source(op, err))?;
+    Ok(tensor_from_array(out))
+}
+
+fn typed_ordered_compare_view_with_pool<T, L, R>(
+    buffers: &mut BufferPool,
+    lhs: &TypedTensorView<'_, T, L>,
+    rhs: &TypedTensorView<'_, T, R>,
+    dir: &CompareDir,
+) -> crate::Result<TypedTensor<bool>>
+where
+    T: Copy + Send + Sync + PartialOrd + 'static,
+    L: TensorRank,
+    R: TensorRank,
+{
+    if lhs.shape() != rhs.shape() {
+        return Err(crate::Error::shape_mismatch(
+            "compare",
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ));
+    }
+    let op = match dir {
+        CompareDir::Eq => CompareOp::Eq,
+        CompareDir::Lt => CompareOp::Lt,
+        CompareDir::Le => CompareOp::Le,
+        CompareDir::Gt => CompareOp::Gt,
+        CompareDir::Ge => CompareOp::Ge,
+    };
+    // SAFETY: compare_into validates the output layout and overwrites every element.
+    let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
+    compare_into(
+        &mut out.view_mut(),
+        &typed_view_from_view("compare", lhs)?,
+        &typed_view_from_view("compare", rhs)?,
+        op,
+    )
+    .map_err(|err| crate::Error::backend_source("compare", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -3084,21 +3122,33 @@ pub fn compare_with_pool(
     reject_complex_unsupported_compare_dtypes(dir, &[lhs.dtype(), rhs.dtype()])?;
 
     match (lhs, rhs) {
-        (Tensor::F32(a), Tensor::F32(b)) => {
-            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
-        }
-        (Tensor::F64(a), Tensor::F64(b)) => {
-            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
-        }
-        (Tensor::I32(a), Tensor::I32(b)) => {
-            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
-        }
-        (Tensor::I64(a), Tensor::I64(b)) => {
-            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
-        }
-        (Tensor::Bool(a), Tensor::Bool(b)) => {
-            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
-        }
+        (Tensor::F32(a), Tensor::F32(b)) => Ok(Tensor::Bool(typed_ordered_compare_view_with_pool(
+            buffers,
+            &a.as_view(),
+            &b.as_view(),
+            dir,
+        )?)),
+        (Tensor::F64(a), Tensor::F64(b)) => Ok(Tensor::Bool(typed_ordered_compare_view_with_pool(
+            buffers,
+            &a.as_view(),
+            &b.as_view(),
+            dir,
+        )?)),
+        (Tensor::I32(a), Tensor::I32(b)) => Ok(Tensor::Bool(typed_ordered_compare_view_with_pool(
+            buffers,
+            &a.as_view(),
+            &b.as_view(),
+            dir,
+        )?)),
+        (Tensor::I64(a), Tensor::I64(b)) => Ok(Tensor::Bool(typed_ordered_compare_view_with_pool(
+            buffers,
+            &a.as_view(),
+            &b.as_view(),
+            dir,
+        )?)),
+        (Tensor::Bool(a), Tensor::Bool(b)) => Ok(Tensor::Bool(
+            typed_ordered_compare_view_with_pool(buffers, &a.as_view(), &b.as_view(), dir)?,
+        )),
         (Tensor::C32(a), Tensor::C32(b)) => {
             Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
         }
@@ -3126,29 +3176,19 @@ pub fn compare_read_with_pool(
 
     match (read_as_cpu_view(lhs), read_as_cpu_view(rhs)) {
         (CpuReadView::F32(a), CpuReadView::F32(b)) => Ok(Tensor::Bool(
-            typed_same_shape_binary_view_with_pool("compare", buffers, &a, &b, |x, y| {
-                x.compare_elem(y, dir)
-            })?,
+            typed_ordered_compare_view_with_pool(buffers, &a, &b, dir)?,
         )),
         (CpuReadView::F64(a), CpuReadView::F64(b)) => Ok(Tensor::Bool(
-            typed_same_shape_binary_view_with_pool("compare", buffers, &a, &b, |x, y| {
-                x.compare_elem(y, dir)
-            })?,
+            typed_ordered_compare_view_with_pool(buffers, &a, &b, dir)?,
         )),
         (CpuReadView::I32(a), CpuReadView::I32(b)) => Ok(Tensor::Bool(
-            typed_same_shape_binary_view_with_pool("compare", buffers, &a, &b, |x, y| {
-                x.compare_elem(y, dir)
-            })?,
+            typed_ordered_compare_view_with_pool(buffers, &a, &b, dir)?,
         )),
         (CpuReadView::I64(a), CpuReadView::I64(b)) => Ok(Tensor::Bool(
-            typed_same_shape_binary_view_with_pool("compare", buffers, &a, &b, |x, y| {
-                x.compare_elem(y, dir)
-            })?,
+            typed_ordered_compare_view_with_pool(buffers, &a, &b, dir)?,
         )),
         (CpuReadView::Bool(a), CpuReadView::Bool(b)) => Ok(Tensor::Bool(
-            typed_same_shape_binary_view_with_pool("compare", buffers, &a, &b, |x, y| {
-                x.compare_elem(y, dir)
-            })?,
+            typed_ordered_compare_view_with_pool(buffers, &a, &b, dir)?,
         )),
         (CpuReadView::C32(a), CpuReadView::C32(b)) => Ok(Tensor::Bool(
             typed_same_shape_binary_view_with_pool("compare", buffers, &a, &b, |x, y| {

--- a/crates/tenferro-internal-cpu-kernels/src/elementwise/tests.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/elementwise/tests.rs
@@ -1324,6 +1324,77 @@ fn tensor_read_elementwise_dispatch_covers_view_and_complex_scalar_branches() {
 }
 
 #[test]
+fn ordered_compare_fixed_dispatch_preserves_owned_and_view_semantics() {
+    let lhs = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, f64::NAN]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 3.0, 4.0]).unwrap();
+    let Tensor::F64(lhs_typed) = &lhs else {
+        unreachable!("f64 fixture");
+    };
+    let Tensor::F64(rhs_typed) = &rhs else {
+        unreachable!("f64 fixture");
+    };
+    let cases = [
+        (CompareDir::Eq, [true, false, false]),
+        (CompareDir::Lt, [false, true, false]),
+        (CompareDir::Le, [true, true, false]),
+        (CompareDir::Gt, [false, false, false]),
+        (CompareDir::Ge, [true, false, false]),
+    ];
+    let mut buffers = BufferPool::new();
+
+    for (dir, expected) in cases {
+        let owned = compare_with_pool(&mut buffers, &lhs, &rhs, &dir).unwrap();
+        let borrowed = compare_read_with_pool(
+            &mut buffers,
+            TensorRead::from_view(TensorView::F64(lhs_typed.as_view())),
+            TensorRead::from_view(TensorView::F64(rhs_typed.as_view())),
+            &dir,
+        )
+        .unwrap();
+
+        assert_eq!(owned.as_slice::<bool>().unwrap(), &expected);
+        assert_eq!(borrowed.as_slice::<bool>().unwrap(), &expected);
+    }
+}
+
+#[test]
+fn ordered_compare_owned_and_read_routes_use_fixed_dispatch() {
+    let source = include_str!("../elementwise.rs");
+    let helper = source
+        .split_once("fn typed_ordered_compare_view_with_pool")
+        .and_then(|(_, suffix)| suffix.split_once("fn typed_select_view_with_pool"))
+        .map(|(body, _)| body)
+        .expect("fixed comparison helper must remain defined");
+    assert!(
+        helper.contains("compare_into("),
+        "fixed comparison helper must dispatch through strided compare_into"
+    );
+
+    for (start, end, route) in [
+        (
+            "pub fn compare_with_pool(",
+            "pub fn compare_read_with_pool(",
+            "owned",
+        ),
+        (
+            "pub fn compare_read_with_pool(",
+            "/// Select values",
+            "borrowed",
+        ),
+    ] {
+        let body = source
+            .split_once(start)
+            .and_then(|(_, suffix)| suffix.split_once(end))
+            .map(|(body, _)| body)
+            .unwrap_or_else(|| panic!("{route} comparison route must remain defined"));
+        assert!(
+            body.matches("typed_ordered_compare_view_with_pool").count() >= 5,
+            "{route} real, integer, and Bool comparisons must use fixed dispatch"
+        );
+    }
+}
+
+#[test]
 fn broadcast_multiply_read_and_value_cover_dtypes_and_error_paths() {
     let mut buffers = BufferPool::default();
     let lhs_shape = [2, 3, 4];

--- a/docs/worklogs/2026-07-30-w9-compare-fixed-dispatch.md
+++ b/docs/worklogs/2026-07-30-w9-compare-fixed-dispatch.md
@@ -1,0 +1,97 @@
+# Worklog: W9 Fixed CPU Comparison Dispatch
+
+## Scope
+
+Adopt the fixed-operation comparison entry point merged in strided-rs #180.
+This addresses the `compare_lt` attribution recorded under #1490 without
+changing comparison semantics, threading policy, or allocation ownership.
+
+## Design
+
+The workspace strided pin advances to
+`fa312f9ef3766163540869ee8fb6be3e7199a3e0`.
+
+CPU comparison maps `CompareDir` to `strided_kernel::CompareOp` once, before
+entering the element traversal. Owned tensors and borrowed views share the same
+helper. Real, integer, and Boolean dtypes use the fixed dispatch. Complex
+equality remains on the existing generic closure because complex scalars do not
+implement `PartialOrd`; ordered complex comparisons remain typed errors.
+
+The destination is allocated from the existing backend-owned buffer pool.
+`compare_into` validates destination injectivity before mutation and inherits
+the explicit execution policy already installed by `CpuBackend`.
+
+## Performance Evidence
+
+The paired experiment was fixed before execution:
+
+- baseline tenferro commit: `9e06764a3333b9b3eb464c2b7b873a3187bd128c`;
+- candidate implementation commit: `5f9de40ab65535d144f2d6d17263eb2457172df2`
+  (the later amendment adds tests and this worklog only);
+- benchmark source: tenferro-benchmark
+  `3cef513291099591ce94e419ebf06bd8630396b7`;
+- release profile, Rust 1.97.1, default/faer CPU provider;
+- AMD EPYC 7713P, t1 on CPU 60 and t4 on CPUs 60-63;
+- `RAYON_NUM_THREADS`, `OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, and
+  `MKL_NUM_THREADS` fixed to the row thread count;
+- separate cold build targets, with both release builds completed before any
+  timing;
+- exact public API row `cpu/elementwise_reduction`, `compare_lt`, f64,
+  33,554,432 elements, direct execution;
+- 10 paired cells per thread count, each with 3 warmups and 15 samples;
+- odd/even pairs reverse baseline/candidate execution order;
+- statistic: paired `(candidate / baseline - 1)` mean with a two-sided 95%
+  Student-t interval;
+- blocking gate: interval upper bound above +20%;
+- validity gates: every status is `ok`, selected CPUs are at least 90% idle in
+  the three-second preflight, and every cell has IQR/median at most 15%.
+
+Preflight idle was 98.33% or higher on CPUs 60-63. All 20 cells reported `ok`;
+the maximum IQR/median was 3.65% at t1 and 7.73% at t4.
+
+| Threads | Pair | Baseline ms | Candidate ms | Change |
+|---:|---:|---:|---:|---:|
+| 1 | 1 | 61.666 | 42.230 | -31.52% |
+| 1 | 2 | 61.167 | 41.596 | -32.00% |
+| 1 | 3 | 61.981 | 42.377 | -31.63% |
+| 1 | 4 | 61.075 | 42.417 | -30.55% |
+| 1 | 5 | 62.334 | 42.137 | -32.40% |
+| 1 | 6 | 61.658 | 42.109 | -31.71% |
+| 1 | 7 | 61.786 | 42.153 | -31.78% |
+| 1 | 8 | 61.634 | 42.224 | -31.49% |
+| 1 | 9 | 61.591 | 42.231 | -31.43% |
+| 1 | 10 | 61.685 | 42.231 | -31.54% |
+| 4 | 1 | 21.056 | 18.621 | -11.57% |
+| 4 | 2 | 21.460 | 18.499 | -13.80% |
+| 4 | 3 | 21.952 | 18.319 | -16.55% |
+| 4 | 4 | 20.507 | 19.324 | -5.77% |
+| 4 | 5 | 21.389 | 18.852 | -11.86% |
+| 4 | 6 | 21.655 | 18.274 | -15.61% |
+| 4 | 7 | 20.350 | 18.403 | -9.57% |
+| 4 | 8 | 20.583 | 18.805 | -8.64% |
+| 4 | 9 | 20.777 | 18.856 | -9.25% |
+| 4 | 10 | 20.822 | 18.492 | -11.19% |
+
+| Threads | Baseline median | Candidate median | Mean change | 95% CI | Verdict |
+|---:|---:|---:|---:|---:|:---|
+| 1 | 61.662 ms | 42.227 ms | -31.60% | [-31.94%, -31.27%] | PASS |
+| 4 | 20.939 ms | 18.560 ms | -11.38% | [-13.74%, -9.03%] | PASS |
+
+Only comparison dispatch changes. Neighboring elementwise operations retain
+their existing call paths.
+
+## Verification
+
+- Owned and borrowed-view paths cover all five comparison directions,
+  including unordered NaN behavior.
+- The routing source-contract test fails against the baseline source and passes
+  against the candidate.
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-internal-cpu-kernels
+  elementwise::tests::ordered_compare_fixed_dispatch_preserves_owned_and_view_semantics
+  -- --exact`
+- `cargo test -p tenferro-internal-cpu-kernels
+  elementwise::tests::ordered_compare_owned_and_read_routes_use_fixed_dispatch
+  -- --exact`
+- full `tenferro-internal-cpu-kernels` tests: 44 passed, 20 doctests passed
+- repository fast check and repository-rules review before PR

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "95a607c061e95cc3a698a083dd279283a905f99c"
+        revision = "fa312f9ef3766163540869ee8fb6be3e7199a3e0"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
Part of #1490 W9.

## Summary

- bump all strided-rs workspace pins to merged commit `fa312f9ef3766163540869ee8fb6be3e7199a3e0`;
- route real, integer, and Bool owned/read CPU comparisons through the fixed `CompareOp`/`compare_into` path;
- retain complex equality and typed ordered-complex rejection semantics;
- add numerical and source-contract regression coverage proving both owned and borrowed routes use fixed dispatch.

Design and the complete paired benchmark record are in [`docs/worklogs/2026-07-30-w9-compare-fixed-dispatch.md`](https://github.com/tensor4all/tenferro-rs/blob/codex/w9-compare-adoption/docs/worklogs/2026-07-30-w9-compare-fixed-dispatch.md).

## Performance

Exact public API row: `cpu/elementwise_reduction compare_lt f64 33554432`, direct execution, AMD EPYC 7713P, t1 CPU 60 / t4 CPUs 60-63, 10 paired cells per thread count, each 3 warmups + 15 samples.

| Threads | Baseline median | Candidate median | Paired mean change | 95% CI | Gate |
|---:|---:|---:|---:|---:|:---|
| 1 | 61.662 ms | 42.227 ms | -31.60% | [-31.94%, -31.27%] | PASS |
| 4 | 20.939 ms | 18.560 ms | -11.38% | [-13.74%, -9.03%] | PASS |

All 20 cells reported `ok`; maximum IQR/median was 7.73%, below the predeclared 15% validity threshold. The +20% candidate-relative upper-bound gate passes.

## Verification

- routing test RED against baseline `9e06764a`, GREEN on this branch;
- `cargo test -p tenferro-internal-cpu-kernels`: 44 passed, 20 doctests passed;
- `scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-internal-cpu-kernels'`: passed;
- `scripts/repository-rules-review.py --base origin/main --head d8fc8038...`: passed, no findings.