### PR TITLE
chore: ignore CodeGraph index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,9 @@ Thumbs.db
 # Git worktrees
 .worktrees/
 
+# CodeGraph index
+/.codegraph/
+
 # External / vendored source
 external/
 


### PR DESCRIPTION
Ignore the repository-root /.codegraph/ index directory. Validation: cargo fmt --all -- --check; cargo check -p tenferro-tensor; cargo doc -p tenferro-tensor --no-deps; git diff --check.