### PR TITLE
Avoid heap metadata for small borrowed views

### DIFF
--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -431,6 +431,7 @@ fn grouped_gemm_rejects_overlapping_output_ranges() {
     )
     .unwrap_err();
     assert!(format!("{err}").contains("overlaps"));
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[0.0; 8]);
 }
 
 #[test]

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -926,8 +926,8 @@ impl<'a, T: 'static> TypedTensorView<'a, T, DynRank> {
         data: &'a [T],
     ) -> crate::Result<Self> {
         Self::from_buffer_ref(
-            shape.as_ref().to_vec(),
-            strides.as_ref().to_vec(),
+            shape_vec(shape.as_ref()),
+            stride_vec(strides.as_ref()),
             offset,
             TensorBufferRef::Host(data),
             default_placement(),
@@ -1557,8 +1557,8 @@ impl<'a, T: 'static> TypedTensorViewMut<'a, T, DynRank> {
         data: &'a mut [T],
     ) -> crate::Result<Self> {
         Self::from_buffer_ref_mut(
-            shape.as_ref().to_vec(),
-            strides.as_ref().to_vec(),
+            shape_vec(shape.as_ref()),
+            stride_vec(strides.as_ref()),
             offset,
             TensorBufferRefMut::Host(data),
             default_placement(),

--- a/crates/tenferro-tensor/tests/borrowed_view_allocation_tests.rs
+++ b/crates/tenferro-tensor/tests/borrowed_view_allocation_tests.rs
@@ -1,0 +1,64 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::hint::black_box;
+
+use tenferro_tensor::{TypedTensorView, TypedTensorViewMut};
+
+struct CountingAllocator;
+
+thread_local! {
+    static COUNTING: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNTING.get() {
+            ALLOCATIONS.set(ALLOCATIONS.get() + 1);
+        }
+        // SAFETY: this allocator forwards the unchanged layout to System.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: ptr and layout came from the corresponding System allocation.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if COUNTING.get() {
+            ALLOCATIONS.set(ALLOCATIONS.get() + 1);
+        }
+        // SAFETY: ptr and layout came from System, and new_size is forwarded unchanged.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn count_allocations(op: impl FnOnce()) -> usize {
+    ALLOCATIONS.set(0);
+    COUNTING.set(true);
+    op();
+    COUNTING.set(false);
+    ALLOCATIONS.get()
+}
+
+#[test]
+fn small_dynamic_borrowed_view_metadata_stays_inline() {
+    let data = [0_i32; 6];
+    let read_allocations = count_allocations(|| {
+        let view = TypedTensorView::from_slice([2, 3], [1, 2], 0, &data).unwrap();
+        black_box(view);
+    });
+
+    let mut data = [0_i32; 6];
+    let write_allocations = count_allocations(|| {
+        let view = TypedTensorViewMut::from_slice([2, 3], [1, 2], 0, &mut data).unwrap();
+        black_box(view);
+    });
+
+    assert_eq!(read_allocations, 0);
+    assert_eq!(write_allocations, 0);
+}

--- a/docs/worklogs/2026-07-30-tenet-665-small-borrowed-view-metadata.md
+++ b/docs/worklogs/2026-07-30-tenet-665-small-borrowed-view-metadata.md
@@ -1,0 +1,51 @@
+# Small Borrowed-View Metadata For TeNeT #665
+
+## Summary
+
+Dynamic borrowed tensor views now collect shape and stride metadata into
+tenferro's existing inline `ShapeVec` and `StrideVec` storage. This removes the
+small-rank heap allocations observed while TeNeT rebuilds warmed grouped-GEMM
+views without changing validation or the rank-generic API.
+
+## Context Read
+
+- `AGENTS.md` and `REPOSITORY_RULES.md`
+- shared tensor4all repository, Rust, performance, numerical, documentation,
+  and test rules
+- `tenferro-tensor/src/types.rs` borrowed-view constructors
+- `tenferro-tensor/src/backend.rs` grouped-GEMM validation
+- `tenferro-cpu/src/dot_runtime.rs` grouped-GEMM dispatch
+- TeNeT's `tenferro_adapter.rs` and prepared fusion replay allocation probe
+
+## Decisions
+
+- Reuse the existing rank-eight inline metadata types instead of adding a new
+  view type, public prepared API, cache, or provider contract.
+- Preserve the dynamic-rank constructors and all layout validation. Ranks above
+  inline capacity continue to spill to the heap.
+- Leave grouped-GEMM output-range validation unchanged. On current upstream it
+  executes on a backend worker, while TeNeT #665 measures caller-thread
+  allocations.
+
+## Rejected Or Deferred
+
+- A grouped-GEMM validation workspace was rejected because process-wide and
+  backend-worker allocation removal is outside TeNeT #665.
+- TeNeT-only stack metadata was insufficient on its own because restoring
+  constructor-local `.to_vec()` calls would silently reintroduce allocations.
+
+## Verification
+
+- `cargo test --offline -p tenferro-tensor small_dynamic_borrowed_view_metadata_stays_inline`
+- `cargo test --offline -p tenferro-tensor inline_metadata_collection_keeps_small_shapes_and_strides_inline`
+- `cargo test --offline -p tenferro-cpu grouped_gemm_rejects_overlapping_output_ranges`
+- `cargo clippy --offline -p tenferro-tensor -p tenferro-cpu --all-targets -- -D warnings`
+- TeNeT rank-four prepared replay: zero caller-thread allocations and
+  reallocations for U(1), fZ2, SU(2), and U(1) x fZ2 across compose, source
+  transform, and output-transform workloads.
+
+## Remaining Risks
+
+- Rank greater than eight intentionally retains heap-spill behavior.
+- Backend-worker grouped-GEMM validation allocation remains outside this
+  caller-thread acceptance boundary.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs https://github.com/Ryo-wtnb11/TeNeT/issues/665

## Summary

Dynamic borrowed views copied small shape and stride metadata into heap-backed
`Vec`s. Reuse the existing inline `ShapeVec` and `StrideVec` representation so
small borrowed views do not allocate. TeNeT also removes its remaining
caller-thread stride allocation at the flat grouped-GEMM seam.

This is an internal root-cause performance fix: no public API, dependency,
backend, feature, or validation contract changes. Ranks above the existing
inline capacity still spill to the heap.

Same-root-cause search covered the immutable and mutable constructors. Grouped
GEMM worker-side range metadata is intentionally unchanged because TeNeT #665
only measures caller-thread replay allocations.

## Work log

[Small borrowed-view metadata](docs/worklogs/2026-07-30-tenet-665-small-borrowed-view-metadata.md)

## Verification

- `bash scripts/check-pr-fast.sh --base upstream/main --coverage-reviewed --ci-profile clippy --test 'cargo test --offline -p tenferro-tensor small_dynamic_borrowed_view_metadata_stays_inline'`
- `cargo test --offline -p tenferro-cpu grouped_gemm_rejects_overlapping_output_ranges`
- Independent cross-repository review: no P1/P2 findings

`scripts/repository-rules-review.py` was invoked but could not run because
`DEEPSEEK_API_KEY` is unavailable locally. The complete repository rules were
reviewed manually with no candidate-diff finding; hosted checks remain
authoritative.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [ ] I ran local repository-rules LLM review and resolved or documented its
      findings. (Attempted; unavailable as documented above.)
- [x] If this implements a new feature, the linked issue has been accepted by
      maintainers. (Not a new feature.)
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from
      `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and
      linked it above.
