### PR TITLE
chore: adopt strided full-overwrite replay fix (#184)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "6885f52edb5fa2348fea47413bc43561e436ef63", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "6885f52edb5fa2348fea47413bc43561e436ef63", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "6885f52edb5fa2348fea47413bc43561e436ef63", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "6885f52edb5fa2348fea47413bc43561e436ef63", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "6885f52edb5fa2348fea47413bc43561e436ef63", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/docs/worklogs/2026-07-30-strided-uninitialized-full-overwrite-replay-adoption.md
+++ b/docs/worklogs/2026-07-30-strided-uninitialized-full-overwrite-replay-adoption.md
@@ -2,27 +2,30 @@
 
 ## Summary
 
-Advanced every workspace `strided-*` dependency from `4be1c8a8` to merged
-tensor4all/strided-rs#184, commit
-`6885f52edb5fa2348fea47413bc43561e436ef63`.
+Advanced every workspace `strided-*` dependency from `4be1c8a8` to merge
+commit `6885f52edb5fa2348fea47413bc43561e436ef63` from
+tensor4all/strided-rs#185, which implemented and closed issue
+tensor4all/strided-rs#184.
 
 ## Context And Decision
 
-- This adopts the upstream uninitialized full-overwrite replay behavior from
-  strided-rs#184, following the prior merged strided adoption pattern.
-- The adoption depends on the merged upstream strided change and does not
-  change tenferro implementation or call paths.
+- This adopts the upstream uninitialized full-overwrite replay behavior
+  specified by strided-rs#184 and implemented by strided-rs#185, following the
+  prior merged strided adoption pattern.
+- The adoption depends on merged upstream PR strided-rs#185 and does not change
+  tenferro implementation or call paths.
 - No tenferro call path changes are included yet; follow-up work remains
   separate from this pin update and does not start #1516A.
 
 ## Verification
 
 - Updated the workspace manifest and exact-revision source contract.
-- Resolved workspace metadata against the merged strided revision, then ran
-  formatting, the focused source-contract test, and the focused fast PR check.
+- Resolved workspace metadata against the strided-rs#185 merge commit, then
+  ran formatting, the focused source-contract test, and the focused fast PR
+  check.
 
 ## Remaining Risk
 
-The new replay behavior is supplied by the merged upstream dependency. This
+The new replay behavior is supplied by merged upstream PR strided-rs#185. This
 PR does not independently exercise or alter tenferro callers beyond compiling
 and testing them against the adopted revision.

--- a/docs/worklogs/2026-07-30-strided-uninitialized-full-overwrite-replay-adoption.md
+++ b/docs/worklogs/2026-07-30-strided-uninitialized-full-overwrite-replay-adoption.md
@@ -1,0 +1,28 @@
+# Strided Uninitialized Full-Overwrite Replay Adoption
+
+## Summary
+
+Advanced every workspace `strided-*` dependency from `4be1c8a8` to merged
+tensor4all/strided-rs#184, commit
+`6885f52edb5fa2348fea47413bc43561e436ef63`.
+
+## Context And Decision
+
+- This adopts the upstream uninitialized full-overwrite replay behavior from
+  strided-rs#184, following the prior merged strided adoption pattern.
+- The adoption depends on the merged upstream strided change and does not
+  change tenferro implementation or call paths.
+- No tenferro call path changes are included yet; follow-up work remains
+  separate from this pin update and does not start #1516A.
+
+## Verification
+
+- Updated the workspace manifest and exact-revision source contract.
+- Resolved workspace metadata against the merged strided revision, then ran
+  formatting, the focused source-contract test, and the focused fast PR check.
+
+## Remaining Risk
+
+The new replay behavior is supplied by the merged upstream dependency. This
+PR does not independently exercise or alter tenferro callers beyond compiling
+and testing them against the adopted revision.

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "4be1c8a82c0eaf78ee5a9f42ce4b7ac72416e86a"
+        revision = "6885f52edb5fa2348fea47413bc43561e436ef63"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
## Summary

- Update all five workspace `strided-*` dependencies from `4be1c8a` to merged strided-rs commit `6885f52edb5fa2348fea47413bc43561e436ef63`.
- Update the exact-revision source contract.
- Document adoption of upstream uninitialized full-overwrite replay behavior.

## Scope

This is a dependency pin adoption only. It makes no tenferro implementation or call-path changes and does not start #1516A.

## References

- Closes/relates to tensor4all/strided-rs#184 and #185.
- Part of tenferro umbrella #1535.

## Verification

- `cargo metadata --format-version 1`
- `cargo fmt --all --check`
- `python3 -m unittest scripts/ci/tests/test_build_artifact_contracts.py`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'python3 -m unittest scripts/ci/tests/test_build_artifact_contracts.py'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/tenferro-strided-184-repository-rules-review.json`
