### PR TITLE
Activate production event-domain scheduling

### DIFF
--- a/crates/tenferro-gpu/src/cubecl/event_domain.rs
+++ b/crates/tenferro-gpu/src/cubecl/event_domain.rs
@@ -49,10 +49,8 @@ impl EventDomainRun for CudaEventDomainRun {
     }
 
     fn drain(&mut self) -> tenferro_runtime::Result<()> {
-        self.stream_id.executes(|| {
-            let stream = raw_stream(&self.runtime).map_err(RuntimeError::from)?;
-            synchronize_stream(&self.runtime, stream).map_err(RuntimeError::from)
-        })
+        self.stream_id
+            .executes(|| retire_cuda_run(&self.runtime).map_err(RuntimeError::from))
     }
 }
 
@@ -100,10 +98,7 @@ impl CudaEventDomainRun {
 
 impl Drop for CudaEventDomainRun {
     fn drop(&mut self) {
-        let result = self.stream_id.executes(|| {
-            let stream = raw_stream(&self.runtime)?;
-            synchronize_stream(&self.runtime, stream)
-        });
+        let result = self.stream_id.executes(|| retire_cuda_run(&self.runtime));
         if let Err(error) = result {
             eprintln!("tenferro-gpu: failed to drain CUDA event-domain run during Drop: {error}");
         }
@@ -244,18 +239,112 @@ fn raw_stream(runtime: &CudaRuntime) -> crate::Result<CUstream> {
 }
 
 fn synchronize_stream(runtime: &CudaRuntime, stream: CUstream) -> crate::Result<()> {
-    runtime.set_current_cuda_context(EVENT_OP)?;
+    let activation = runtime.set_current_cuda_context(EVENT_OP);
     // `cuStreamSynchronize` is the retirement barrier even when it reports an
     // asynchronous launch failure discovered while waiting. Invalid
-    // context/handle errors instead mean the retained runtime domain is
-    // unusable; callers preserve that fatal backend error and must not reuse
-    // the domain.
-    unsafe { cuda_result::stream::synchronize(stream) }
-        .map_err(|source| crate::Error::backend_source(EVENT_OP, source))
+    // context/handle errors mean the retained runtime domain is unusable. The
+    // barrier is still attempted when context selection reports an error so
+    // cleanup never returns before trying either retirement path.
+    let barrier = unsafe { cuda_result::stream::synchronize(stream) };
+    match (activation, barrier) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(activation), Ok(())) => Err(crate::Error::backend_source(
+            EVENT_OP,
+            CudaStreamActivationError { activation },
+        )),
+        (Ok(()), Err(barrier)) => Err(crate::Error::backend_source(EVENT_OP, barrier)),
+        (Err(activation), Err(barrier)) => Err(crate::Error::backend_source(
+            EVENT_OP,
+            CudaStreamRetirementError {
+                activation,
+                barrier,
+            },
+        )),
+    }
+}
+
+fn retire_cuda_run(runtime: &CudaRuntime) -> crate::Result<()> {
+    let stream = match raw_stream(runtime) {
+        Ok(stream) => return synchronize_stream(runtime, stream),
+        Err(primary) => primary,
+    };
+    // Stream lookup can fail after work was admitted. A context-wide barrier is
+    // the retirement fallback; returning the lookup error after it succeeds
+    // preserves the operational failure without releasing live storage.
+    let activation = runtime.set_current_cuda_context(EVENT_OP);
+    let fallback = cuda_result::ctx::synchronize();
+    match (activation, fallback) {
+        (Ok(()), Ok(())) => Err(stream),
+        (Err(activation), Ok(())) => Err(crate::Error::backend_source(
+            EVENT_OP,
+            CudaContextActivationFallbackError {
+                primary: stream,
+                activation,
+            },
+        )),
+        (Ok(()), Err(fallback)) => Err(crate::Error::backend_source(
+            EVENT_OP,
+            CudaRetirementFallbackError {
+                primary: stream,
+                fallback,
+            },
+        )),
+        (Err(activation), Err(fallback)) => Err(crate::Error::backend_source(
+            EVENT_OP,
+            CudaRetirementFallbackCombinedError {
+                primary: stream,
+                activation,
+                fallback,
+            },
+        )),
+    }
 }
 
 fn cuda_backend_error(source: impl std::error::Error + Send + Sync + 'static) -> RuntimeError {
     RuntimeError::from(crate::Error::backend_source(EVENT_OP, source))
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("CUDA stream lookup failed ({primary}); context retirement also reported {fallback}")]
+struct CudaRetirementFallbackError {
+    primary: crate::Error,
+    #[source]
+    fallback: cudarc::driver::DriverError,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("CUDA context selection reported {activation} before stream retirement completed")]
+struct CudaStreamActivationError {
+    #[source]
+    activation: crate::Error,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("CUDA context selection failed ({activation}); stream retirement also reported {barrier}")]
+struct CudaStreamRetirementError {
+    activation: crate::Error,
+    #[source]
+    barrier: cudarc::driver::DriverError,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("CUDA stream lookup failed ({primary}); context selection also reported {activation}")]
+struct CudaContextActivationFallbackError {
+    primary: crate::Error,
+    #[source]
+    activation: crate::Error,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "CUDA stream lookup failed ({primary}); context selection failed ({activation}); \
+     context retirement also reported {fallback}"
+)]
+struct CudaRetirementFallbackCombinedError {
+    primary: crate::Error,
+    activation: crate::Error,
+    #[source]
+    fallback: cudarc::driver::DriverError,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/tenferro-gpu/src/webgpu/event_domain.rs
+++ b/crates/tenferro-gpu/src/webgpu/event_domain.rs
@@ -54,7 +54,7 @@ impl EventDomainRun for WebGpuEventDomainRun {
 
     fn drain(&mut self) -> tenferro_runtime::Result<()> {
         self.stream_id
-            .executes(|| submit_and_wait(&self.runtime, self.stream_id))
+            .executes(|| retire_webgpu_run(&self.runtime, self.stream_id))
     }
 }
 
@@ -94,7 +94,7 @@ impl Drop for WebGpuEventDomainRun {
     fn drop(&mut self) {
         if let Err(error) = self
             .stream_id
-            .executes(|| submit_and_wait(&self.runtime, self.stream_id))
+            .executes(|| retire_webgpu_run(&self.runtime, self.stream_id))
         {
             eprintln!("tenferro-gpu: failed to drain WebGPU event-domain run during Drop: {error}");
         }
@@ -117,7 +117,7 @@ impl<'a> SubmissionCleanupGuard<'a> {
     }
 
     fn finish_with_error(&mut self, primary: RuntimeError) -> RuntimeError {
-        let cleanup = submit_and_wait(self.runtime, self.stream_id);
+        let cleanup = retire_webgpu_run(self.runtime, self.stream_id);
         self.armed = false;
         match cleanup {
             Ok(()) => primary,
@@ -136,7 +136,7 @@ impl<'a> SubmissionCleanupGuard<'a> {
 impl Drop for SubmissionCleanupGuard<'_> {
     fn drop(&mut self) {
         if self.armed {
-            if let Err(error) = submit_and_wait(self.runtime, self.stream_id) {
+            if let Err(error) = retire_webgpu_run(self.runtime, self.stream_id) {
                 eprintln!(
                     "tenferro-gpu: failed to retire WebGPU work during submission unwind: {error}"
                 );
@@ -177,10 +177,24 @@ fn submit_completion(
         .map_err(webgpu_backend_error)
 }
 
-fn submit_and_wait(runtime: &WebGpuRuntime, stream_id: StreamId) -> tenferro_runtime::Result<()> {
-    submit_completion(runtime, stream_id)?
-        .wait()
-        .map_err(webgpu_backend_error)
+fn retire_webgpu_run(runtime: &WebGpuRuntime, stream_id: StreamId) -> tenferro_runtime::Result<()> {
+    let submission = match submit_completion(runtime, stream_id) {
+        Ok(submission) => submission,
+        Err(primary) => {
+            // If the exact stream completion cannot be submitted, synchronize
+            // the whole CubeCL client before allowing scheduler storage to drop.
+            return match runtime.synchronize() {
+                Ok(()) => Err(primary),
+                Err(fallback) => Err(RuntimeError::from(crate::Error::backend_source(
+                    EVENT_OP,
+                    WebGpuRetirementFallbackError { primary, fallback },
+                ))),
+            };
+        }
+    };
+    // `wait` is itself the retirement barrier even when it reports a queued
+    // execution failure.
+    submission.wait().map_err(webgpu_backend_error)
 }
 
 fn webgpu_backend_error(source: impl std::error::Error + Send + Sync + 'static) -> RuntimeError {
@@ -190,6 +204,16 @@ fn webgpu_backend_error(source: impl std::error::Error + Send + Sync + 'static) 
 #[derive(Debug, thiserror::Error)]
 #[error("the CubeCL WebGPU server is unavailable")]
 struct WebGpuServerUnavailable;
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "WebGPU completion submission failed ({primary}); client retirement also reported {fallback}"
+)]
+struct WebGpuRetirementFallbackError {
+    primary: RuntimeError,
+    #[source]
+    fallback: crate::Error,
+}
 
 #[derive(Debug, thiserror::Error)]
 #[error("submission failed ({primary}); WebGPU queue cleanup also failed ({cleanup})")]

--- a/crates/tenferro-runtime/src/runtime/engine_registration.rs
+++ b/crates/tenferro-runtime/src/runtime/engine_registration.rs
@@ -472,8 +472,7 @@ impl EngineRegistration {
         self.execution_engine.is_some()
     }
 
-    #[cfg(test)]
-    pub(crate) fn event_domain_driver(&self) -> Option<&Arc<dyn EventDomainDriver>> {
+    pub(super) fn event_domain_driver(&self) -> Option<&Arc<dyn EventDomainDriver>> {
         self.event_domain_driver.as_ref()
     }
 

--- a/crates/tenferro-runtime/src/runtime/event_domain.rs
+++ b/crates/tenferro-runtime/src/runtime/event_domain.rs
@@ -145,8 +145,17 @@ pub trait EventDomainRun: fmt::Debug + Send {
     /// [`crate::Error::Internal`], when a queued completion reports failure or
     /// the native queue cannot be synchronized.
     ///
+    /// Success and error are both retirement boundaries: before returning, the
+    /// run must ensure that no previously enqueued work can access tensors,
+    /// tokens, or native resources retained by the caller. An error reports the
+    /// completion failure; it must not mean that work is still using those
+    /// resources. Implementations must not unwind from this method.
+    ///
     /// Draining observes already-progressing work. It must not require another
     /// event domain's `drain` call to start that work.
+    ///
+    /// Dropping a run must perform equivalent best-effort retirement when
+    /// explicit draining is skipped by panic unwinding.
     ///
     /// # Examples
     ///

--- a/crates/tenferro-runtime/src/runtime/execution.rs
+++ b/crates/tenferro-runtime/src/runtime/execution.rs
@@ -3,7 +3,7 @@
 //! This module owns the private execution bridge used by
 //! `Runtime::run_compiled*`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::error::Error as StdError;
 use std::fmt;
 use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -21,12 +21,13 @@ use crate::exec::{
 use crate::extension_cache::{ExtensionCacheSelector, ExtensionCacheStore};
 use crate::graph::CompiledGraph;
 use crate::runtime::schedule::{
-    ExecutionLocation, ScheduledGraph, ScheduledNode, ScheduledTransfer,
+    EventDependency, ExecutionLocation, ScheduledGraph, ScheduledNode, ScheduledTransfer,
 };
 use crate::runtime::{
-    CacheOwnerError, CacheStats, InputSignature, PrepareError, PrepareOptions,
-    PreparedOperationPlan, Runtime, RuntimeCacheOwner, StorageClass, SubmissionError,
-    TransferError, TransferProvider, TransferProviderContractError, TransferRequest,
+    CacheOwnerError, CacheStats, EventDomainRun, EventToken, InputSignature, PrepareError,
+    PrepareOptions, PreparedOperationPlan, Runtime, RuntimeCacheOwner, StorageClass,
+    SubmissionError, TransferError, TransferProvider, TransferProviderContractError,
+    TransferRequest,
 };
 use crate::{Error, Result};
 
@@ -1067,6 +1068,10 @@ fn execute_scheduled_slots<'input>(
     let mut located = (0..program.n_slots)
         .map(|_| Vec::new())
         .collect::<Vec<Vec<LocatedExecSlot<'input>>>>();
+    // INVARIANT: runs are declared after the value stores so unwinding drops
+    // and drains native domain work before any tensor storage is released.
+    // Driver preflight completes before input ingress or any operation launch.
+    let mut event_domains = ScheduledEventDomains::new(&execution.snapshot, schedule)?;
     let result = (|| {
         crate::exec::initialize_exec_slots_in(program, inputs, &mut staged)?;
         if execution.input_locations.len() != program.input_slots.len() {
@@ -1098,61 +1103,66 @@ fn execute_scheduled_slots<'input>(
         for node in schedule.nodes() {
             match node {
                 ScheduledNode::Operation(operation_node) => {
-                    let instruction_index = operation_node.instruction_index();
-                    let instruction =
-                        program.instructions.get(instruction_index).ok_or_else(|| {
-                            Error::runtime_state(
+                    let mut launch = || {
+                        let instruction_index = operation_node.instruction_index();
+                        let instruction =
+                            program.instructions.get(instruction_index).ok_or_else(|| {
+                                Error::runtime_state(
+                                    "Runtime::run_compiled",
+                                    ErrorPhase::Execution,
+                                    format!(
+                                        "scheduled operation references instruction \
+                                         {instruction_index}, but the execution program has {} \
+                                         instructions",
+                                        program.instructions.len()
+                                    ),
+                                )
+                            })?;
+                        let operation = instruction_execution(execution, instruction)?;
+                        if operation.location() != operation_node.location() {
+                            return Err(Error::runtime_state(
                                 "Runtime::run_compiled",
                                 ErrorPhase::Execution,
                                 format!(
-                                    "scheduled operation references instruction \
-                                     {instruction_index}, but the execution program has {} \
-                                     instructions",
-                                    program.instructions.len()
+                                    "scheduled instruction {instruction_index} location does not \
+                                     match its prepared executor"
                                 ),
-                            )
-                        })?;
-                    let operation = instruction_execution(execution, instruction)?;
-                    if operation.location() != operation_node.location() {
-                        return Err(Error::runtime_state(
-                            "Runtime::run_compiled",
-                            ErrorPhase::Execution,
-                            format!(
-                                "scheduled instruction {instruction_index} location does not \
-                                 match its prepared executor"
-                            ),
-                        ));
-                    }
-                    stage_instruction_inputs(
-                        instruction,
-                        operation.location(),
-                        &mut located,
-                        &mut staged,
-                    )?;
-                    operation.executor().execute_slot_instruction(
-                        instruction_index,
-                        instruction,
-                        operations,
-                        &mut staged,
-                        output_mode,
-                        &terminal_slots,
-                    )?;
-                    validate_instruction_outputs(
-                        execution,
-                        instruction_index,
-                        instruction,
-                        operation.location(),
-                        &staged,
-                    )?;
-                    retain_instruction_results(
-                        instruction,
-                        operation.location(),
-                        &mut located,
-                        &mut staged,
-                    )?;
+                            ));
+                        }
+                        stage_instruction_inputs(
+                            instruction,
+                            operation.location(),
+                            &mut located,
+                            &mut staged,
+                        )?;
+                        operation.executor().execute_slot_instruction(
+                            instruction_index,
+                            instruction,
+                            operations,
+                            &mut staged,
+                            output_mode,
+                            &terminal_slots,
+                        )?;
+                        validate_instruction_outputs(
+                            execution,
+                            instruction_index,
+                            instruction,
+                            operation.location(),
+                            &staged,
+                        )?;
+                        retain_instruction_results(
+                            instruction,
+                            operation.location(),
+                            &mut located,
+                            &mut staged,
+                        )
+                    };
+                    event_domains.enqueue(node, &mut launch)?;
                 }
                 ScheduledNode::Transfer(transfer) => {
-                    execute_scheduled_transfer(execution, transfer, &mut located)?;
+                    let mut launch =
+                        || execute_scheduled_transfer(execution, transfer, &mut located);
+                    event_domains.enqueue(node, &mut launch)?;
                 }
                 ScheduledNode::Collective(_) => {
                     return Err(Error::runtime_state(
@@ -1161,19 +1171,128 @@ fn execute_scheduled_slots<'input>(
                         "collective node execution is not implemented",
                     ));
                 }
-                ScheduledNode::Barrier(_) => {}
+                ScheduledNode::Barrier(_) => {
+                    let mut launch = || Ok(());
+                    event_domains.enqueue(node, &mut launch)?;
+                }
             }
         }
-        collect_located_outputs(program, &mut located)
+        Ok(())
     })();
-    match result {
-        Ok(slots) => Ok(slots),
-        Err(error) => {
+    let drain = event_domains.drain();
+    match (result, drain) {
+        (Ok(()), Ok(())) => collect_located_outputs(program, &mut located),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => {
             staged.clear();
             located.clear();
             Err(error)
         }
+        (Err(primary), Err(cleanup)) => {
+            staged.clear();
+            located.clear();
+            Err(Error::runtime_state_source(
+                "Runtime::run_compiled",
+                ErrorPhase::Execution,
+                ScheduledExecutionCleanupError { primary, cleanup },
+            ))
+        }
     }
+}
+
+struct ScheduledEventDomains {
+    runs: Vec<(super::EventDomainId, Box<dyn EventDomainRun>)>,
+    completions: HashMap<EventDependency, Arc<dyn EventToken>>,
+}
+
+impl ScheduledEventDomains {
+    fn new(snapshot: &super::RuntimeConfigSnapshot, schedule: &ScheduledGraph) -> Result<Self> {
+        let mut drivers = Vec::new();
+        for node in schedule.nodes() {
+            let domain = node.completion().domain();
+            if drivers.iter().any(|(candidate, _)| *candidate == domain) {
+                continue;
+            }
+            let driver = snapshot
+                .engine_views_for_preparation()
+                .find(|engine| engine.event_domain_id() == domain)
+                .and_then(|engine| engine.event_domain_driver().cloned())
+                .ok_or_else(|| missing_event_domain_driver(domain))?;
+            drivers.push((domain, driver));
+        }
+        let mut runs = Vec::with_capacity(drivers.len());
+        for (domain, driver) in drivers {
+            runs.push((domain, driver.begin_run()?));
+        }
+        Ok(Self {
+            runs,
+            completions: HashMap::new(),
+        })
+    }
+
+    fn enqueue(
+        &mut self,
+        node: &ScheduledNode,
+        launch: &mut dyn FnMut() -> Result<()>,
+    ) -> Result<()> {
+        let dependencies = node
+            .dependencies()
+            .iter()
+            .map(|dependency| {
+                self.completions.get(dependency).cloned().ok_or_else(|| {
+                    Error::runtime_state(
+                        "Runtime::run_compiled",
+                        ErrorPhase::Execution,
+                        format!("scheduled dependency {dependency:?} has no completion token"),
+                    )
+                })
+            })
+            .collect::<Result<SmallVec<[Arc<dyn EventToken>; 4]>>>()?;
+        let completion = node.completion();
+        let run_index = self.run_index(completion.domain())?;
+        let completion_event = self.runs[run_index].1.enqueue(&dependencies, launch)?;
+        self.completions.insert(
+            EventDependency::from_completion(completion),
+            completion_event,
+        );
+        Ok(())
+    }
+
+    fn run_index(&mut self, domain: super::EventDomainId) -> Result<usize> {
+        if let Some(index) = self
+            .runs
+            .iter()
+            .position(|(candidate, _)| *candidate == domain)
+        {
+            return Ok(index);
+        }
+        Err(missing_event_domain_driver(domain))
+    }
+
+    fn drain(&mut self) -> Result<()> {
+        let mut first_error = None;
+        for (_, run) in &mut self.runs {
+            if let Err(error) = run.drain() {
+                first_error.get_or_insert(error);
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
+}
+
+fn missing_event_domain_driver(domain: super::EventDomainId) -> Error {
+    Error::runtime_state(
+        "Runtime::run_compiled",
+        ErrorPhase::Execution,
+        format!("event domain {domain:?} has no registered driver"),
+    )
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("scheduled execution failed ({primary}); event-domain cleanup also failed ({cleanup})")]
+struct ScheduledExecutionCleanupError {
+    #[source]
+    primary: Error,
+    cleanup: Error,
 }
 
 fn instruction_execution<'a>(

--- a/crates/tenferro-runtime/src/runtime/schedule.rs
+++ b/crates/tenferro-runtime/src/runtime/schedule.rs
@@ -101,7 +101,7 @@ impl EventDependency {
         self.domain
     }
 
-    fn from_completion(completion: EventCompletion) -> Self {
+    pub(crate) fn from_completion(completion: EventCompletion) -> Self {
         Self::new(completion.domain, completion.slot, completion.generation)
     }
 }
@@ -349,11 +349,11 @@ pub(crate) enum ScheduledNode {
         reason = "collective scheduling remains representation-only in this scoped change"
     )]
     Collective(ScheduledCollective),
-    // INVARIANT: barrier nodes remain representation-only until the explicitly
-    // deferred asynchronous event scheduler work lands.
+    // INVARIANT: execution supports explicit barriers, but schedule construction
+    // does not emit them until a later scheduling-policy change requires one.
     #[allow(
         dead_code,
-        reason = "barrier scheduling remains representation-only in this scoped change"
+        reason = "barrier construction is deferred until scheduling policy emits explicit barriers"
     )]
     Barrier(ScheduledBarrier),
 }

--- a/crates/tenferro-runtime/src/runtime/snapshot.rs
+++ b/crates/tenferro-runtime/src/runtime/snapshot.rs
@@ -1132,8 +1132,6 @@ impl<'a> EngineSnapshotView<'a> {
         self.slot.event_domain_id
     }
 
-    // Scheduler activation will make this production-visible inside the runtime.
-    #[cfg(test)]
     pub(crate) fn event_domain_driver(&self) -> Option<&'a Arc<dyn super::EventDomainDriver>> {
         self.slot.registration.event_domain_driver()
     }

--- a/crates/tenferro-runtime/tests/integration/runtime_execution.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_execution.rs
@@ -1,13 +1,17 @@
 use std::any::Any;
 use std::error::Error as StdError;
 use std::hash::Hasher;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tenferro_cpu::CpuBackend;
 use tenferro_ops::{
     ext_op::{ExtensionAliasDeclaration, ExtensionEffectDeclaration, ExtensionOp},
     ExtensionShapeContext, SymDim,
+};
+use tenferro_runtime::runtime::{
+    EventDomainDriver, EventDomainRun, EventToken, ImmediateEventDomainDriver,
 };
 use tenferro_runtime::{
     CoreCapabilityBundle, DType, DotGeneralPreparation, ElementwiseRuntime,
@@ -32,6 +36,122 @@ const CPU_HARDWARE_CLASS_ID: &str = "tenferro-cpu.host.v1";
 const CPU_STORAGE_CLASS_ID: &str = "tenferro-cpu.host.v1";
 const COUNTING_EXTENSION_FAMILY: &str = "tenferro-test.counting-extension.v1";
 const DOWNSTREAM_COUNTING_EXTENSION_FAMILY: &str = "tenferro-test.downstream-counting-extension.v1";
+
+#[derive(Debug)]
+struct RecordingEventToken {
+    label: &'static str,
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+impl EventToken for RecordingEventToken {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn wait(&self) -> tenferro_runtime::Result<()> {
+        self.events
+            .lock()
+            .expect("event log lock")
+            .push(format!("{}:wait", self.label));
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct RecordingEventDomainRun {
+    label: &'static str,
+    events: Arc<Mutex<Vec<String>>>,
+    fail_drain: bool,
+}
+
+impl EventDomainRun for RecordingEventDomainRun {
+    fn enqueue(
+        &mut self,
+        dependencies: &[Arc<dyn EventToken>],
+        launch: &mut dyn FnMut() -> tenferro_runtime::Result<()>,
+    ) -> tenferro_runtime::Result<Arc<dyn EventToken>> {
+        self.events.lock().expect("event log lock").push(format!(
+            "{}:enqueue:{}",
+            self.label,
+            dependencies.len()
+        ));
+        for dependency in dependencies {
+            dependency.wait()?;
+        }
+        launch()?;
+        Ok(Arc::new(RecordingEventToken {
+            label: self.label,
+            events: Arc::clone(&self.events),
+        }))
+    }
+
+    fn drain(&mut self) -> tenferro_runtime::Result<()> {
+        self.events
+            .lock()
+            .expect("event log lock")
+            .push(format!("{}:drain", self.label));
+        if self.fail_drain {
+            Err(Error::Internal(format!(
+                "{} event-domain drain failure",
+                self.label
+            )))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for RecordingEventDomainRun {
+    fn drop(&mut self) {
+        self.events
+            .lock()
+            .expect("event log lock")
+            .push(format!("{}:drop", self.label));
+    }
+}
+
+#[derive(Debug)]
+struct RecordingEventDomainDriver {
+    label: &'static str,
+    events: Arc<Mutex<Vec<String>>>,
+    fail_drain: bool,
+}
+
+impl EventDomainDriver for RecordingEventDomainDriver {
+    fn begin_run(&self) -> tenferro_runtime::Result<Box<dyn EventDomainRun>> {
+        self.events
+            .lock()
+            .expect("event log lock")
+            .push(format!("{}:begin", self.label));
+        Ok(Box::new(RecordingEventDomainRun {
+            label: self.label,
+            events: Arc::clone(&self.events),
+            fail_drain: self.fail_drain,
+        }))
+    }
+}
+
+fn recording_event_domain(
+    label: &'static str,
+    events: &Arc<Mutex<Vec<String>>>,
+) -> Arc<dyn EventDomainDriver> {
+    Arc::new(RecordingEventDomainDriver {
+        label,
+        events: Arc::clone(events),
+        fail_drain: false,
+    })
+}
+
+fn failing_drain_event_domain(
+    label: &'static str,
+    events: &Arc<Mutex<Vec<String>>>,
+) -> Arc<dyn EventDomainDriver> {
+    Arc::new(RecordingEventDomainDriver {
+        label,
+        events: Arc::clone(events),
+        fail_drain: true,
+    })
+}
 
 fn cpu_registration(
     backend: &CpuBackend,
@@ -65,6 +185,7 @@ fn cpu_registration(
     .map(|registration| {
         let registration = registration
             .with_cache_owner(cache_owner)
+            .with_event_domain_driver(Arc::new(ImmediateEventDomainDriver::new()))
             .with_input_signature_validator({
                 let storage = storage.clone();
                 let allocation_domain = backend.allocation_domain();
@@ -163,8 +284,10 @@ fn tensor_f64_values(tensor: &Tensor) -> tenferro_tensor::Result<Vec<f64>> {
 struct ExtensionCounters {
     prepare: AtomicUsize,
     execute: AtomicUsize,
+    panic_execute: AtomicBool,
     last_execute_domain: Mutex<Option<AllocationDomainId>>,
     tracked_output_drops: Mutex<Option<Arc<AtomicUsize>>>,
+    tracked_output_drop_events: Mutex<Option<Arc<Mutex<Vec<String>>>>>,
     foreign_output_domain: Mutex<Option<AllocationDomainId>>,
 }
 
@@ -498,11 +621,18 @@ struct DropTrackedBuffer {
     len: usize,
     drops: Arc<AtomicUsize>,
     domain: AllocationDomainId,
+    events: Option<Arc<Mutex<Vec<String>>>>,
 }
 
 impl Drop for DropTrackedBuffer {
     fn drop(&mut self) {
         self.drops.fetch_add(1, Ordering::SeqCst);
+        if let Some(events) = &self.events {
+            events
+                .lock()
+                .expect("drop event log lock")
+                .push("tensor:drop".to_owned());
+        }
     }
 }
 
@@ -674,6 +804,10 @@ impl PreparedOperationExecutor for CountingPreparedOperation {
         inputs: &[TensorRead<'_>],
     ) -> tenferro_runtime::Result<Vec<Tensor>> {
         self.counters.execute.fetch_add(1, Ordering::SeqCst);
+        assert!(
+            !self.counters.panic_execute.load(Ordering::SeqCst),
+            "intentional prepared-operation panic"
+        );
         let backend = context
             .downcast_mut::<CpuBackend>(self.binding.context_identity())
             .map_err(|source| {
@@ -719,7 +853,18 @@ impl PreparedOperationExecutor for CountingPreparedOperation {
             let domain = backend.allocation_domain().ok_or_else(|| {
                 Error::Internal("drop-tracked output requires an allocation domain".into())
             })?;
-            let buffer = Buffer::Backend(Arc::new(DropTrackedBuffer { len, drops, domain }));
+            let events = self
+                .counters
+                .tracked_output_drop_events
+                .lock()
+                .expect("tracked output drop event lock")
+                .clone();
+            let buffer = Buffer::Backend(Arc::new(DropTrackedBuffer {
+                len,
+                drops,
+                domain,
+                events,
+            }));
             return Ok(vec![TypedTensor::<f64>::from_buffer_col_major(
                 shape,
                 buffer,
@@ -797,6 +942,22 @@ fn cpu_registration_with_id(
     include_core_capabilities: bool,
     include_execution_bridge: bool,
 ) -> Result<EngineRegistration, RuntimeConfigError> {
+    cpu_registration_with_id_and_driver(
+        backend,
+        engine_id,
+        include_core_capabilities,
+        include_execution_bridge,
+        true,
+    )
+}
+
+fn cpu_registration_with_id_and_driver(
+    backend: &CpuBackend,
+    engine_id: &str,
+    include_core_capabilities: bool,
+    include_execution_bridge: bool,
+    include_event_domain_driver: bool,
+) -> Result<EngineRegistration, RuntimeConfigError> {
     let backend = Arc::new(backend.clone());
     let mut capabilities = CoreCapabilityBundle::builder();
     if include_core_capabilities {
@@ -854,6 +1015,11 @@ fn cpu_registration_with_id(
                     }
                 },
             );
+        let registration = if include_event_domain_driver {
+            registration.with_event_domain_driver(Arc::new(ImmediateEventDomainDriver::new()))
+        } else {
+            registration
+        };
         if include_execution_bridge {
             registration.with_tensor_backend_executor(backend.as_ref().clone())
         } else {
@@ -896,6 +1062,7 @@ fn cpu_registration_with_storage_id(
     )
     .map(|registration| {
         let registration = registration
+            .with_event_domain_driver(Arc::new(ImmediateEventDomainDriver::new()))
             .with_input_signature_validator({
                 let storage = storage.clone();
                 let allocation_domain = backend.allocation_domain();
@@ -983,6 +1150,7 @@ fn cpu_registration_with_storage_classes(
                     }
                 },
             )
+            .with_event_domain_driver(Arc::new(ImmediateEventDomainDriver::new()))
             .with_tensor_backend_executor(backend.as_ref().clone())
     })
 }
@@ -1984,6 +2152,179 @@ fn runtime_run_compiled_dispatches_same_storage_extension_on_selected_engine(
 }
 
 #[test]
+fn runtime_run_compiled_preflights_all_event_domain_drivers_before_launch(
+) -> Result<(), Box<dyn StdError>> {
+    let core_backend = CpuBackend::new();
+    let extension_backend = CpuBackend::new();
+    let counters = Arc::new(ExtensionCounters::default());
+    let core_engine_id = "tenferro-test.driver-preflight-core.v1";
+    let extension_engine_id = "tenferro-test.driver-preflight-extension.v1";
+    let storage = StorageClass::new(CPU_STORAGE_CLASS_ID)?;
+    let transfer = Arc::new(RecordingTransferProvider::new(
+        storage.clone(),
+        storage.clone(),
+    ));
+    let event_log = Arc::new(Mutex::new(Vec::new()));
+
+    let mut builder = Runtime::builder();
+    builder.register_engine(
+        cpu_registration_with_id(&core_backend, core_engine_id, true, true)?
+            .with_event_domain_driver(recording_event_domain("source", &event_log)),
+    )?;
+    builder.register_engine(cpu_registration_with_id_and_driver(
+        &extension_backend,
+        extension_engine_id,
+        false,
+        true,
+        false,
+    )?)?;
+    builder.register_transfer_provider(storage.clone(), storage, transfer.clone())?;
+    builder.install_extension_module(Arc::new(CountingExtensionModule {
+        module_id: ExtensionModuleId::new("tenferro-test.driver-preflight-module")?,
+        family_id: COUNTING_EXTENSION_FAMILY,
+        engine_id: EngineId::new(extension_engine_id)?,
+        counters: Arc::clone(&counters),
+    }))?;
+    let runtime = builder.build()?;
+
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
+    let sum = (&x + &x)?;
+    let y = tenferro_runtime::extension::apply(
+        Arc::new(CountingExtensionOp {
+            family_id: COUNTING_EXTENSION_FAMILY,
+        }),
+        &[&sum],
+    )?
+    .pop()
+    .expect("extension has one output");
+    let program = GraphCompiler::new().compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])?;
+    let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0])?;
+
+    let error = runtime
+        .run_compiled(&program, &[&input])
+        .expect_err("missing event-domain driver must fail preflight");
+
+    assert_eq!(error.phase(), Some(ErrorPhase::Execution));
+    assert!(error.to_string().contains("has no registered driver"));
+    assert_eq!(counters.execute.load(Ordering::SeqCst), 0);
+    assert_eq!(transfer.calls(), 0);
+    assert!(
+        event_log.lock().expect("event log lock").is_empty(),
+        "preflight failure must occur before any domain begins"
+    );
+    Ok(())
+}
+
+#[test]
+fn runtime_run_compiled_returns_drain_failure_without_outputs() -> Result<(), Box<dyn StdError>> {
+    let backend = CpuBackend::new();
+    let event_log = Arc::new(Mutex::new(Vec::new()));
+    let mut builder = Runtime::builder();
+    builder.register_engine(
+        cpu_registration(&backend, true)?
+            .with_event_domain_driver(failing_drain_event_domain("cpu", &event_log)),
+    )?;
+    let runtime = builder.build()?;
+
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
+    let y = (&x + &x)?;
+    let program = GraphCompiler::new().compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])?;
+    let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0])?;
+
+    let error = runtime
+        .run_compiled(&program, &[&input])
+        .expect_err("drain failure must suppress outputs");
+
+    assert!(error.to_string().contains("cpu event-domain drain failure"));
+    assert_eq!(
+        event_log.lock().expect("event log lock").as_slice(),
+        ["cpu:begin", "cpu:enqueue:0", "cpu:drain", "cpu:drop"]
+    );
+    Ok(())
+}
+
+#[test]
+fn runtime_run_compiled_unwind_drops_event_run_before_tensor_storage(
+) -> Result<(), Box<dyn StdError>> {
+    let domain = AllocationDomainId::fresh();
+    let backend = CpuBackend::new().with_allocation_domain(Arc::new(TestAllocationDomain(domain)));
+    let event_log = Arc::new(Mutex::new(Vec::new()));
+    let output_drops = Arc::new(AtomicUsize::new(0));
+    let producer_counters = Arc::new(ExtensionCounters::default());
+    *producer_counters
+        .tracked_output_drops
+        .lock()
+        .expect("tracked output lock") = Some(Arc::clone(&output_drops));
+    *producer_counters
+        .tracked_output_drop_events
+        .lock()
+        .expect("tracked output drop event lock") = Some(Arc::clone(&event_log));
+    let panic_counters = Arc::new(ExtensionCounters::default());
+    panic_counters.panic_execute.store(true, Ordering::SeqCst);
+
+    let mut builder = Runtime::builder();
+    builder.register_engine(
+        cpu_registration(&backend, true)?
+            .with_event_domain_driver(recording_event_domain("cpu", &event_log)),
+    )?;
+    builder.install_extension_module(Arc::new(CountingExtensionModule {
+        module_id: ExtensionModuleId::new("tenferro-test.panic-producer-module")?,
+        family_id: COUNTING_EXTENSION_FAMILY,
+        engine_id: EngineId::new(CPU_ENGINE_ID)?,
+        counters: producer_counters,
+    }))?;
+    builder.install_extension_module(Arc::new(CountingExtensionModule {
+        module_id: ExtensionModuleId::new("tenferro-test.panic-consumer-module")?,
+        family_id: DOWNSTREAM_COUNTING_EXTENSION_FAMILY,
+        engine_id: EngineId::new(CPU_ENGINE_ID)?,
+        counters: Arc::clone(&panic_counters),
+    }))?;
+    let runtime = builder.build()?;
+
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 1)?;
+    let produced = tenferro_runtime::extension::apply(
+        Arc::new(CountingExtensionOp {
+            family_id: COUNTING_EXTENSION_FAMILY,
+        }),
+        &[&x],
+    )?
+    .pop()
+    .expect("producer has one output");
+    let y = tenferro_runtime::extension::apply(
+        Arc::new(CountingExtensionOp {
+            family_id: DOWNSTREAM_COUNTING_EXTENSION_FAMILY,
+        }),
+        &[&produced],
+    )?
+    .pop()
+    .expect("consumer has one output");
+    let program = GraphCompiler::new().compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])?;
+    let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0])?;
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        let _ = runtime.run_compiled(&program, &[&input]);
+    }));
+
+    assert!(panic.is_err(), "prepared-operation panic must unwind");
+    assert_eq!(panic_counters.execute.load(Ordering::SeqCst), 1);
+    assert_eq!(output_drops.load(Ordering::SeqCst), 1);
+    let events = event_log.lock().expect("event log lock").clone();
+    let run_drop = events
+        .iter()
+        .position(|event| event == "cpu:drop")
+        .expect("event-domain run must drop during unwind");
+    let tensor_drop = events
+        .iter()
+        .position(|event| event == "tensor:drop")
+        .expect("intermediate tensor storage must drop during unwind");
+    assert!(
+        run_drop < tensor_drop,
+        "event-domain cleanup must precede tensor storage release: {events:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn runtime_run_compiled_transfers_between_storage_classes_on_scheduled_path(
 ) -> Result<(), Box<dyn StdError>> {
     let core_domain = AllocationDomainId::fresh();
@@ -2002,22 +2343,29 @@ fn runtime_run_compiled_transfers_between_storage_classes_on_scheduled_path(
         destination_storage.clone(),
         extension_backend.clone(),
     ));
+    let event_log = Arc::new(Mutex::new(Vec::new()));
 
     let mut builder = Runtime::builder();
-    builder.register_engine(cpu_registration_with_storage_id(
-        &core_backend,
-        core_engine_id,
-        source_storage.as_str(),
-        true,
-        true,
-    )?)?;
-    builder.register_engine(cpu_registration_with_storage_id(
-        &extension_backend,
-        extension_engine_id,
-        destination_storage.as_str(),
-        false,
-        true,
-    )?)?;
+    builder.register_engine(
+        cpu_registration_with_storage_id(
+            &core_backend,
+            core_engine_id,
+            source_storage.as_str(),
+            true,
+            true,
+        )?
+        .with_event_domain_driver(recording_event_domain("source", &event_log)),
+    )?;
+    builder.register_engine(
+        cpu_registration_with_storage_id(
+            &extension_backend,
+            extension_engine_id,
+            destination_storage.as_str(),
+            false,
+            true,
+        )?
+        .with_event_domain_driver(recording_event_domain("destination", &event_log)),
+    )?;
     builder.register_transfer_provider(
         source_storage.clone(),
         destination_storage.clone(),
@@ -2079,6 +2427,30 @@ fn runtime_run_compiled_transfers_between_storage_classes_on_scheduled_path(
     assert_eq!(
         *counters.last_execute_domain.lock().expect("domain lock"),
         Some(extension_domain)
+    );
+    let events = event_log.lock().expect("event log lock").clone();
+    assert!(events.contains(&"source:begin".to_owned()), "{events:?}");
+    assert!(
+        events.contains(&"destination:begin".to_owned()),
+        "{events:?}"
+    );
+    assert!(
+        events.contains(&"source:enqueue:0".to_owned()),
+        "{events:?}"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.as_str() == "destination:enqueue:1")
+            .count(),
+        2,
+        "transfer and destination operation must both consume dependencies: {events:?}"
+    );
+    assert!(events.contains(&"source:wait".to_owned()), "{events:?}");
+    assert!(events.contains(&"source:drain".to_owned()), "{events:?}");
+    assert!(
+        events.contains(&"destination:drain".to_owned()),
+        "{events:?}"
     );
 
     Ok(())
@@ -2372,7 +2744,7 @@ fn runtime_run_compiled_split_use_retains_source_and_destination_values(
 }
 
 #[test]
-fn transfer_failure_skips_downstream_execution_and_releases_located_values(
+fn transfer_and_drain_failure_preserve_both_errors_and_release_located_values(
 ) -> Result<(), Box<dyn StdError>> {
     let core_backend = CpuBackend::new();
     let extension_domain = AllocationDomainId::fresh();
@@ -2397,22 +2769,29 @@ fn transfer_failure_skips_downstream_execution_and_releases_located_values(
     let failing = Arc::new(FailingTransferProvider {
         calls: AtomicUsize::new(0),
     });
+    let event_log = Arc::new(Mutex::new(Vec::new()));
 
     let mut builder = Runtime::builder();
-    builder.register_engine(cpu_registration_with_storage_id(
-        &core_backend,
-        core_engine_id,
-        source_storage.as_str(),
-        true,
-        true,
-    )?)?;
-    builder.register_engine(cpu_registration_with_storage_id(
-        &extension_backend,
-        extension_engine_id,
-        destination_storage.as_str(),
-        false,
-        true,
-    )?)?;
+    builder.register_engine(
+        cpu_registration_with_storage_id(
+            &core_backend,
+            core_engine_id,
+            source_storage.as_str(),
+            true,
+            true,
+        )?
+        .with_event_domain_driver(failing_drain_event_domain("source", &event_log)),
+    )?;
+    builder.register_engine(
+        cpu_registration_with_storage_id(
+            &extension_backend,
+            extension_engine_id,
+            destination_storage.as_str(),
+            false,
+            true,
+        )?
+        .with_event_domain_driver(recording_event_domain("destination", &event_log)),
+    )?;
     builder.register_transfer_provider(
         source_storage.clone(),
         destination_storage.clone(),
@@ -2464,6 +2843,12 @@ fn transfer_failure_skips_downstream_execution_and_releases_located_values(
     let error = runtime.run_compiled(&program, &[&input]).unwrap_err();
 
     assert!(error.to_string().contains("intentional transfer failure"));
+    assert!(
+        error
+            .to_string()
+            .contains("source event-domain drain failure"),
+        "combined execution and cleanup diagnostics must preserve both failures: {error}"
+    );
     assert_eq!(forward.calls(), 1);
     assert_eq!(failing.calls.load(Ordering::SeqCst), 1);
     assert_eq!(upstream_counters.execute.load(Ordering::SeqCst), 1);
@@ -2476,6 +2861,20 @@ fn transfer_failure_skips_downstream_execution_and_releases_located_values(
         drops.load(Ordering::SeqCst),
         1,
         "the extension output retained at its source location must be released on failure"
+    );
+    let events = event_log.lock().expect("event log lock").clone();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.as_str() == "source:enqueue:1")
+            .count(),
+        1,
+        "the failing reverse transfer is admitted, but the downstream operation is not: {events:?}"
+    );
+    assert!(events.contains(&"source:drain".to_owned()), "{events:?}");
+    assert!(
+        events.contains(&"destination:drain".to_owned()),
+        "{events:?}"
     );
     Ok(())
 }

--- a/docs/design/execution-engine-provider-architecture.md
+++ b/docs/design/execution-engine-provider-architecture.md
@@ -36,10 +36,13 @@ crate-private `ScheduledGraph`, synchronous `Runtime::run_compiled*` walks that
 schedule, and each semantic operation runs on its selected same-storage engine
 bridge. #1471 extends that production path with `Runtime::submit`,
 `ExecutionHandle`, runtime-allocated engine event domains, and a storage-class
-keyed transfer provider registry. Full asynchronous admission, device-native
-stream/queue integration, collectives, and real GPU transfer scheduling remain
-reserved follow-up work; they must extend this production dispatch path rather
-than building a second metadata-only layer.
+keyed transfer provider registry. Scheduled operations, transfers, and explicit
+barriers now execute through per-run event-domain drivers. CUDA and WebGPU
+registrations provide native stream/event and queue/submission-completion
+adapters respectively. Collectives, cancellation, admission control, real
+two-card CI, and non-blocking public submission remain reserved follow-up work;
+they must extend this production dispatch path rather than building a second
+metadata-only layer.
 
 Full runtime-owned `SubgraphCompiler` selection, one-node scheduled XLA
 subgraphs, and PJRT executable caching remain separate follow-up work.
@@ -1745,13 +1748,51 @@ encapsulates runtime resources without that contract.
 
 ## Asynchronous Execution and Events
 
-The runtime owns event storage rather than allocating an
-`Arc<dyn CompletionEvent>` for every node or defining a closed backend-event
-enum. One illustrative implementation preplans slots identified by
-`EventDomainId`, `EventSlotId`, and a generation, with the actual CUDA, WebGPU,
-PJRT, or CPU completion token stored in engine-owned per-run workspace. Exact
-slot identity, recycling, and generation management are reserved for the event
-child design.
+Before input ingress or the first launch, the runtime scheduler preflights and
+starts one `EventDomainRun` for each event domain used by an execution. This
+prevents a missing driver or run-allocation failure from appearing after an
+earlier effect has executed. The scheduler resolves each dependency to the
+opaque `EventToken` returned by the dependency's run, then asks the completion
+domain's run to enqueue the node. The first scheduled use of an event domain
+fixes its position in the canonical per-execution drain order. A missing driver
+is a typed runtime execution error; there is no implicit synchronous fallback.
+
+The CPU immediate driver waits every dependency before launching work. CUDA
+and WebGPU drivers preserve same-backend ordering with native stream/event or
+queue/submission primitives and use host waits only for foreign tokens. The
+scheduler holds no runtime, driver, backend, or provider lock while invoking
+`enqueue`, launching work, or draining runs.
+
+Native retirement has a wider exceptional fallback. If CUDA cannot recover the
+scheduled stream, it attempts a context-wide barrier; both stream and context
+barriers are attempted even when context activation reports an error. If
+WebGPU cannot submit an exact stream-completion marker, it synchronizes the
+whole CubeCL client. These fallbacks preserve the primary operational error and
+any cleanup error. A synchronization call that reports queued execution failure
+is still a retirement boundary; an invalid or lost native domain is
+non-reusable.
+
+After the first enqueue or launch failure, the scheduler admits no later node
+and drains every run that was started. It also drains after successful output
+execution and collects outputs only after draining. Input, intermediate,
+transfer, and output storage remains retained until this drain completes.
+`EventDomainRun::drain` is a retirement boundary on both success and error; a
+driver may report completion failure only after work can no longer access
+retained resources. During panic unwinding, domain runs are dropped before
+value stores, so driver `Drop` cleanup drains outstanding work before tensor
+storage can be released. If execution and explicit cleanup both fail, the
+execution error remains the typed source and the cleanup failure is included in
+the diagnostic.
+
+Scheduled operation, transfer, and barrier nodes use this path in production.
+The current schedule builder does not yet emit explicit barriers, and
+collective execution remains a typed unsupported operation.
+
+The longer-term design may replace one token allocation per node with
+preplanned slots identified by `EventDomainId`, `EventSlotId`, and a
+generation, with concrete CUDA, WebGPU, PJRT, or CPU completion state stored in
+engine-owned per-run workspace. Exact slot recycling and generation management
+remain reserved for that optimization and must preserve the contract above.
 
 The engine attaches dependencies to subsequent work and providers never call a
 global synchronize after each operation. Cross-event-domain dependencies

--- a/docs/worklogs/2026-07-30-issue-1471-production-scheduler.md
+++ b/docs/worklogs/2026-07-30-issue-1471-production-scheduler.md
@@ -1,0 +1,96 @@
+# Worklog: #1471 Production Event-Domain Scheduler
+
+## Scope
+
+This PR activates the previously merged event-domain contract in the
+production `Runtime::run_compiled*` scheduler. Scheduled operations, transfers,
+and explicit barriers now execute through their registered
+`EventDomainDriver`. Collectives remain explicitly unsupported.
+
+Native CUDA and WebGPU event-domain adapters landed before this activation.
+This PR does not add cancellation, admission control, collectives, distributed
+tensors, real two-card CI, or a non-blocking public submission API.
+
+## Execution Contract
+
+The scheduler preflights and begins one run for each event domain used by a
+scheduled execution before input ingress or the first launch. Runs are retained
+in deterministic first-use order. Every scheduled dependency is resolved to
+its prior opaque completion token and passed to the completion domain before
+the node's launch closure runs.
+
+The first enqueue or launch error stops later admission. All started domains
+are drained in first-use order on success and failure without holding runtime,
+driver, backend, or provider locks. Tensor values remain retained until drain
+finishes. Output collection occurs only after successful drain. The public
+driver contract requires `drain` to retire resource access before returning on
+both success and error and requires best-effort retirement from `Drop` during
+unwinding. If execution and drain both fail, the primary execution error
+remains the typed source and the cleanup error is retained in the diagnostic.
+
+The event-domain run store is declared after the execution value stores. Rust's
+reverse drop order therefore invokes native run `Drop` cleanup before releasing
+tensor storage during panic unwinding.
+
+CUDA retirement falls back from unavailable stream lookup to a context-wide
+barrier and attempts the barrier even when context selection reports an error.
+WebGPU retirement falls back from exact completion-submission failure to a
+whole-client synchronization. Both adapters preserve primary and cleanup
+diagnostics while satisfying the retirement boundary on `drain` and `Drop`.
+
+An engine used by a schedule must register a driver. Missing drivers fail with
+a typed runtime execution error during whole-schedule preflight, before input
+ingress or any node launch, rather than silently selecting immediate execution.
+
+## TDD Record
+
+RED:
+
+- the two-logical-device transfer integration test observed no event-domain
+  activity because production execution bypassed `EventDomainRun`;
+- transfer failure cleanup could not prove that every started domain drained.
+
+GREEN:
+
+- operation and transfer nodes produce and consume recorded completion tokens;
+- the transfer path crosses source and destination domains end to end;
+- a failed reverse transfer is admitted once, later execution is suppressed,
+  and both started domains drain;
+- a later scheduled domain without a driver fails whole-schedule preflight
+  before the first domain begins;
+- drain failure suppresses outputs, combined execution and drain failures
+  preserve both diagnostics, and a failure in one domain does not skip later
+  drains;
+- injected launch panic drops the event-domain run before tracked intermediate
+  tensor storage;
+- all integration fixtures opt into the immediate driver explicitly.
+
+## Correctness And Lifetime Audit
+
+- schedule validation guarantees every dependency names an earlier completion;
+- completion tokens remain retained for the whole scheduled execution;
+- outputs are collected only after drain succeeds;
+- success, execution failure, drain failure, and combined failure all release
+  value stores only after explicit drain;
+- panic cleanup is delegated to the already tested native run `Drop`
+  implementations, with scheduler declaration order preserving storage
+  lifetime;
+- transfer provider execution remains on the existing typed, validated path.
+
+## Verification
+
+- `cargo test -p tenferro-runtime --lib`: 349 passed.
+- `cargo test -p tenferro-runtime --test integration`: 109 passed.
+- Focused two-engine transfer success and failure tests: passed.
+- `cargo check -p tenferro-gpu --no-default-features --features
+  cpu-faer,cuda,webgpu`: passed.
+- CUDA event-domain ignored hardware test: passed on local NVIDIA A100 80 GB
+  PCIe.
+- WebGPU event-domain ignored hardware test: passed on the local Vulkan
+  adapter.
+- `scripts/check-pr-fast.sh --coverage-reviewed` with the focused runtime and
+  CUDA/WebGPU feature commands: passed.
+- `scripts/repository-rules-review.py`: passed with no findings.
+- Independent correctness review: drain retirement, panic lifetime,
+  missing-driver preflight, and native fallback findings resolved; final
+  review reported no blocker.


### PR DESCRIPTION
## Summary

- execute scheduled operations, transfers, and barriers through registered per-run event domains
- preflight every scheduled driver/run before ingress, propagate dependency tokens, and drain all started domains deterministically
- define and enforce retirement/lifetime behavior across success, failure, and panic, including CUDA context and WebGPU client synchronization fallbacks
- add two-logical-device ordering, missing-driver, combined-error, and cleanup-before-storage-drop coverage

## Verification

- `scripts/check-pr-fast.sh --coverage-reviewed` with runtime lib/integration/doc and CUDA+WebGPU feature checks
- `cargo test -p tenferro-runtime --lib` (349 passed)
- `cargo test -p tenferro-runtime --test integration` (109 passed)
- `cargo test -p tenferro-runtime --doc` (382 passed)
- CUDA event-domain hardware test on local NVIDIA A100 80 GB PCIe
- WebGPU event-domain hardware test on local Vulkan adapter
- `scripts/repository-rules-review.py` (pass, no findings)
- independent correctness review (no blocker after fixes)

Closes #1471
