### PR TITLE
chore: adopt strided destination safety fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4c19952f0ab647fc63639d2923d1903a2f84c87a", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4c19952f0ab647fc63639d2923d1903a2f84c87a", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4c19952f0ab647fc63639d2923d1903a2f84c87a", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4c19952f0ab647fc63639d2923d1903a2f84c87a", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4c19952f0ab647fc63639d2923d1903a2f84c87a", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/docs/worklogs/2026-07-30-strided-destination-injectivity-adoption.md
+++ b/docs/worklogs/2026-07-30-strided-destination-injectivity-adoption.md
@@ -3,18 +3,22 @@
 ## Summary
 
 Advanced every workspace `strided-*` dependency from `4c19952f` to merged
-strided-rs PR #183, commit `4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a`.
+tensor4all/strided-rs#183, commit
+`4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a`.
 The upstream fix rejects non-injective map, zip, and multiply destinations
 before any write, including identity fast paths and erased replay.
 
 ## Context And Decision
 
-- Upstream issue #181 and PR #183 were reviewed for destination aliasing,
+- tensor4all/strided-rs#181 and tensor4all/strided-rs#183 were reviewed for
+  destination aliasing,
   erased one-shot validation, allocation behavior, and bounded-layout policy.
 - This PR only adopts the merged dependency and updates the existing source
   contract to keep all five workspace strided packages on one revision.
-- No tenferro source, behavior, public API, or execution policy changes are
-  intended. The safety semantics are supplied by the merged upstream package.
+- No tenferro Rust implementation or public API changes are included. The pin
+  intentionally adopts the observable upstream safety behavior change: the
+  merged package rejects non-injective destinations before writes. The safety
+  semantics are supplied by the merged upstream package.
 
 ## Verification
 

--- a/docs/worklogs/2026-07-30-strided-destination-injectivity-adoption.md
+++ b/docs/worklogs/2026-07-30-strided-destination-injectivity-adoption.md
@@ -1,0 +1,31 @@
+# Strided Destination Injectivity Adoption
+
+## Summary
+
+Advanced every workspace `strided-*` dependency from `4c19952f` to merged
+strided-rs PR #183, commit `4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a`.
+The upstream fix rejects non-injective map, zip, and multiply destinations
+before any write, including identity fast paths and erased replay.
+
+## Context And Decision
+
+- Upstream issue #181 and PR #183 were reviewed for destination aliasing,
+  erased one-shot validation, allocation behavior, and bounded-layout policy.
+- This PR only adopts the merged dependency and updates the existing source
+  contract to keep all five workspace strided packages on one revision.
+- No tenferro source, behavior, public API, or execution policy changes are
+  intended. The safety semantics are supplied by the merged upstream package.
+
+## Verification
+
+- Updated the workspace manifest and Cargo lock resolution.
+- Ran formatting, the focused dependency/build test, `check-pr-fast.sh`, and
+  `scripts/repository-rules-review.py` against `origin/main`.
+- Confirmed every resolved strided package in `Cargo.lock` uses the merged
+  `strided-rs` revision.
+
+## Remaining Risk
+
+This adoption does not independently change tenferro call paths. Upstream
+behavior and allocation tests remain the authority for the new destination
+injectivity contract; tenferro CI provides downstream compilation and tests.

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "4c19952f0ab647fc63639d2923d1903a2f84c87a"
+        revision = "4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
## Summary

- update all five workspace `strided-*` git pins to merged tensor4all/strided-rs commit `4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a`
- synchronize the existing Cargo source-contract test
- add the adoption worklog

This is dependency-only adoption of tensor4all/strided-rs#183 for tensor4all/strided-rs#181. No tenferro Rust implementation or public API changes are included. The pin intentionally adopts the observable upstream safety behavior change: the merged strided-rs package rejects non-injective destinations before writes.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p tenferro-tensor`
- `cargo test -p tenferro-tensor --lib` (216 passed)
- `python3 -m unittest scripts.ci.tests.test_build_artifact_contracts -v` (6 passed)
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-tensor --lib'` (passed)
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json` (`pass`, no findings)
- all five strided packages in `Cargo.lock` resolve to the merged revision

Closes/relates to #1535. Relates to tensor4all/strided-rs#181 and tensor4all/strided-rs#183.
