### PR TITLE
feat(gpu): add native CUDA event-domain driver

### DIFF
--- a/crates/tenferro-gpu/src/cubecl/event_domain.rs
+++ b/crates/tenferro-gpu/src/cubecl/event_domain.rs
@@ -1,0 +1,267 @@
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use cubecl::stream_id::StreamId;
+use cudarc::driver::result as cuda_result;
+use cudarc::driver::sys::{CUevent, CUevent_flags, CUevent_wait_flags, CUstream};
+use tenferro_runtime::runtime::{EventDomainDriver, EventDomainRun, EventToken};
+use tenferro_runtime::Error as RuntimeError;
+
+use super::CudaRuntime;
+
+const EVENT_OP: &str = "cuda_event_domain";
+
+#[derive(Clone, Debug)]
+pub(super) struct CudaEventDomainDriver {
+    runtime: CudaRuntime,
+}
+
+impl CudaEventDomainDriver {
+    pub(super) fn new(runtime: CudaRuntime) -> Self {
+        Self { runtime }
+    }
+}
+
+impl EventDomainDriver for CudaEventDomainDriver {
+    fn begin_run(&self) -> tenferro_runtime::Result<Box<dyn EventDomainRun>> {
+        Ok(Box::new(CudaEventDomainRun {
+            runtime: self.runtime.clone(),
+            stream_id: StreamId::current(),
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct CudaEventDomainRun {
+    runtime: CudaRuntime,
+    stream_id: StreamId,
+}
+
+impl EventDomainRun for CudaEventDomainRun {
+    fn enqueue(
+        &mut self,
+        dependencies: &[Arc<dyn EventToken>],
+        launch: &mut dyn FnMut() -> tenferro_runtime::Result<()>,
+    ) -> tenferro_runtime::Result<Arc<dyn EventToken>> {
+        self.stream_id
+            .executes(|| self.enqueue_on_current_stream(dependencies, launch))
+    }
+
+    fn drain(&mut self) -> tenferro_runtime::Result<()> {
+        self.stream_id.executes(|| {
+            let stream = raw_stream(&self.runtime).map_err(RuntimeError::from)?;
+            synchronize_stream(&self.runtime, stream).map_err(RuntimeError::from)
+        })
+    }
+}
+
+impl CudaEventDomainRun {
+    fn enqueue_on_current_stream(
+        &mut self,
+        dependencies: &[Arc<dyn EventToken>],
+        launch: &mut dyn FnMut() -> tenferro_runtime::Result<()>,
+    ) -> tenferro_runtime::Result<Arc<dyn EventToken>> {
+        self.runtime
+            .set_current_cuda_context(EVENT_OP)
+            .map_err(RuntimeError::from)?;
+        let stream = raw_stream(&self.runtime).map_err(RuntimeError::from)?;
+
+        for dependency in dependencies {
+            match dependency.as_any().downcast_ref::<CudaEventToken>() {
+                Some(token)
+                    if token.event.runtime.device_ordinal() == self.runtime.device_ordinal() =>
+                {
+                    unsafe {
+                        cuda_result::stream::wait_event(
+                            stream,
+                            token.event.raw(),
+                            CUevent_wait_flags::CU_EVENT_WAIT_DEFAULT,
+                        )
+                    }
+                    .map_err(cuda_backend_error)?;
+                }
+                _ => dependency.wait()?,
+            }
+        }
+
+        let event = CudaEventHandle::new(self.runtime.clone()).map_err(RuntimeError::from)?;
+        let mut cleanup = SubmissionCleanupGuard::new(&self.runtime, stream);
+        if let Err(launch_error) = launch() {
+            return Err(cleanup.finish_with_error(launch_error));
+        }
+        if let Err(record_error) = event.record(stream) {
+            return Err(cleanup.finish_with_error(RuntimeError::from(record_error)));
+        }
+        cleanup.disarm();
+        Ok(Arc::new(CudaEventToken { event }))
+    }
+}
+
+impl Drop for CudaEventDomainRun {
+    fn drop(&mut self) {
+        let result = self.stream_id.executes(|| {
+            let stream = raw_stream(&self.runtime)?;
+            synchronize_stream(&self.runtime, stream)
+        });
+        if let Err(error) = result {
+            eprintln!("tenferro-gpu: failed to drain CUDA event-domain run during Drop: {error}");
+        }
+    }
+}
+
+struct SubmissionCleanupGuard<'a> {
+    runtime: &'a CudaRuntime,
+    stream: CUstream,
+    armed: bool,
+}
+
+impl<'a> SubmissionCleanupGuard<'a> {
+    fn new(runtime: &'a CudaRuntime, stream: CUstream) -> Self {
+        Self {
+            runtime,
+            stream,
+            armed: true,
+        }
+    }
+
+    fn finish_with_error(&mut self, primary: RuntimeError) -> RuntimeError {
+        let cleanup = synchronize_stream(self.runtime, self.stream);
+        self.armed = false;
+        match cleanup {
+            Ok(()) => primary,
+            Err(cleanup) => RuntimeError::from(crate::Error::backend_source(
+                EVENT_OP,
+                CudaSubmissionCleanupError { primary, cleanup },
+            )),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for SubmissionCleanupGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            if let Err(error) = synchronize_stream(self.runtime, self.stream) {
+                eprintln!(
+                    "tenferro-gpu: failed to retire CUDA work during submission unwind: {error}"
+                );
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CudaEventToken {
+    event: Arc<CudaEventHandle>,
+}
+
+impl EventToken for CudaEventToken {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn wait(&self) -> tenferro_runtime::Result<()> {
+        self.event.wait()
+    }
+}
+
+struct CudaEventHandle {
+    runtime: CudaRuntime,
+    raw: RawCudaEvent,
+}
+
+#[derive(Debug)]
+struct RawCudaEvent(CUevent);
+
+// SAFETY: the retained CUDA primary context owns the event's device lifetime.
+// Every operation selects that context first, and CUDA event record/wait/destroy
+// operations are thread-safe for an externally synchronized handle.
+unsafe impl Send for RawCudaEvent {}
+// SAFETY: shared access only records or waits through CUDA's thread-safe driver
+// API; destruction requires unique ownership of the enclosing handle.
+unsafe impl Sync for RawCudaEvent {}
+
+impl CudaEventHandle {
+    fn new(runtime: CudaRuntime) -> crate::Result<Arc<Self>> {
+        runtime.set_current_cuda_context(EVENT_OP)?;
+        let event = cuda_result::event::create(CUevent_flags::CU_EVENT_DISABLE_TIMING)
+            .map_err(|source| crate::Error::backend_source(EVENT_OP, source))?;
+        Ok(Arc::new(Self {
+            runtime,
+            raw: RawCudaEvent(event),
+        }))
+    }
+
+    fn raw(&self) -> CUevent {
+        self.raw.0
+    }
+
+    fn record(&self, stream: CUstream) -> crate::Result<()> {
+        self.runtime.set_current_cuda_context(EVENT_OP)?;
+        unsafe { cuda_result::event::record(self.raw(), stream) }
+            .map_err(|source| crate::Error::backend_source(EVENT_OP, source))
+    }
+
+    fn wait(&self) -> tenferro_runtime::Result<()> {
+        self.runtime
+            .set_current_cuda_context(EVENT_OP)
+            .map_err(RuntimeError::from)?;
+        unsafe { cuda_result::event::synchronize(self.raw()) }.map_err(cuda_backend_error)
+    }
+}
+
+impl fmt::Debug for CudaEventHandle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CudaEventHandle")
+            .field("device_ordinal", &self.runtime.device_ordinal())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for CudaEventHandle {
+    fn drop(&mut self) {
+        if let Err(error) = self.runtime.set_current_cuda_context(EVENT_OP) {
+            eprintln!(
+                "tenferro-gpu: failed to select CUDA context before event destruction: {error}"
+            );
+            return;
+        }
+        if let Err(error) = unsafe { cuda_result::event::destroy(self.raw()) } {
+            eprintln!("tenferro-gpu: failed to destroy CUDA event during Drop: {error:?}");
+        }
+    }
+}
+
+fn raw_stream(runtime: &CudaRuntime) -> crate::Result<CUstream> {
+    runtime
+        .raw_cuda_stream()
+        .map(|stream| stream as usize as CUstream)
+}
+
+fn synchronize_stream(runtime: &CudaRuntime, stream: CUstream) -> crate::Result<()> {
+    runtime.set_current_cuda_context(EVENT_OP)?;
+    // `cuStreamSynchronize` is the retirement barrier even when it reports an
+    // asynchronous launch failure discovered while waiting. Invalid
+    // context/handle errors instead mean the retained runtime domain is
+    // unusable; callers preserve that fatal backend error and must not reuse
+    // the domain.
+    unsafe { cuda_result::stream::synchronize(stream) }
+        .map_err(|source| crate::Error::backend_source(EVENT_OP, source))
+}
+
+fn cuda_backend_error(source: impl std::error::Error + Send + Sync + 'static) -> RuntimeError {
+    RuntimeError::from(crate::Error::backend_source(EVENT_OP, source))
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("submission failed ({primary}); CUDA stream cleanup also failed ({cleanup})")]
+struct CudaSubmissionCleanupError {
+    primary: RuntimeError,
+    #[source]
+    cleanup: crate::Error,
+}

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -119,6 +119,7 @@ use crate::{
 mod capability;
 mod dispatch;
 mod error;
+mod event_domain;
 mod ffi;
 mod fusion;
 mod gemm;

--- a/crates/tenferro-gpu/src/cubecl/runtime_adapter.rs
+++ b/crates/tenferro-gpu/src/cubecl/runtime_adapter.rs
@@ -17,6 +17,7 @@ use tenferro_runtime::{
 };
 use tenferro_tensor::{DeviceKind, GpuBackendKind, MemoryKind, Placement, TensorRead, TensorView};
 
+use super::event_domain::CudaEventDomainDriver;
 use super::CudaBackend;
 
 const CUDA_ENGINE_ID: &str = "tenferro-cuda.default.v1";
@@ -90,6 +91,9 @@ pub fn cuda_runtime_engine_registration(
     )
     .map(|registration| {
         registration
+            .with_event_domain_driver(Arc::new(CudaEventDomainDriver::new(
+                backend.runtime().clone(),
+            )))
             .with_cache_owner(cache_owner)
             .with_tensor_backend_executor(execution_backend)
             .with_input_signature_validator(move |placement, family, domain, candidate| {

--- a/crates/tenferro-gpu/src/cubecl/tests/runtime_adapter.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/runtime_adapter.rs
@@ -1,14 +1,32 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use tenferro_tensor::{BackendBuffer, Buffer, DeviceId, Tensor, TypedTensor};
+use tenferro_runtime::runtime::{EventDomainDriver, EventToken};
+use tenferro_tensor::{BackendBuffer, Buffer, DeviceId, Tensor, TensorElementwise, TypedTensor};
 
 use super::*;
-use crate::{gpu_available, upload_tensor, CudaRuntime};
+use crate::{download_tensor, gpu_available, upload_tensor, CudaBackend, CudaRuntime};
 
 #[derive(Debug)]
 struct TestCudaBuffer {
     family: &'static str,
+}
+
+#[derive(Debug)]
+struct FailingEventToken;
+
+impl EventToken for FailingEventToken {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn wait(&self) -> tenferro_runtime::Result<()> {
+        Err(tenferro_runtime::Error::runtime_state(
+            "failing_event_token",
+            tenferro_runtime::ErrorPhase::Execution,
+            "injected dependency failure",
+        ))
+    }
 }
 
 impl BackendBuffer<f32> for TestCudaBuffer {
@@ -107,4 +125,125 @@ fn sum_squares_routes_through_runtime_reduction_preparation() {
         core_operation_name(&CoreSemanticOp::ReduceSumSquares { axes: vec![0] }),
         "reduce_sum_squares"
     );
+}
+
+#[test]
+fn cuda_registration_installs_native_event_domain_driver() {
+    let source = include_str!("../runtime_adapter.rs");
+    assert!(
+        source.contains(".with_event_domain_driver(Arc::new(CudaEventDomainDriver::new(")
+            && source.contains("backend.runtime().clone(),"),
+        "CUDA registration must install its native event-domain driver"
+    );
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_event_domain_tokens_are_repeatable_and_order_native_dependencies() {
+    if !gpu_available() {
+        return;
+    }
+
+    let backend = CudaBackend::new(0).expect("CUDA backend");
+    let runtime = backend.runtime().clone();
+    let host = Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).expect("host input");
+    let input = upload_tensor(&runtime, &host).expect("CUDA upload");
+    let driver = CudaEventDomainDriver::new(runtime.clone());
+    let run = driver.begin_run().expect("CUDA event-domain run");
+
+    // A run may cross scheduler worker threads. Its captured CubeCL stream must
+    // remain stable rather than following each worker's thread-local stream.
+    let input_for_first = input.clone();
+    let (mut run, mut backend, first_output, first_completion, first_launches) =
+        std::thread::spawn(move || {
+            let mut run = run;
+            let mut backend = backend;
+            let mut first_output = None;
+            let mut first_launches = 0;
+            let mut first = || {
+                first_launches += 1;
+                first_output = Some(
+                    backend
+                        .add(&input_for_first, &input_for_first)
+                        .map_err(tenferro_runtime::Error::from)?,
+                );
+                Ok(())
+            };
+            let first_completion = run.enqueue(&[], &mut first).expect("first enqueue");
+            drop(first);
+            (
+                run,
+                backend,
+                first_output.expect("first output"),
+                first_completion,
+                first_launches,
+            )
+        })
+        .join()
+        .expect("CUDA launch worker");
+    assert_eq!(first_launches, 1);
+
+    let mut second_output = None;
+    let mut second_launches = 0;
+    let mut second = || {
+        second_launches += 1;
+        second_output = Some(
+            backend
+                .add(&first_output, &input)
+                .map_err(tenferro_runtime::Error::from)?,
+        );
+        Ok(())
+    };
+    let second_completion = run
+        .enqueue(&[first_completion], &mut second)
+        .expect("dependent enqueue");
+    drop(second);
+    assert_eq!(second_launches, 1);
+
+    second_completion.wait().expect("first completion wait");
+    second_completion.wait().expect("repeat completion wait");
+    run.drain().expect("CUDA event-domain drain");
+
+    let mut forbidden_launches = 0;
+    let mut forbidden = || {
+        forbidden_launches += 1;
+        Ok(())
+    };
+    let dependency_error = run.enqueue(&[Arc::new(FailingEventToken)], &mut forbidden);
+    assert!(dependency_error.is_err());
+    drop(forbidden);
+    assert_eq!(forbidden_launches, 0);
+
+    let mut panic_output = None;
+    let unwind = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut panicking = || -> tenferro_runtime::Result<()> {
+            panic_output = Some(
+                backend
+                    .add(&input, &input)
+                    .map_err(tenferro_runtime::Error::from)?,
+            );
+            panic!("injected post-launch panic");
+        };
+        let _ = run.enqueue(&[], &mut panicking);
+    }));
+    assert!(unwind.is_err());
+    let panic_output = download_tensor(
+        &runtime,
+        panic_output.as_ref().expect("panic-path output retained"),
+    )
+    .expect("panic-path work retired before unwind returned");
+    let Tensor::F32(panic_output) = panic_output else {
+        unreachable!("f32 panic-path output")
+    };
+    assert_eq!(
+        panic_output.as_slice().expect("panic-path host slice"),
+        &[2.0, 4.0]
+    );
+
+    let output = download_tensor(&runtime, second_output.as_ref().expect("second output"))
+        .expect("CUDA download");
+    let Tensor::F32(output) = output else {
+        unreachable!("f32 elementwise output")
+    };
+    assert_eq!(output.as_slice().expect("host slice"), &[3.0, 6.0]);
 }

--- a/docs/worklogs/2026-07-30-issue-1471-cuda-event-domain.md
+++ b/docs/worklogs/2026-07-30-issue-1471-cuda-event-domain.md
@@ -1,0 +1,74 @@
+# Worklog: #1471 CUDA Event Domain
+
+## Scope
+
+This PR installs a native CUDA event-domain driver in the CUDA engine
+registration. It is the CUDA adapter required by the backend-neutral
+event-domain contract; production scheduler activation remains a separate PR
+under #1471.
+
+## Design
+
+Each run captures the current CubeCL `StreamId` once. Every enqueue restores
+that identity around dependency admission, kernel submission, and completion
+recording, so moving a run between scheduler workers cannot silently split it
+across thread-local CubeCL streams.
+
+Same-device CUDA dependencies become native `cuStreamWaitEvent` operations.
+Foreign event tokens use the contract's repeatable host-wait fallback. A
+timing-disabled CUDA event recorded after each successful launch is both the
+returned completion token and the run's drain boundary.
+
+CUDA driver failures retain their backend source through
+`tenferro_tensor::Error::BackendSource` and the runtime `TensorRuntime`
+boundary. If a launch partially submits work and then fails, or completion
+recording fails, the driver synchronizes the captured stream before returning
+the error. An armed submission guard performs the same retirement barrier
+during panic unwinding. Run drain and drop also synchronize the captured stream
+directly rather than relying only on the last successfully recorded event.
+This prevents buffer ownership from unwinding while untracked CUDA work is
+still in flight.
+
+The raw event wrapper has explicit `Send` and `Sync` safety invariants. It
+retains the CUDA runtime and primary context, selects that context before every
+driver call, and destroys the event only under unique ownership.
+
+## TDD Record
+
+RED:
+
+- CUDA registration had no native event-domain driver.
+- A CUDA run had no completion token for native dependency ordering.
+
+GREEN:
+
+- registration attaches `CudaEventDomainDriver`;
+- the A100 test launches two dependent kernels, moves the run across a worker
+  thread and back, waits one token twice, drains the run, and checks `[3, 6]`;
+- a failing foreign dependency suppresses the launch closure;
+- a post-launch panic retires the queued work during unwind and preserves the
+  externally retained output;
+- launch or event-record failure synchronizes the captured stream before error
+  return.
+
+## Explicit Non-Goals
+
+- WebGPU queue completion.
+- Production scheduled-node activation.
+- CUDA graph capture, event pooling, multiple streams per event domain, or
+  real two-card CI.
+
+## Verification
+
+- `cargo test -p tenferro-gpu --features cuda cubecl::tests::runtime_adapter
+  --no-run`: passed.
+- Local NVIDIA A100 80GB PCIe:
+  `cuda_event_domain_tokens_are_repeatable_and_order_native_dependencies`
+  passed.
+- `cargo test -p tenferro-gpu --features cuda --lib`: 62 passed, 113
+  hardware-gated tests ignored.
+- `scripts/check-pr-fast.sh --coverage-reviewed` with the CUDA library and A100
+  event-domain tests: passed.
+- `scripts/repository-rules-review.py`: passed with no findings.
+- Independent CUDA lifetime and failure-path review: no remaining merge
+  blockers.


### PR DESCRIPTION
## Summary
- attach a native CUDA event-domain driver to CUDA engine registration
- preserve one CubeCL stream identity across scheduler worker migration
- encode same-device dependencies with CUDA events and use host waits only for foreign domains
- retire partially submitted work on Result failure and panic unwind

## Verification
- `scripts/check-pr-fast.sh --coverage-reviewed` passed
- CUDA library tests: 62 passed, 113 hardware-gated ignored
- local NVIDIA A100 80GB PCIe: cross-thread dependency ordering, repeatable waits, dependency failure suppression, and post-launch panic cleanup passed
- repository rules review passed with no findings
- independent lifetime/failure-path review found no remaining blockers

Part of #1471. Production scheduler activation and WebGPU completion remain separate PRs.