### PR TITLE
Adopt strided indexed replay fast path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "fa312f9ef3766163540869ee8fb6be3e7199a3e0", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "fa312f9ef3766163540869ee8fb6be3e7199a3e0", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "fa312f9ef3766163540869ee8fb6be3e7199a3e0", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "fa312f9ef3766163540869ee8fb6be3e7199a3e0", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "fa312f9ef3766163540869ee8fb6be3e7199a3e0", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4c19952f0ab647fc63639d2923d1903a2f84c87a", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4c19952f0ab647fc63639d2923d1903a2f84c87a", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4c19952f0ab647fc63639d2923d1903a2f84c87a", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4c19952f0ab647fc63639d2923d1903a2f84c87a", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4c19952f0ab647fc63639d2923d1903a2f84c87a", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/docs/worklogs/2026-07-30-strided-indexed-replay-adoption.md
+++ b/docs/worklogs/2026-07-30-strided-indexed-replay-adoption.md
@@ -1,0 +1,62 @@
+# Strided Indexed Replay Adoption
+
+## Summary
+
+Advanced every workspace strided-rs dependency from `fa312f9e` to merged
+commit `4c19952f`. The upstream change adds checked contiguous rank-one replay
+for dynamic slice and dynamic update while preserving the existing generic
+strided path.
+
+## Context Read
+
+- tenferro-rs issues #1490 and #1511
+- strided-rs issues #149 and #169
+- strided-rs PR #182
+- `AGENTS.md`, `REPOSITORY_RULES.md`, and the shared tensor4all performance,
+  numerical, documentation, and test rules
+
+## Boundary And Correctness
+
+- This adoption changes only the merged dependency pin. Tenferro continues to
+  pass its backend-owned explicit `ExecContext`; no ambient execution policy is
+  introduced.
+- Upstream validates the contiguous source and destination ranges before using
+  safe slice copies. Non-unit, negative-stride, and higher-rank layouts retain
+  the generic coordinate/offset decoder.
+- Dynamic update retains copy-then-overwrite semantics. Upstream differential
+  tests cover every `KernelDType`, clamped starts, empty windows, negative
+  strides, and bounded execution contexts.
+
+## Performance Evidence
+
+The focused public API benchmark used the full publication profile with 15
+measured runs after three warmups. The baseline was tenferro-rs `5ef41cc9`
+with strided-rs `fa312f9e`; the candidate was this pin update. One-thread runs
+were pinned to CPU 60 and four-thread runs to CPUs 60-63.
+
+| Row | Baseline | Candidate | Change | Bootstrap 95% interval |
+| --- | ---: | ---: | ---: | ---: |
+| dynamic_slice direct t1 | 19.435 ms | 0.809 ms | -95.84% | [-96.03%, -95.82%] |
+| dynamic_slice trace t1 | 19.490 ms | 0.809 ms | -95.85% | [-95.97%, -95.67%] |
+| dynamic_update direct t1 | 10.496 ms | 1.082 ms | -89.69% | [-89.76%, -89.64%] |
+| dynamic_slice direct t4 | 2.600 ms | 0.740 ms | -71.53% | [-71.81%, -70.17%] |
+| dynamic_slice trace t4 | 2.320 ms | 1.195 ms | -48.49% | [-59.76%, -36.79%] |
+| dynamic_update direct t4 | 2.195 ms | 1.097 ms | -50.00% | [-51.60%, -46.23%] |
+
+All candidate-relative upper bounds are below the +20 percent stop-the-line
+threshold. The former dynamic-slice one-thread anomaly is removed.
+
+## Verification
+
+- strided-rs PR #182 passed formatting, workspace tests, documentation,
+  coverage, and Linux/macOS CI before squash merge.
+- Tenferro's focused CPU indexing tests and fast-check passed. The
+  repository-rules review reported no findings.
+- The source-contract check continues to require one exact merged revision
+  across all five strided workspace dependencies.
+
+## Remaining Work
+
+- The full cross-row campaign record remains under tenferro-rs #1490.
+- Additive scatter and raw copy replay remain intentionally serial under the
+  strided-rs #164 decision and are not changed by this adoption.

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "fa312f9ef3766163540869ee8fb6be3e7199a3e0"
+        revision = "4c19952f0ab647fc63639d2923d1903a2f84c87a"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
## Summary

- update all workspace `strided-*` pins to merged strided-rs PR #182 (`4c19952f`)
- adopt checked contiguous rank-one replay for dynamic slice/update without tenferro call-site changes
- record focused t1/t4 public API evidence and boundary verification

Addresses #1490. Follow-up to #1511 and tensor4all/strided-rs#169.

## Performance

Full publication profile, 3 warmups and 15 samples, t1 CPU 60 and t4 CPUs 60-63. Baseline is tenferro `5ef41cc9` with strided `fa312f9e`.

| Row | Baseline | Candidate | Change | 95% interval |
| --- | ---: | ---: | ---: | ---: |
| dynamic_slice direct t1 | 19.435 ms | 0.809 ms | -95.84% | [-96.03%, -95.82%] |
| dynamic_slice trace t1 | 19.490 ms | 0.809 ms | -95.85% | [-95.97%, -95.67%] |
| dynamic_update direct t1 | 10.496 ms | 1.082 ms | -89.69% | [-89.76%, -89.64%] |
| dynamic_slice direct t4 | 2.600 ms | 0.740 ms | -71.53% | [-71.81%, -70.17%] |
| dynamic_slice trace t4 | 2.320 ms | 1.195 ms | -48.49% | [-59.76%, -36.79%] |
| dynamic_update direct t4 | 2.195 ms | 1.097 ms | -50.00% | [-51.60%, -46.23%] |

The former cumulative-gate t1 regression is removed. Every measured upper bound is below +20%.

## Verification

- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-cpu dynamic_slice' --test 'cargo test -p tenferro-cpu dynamic_update_slice'`
- repository-rules review: pass, no findings
- upstream PR #182: fmt, workspace tests, docs, coverage, Linux/macOS CI passed
