### PR TITLE
feat(gpu): add native WebGPU event domain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,14 +70,14 @@ lapack-inject = "0.1.2"
 cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "dynamic-loading", "cuda-12080"] }
 # Pre-publish staging: Cargo uses these fork commits locally, while packaged
 # manifests retain only the crates.io version requirements.
-cubecl = { package = "t4a-cubecl", git = "https://github.com/tensor4all/cubecl.git", rev = "346135ab43cececf6405d52a3dbc987537402d27", version = "=0.10.0", default-features = false }
-cubecl-cuda = { package = "t4a-cubecl-cuda", git = "https://github.com/tensor4all/cubecl.git", rev = "346135ab43cececf6405d52a3dbc987537402d27", version = "=0.10.0" }
-cubecl-common = { package = "t4a-cubecl-common", git = "https://github.com/tensor4all/cubecl.git", rev = "346135ab43cececf6405d52a3dbc987537402d27", version = "=0.10.0" }
-cubecl-runtime = { package = "t4a-cubecl-runtime", git = "https://github.com/tensor4all/cubecl.git", rev = "346135ab43cececf6405d52a3dbc987537402d27", version = "=0.10.0" }
-cubecl-wgpu = { package = "t4a-cubecl-wgpu", git = "https://github.com/tensor4all/cubecl.git", rev = "346135ab43cececf6405d52a3dbc987537402d27", version = "=0.10.0" }
-cubek-matmul = { package = "t4a-cubek-matmul", git = "https://github.com/tensor4all/cubek.git", rev = "efc43529449b67d83f53e585cc7d71018a252ac7", version = "=0.2.0", default-features = false }
-cubek-std = { package = "t4a-cubek-std", git = "https://github.com/tensor4all/cubek.git", rev = "efc43529449b67d83f53e585cc7d71018a252ac7", version = "=0.2.0", default-features = false }
-cubek-fft = { package = "cubek-fft", git = "https://github.com/tensor4all/cubek.git", rev = "efc43529449b67d83f53e585cc7d71018a252ac7", version = "=0.2.0", default-features = false }
+cubecl = { package = "t4a-cubecl", git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1", version = "=0.10.0", default-features = false }
+cubecl-cuda = { package = "t4a-cubecl-cuda", git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1", version = "=0.10.0" }
+cubecl-common = { package = "t4a-cubecl-common", git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1", version = "=0.10.0" }
+cubecl-runtime = { package = "t4a-cubecl-runtime", git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1", version = "=0.10.0" }
+cubecl-wgpu = { package = "t4a-cubecl-wgpu", git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1", version = "=0.10.0" }
+cubek-matmul = { package = "t4a-cubek-matmul", git = "https://github.com/tensor4all/cubek.git", rev = "5535bda85c68b1d286f1e4660fa15f7b0eb5cf04", version = "=0.2.0", default-features = false }
+cubek-std = { package = "t4a-cubek-std", git = "https://github.com/tensor4all/cubek.git", rev = "5535bda85c68b1d286f1e4660fa15f7b0eb5cf04", version = "=0.2.0", default-features = false }
+cubek-fft = { package = "cubek-fft", git = "https://github.com/tensor4all/cubek.git", rev = "5535bda85c68b1d286f1e4660fa15f7b0eb5cf04", version = "=0.2.0", default-features = false }
 sha2 = "0.10"
 omeco = "0.2.4"
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7", version = "0.1.0" }

--- a/crates/tenferro-gpu/src/webgpu/event_domain.rs
+++ b/crates/tenferro-gpu/src/webgpu/event_domain.rs
@@ -1,0 +1,200 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use cubecl::stream_id::StreamId;
+use cubecl_wgpu::WgpuSubmission;
+use tenferro_runtime::runtime::{EventDomainDriver, EventDomainRun, EventToken};
+use tenferro_runtime::Error as RuntimeError;
+
+use super::WebGpuRuntime;
+
+const EVENT_OP: &str = "webgpu_event_domain";
+
+#[derive(Clone, Debug)]
+pub(super) struct WebGpuEventDomainDriver {
+    runtime: WebGpuRuntime,
+    identity: Arc<()>,
+}
+
+impl WebGpuEventDomainDriver {
+    pub(super) fn new(runtime: WebGpuRuntime) -> Self {
+        Self {
+            runtime,
+            identity: Arc::new(()),
+        }
+    }
+}
+
+impl EventDomainDriver for WebGpuEventDomainDriver {
+    fn begin_run(&self) -> tenferro_runtime::Result<Box<dyn EventDomainRun>> {
+        Ok(Box::new(WebGpuEventDomainRun {
+            runtime: self.runtime.clone(),
+            identity: Arc::clone(&self.identity),
+            stream_id: StreamId::current(),
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct WebGpuEventDomainRun {
+    runtime: WebGpuRuntime,
+    identity: Arc<()>,
+    stream_id: StreamId,
+}
+
+impl EventDomainRun for WebGpuEventDomainRun {
+    fn enqueue(
+        &mut self,
+        dependencies: &[Arc<dyn EventToken>],
+        launch: &mut dyn FnMut() -> tenferro_runtime::Result<()>,
+    ) -> tenferro_runtime::Result<Arc<dyn EventToken>> {
+        self.stream_id
+            .executes(|| self.enqueue_on_current_stream(dependencies, launch))
+    }
+
+    fn drain(&mut self) -> tenferro_runtime::Result<()> {
+        self.stream_id
+            .executes(|| submit_and_wait(&self.runtime, self.stream_id))
+    }
+}
+
+impl WebGpuEventDomainRun {
+    fn enqueue_on_current_stream(
+        &mut self,
+        dependencies: &[Arc<dyn EventToken>],
+        launch: &mut dyn FnMut() -> tenferro_runtime::Result<()>,
+    ) -> tenferro_runtime::Result<Arc<dyn EventToken>> {
+        for dependency in dependencies {
+            match dependency.as_any().downcast_ref::<WebGpuEventToken>() {
+                Some(token) if Arc::ptr_eq(&token.identity, &self.identity) => {
+                    // WGPU preserves submission order on one queue. The completion
+                    // remains a scheduler dependency without a host-side wait.
+                }
+                _ => dependency.wait()?,
+            }
+        }
+
+        let mut cleanup = SubmissionCleanupGuard::new(&self.runtime, self.stream_id);
+        if let Err(launch_error) = launch() {
+            return Err(cleanup.finish_with_error(launch_error));
+        }
+        let submission = match submit_completion(&self.runtime, self.stream_id) {
+            Ok(submission) => submission,
+            Err(submit_error) => return Err(cleanup.finish_with_error(submit_error)),
+        };
+        cleanup.disarm();
+        Ok(Arc::new(WebGpuEventToken {
+            identity: Arc::clone(&self.identity),
+            submission,
+        }))
+    }
+}
+
+impl Drop for WebGpuEventDomainRun {
+    fn drop(&mut self) {
+        if let Err(error) = self
+            .stream_id
+            .executes(|| submit_and_wait(&self.runtime, self.stream_id))
+        {
+            eprintln!("tenferro-gpu: failed to drain WebGPU event-domain run during Drop: {error}");
+        }
+    }
+}
+
+struct SubmissionCleanupGuard<'a> {
+    runtime: &'a WebGpuRuntime,
+    stream_id: StreamId,
+    armed: bool,
+}
+
+impl<'a> SubmissionCleanupGuard<'a> {
+    fn new(runtime: &'a WebGpuRuntime, stream_id: StreamId) -> Self {
+        Self {
+            runtime,
+            stream_id,
+            armed: true,
+        }
+    }
+
+    fn finish_with_error(&mut self, primary: RuntimeError) -> RuntimeError {
+        let cleanup = submit_and_wait(self.runtime, self.stream_id);
+        self.armed = false;
+        match cleanup {
+            Ok(()) => primary,
+            Err(cleanup) => RuntimeError::from(crate::Error::backend_source(
+                EVENT_OP,
+                WebGpuSubmissionCleanupError { primary, cleanup },
+            )),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for SubmissionCleanupGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            if let Err(error) = submit_and_wait(self.runtime, self.stream_id) {
+                eprintln!(
+                    "tenferro-gpu: failed to retire WebGPU work during submission unwind: {error}"
+                );
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct WebGpuEventToken {
+    identity: Arc<()>,
+    submission: WgpuSubmission,
+}
+
+impl EventToken for WebGpuEventToken {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn wait(&self) -> tenferro_runtime::Result<()> {
+        self.submission.wait().map_err(webgpu_backend_error)
+    }
+}
+
+fn submit_completion(
+    runtime: &WebGpuRuntime,
+    stream_id: StreamId,
+) -> tenferro_runtime::Result<WgpuSubmission> {
+    runtime
+        .client()
+        .with_server(move |server| server.submit_stream_completion(stream_id))
+        .ok_or_else(|| {
+            RuntimeError::from(crate::Error::backend_source(
+                EVENT_OP,
+                WebGpuServerUnavailable,
+            ))
+        })?
+        .map_err(webgpu_backend_error)
+}
+
+fn submit_and_wait(runtime: &WebGpuRuntime, stream_id: StreamId) -> tenferro_runtime::Result<()> {
+    submit_completion(runtime, stream_id)?
+        .wait()
+        .map_err(webgpu_backend_error)
+}
+
+fn webgpu_backend_error(source: impl std::error::Error + Send + Sync + 'static) -> RuntimeError {
+    RuntimeError::from(crate::Error::backend_source(EVENT_OP, source))
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("the CubeCL WebGPU server is unavailable")]
+struct WebGpuServerUnavailable;
+
+#[derive(Debug, thiserror::Error)]
+#[error("submission failed ({primary}); WebGPU queue cleanup also failed ({cleanup})")]
+struct WebGpuSubmissionCleanupError {
+    primary: RuntimeError,
+    #[source]
+    cleanup: RuntimeError,
+}

--- a/crates/tenferro-gpu/src/webgpu/mod.rs
+++ b/crates/tenferro-gpu/src/webgpu/mod.rs
@@ -19,6 +19,8 @@ const DEFAULT_CUBE_DIM_X: u32 = 256;
 
 mod apple;
 mod error;
+#[cfg(not(target_family = "wasm"))]
+mod event_domain;
 mod gemm;
 pub(crate) mod interop;
 mod kernels;

--- a/crates/tenferro-gpu/src/webgpu/runtime_adapter.rs
+++ b/crates/tenferro-gpu/src/webgpu/runtime_adapter.rs
@@ -15,6 +15,8 @@ use tenferro_tensor::{
     AllocationDomainId, DeviceKind, GpuBackendKind, MemoryKind, Placement, TensorRead, TensorView,
 };
 
+#[cfg(not(target_family = "wasm"))]
+use super::event_domain::WebGpuEventDomainDriver;
 use super::{WebGpuBackend, WebGpuBuffer};
 
 const WEBGPU_ENGINE_ID: &str = "tenferro-webgpu.default.v1";
@@ -117,7 +119,7 @@ pub fn webgpu_runtime_engine_registration(
         capabilities.build(),
     )
     .map(|registration| {
-        registration
+        let registration = registration
             .with_tensor_backend_executor(execution_backend)
             .with_input_signature_validator(move |placement, family, domain, candidate| {
                 candidate == &signature_storage
@@ -142,7 +144,12 @@ pub fn webgpu_runtime_engine_registration(
                     candidate == &resident_storage
                         && webgpu_input_tensor(input, device_ordinal, allocation_domain)
                 },
-            )
+            );
+        #[cfg(not(target_family = "wasm"))]
+        let registration = registration.with_event_domain_driver(Arc::new(
+            WebGpuEventDomainDriver::new(backend.runtime().clone()),
+        ));
+        registration
     })
 }
 

--- a/crates/tenferro-gpu/src/webgpu/tests/runtime_adapter.rs
+++ b/crates/tenferro-gpu/src/webgpu/tests/runtime_adapter.rs
@@ -1,15 +1,38 @@
 use std::any::Any;
 use std::sync::Arc;
 
+#[cfg(not(target_family = "wasm"))]
+use tenferro_runtime::runtime::{EventDomainDriver, EventToken};
+#[cfg(not(target_family = "wasm"))]
+use tenferro_tensor::TensorStructural;
 use tenferro_tensor::{BackendBuffer, Buffer, DeviceId, Tensor, TypedTensor};
 
 use super::*;
-use crate::{upload_webgpu_tensor, webgpu_available};
+use crate::{download_webgpu_tensor, upload_webgpu_tensor, webgpu_available};
 
 #[derive(Debug)]
 struct TestWebGpuBuffer {
     family: &'static str,
     domain: Option<AllocationDomainId>,
+}
+
+#[derive(Debug)]
+#[cfg(not(target_family = "wasm"))]
+struct FailingEventToken;
+
+#[cfg(not(target_family = "wasm"))]
+impl EventToken for FailingEventToken {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn wait(&self) -> tenferro_runtime::Result<()> {
+        Err(tenferro_runtime::Error::runtime_state(
+            "failing_event_token",
+            tenferro_runtime::ErrorPhase::Execution,
+            "injected dependency failure",
+        ))
+    }
 }
 
 impl BackendBuffer<f32> for TestWebGpuBuffer {
@@ -127,4 +150,131 @@ fn webgpu_registration_ingress_accepts_backend_created_tensor() {
         foreign_ordinal,
         domain
     ));
+}
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn webgpu_registration_installs_native_event_domain_driver() {
+    let source = include_str!("../runtime_adapter.rs");
+    assert!(
+        source.contains(".with_event_domain_driver(Arc::new(")
+            && source.contains("WebGpuEventDomainDriver::new(")
+            && source.contains("backend.runtime().clone()"),
+        "WebGPU registration must install its native event-domain driver"
+    );
+}
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+#[ignore = "requires a native WebGPU adapter"]
+fn webgpu_event_domain_tokens_are_repeatable_and_order_native_dependencies() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().expect("WebGPU backend");
+    let runtime = backend.runtime().clone();
+    let host =
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f32, 2.0, 3.0, 4.0]).expect("host input");
+    let input = upload_webgpu_tensor(&runtime, &host).expect("WebGPU upload");
+    let driver = WebGpuEventDomainDriver::new(runtime.clone());
+    let run = driver.begin_run().expect("WebGPU event-domain run");
+
+    // A run may cross scheduler worker threads. Its captured CubeCL stream must
+    // remain stable rather than following each worker's thread-local stream.
+    let input_for_first = input.clone();
+    let (mut run, mut backend, first_output, first_completion, first_launches) =
+        std::thread::spawn(move || {
+            let mut run = run;
+            let mut first_output = None;
+            let mut first_launches = 0;
+            let mut first = || {
+                first_launches += 1;
+                first_output = Some(
+                    backend
+                        .transpose(&input_for_first, &[1, 0])
+                        .map_err(tenferro_runtime::Error::from)?,
+                );
+                Ok(())
+            };
+            let first_completion = run.enqueue(&[], &mut first).expect("first enqueue");
+            drop(first);
+            (
+                run,
+                backend,
+                first_output.expect("first output"),
+                first_completion,
+                first_launches,
+            )
+        })
+        .join()
+        .expect("WebGPU launch worker");
+    assert_eq!(first_launches, 1);
+
+    let mut second_output = None;
+    let mut second_launches = 0;
+    let mut second = || {
+        second_launches += 1;
+        second_output = Some(
+            backend
+                .transpose(&first_output, &[1, 0])
+                .map_err(tenferro_runtime::Error::from)?,
+        );
+        Ok(())
+    };
+    let second_completion = run
+        .enqueue(&[first_completion], &mut second)
+        .expect("dependent enqueue");
+    drop(second);
+    assert_eq!(second_launches, 1);
+
+    second_completion.wait().expect("first completion wait");
+    second_completion.wait().expect("repeat completion wait");
+    run.drain().expect("WebGPU event-domain drain");
+
+    let mut forbidden_launches = 0;
+    let mut forbidden = || {
+        forbidden_launches += 1;
+        Ok(())
+    };
+    let dependency_error = run.enqueue(&[Arc::new(FailingEventToken)], &mut forbidden);
+    assert!(dependency_error.is_err());
+    drop(forbidden);
+    assert_eq!(forbidden_launches, 0);
+
+    let mut panic_output = None;
+    let unwind = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut panicking = || -> tenferro_runtime::Result<()> {
+            panic_output = Some(
+                backend
+                    .transpose(&input, &[1, 0])
+                    .map_err(tenferro_runtime::Error::from)?,
+            );
+            panic!("injected post-launch panic");
+        };
+        let _ = run.enqueue(&[], &mut panicking);
+    }));
+    assert!(unwind.is_err());
+    let panic_output = download_webgpu_tensor(
+        &runtime,
+        panic_output.as_ref().expect("panic-path output retained"),
+    )
+    .expect("panic-path work retired before unwind returned");
+    let Tensor::F32(panic_output) = panic_output else {
+        unreachable!("f32 panic-path output")
+    };
+    assert_eq!(
+        panic_output.as_slice().expect("panic-path host slice"),
+        &[1.0, 3.0, 2.0, 4.0]
+    );
+
+    let output = download_webgpu_tensor(&runtime, second_output.as_ref().expect("second output"))
+        .expect("WebGPU download");
+    let Tensor::F32(output) = output else {
+        unreachable!("f32 elementwise output")
+    };
+    assert_eq!(
+        output.as_slice().expect("host slice"),
+        &[1.0, 2.0, 3.0, 4.0]
+    );
 }

--- a/docs/worklogs/2026-07-30-issue-1471-webgpu-event-domain.md
+++ b/docs/worklogs/2026-07-30-issue-1471-webgpu-event-domain.md
@@ -1,0 +1,59 @@
+# Worklog: #1471 WebGPU Event Domain
+
+## Scope
+
+This PR installs a native WebGPU event-domain driver in the WebGPU engine
+registration. It depends on CubeCL #15 for exact native WGPU submission
+completions and cubek #11 for a single aligned CubeCL dependency graph.
+Production scheduler activation remains a separate PR under #1471.
+
+## Design
+
+Each run captures one CubeCL `StreamId` and restores it for every enqueue,
+completion submission, drain, and drop. Successful launches are flushed
+through `WgpuServer::submit_stream_completion`, which returns the exact
+`wgpu::SubmissionIndex` represented by the event token.
+
+Tokens from clones of the same driver rely on WGPU's ordered queue submissions
+and do not block the host. Foreign tokens use the event-domain contract's
+repeatable host-wait fallback before the launch closure runs.
+
+The launch closure runs exactly once. An armed cleanup guard submits and waits
+for the captured stream when the closure returns an error or unwinds after
+submitting work. Run drain and drop use the same exact submission boundary
+rather than a process-wide or device-wide synchronization.
+
+The native-only driver is not compiled for wasm, where CubeCL does not expose
+native submission handles.
+
+## TDD Record
+
+RED:
+
+- WebGPU engine registration had no native event-domain driver.
+- No WebGPU event token could represent the exact queue submission for a run.
+
+GREEN:
+
+- registration attaches `WebGpuEventDomainDriver`;
+- the A100 Vulkan test moves a run across a worker thread, launches two
+  dependent transposes, waits one token twice, and drains the run;
+- a failing foreign dependency suppresses the launch closure;
+- a post-launch panic retires queued work before the retained output is read.
+
+## Explicit Non-Goals
+
+- Production scheduled-node activation.
+- Browser/wasm queue completion handles.
+- Multiple physical GPU CI, collectives, or distributed tensors.
+- WebGPU elementwise coverage.
+
+## Verification
+
+- `cargo test -p tenferro-gpu --features webgpu
+  webgpu_registration_installs_native_event_domain_driver`: passed.
+- Local NVIDIA A100 80GB PCIe through Vulkan:
+  `webgpu_event_domain_tokens_are_repeatable_and_order_native_dependencies`
+  passed.
+- `python3 scripts/ci/run_profile.py ci-config`: passed after aligning the
+  checked CubeCL revision with the workspace pin.

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -101,7 +101,7 @@ class BuildArtifactContracts(unittest.TestCase):
         manifest = tomllib.loads((ROOT / "Cargo.toml").read_text())
         dependencies = manifest["workspace"]["dependencies"]
 
-        revision = "346135ab43cececf6405d52a3dbc987537402d27"
+        revision = "1c88bb6f1a47ffb11755e05048b7828a743f53e1"
         for name in (
             "cubecl",
             "cubecl-cuda",


### PR DESCRIPTION
## Summary
- install a native WebGPU event-domain driver in the WebGPU engine registration
- capture one CubeCL stream per run and return exact WGPU submission tokens
- preserve native queue ordering, repeatable waits, foreign-token fallback, and failure/panic cleanup
- align CubeCL and cubek pins to merged upstream prerequisites

Part of #1471. Production scheduled-node activation remains a separate PR.

## Upstream prerequisites
- tensor4all/cubecl#15 (`1c88bb6f`)
- tensor4all/cubek#11 (`5535bda8`)

## Verification
- `scripts/check-pr-fast.sh --coverage-reviewed` with WebGPU library and hardware tests
- repository rules review: pass, no findings
- WebGPU library: 18 passed, 1 hardware test ignored
- local NVIDIA A100 80GB PCIe via Vulkan: dependency ordering, repeatable wait, foreign failure suppression, and panic cleanup passed