### PR TITLE
fix(cpu): guard pooled uninitialized outputs

### DIFF
--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -943,7 +943,7 @@ fn linalg_pool_acquire_then_panic_replenishes_buffer_but_reports_poison() {
 }
 
 #[test]
-fn uninit_output_partial_write_then_panic_replenishes_only_capacity() {
+fn uninit_output_partial_write_then_panic_discards_without_replenishment() {
     let mut backend = CpuBackend::with_threads(1).unwrap();
     backend
         .with_linalg_pool(|_, pool| {
@@ -963,8 +963,8 @@ fn uninit_output_partial_write_then_panic_replenishes_only_capacity() {
 
     assert!(result.is_err());
     let resources = backend.engine.resources.lock().unwrap_err().into_inner();
-    assert_eq!(resources.buffers.len(), 1);
-    assert_eq!(resources.buffers.stats().capacity_bytes, 1024);
+    assert_eq!(resources.buffers.len(), 0);
+    assert_eq!(resources.buffers.stats().capacity_bytes, 0);
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -9,8 +9,9 @@ use strided_kernel::{
 };
 
 use super::indexed_plan_cache::{IndexedPlanCache, IndexedPlanFamily, IndexedPlanKey};
-use super::indexing_alloc::{pooled_uninit_tensor, PooledUninitOutput};
+use super::indexing_alloc::pooled_uninit_tensor;
 use super::typed_host_data;
+use super::PooledUninitOutput;
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use tenferro_tensor::TensorScalar;
 use tenferro_tensor::{DType, GatherConfig, PadConfig, ScatterConfig, SliceConfig};

--- a/crates/tenferro-cpu/src/indexing_alloc.rs
+++ b/crates/tenferro-cpu/src/indexing_alloc.rs
@@ -1,6 +1,6 @@
-use std::mem::{ManuallyDrop, MaybeUninit};
-
 use crate::buffer_pool::{BufferPool, PoolScalar};
+#[cfg(test)]
+pub(crate) use crate::PooledUninitOutput;
 use crate::TypedTensor;
 
 fn checked_shape_product(op: &'static str, shape: &[usize]) -> crate::Result<usize> {
@@ -27,57 +27,6 @@ where
     // SAFETY: callers use this helper only for pooled outputs that are fully overwritten.
     let data = unsafe { T::pool_acquire(buffers, len) };
     TypedTensor::from_vec_col_major(shape, data)
-}
-
-pub(crate) struct PooledUninitOutput<T> {
-    shape: Vec<usize>,
-    data: Vec<MaybeUninit<T>>,
-}
-
-impl<T> PooledUninitOutput<T>
-where
-    T: Clone + PoolScalar,
-{
-    pub(crate) fn new(buffers: &mut BufferPool, shape: Vec<usize>) -> crate::Result<Self> {
-        let len = checked_shape_product("cpu_pooled_output", &shape)?;
-        // INVARIANT: this owner exposes only MaybeUninit storage until a
-        // full-overwrite caller proves initialization through assume_init.
-        Ok(Self {
-            shape,
-            data: T::pool_acquire_uninit(buffers, len),
-        })
-    }
-
-    pub(crate) fn as_uninit_bytes_mut(&mut self) -> &mut [MaybeUninit<u8>] {
-        // INVARIANT: MaybeUninit<T> may be viewed as size_of::<T>() uninitialized
-        // bytes; no initialized T reference is constructed at this boundary.
-        // SAFETY: MaybeUninit<T> and its byte range share the same allocation,
-        // and the returned lifetime remains bounded by this exclusive borrow.
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                self.data.as_mut_ptr().cast::<MaybeUninit<u8>>(),
-                std::mem::size_of_val(self.data.as_slice()),
-            )
-        }
-    }
-
-    /// Convert the owner after a full-overwrite kernel succeeds.
-    ///
-    /// # Safety
-    ///
-    /// Every element in `self.data` must contain a valid initialized `T`.
-    pub(crate) unsafe fn assume_init(self) -> crate::Result<TypedTensor<T>> {
-        let Self { shape, data } = self;
-        let mut data = ManuallyDrop::new(data);
-        // INVARIANT: the caller's successful full-overwrite replay initialized
-        // every element, and MaybeUninit<T> has the same allocation layout as T.
-        // SAFETY: the caller guarantees every element is initialized, while
-        // ManuallyDrop transfers the unchanged allocation exactly once.
-        let initialized = unsafe {
-            Vec::from_raw_parts(data.as_mut_ptr().cast::<T>(), data.len(), data.capacity())
-        };
-        TypedTensor::from_vec_col_major(shape, initialized)
-    }
 }
 
 #[cfg(test)]
@@ -112,7 +61,7 @@ mod tests {
         let mut buffers = BufferPool::new();
         <bool as PoolScalar>::pool_release(&mut buffers, vec![true; 6]);
         let mut output = PooledUninitOutput::<bool>::new(&mut buffers, vec![2, 3]).unwrap();
-        output.data.iter_mut().for_each(|value| {
+        output.as_uninit_slice_mut().iter_mut().for_each(|value| {
             value.write(false);
         });
         let output = unsafe { output.assume_init() }.unwrap();

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -65,6 +65,7 @@ mod domain_executor;
 #[allow(dead_code)]
 mod dot_runtime;
 pub(crate) use tenferro_internal_cpu_kernels::elementwise;
+pub(crate) use tenferro_internal_cpu_kernels::PooledUninitOutput;
 mod engine;
 mod exec_session;
 mod gemm;

--- a/crates/tenferro-internal-cpu-kernels/src/buffer_pool.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/buffer_pool.rs
@@ -23,6 +23,15 @@ use num_complex::{Complex32, Complex64};
 
 use crate::CacheStats;
 
+/// Non-Copy proof of a tracked pool checkout.
+#[derive(Debug)]
+pub(crate) enum UninitCheckoutToken {
+    /// The allocation was freshly allocated.
+    Fresh { actual_capacity: usize },
+    /// Retained storage was removed, with its actual capacity.
+    Reused { actual_capacity: usize },
+}
+
 /// Environment variable overriding the CPU buffer-pool retention cap in bytes.
 ///
 /// The value is parsed as an unsigned integer. Invalid values fall back to
@@ -199,16 +208,31 @@ pub trait PoolScalar: Copy + Sized + Send + Sync + private::Sealed {
     fn pool_release(pool: &mut BufferPool, buf: Vec<Self>);
 }
 
-mod private {
-    pub trait Sealed {}
+pub(crate) mod private {
+    use std::mem::MaybeUninit;
 
-    impl Sealed for f64 {}
-    impl Sealed for f32 {}
-    impl Sealed for i32 {}
-    impl Sealed for i64 {}
-    impl Sealed for bool {}
-    impl Sealed for num_complex::Complex64 {}
-    impl Sealed for num_complex::Complex32 {}
+    // INVARIANT: this sealed crate-private trait is the only implementation
+    // boundary for tracked guard tokens; it is not part of the public API.
+    #[allow(private_interfaces)]
+    pub trait Sealed {
+        /// Checks out uninitialized storage with an exact cleanup token.
+        ///
+        /// # Errors
+        /// Returns `Error::Validation` if retained-capacity byte accounting
+        /// overflows, or `Error::BackendSource` if fresh allocation fails.
+        fn pool_acquire_uninit_tracked(
+            pool: &mut super::BufferPool,
+            len: usize,
+        ) -> crate::Result<(Vec<MaybeUninit<Self>>, super::UninitCheckoutToken)>
+        where
+            Self: Sized;
+        fn pool_discard_uninit(
+            pool: &mut super::BufferPool,
+            data: Vec<MaybeUninit<Self>>,
+            checkout: super::UninitCheckoutToken,
+        ) where
+            Self: Sized;
+    }
 }
 
 fn take_best_fit<T>(pool: &mut BTreeMap<usize, Vec<Vec<T>>>, len: usize) -> Option<Vec<T>> {
@@ -298,6 +322,61 @@ fn replenish_in_flight_for<T>(
 
 macro_rules! impl_pool_scalar {
     ($ty:ty, $field:ident, $in_flight:ident, $zero:expr) => {
+        // INVARIANT: this implementation is reachable only through the sealed
+        // crate-private helper and cannot be named by sibling crates.
+        #[allow(private_interfaces)]
+        impl private::Sealed for $ty {
+            fn pool_acquire_uninit_tracked(
+                pool: &mut BufferPool,
+                len: usize,
+            ) -> crate::Result<(Vec<MaybeUninit<Self>>, UninitCheckoutToken)> {
+                match take_best_fit(&mut pool.$field, len) {
+                    Some(buf) => {
+                        let cap = buf.capacity();
+                        let bytes = cap.checked_mul(size_of::<Self>()).ok_or_else(|| {
+                            crate::Error::invalid_argument(
+                                "pooled_uninit_output",
+                                "length",
+                                "pool capacity byte length overflow",
+                            )
+                        })?;
+                        pool.retained_capacity_bytes -= bytes;
+                        increment_in_flight(&mut pool.$in_flight, cap);
+                        let mut buf = ManuallyDrop::new(buf);
+                        // SAFETY: MaybeUninit<Self> has the same layout as Self and len <= cap.
+                        let buf = unsafe { Vec::from_raw_parts(buf.as_mut_ptr().cast(), len, cap) };
+                        Ok((
+                            buf,
+                            UninitCheckoutToken::Reused {
+                                actual_capacity: cap,
+                            },
+                        ))
+                    }
+                    None => {
+                        let mut buf = Vec::new();
+                        buf.try_reserve_exact(len).map_err(|err| {
+                            crate::Error::backend_source("pooled_uninit_output", err)
+                        })?;
+                        // SAFETY: every bit pattern is valid for MaybeUninit.
+                        unsafe { buf.set_len(len) };
+                        let actual_capacity = buf.capacity();
+                        Ok((buf, UninitCheckoutToken::Fresh { actual_capacity }))
+                    }
+                }
+            }
+
+            fn pool_discard_uninit(
+                pool: &mut BufferPool,
+                data: Vec<MaybeUninit<Self>>,
+                checkout: UninitCheckoutToken,
+            ) {
+                drop(data);
+                if let UninitCheckoutToken::Reused { actual_capacity } = checkout {
+                    decrement_in_flight(&mut pool.$in_flight, actual_capacity);
+                }
+            }
+        }
+
         impl PoolScalar for $ty {
             fn pool_zero() -> Self {
                 $zero
@@ -395,6 +474,16 @@ impl_pool_scalar!(Complex64, c64_pool, c64_in_flight, Complex64::new(0.0, 0.0));
 impl_pool_scalar!(Complex32, c32_pool, c32_in_flight, Complex32::new(0.0, 0.0));
 
 impl BufferPool {
+    #[cfg(test)]
+    pub(crate) fn in_flight_is_empty(&self) -> bool {
+        self.f64_in_flight.is_empty()
+            && self.f32_in_flight.is_empty()
+            && self.i32_in_flight.is_empty()
+            && self.i64_in_flight.is_empty()
+            && self.bool_in_flight.is_empty()
+            && self.c64_in_flight.is_empty()
+            && self.c32_in_flight.is_empty()
+    }
     /// Create an empty typed buffer pool.
     ///
     /// # Examples

--- a/crates/tenferro-internal-cpu-kernels/src/buffer_pool/tests.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/buffer_pool/tests.rs
@@ -4,6 +4,7 @@ use super::{
     parse_default_max_retained_capacity_bytes, BufferPool, PoolScalar,
     DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
 };
+use crate::PooledUninitOutput;
 
 #[test]
 fn default_retention_limit_parser_covers_missing_invalid_zero_and_valid_values() {
@@ -318,4 +319,259 @@ fn retention_limit_documents_zero_byte_eviction_progress() {
         source.contains("evicted_bytes == 0"),
         "retention-limit eviction must explicitly handle zero-byte retained entries"
     );
+}
+
+#[test]
+fn pooled_uninit_guard_discards_partial_reused_storage_without_replacement() {
+    let mut pool = BufferPool::new();
+    <f64 as PoolScalar>::pool_release(&mut pool, Vec::with_capacity(8));
+    let before = pool.stats();
+
+    let mut output = PooledUninitOutput::<f64>::new(&mut pool, vec![3]).unwrap();
+    assert!(output.token_is_reused_with_capacity(8));
+    output.as_uninit_slice_mut()[0].write(1.0);
+    drop(output);
+
+    assert_eq!(pool.stats().buffers, before.buffers - 1);
+    assert_eq!(
+        pool.stats().capacity_bytes,
+        before.capacity_bytes - 8 * size_of::<f64>()
+    );
+    assert!(pool.in_flight_is_empty());
+}
+
+#[test]
+fn pooled_uninit_guard_fresh_handoff_and_panic_discard_are_exact() {
+    let mut pool = BufferPool::new();
+    {
+        let mut output = PooledUninitOutput::<f64>::new(&mut pool, vec![2]).unwrap();
+        assert!(output.token_is_fresh());
+        output.as_uninit_slice_mut().iter_mut().for_each(|v| {
+            v.write(3.0);
+        });
+        let tensor = unsafe { output.assume_init() }.unwrap();
+        assert_eq!(tensor.as_slice().unwrap(), &[3.0, 3.0]);
+    }
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut output = PooledUninitOutput::<f64>::new(&mut pool, vec![4]).unwrap();
+        output.as_uninit_slice_mut()[0].write(1.0);
+        panic!("partial kernel panic");
+    }));
+    assert!(result.is_err());
+    assert_eq!(pool.stats(), Default::default());
+}
+
+#[test]
+fn pooled_uninit_guard_keeps_unrelated_dtype_markers_untouched() {
+    let mut pool = BufferPool::new();
+    <f64 as PoolScalar>::pool_release(&mut pool, vec![0.0; 8]);
+    let unrelated = unsafe { <f64 as PoolScalar>::pool_acquire(&mut pool, 8) };
+    let marker_before = pool.f64_in_flight.clone();
+    assert_eq!(marker_before.get(&8), Some(&1));
+    <f64 as PoolScalar>::pool_release(&mut pool, vec![0.0; 16]);
+    {
+        let _output = PooledUninitOutput::<f64>::new(&mut pool, vec![3]).unwrap();
+    }
+    assert_eq!(pool.f64_in_flight, marker_before);
+    drop(unrelated);
+    pool.clear_in_flight_retained();
+}
+
+#[test]
+fn pooled_uninit_guard_bool_invalid_byte_error_drops_without_typed_read() {
+    let mut pool = BufferPool::new();
+    <bool as PoolScalar>::pool_release(&mut pool, vec![false; 8]);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut output = PooledUninitOutput::<bool>::new(&mut pool, vec![3]).unwrap();
+        output.as_uninit_bytes_mut()[0].write(2);
+        panic!("invalid bool partial panic");
+    }));
+    assert!(result.is_err());
+    assert!(pool.bool_in_flight.is_empty());
+    assert_eq!(pool.retained_capacity_bytes(), 0);
+    assert!(!pool.bool_pool.contains_key(&8));
+}
+
+#[test]
+fn pooled_uninit_guard_reused_success_handoff_reclaims_exact_capacity() {
+    let mut pool = BufferPool::new();
+    <f64 as PoolScalar>::pool_release(&mut pool, vec![0.0; 8]);
+    let mut output = PooledUninitOutput::<f64>::new(&mut pool, vec![3]).unwrap();
+    assert!(output.token_is_reused_with_capacity(8));
+    output
+        .as_uninit_slice_mut()
+        .iter_mut()
+        .enumerate()
+        .for_each(|(i, value)| {
+            value.write(i as f64 + 1.0);
+        });
+    let tensor = unsafe { output.assume_init() }.unwrap();
+    assert_eq!(tensor.as_slice().unwrap(), &[1.0, 2.0, 3.0]);
+    assert_eq!(pool.retained_capacity_bytes(), 0);
+    assert_eq!(pool.f64_in_flight.get(&8), Some(&1));
+    pool.replenish_in_flight_retained();
+    assert!(pool.f64_in_flight.is_empty());
+    assert_eq!(pool.retained_capacity_bytes(), 8 * size_of::<f64>());
+    assert_eq!(pool.f64_pool.get(&8).map(Vec::len), Some(1));
+}
+
+#[test]
+fn pooled_uninit_guard_reused_error_discards_exact_capacity() {
+    let mut pool = BufferPool::new();
+    <f64 as PoolScalar>::pool_release(&mut pool, vec![0.0; 8]);
+    let output = PooledUninitOutput::<f64>::new(&mut pool, vec![3]).unwrap();
+    let error = unsafe { output.assume_init_as::<tenferro_tensor::Rank<2>>() }.unwrap_err();
+    assert!(error.to_string().contains("pooled_uninit_output"));
+    assert!(pool.f64_in_flight.is_empty());
+    assert_eq!(pool.retained_capacity_bytes(), 0);
+}
+
+#[test]
+fn pooled_uninit_guard_reused_partial_panic_discards_exact_capacity() {
+    let mut pool = BufferPool::new();
+    <f64 as PoolScalar>::pool_release(&mut pool, vec![0.0; 8]);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut output = PooledUninitOutput::<f64>::new(&mut pool, vec![3]).unwrap();
+        assert!(output.token_is_reused_with_capacity(8));
+        output.as_uninit_slice_mut()[0].write(1.0);
+        panic!("partial reused C>len panic");
+    }));
+    assert!(result.is_err());
+    assert!(pool.f64_in_flight.is_empty());
+    assert_eq!(pool.retained_capacity_bytes(), 0);
+    assert!(!pool.f64_pool.contains_key(&8));
+}
+
+#[test]
+fn internal_full_overwrite_sources_use_the_guard_boundary() {
+    let production_sources = [
+        ("lib.rs", include_str!("../lib.rs")),
+        (
+            "pooled_uninit_output.rs",
+            include_str!("../pooled_uninit_output.rs"),
+        ),
+        ("elementwise.rs", include_str!("../elementwise.rs")),
+    ];
+    for (name, source) in production_sources {
+        assert!(
+            !source.contains("typed_array_uninit_from_pool"),
+            "{name} uses legacy uninit helper"
+        );
+        assert!(
+            !source
+                .replace(char::is_whitespace, "")
+                .contains("pool_acquire(buffers"),
+            "{name} directly acquires pooled output"
+        );
+        assert!(
+            !source.contains("ExecContext::ambient"),
+            "{name} selects an ambient context"
+        );
+        let lines: Vec<_> = source.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            // The call may be split after `unsafe {`; inspect every completion
+            // occurrence rather than requiring a single-line expression.
+            let part_of_unsafe_call = line.contains("unsafe {")
+                || index >= 1 && lines[index - 1].contains("unsafe {")
+                || index >= 2 && lines[index - 2].contains("unsafe {");
+            if line.contains("assume_init") && part_of_unsafe_call {
+                let has_safety = index >= 1 && lines[index - 1].contains("// SAFETY:")
+                    || index >= 2 && lines[index - 2].contains("// SAFETY:");
+                assert!(
+                    has_safety,
+                    "{name}:{index} lacks an adjacent assume_init safety proof"
+                );
+            }
+        }
+    }
+    let pooled_output = include_str!("../pooled_uninit_output.rs");
+    assert!(pooled_output.matches("pub unsafe fn assume_init").count() >= 1);
+
+    let cpu_root = include_str!("../../../tenferro-cpu/src/lib.rs");
+    assert!(cpu_root.contains("pub(crate) use tenferro_internal_cpu_kernels::PooledUninitOutput;"));
+    let cpu_indexing = include_str!("../../../tenferro-cpu/src/indexing.rs");
+    assert!(cpu_indexing.contains("use super::PooledUninitOutput;"));
+
+    let pool = include_str!("../buffer_pool.rs");
+    assert!(pool.contains("try_reserve_exact(len)"));
+    assert!(pool.contains("Error::backend_source(\"pooled_uninit_output\", err)"));
+    assert!(!pool.contains("format!(\"unable to reserve"));
+    assert!(!pool.contains("std::io::Error::new"));
+    let pool_scalar = pool
+        .split_once("pub trait PoolScalar")
+        .and_then(|(_, suffix)| suffix.split_once("mod private"))
+        .expect("PoolScalar and sealed module must remain distinct")
+        .0;
+    assert!(!pool_scalar.contains("pool_acquire_uninit_tracked"));
+    assert!(!pool_scalar.contains("pool_discard_uninit"));
+    assert!(!pool.contains("pub enum UninitCheckoutToken"));
+    assert!(pool.contains("impl private::Sealed for"));
+    let elementwise = include_str!("../elementwise.rs");
+    for helper in [
+        "pub fn typed_mul_with_pool",
+        "pub fn typed_mul_view_with_pool",
+    ] {
+        let body = elementwise
+            .split_once(helper)
+            .and_then(|(_, suffix)| suffix.split_once("pub fn typed_"))
+            .map(|(body, _)| body)
+            .unwrap_or(elementwise);
+        assert!(
+            body.contains("mul_into_uninit"),
+            "{helper} must retain the pinned same-shape kernel"
+        );
+    }
+}
+
+#[test]
+fn pooled_uninit_guard_layout_validation_reports_real_shape_errors() {
+    let mut pool = BufferPool::new();
+    let error = PooledUninitOutput::<i32>::new(&mut pool, vec![usize::MAX]).unwrap_err();
+    assert!(error.to_string().contains("pooled_uninit_output"));
+    assert!(pool.is_empty());
+}
+
+#[test]
+fn pooled_uninit_guard_zero_length_view_bytes_and_drop_are_consistent() {
+    let mut pool = BufferPool::new();
+    {
+        let mut output = PooledUninitOutput::<i32>::new(&mut pool, vec![0]).unwrap();
+        assert!(output.token_is_fresh());
+        assert!(output.as_uninit_slice_mut().is_empty());
+        assert!(output.as_uninit_bytes_mut().is_empty());
+        let view = output.as_uninit_view_mut().unwrap();
+        assert_eq!(view.dims(), &[0]);
+    }
+    assert!(pool.is_empty());
+
+    let output = PooledUninitOutput::<i32>::new(&mut pool, vec![0]).unwrap();
+    let tensor = unsafe { output.assume_init() }.unwrap();
+    assert_eq!(tensor.shape(), &[0]);
+    assert!(pool.is_empty());
+}
+
+#[test]
+fn pooled_uninit_guard_static_rank_handoff_preserves_shape_and_values() {
+    let mut pool = BufferPool::new();
+    let mut output = PooledUninitOutput::<i32>::new(&mut pool, vec![2, 2]).unwrap();
+    output
+        .as_uninit_slice_mut()
+        .iter_mut()
+        .enumerate()
+        .for_each(|(index, item)| {
+            item.write(index as i32 + 1);
+        });
+
+    let tensor = unsafe { output.assume_init_as::<tenferro_tensor::Rank<2>>() }.unwrap();
+    assert_eq!(tensor.shape(), &[2, 2]);
+    assert_eq!(tensor.as_slice().unwrap(), &[1, 2, 3, 4]);
+    assert!(pool.is_empty());
+}
+
+#[test]
+fn pooled_uninit_guard_shape_product_failure_does_not_touch_pool() {
+    let mut pool = BufferPool::new();
+    let error = PooledUninitOutput::<i32>::new(&mut pool, vec![usize::MAX, 2]).unwrap_err();
+    assert!(error.to_string().contains("pooled_uninit_output"));
+    assert!(pool.is_empty());
 }

--- a/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
@@ -1,18 +1,19 @@
-use std::mem::size_of_val;
+use std::mem::{size_of_val, MaybeUninit};
 use std::ops::{Add, Div, Mul, Neg, Rem as StdRem, Sub};
 use std::sync::Arc;
 
 use num_complex::Complex;
 use num_traits::{One, Zero};
 use strided_kernel::{
-    batched_outer_product_into, broadcast_mul_into, compare_into, map_into, mul_into, reduce,
-    zip_map2_into, zip_map3_into, CompareOp, ErasedFusedPlan, ErasedRawStridedMut,
-    ErasedRawStridedRef, ExecContext, FusedInst, FusedOp, FusedPlan, KernelDType, StridedArray,
-    StridedView,
+    batched_outer_product_into_uninit, broadcast_mul_into_uninit, compare_into_uninit, map_into,
+    mul_into_uninit, reduce, zip_map2_into, zip_map3_into, CompareOp, ErasedFusedPlan,
+    ErasedRawStridedPtr, ErasedRawStridedRef, ErasedRawStridedUninitMut, ExecContext, FusedInst,
+    FusedOp, FusedPlan, KernelDType, StridedView,
 };
 
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::ConjElem;
+use crate::PooledUninitOutput;
 use tenferro_tensor::backend::{
     ElementwiseFusionInputView, ElementwiseFusionOp, ElementwiseFusionPlan,
 };
@@ -21,10 +22,7 @@ use tenferro_tensor::{
     TensorScalar, TensorValue, TensorView, TypedTensor, TypedTensorView,
 };
 
-use super::{
-    tensor_from_array, typed_array_uninit_from_pool, typed_host_data, typed_view,
-    typed_view_from_view,
-};
+use super::{typed_host_data, typed_view, typed_view_from_view};
 
 macro_rules! dispatch_ternary_result_with_pool {
     ($op:literal, $a:expr, $b:expr, $c:expr, |$x:ident, $y:ident, $z:ident| $body:expr) => {
@@ -224,13 +222,6 @@ fn typed_bytes<T>(data: &[T]) -> &[u8] {
     unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), size_of_val(data)) }
 }
 
-fn typed_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    // SAFETY: `data` is an aligned typed slice. The returned byte slice has
-    // the same lifetime and exact byte length; erased kernels restore the
-    // dtype-specific byte validity invariant before typed reads resume.
-    unsafe { std::slice::from_raw_parts_mut(data.as_mut_ptr().cast::<u8>(), size_of_val(data)) }
-}
-
 struct ErasedFusionInput<'a> {
     data: &'a [u8],
     dims: Vec<usize>,
@@ -321,24 +312,6 @@ fn erased_fusion_input<'a>(
     })
 }
 
-fn typed_array_zeroed_from_pool<T>(
-    buffers: &mut BufferPool,
-    shape: &[usize],
-) -> crate::Result<StridedArray<T>>
-where
-    T: PoolScalar,
-{
-    let total = tenferro_tensor::validate::checked_shape_product(
-        "typed_array_zeroed_from_pool",
-        "shape",
-        shape,
-    )?;
-    let strides = col_major_strides(shape)?;
-    let data = T::pool_acquire_zeroed(buffers, total);
-    StridedArray::from_parts(data, shape, &strides, 0)
-        .map_err(|err| crate::Error::backend_source("typed_array_zeroed_from_pool", err))
-}
-
 #[doc(hidden)]
 pub trait Tier2Elem: Copy + Clone + One + Zero + Send + Sync {
     fn abs_elem(self) -> Self;
@@ -359,7 +332,16 @@ pub trait CompareElem: Copy + Send + Sync {
 }
 
 trait WrappingIntegerElem:
-    Copy + PoolScalar + TensorScalar + Zero + PartialEq + Eq + Send + Sync + 'static
+    Copy
+    + PoolScalar
+    + TensorScalar
+    + Zero
+    + PartialEq
+    + Eq
+    + Send
+    + Sync
+    + Mul<Output = Self>
+    + 'static
 {
     fn wrapping_add_elem(self, other: Self) -> Self;
     fn wrapping_sub_elem(self, other: Self) -> Self;
@@ -1250,6 +1232,10 @@ fn execute_erased_fused_outputs(
     shape: &[usize],
     plan: &ElementwiseFusionPlan,
 ) -> crate::Result<Vec<Tensor>> {
+    let input_ptrs: Vec<_> = input_refs
+        .iter()
+        .map(ErasedRawStridedPtr::from_ref)
+        .collect();
     match dtype {
         KernelDType::F32 => plan
             .outputs()
@@ -1259,11 +1245,10 @@ fn execute_erased_fused_outputs(
                     buffers,
                     exec_context,
                     dtype,
-                    input_refs,
+                    &input_ptrs,
                     shape,
                     plan,
                     output,
-                    false,
                     Tensor::F32,
                 )
             })
@@ -1276,11 +1261,10 @@ fn execute_erased_fused_outputs(
                     buffers,
                     exec_context,
                     dtype,
-                    input_refs,
+                    &input_ptrs,
                     shape,
                     plan,
                     output,
-                    false,
                     Tensor::F64,
                 )
             })
@@ -1293,11 +1277,10 @@ fn execute_erased_fused_outputs(
                     buffers,
                     exec_context,
                     dtype,
-                    input_refs,
+                    &input_ptrs,
                     shape,
                     plan,
                     output,
-                    false,
                     Tensor::I32,
                 )
             })
@@ -1310,11 +1293,10 @@ fn execute_erased_fused_outputs(
                     buffers,
                     exec_context,
                     dtype,
-                    input_refs,
+                    &input_ptrs,
                     shape,
                     plan,
                     output,
-                    false,
                     Tensor::I64,
                 )
             })
@@ -1327,11 +1309,10 @@ fn execute_erased_fused_outputs(
                     buffers,
                     exec_context,
                     dtype,
-                    input_refs,
+                    &input_ptrs,
                     shape,
                     plan,
                     output,
-                    true,
                     Tensor::Bool,
                 )
             })
@@ -1344,11 +1325,10 @@ fn execute_erased_fused_outputs(
                     buffers,
                     exec_context,
                     dtype,
-                    input_refs,
+                    &input_ptrs,
                     shape,
                     plan,
                     output,
-                    false,
                     Tensor::C32,
                 )
             })
@@ -1361,11 +1341,10 @@ fn execute_erased_fused_outputs(
                     buffers,
                     exec_context,
                     dtype,
-                    input_refs,
+                    &input_ptrs,
                     shape,
                     plan,
                     output,
-                    false,
                     Tensor::C64,
                 )
             })
@@ -1382,11 +1361,10 @@ fn execute_erased_fused_output<T>(
     buffers: &mut BufferPool,
     exec_context: &ExecContext,
     dtype: KernelDType,
-    input_refs: &[ErasedRawStridedRef<'_>],
+    input_ptrs: &[ErasedRawStridedPtr<'_>],
     shape: &[usize],
     plan: &ElementwiseFusionPlan,
     output: usize,
-    zeroed_output: bool,
     wrap: fn(TypedTensor<T>) -> Tensor,
 ) -> crate::Result<Tensor>
 where
@@ -1395,25 +1373,16 @@ where
     let fused_plan = single_output_strided_fused_plan(plan, output);
     let erased_plan = ErasedFusedPlan::compile(dtype, fused_plan)
         .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
-    let mut out = if zeroed_output {
-        typed_array_zeroed_from_pool(buffers, shape)?
-    } else {
-        // SAFETY: ErasedFusedPlan overwrites every destination element before typed reads resume.
-        unsafe { typed_array_uninit_from_pool(buffers, shape) }?
-    };
+    let mut out = PooledUninitOutput::<T>::new(buffers, shape.to_vec())?;
     let output_strides = col_major_strides(shape)?;
-    let mut dest = ErasedRawStridedMut::new(
-        dtype,
-        typed_bytes_mut(out.data_mut()),
-        shape,
-        &output_strides,
-        0,
-    )
-    .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
+    let mut dest =
+        ErasedRawStridedUninitMut::new(dtype, out.as_uninit_bytes_mut(), shape, &output_strides, 0)
+            .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
     erased_plan
-        .execute(exec_context, &mut dest, input_refs)
+        .execute_uninit(exec_context, &mut dest, input_ptrs)
         .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
-    Ok(wrap(tensor_from_array(out)))
+    // SAFETY: the fused replay writes every logical destination element and retains no destination view.
+    Ok(wrap(unsafe { out.assume_init()? }))
 }
 
 fn typed_binary_view_with_pool<T, L, R>(
@@ -1429,34 +1398,40 @@ where
     R: TensorRank,
 {
     if lhs.shape() == rhs.shape() {
-        // SAFETY: the following kernel overwrites every output element before any read.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
         zip_map2_into(
-            &mut out.view_mut(),
+            &mut out.as_uninit_view_mut()?,
             &typed_view_from_view(op, lhs)?,
             &typed_view_from_view(op, rhs)?,
-            f,
+            |a, b| MaybeUninit::new(f(a, b)),
         )
         .map_err(|err| crate::Error::backend_source(op, err))?;
-        Ok(tensor_from_array(out))
+        // SAFETY: the successful zip/map replay writes every logical destination element and retains no destination view.
+        // SAFETY: the successful add zip/map replay writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else if lhs.shape().is_empty() {
         let scalar = typed_view_from_view(op, lhs)?.get(&[]);
-        // SAFETY: the following kernel overwrites every output element before any read.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, rhs.shape()) }?;
-        map_into(&mut out.view_mut(), &typed_view_from_view(op, rhs)?, |x| {
-            f(scalar, x)
-        })
+        let mut out = PooledUninitOutput::<T>::new(buffers, rhs.shape().to_vec())?;
+        map_into(
+            &mut out.as_uninit_view_mut()?,
+            &typed_view_from_view(op, rhs)?,
+            |x| MaybeUninit::new(f(scalar, x)),
+        )
         .map_err(|err| crate::Error::backend_source(op, err))?;
-        Ok(tensor_from_array(out))
+        // SAFETY: the successful scalar map replay writes every logical destination element and retains no destination view.
+        // SAFETY: the successful multiplication kernel writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else if rhs.shape().is_empty() {
         let scalar = typed_view_from_view(op, rhs)?.get(&[]);
-        // SAFETY: the following kernel overwrites every output element before any read.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
-        map_into(&mut out.view_mut(), &typed_view_from_view(op, lhs)?, |x| {
-            f(x, scalar)
-        })
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
+        map_into(
+            &mut out.as_uninit_view_mut()?,
+            &typed_view_from_view(op, lhs)?,
+            |x| MaybeUninit::new(f(x, scalar)),
+        )
         .map_err(|err| crate::Error::backend_source(op, err))?;
-        Ok(tensor_from_array(out))
+        // SAFETY: the successful scalar map replay writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else {
         Err(crate::Error::shape_mismatch(
             op,
@@ -1476,11 +1451,15 @@ where
     T: Copy + PoolScalar + 'static,
     R: TensorRank,
 {
-    // SAFETY: the following kernel overwrites every output element before any read.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
-    map_into(&mut out.view_mut(), &typed_view_from_view(op, input)?, f)
-        .map_err(|err| crate::Error::backend_source(op, err))?;
-    Ok(tensor_from_array(out))
+    let mut out = PooledUninitOutput::<T>::new(buffers, input.shape().to_vec())?;
+    map_into(
+        &mut out.as_uninit_view_mut()?,
+        &typed_view_from_view(op, input)?,
+        |x| MaybeUninit::new(f(x)),
+    )
+    .map_err(|err| crate::Error::backend_source(op, err))?;
+    // SAFETY: the successful map replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
 }
 
 fn typed_same_shape_binary_view_with_pool<T, O, L, R>(
@@ -1503,16 +1482,16 @@ where
             rhs.shape().to_vec(),
         ));
     }
-    // SAFETY: the following kernel overwrites every output element before any read.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
+    let mut out = PooledUninitOutput::<O>::new(buffers, lhs.shape().to_vec())?;
     zip_map2_into(
-        &mut out.view_mut(),
+        &mut out.as_uninit_view_mut()?,
         &typed_view_from_view(op, lhs)?,
         &typed_view_from_view(op, rhs)?,
-        f,
+        |a, b| MaybeUninit::new(f(a, b)),
     )
     .map_err(|err| crate::Error::backend_source(op, err))?;
-    Ok(tensor_from_array(out))
+    // SAFETY: the successful zip replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
 }
 
 fn typed_ordered_compare_view_with_pool<T, L, R>(
@@ -1540,16 +1519,16 @@ where
         CompareDir::Gt => CompareOp::Gt,
         CompareDir::Ge => CompareOp::Ge,
     };
-    // SAFETY: compare_into validates the output layout and overwrites every element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
-    compare_into(
-        &mut out.view_mut(),
+    let mut out = PooledUninitOutput::<bool>::new(buffers, lhs.shape().to_vec())?;
+    compare_into_uninit(
+        &mut out.as_uninit_view_mut()?,
         &typed_view_from_view("compare", lhs)?,
         &typed_view_from_view("compare", rhs)?,
         op,
     )
     .map_err(|err| crate::Error::backend_source("compare", err))?;
-    Ok(tensor_from_array(out))
+    // SAFETY: the successful compare replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
 }
 
 fn typed_select_view_with_pool<T, P, A, B>(
@@ -1578,17 +1557,17 @@ where
             on_false.shape().to_vec(),
         ));
     }
-    // SAFETY: the following kernel overwrites every output element before any read.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, pred.shape()) }?;
+    let mut out = PooledUninitOutput::<T>::new(buffers, pred.shape().to_vec())?;
     zip_map3_into(
-        &mut out.view_mut(),
+        &mut out.as_uninit_view_mut()?,
         &typed_view_from_view("select", pred)?,
         &typed_view_from_view("select", on_true)?,
         &typed_view_from_view("select", on_false)?,
-        |p, t, f| if p { t } else { f },
+        |p, t, f| MaybeUninit::new(if p { t } else { f }),
     )
     .map_err(|err| crate::Error::backend_source("select", err))?;
-    Ok(tensor_from_array(out))
+    // SAFETY: the successful select replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
 }
 
 fn typed_clamp_view_with_pool<T, I, L, U>(
@@ -1617,17 +1596,17 @@ where
             upper.shape().to_vec(),
         ));
     }
-    // SAFETY: the following kernel overwrites every output element before any read.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
+    let mut out = PooledUninitOutput::<T>::new(buffers, input.shape().to_vec())?;
     zip_map3_into(
-        &mut out.view_mut(),
+        &mut out.as_uninit_view_mut()?,
         &typed_view_from_view("clamp", input)?,
         &typed_view_from_view("clamp", lower)?,
         &typed_view_from_view("clamp", upper)?,
-        |x, lo, hi| hi.min_elem(lo.max_elem(x)),
+        |x, lo, hi| MaybeUninit::new(hi.min_elem(lo.max_elem(x))),
     )
     .map_err(|err| crate::Error::backend_source("clamp", err))?;
-    Ok(tensor_from_array(out))
+    // SAFETY: the successful clamp replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
 }
 
 #[derive(Clone, Copy)]
@@ -1848,8 +1827,7 @@ where
         return Ok(None);
     };
 
-    // SAFETY: every element in the column-major output is assigned below.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs_shape) }?;
+    let mut out = PooledUninitOutput::<T>::new(buffers, lhs_shape.to_vec())?;
     let lhs_view = typed_view_from_view("broadcast_multiply", lhs)?;
     let rhs_view = typed_view_from_view("broadcast_multiply", rhs)?;
     match plan.layout {
@@ -1872,8 +1850,8 @@ where
             let rhs_outer = rhs_view
                 .permute(&rhs_perm)
                 .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
-            batched_outer_product_into(
-                &mut out.view_mut(),
+            batched_outer_product_into_uninit(
+                &mut out.as_uninit_view_mut()?,
                 &lhs_outer,
                 &rhs_outer,
                 plan.lhs_free_axes.len(),
@@ -1900,8 +1878,8 @@ where
             let rhs_outer = rhs_view
                 .permute(&rhs_perm)
                 .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
-            batched_outer_product_into(
-                &mut out.view_mut(),
+            batched_outer_product_into_uninit(
+                &mut out.as_uninit_view_mut()?,
                 &rhs_outer,
                 &lhs_outer,
                 plan.rhs_free_axes.len(),
@@ -1910,7 +1888,8 @@ where
             .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
         }
     }
-    Ok(Some(tensor_from_array(out)))
+    // SAFETY: the successful outer-product replay writes every logical destination element and retains no destination view.
+    Ok(Some(unsafe { out.assume_init()? }))
 }
 
 struct LazyOuterProduct<T> {
@@ -2096,10 +2075,9 @@ where
                 rhs_dims,
             })?;
 
-            // SAFETY: every element in the physical base output is assigned below.
-            let mut base = unsafe { typed_array_uninit_from_pool(buffers, &base_shape) }?;
-            batched_outer_product_into(
-                &mut base.view_mut(),
+            let mut base = PooledUninitOutput::<T>::new(buffers, base_shape.clone())?;
+            batched_outer_product_into_uninit(
+                &mut base.as_uninit_view_mut()?,
                 &lhs_outer,
                 &rhs_outer,
                 lhs_free_axes.len(),
@@ -2107,7 +2085,8 @@ where
             )
             .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
             Ok(Some(LazyOuterProduct {
-                base: tensor_from_array(base),
+                // SAFETY: the successful outer-product replay writes every logical base element and retains no destination view.
+                base: unsafe { base.assume_init()? },
                 shape: lhs_shape.to_vec(),
                 strides,
             }))
@@ -2147,10 +2126,9 @@ where
                 rhs_dims,
             })?;
 
-            // SAFETY: every element in the physical base output is assigned below.
-            let mut base = unsafe { typed_array_uninit_from_pool(buffers, &base_shape) }?;
-            batched_outer_product_into(
-                &mut base.view_mut(),
+            let mut base = PooledUninitOutput::<T>::new(buffers, base_shape.clone())?;
+            batched_outer_product_into_uninit(
+                &mut base.as_uninit_view_mut()?,
                 &rhs_outer,
                 &lhs_outer,
                 rhs_free_axes.len(),
@@ -2158,7 +2136,8 @@ where
             )
             .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
             Ok(Some(LazyOuterProduct {
-                base: tensor_from_array(base),
+                // SAFETY: the successful outer-product replay writes every logical base element and retains no destination view.
+                base: unsafe { base.assume_init()? },
                 shape: lhs_shape.to_vec(),
                 strides,
             }))
@@ -2175,6 +2154,7 @@ fn typed_broadcast_mul_view_with_pool<T, L, R>(
     rhs: &TypedTensorView<'_, T, R>,
     rhs_shape: &[usize],
     rhs_dims: &[usize],
+    mul: impl Fn(T, T) -> T + Copy + Sync,
 ) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Zero + Mul<Output = T> + PoolScalar + 'static,
@@ -2198,46 +2178,46 @@ where
     if lhs_is_scalar && rhs_is_scalar {
         let lhs_scalar = typed_view_from_view("broadcast_multiply", lhs)?.get(&[]);
         let rhs_scalar = typed_view_from_view("broadcast_multiply", rhs)?.get(&[]);
-        return filled_broadcast_multiply_tensor(buffers, lhs_shape, lhs_scalar * rhs_scalar);
+        return filled_broadcast_multiply_tensor(buffers, lhs_shape, mul(lhs_scalar, rhs_scalar));
     }
     if lhs_is_scalar && rhs_is_full_output {
         let scalar = typed_view_from_view("broadcast_multiply", lhs)?.get(&[]);
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs_shape) }?;
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs_shape.to_vec())?;
         map_into(
-            &mut out.view_mut(),
+            &mut out.as_uninit_view_mut()?,
             &typed_view_from_view("broadcast_multiply", rhs)?,
-            |x| scalar * x,
+            |x| MaybeUninit::new(mul(scalar, x)),
         )
         .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
-        return Ok(tensor_from_array(out));
+        // SAFETY: the successful broadcast map replay writes every logical destination element and retains no destination view.
+        return Ok(unsafe { out.assume_init()? });
     }
     if rhs_is_scalar && lhs_is_full_output {
         let scalar = typed_view_from_view("broadcast_multiply", rhs)?.get(&[]);
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs_shape) }?;
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs_shape.to_vec())?;
         map_into(
-            &mut out.view_mut(),
+            &mut out.as_uninit_view_mut()?,
             &typed_view_from_view("broadcast_multiply", lhs)?,
-            |x| x * scalar,
+            |x| MaybeUninit::new(mul(x, scalar)),
         )
         .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
-        return Ok(tensor_from_array(out));
+        // SAFETY: the successful broadcast map replay writes every logical destination element and retains no destination view.
+        return Ok(unsafe { out.assume_init()? });
     }
 
-    // SAFETY: broadcast_mul_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs_shape) }?;
+    let mut out = PooledUninitOutput::<T>::new(buffers, lhs_shape.to_vec())?;
     let lhs_view = typed_view_from_view("broadcast_multiply", lhs)?;
     let rhs_view = typed_view_from_view("broadcast_multiply", rhs)?;
-    broadcast_mul_into(
-        &mut out.view_mut(),
+    broadcast_mul_into_uninit(
+        &mut out.as_uninit_view_mut()?,
         &lhs_view,
         lhs_dims,
         &rhs_view,
         rhs_dims,
     )
     .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
-    Ok(tensor_from_array(out))
+    // SAFETY: the successful broadcast replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
 }
 
 fn filled_broadcast_multiply_tensor<T>(
@@ -2248,19 +2228,12 @@ fn filled_broadcast_multiply_tensor<T>(
 where
     T: Copy + Clone + PoolScalar + 'static,
 {
-    let len = shape.iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim).ok_or_else(|| {
-            crate::Error::invalid_argument(
-                "broadcast_multiply",
-                "shape",
-                "output shape size overflows usize",
-            )
-        })
-    })?;
-    // SAFETY: every pooled element is initialized with `fill` before tensor construction.
-    let mut data = unsafe { T::pool_acquire(buffers, len) };
-    data.fill(fill);
-    TypedTensor::from_vec_col_major(shape.to_vec(), data)
+    let mut out = PooledUninitOutput::<T>::new(buffers, shape.to_vec())?;
+    for item in out.as_uninit_slice_mut().iter_mut() {
+        item.write(fill);
+    }
+    // SAFETY: the fill replay writes every logical destination element and retains no destination view.
+    unsafe { out.assume_init() }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2278,25 +2251,29 @@ pub fn broadcast_multiply_read_with_pool(
     let rhs = read_as_cpu_view(rhs);
 
     macro_rules! dispatch {
-        ($variant:ident, $lhs:expr, $rhs:expr) => {{
+        ($variant:ident, $lhs:expr, $rhs:expr, $mul:expr) => {{
             if let Some(out) = try_outer_product_with_pool(
                 buffers, &$lhs, lhs_shape, lhs_dims, &$rhs, rhs_shape, rhs_dims,
             )? {
                 return Ok(Some(Tensor::$variant(out)));
             }
             Ok(Some(Tensor::$variant(typed_broadcast_mul_view_with_pool(
-                buffers, &$lhs, lhs_shape, lhs_dims, &$rhs, rhs_shape, rhs_dims,
+                buffers, &$lhs, lhs_shape, lhs_dims, &$rhs, rhs_shape, rhs_dims, $mul,
             )?)))
         }};
     }
 
     match (lhs, rhs) {
-        (CpuReadView::F32(lhs), CpuReadView::F32(rhs)) => dispatch!(F32, lhs, rhs),
-        (CpuReadView::F64(lhs), CpuReadView::F64(rhs)) => dispatch!(F64, lhs, rhs),
-        (CpuReadView::I32(lhs), CpuReadView::I32(rhs)) => dispatch!(I32, lhs, rhs),
-        (CpuReadView::I64(lhs), CpuReadView::I64(rhs)) => dispatch!(I64, lhs, rhs),
-        (CpuReadView::C32(lhs), CpuReadView::C32(rhs)) => dispatch!(C32, lhs, rhs),
-        (CpuReadView::C64(lhs), CpuReadView::C64(rhs)) => dispatch!(C64, lhs, rhs),
+        (CpuReadView::F32(lhs), CpuReadView::F32(rhs)) => dispatch!(F32, lhs, rhs, |x, y| x * y),
+        (CpuReadView::F64(lhs), CpuReadView::F64(rhs)) => dispatch!(F64, lhs, rhs, |x, y| x * y),
+        (CpuReadView::I32(lhs), CpuReadView::I32(rhs)) => {
+            dispatch!(I32, lhs, rhs, |x, y| x.wrapping_mul(y))
+        }
+        (CpuReadView::I64(lhs), CpuReadView::I64(rhs)) => {
+            dispatch!(I64, lhs, rhs, |x, y| x.wrapping_mul(y))
+        }
+        (CpuReadView::C32(lhs), CpuReadView::C32(rhs)) => dispatch!(C32, lhs, rhs, |x, y| x * y),
+        (CpuReadView::C64(lhs), CpuReadView::C64(rhs)) => dispatch!(C64, lhs, rhs, |x, y| x * y),
         _ => Ok(None),
     }
 }
@@ -3394,34 +3371,38 @@ where
     T: Copy + Clone + Zero + Add<Output = T> + PoolScalar,
 {
     if lhs.shape() == rhs.shape() {
-        // SAFETY: zip_map2_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
         zip_map2_into(
-            &mut out.view_mut(),
+            &mut out.as_uninit_view_mut()?,
             &typed_view("add", lhs)?,
             &typed_view("add", rhs)?,
-            |x, y| x + y,
+            |x, y| MaybeUninit::new(x + y),
         )
         .map_err(|err| crate::Error::backend_source("add", err))?;
-        Ok(tensor_from_array(out))
+        // SAFETY: the successful add zip/map replay writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else if lhs.shape().is_empty() {
         let scalar = typed_host_data("add", lhs)?[0];
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, rhs.shape()) }?;
-        map_into(&mut out.view_mut(), &typed_view("add", rhs)?, |x| {
-            scalar + x
-        })
+        let mut out = PooledUninitOutput::<T>::new(buffers, rhs.shape().to_vec())?;
+        map_into(
+            &mut out.as_uninit_view_mut()?,
+            &typed_view("add", rhs)?,
+            |x| MaybeUninit::new(scalar + x),
+        )
         .map_err(|err| crate::Error::backend_source("add", err))?;
-        Ok(tensor_from_array(out))
+        // SAFETY: the successful add scalar map replay writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else if rhs.shape().is_empty() {
         let scalar = typed_host_data("add", rhs)?[0];
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
-        map_into(&mut out.view_mut(), &typed_view("add", lhs)?, |x| {
-            x + scalar
-        })
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
+        map_into(
+            &mut out.as_uninit_view_mut()?,
+            &typed_view("add", lhs)?,
+            |x| MaybeUninit::new(x + scalar),
+        )
         .map_err(|err| crate::Error::backend_source("add", err))?;
-        Ok(tensor_from_array(out))
+        // SAFETY: the successful add scalar map replay writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else {
         Err(crate::Error::shape_mismatch(
             "add",
@@ -3442,30 +3423,34 @@ where
     T: Copy + PoolScalar + 'static,
 {
     if lhs.shape() == rhs.shape() {
-        // SAFETY: zip_map2_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
         zip_map2_into(
-            &mut out.view_mut(),
+            &mut out.as_uninit_view_mut()?,
             &typed_view(op, lhs)?,
             &typed_view(op, rhs)?,
-            f,
+            |x, y| MaybeUninit::new(f(x, y)),
         )
         .map_err(|err| crate::Error::backend_source(op, err))?;
-        Ok(tensor_from_array(out))
+        // SAFETY: the successful binary zip/map replay writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else if lhs.shape().is_empty() {
         let scalar = typed_host_data(op, lhs)?[0];
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, rhs.shape()) }?;
-        map_into(&mut out.view_mut(), &typed_view(op, rhs)?, |x| f(scalar, x))
-            .map_err(|err| crate::Error::backend_source(op, err))?;
-        Ok(tensor_from_array(out))
+        let mut out = PooledUninitOutput::<T>::new(buffers, rhs.shape().to_vec())?;
+        map_into(&mut out.as_uninit_view_mut()?, &typed_view(op, rhs)?, |x| {
+            MaybeUninit::new(f(scalar, x))
+        })
+        .map_err(|err| crate::Error::backend_source(op, err))?;
+        // SAFETY: the successful binary scalar map replay writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else if rhs.shape().is_empty() {
         let scalar = typed_host_data(op, rhs)?[0];
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
-        map_into(&mut out.view_mut(), &typed_view(op, lhs)?, |x| f(x, scalar))
-            .map_err(|err| crate::Error::backend_source(op, err))?;
-        Ok(tensor_from_array(out))
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
+        map_into(&mut out.as_uninit_view_mut()?, &typed_view(op, lhs)?, |x| {
+            MaybeUninit::new(f(x, scalar))
+        })
+        .map_err(|err| crate::Error::backend_source(op, err))?;
+        // SAFETY: the successful binary scalar map replay writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else {
         Err(crate::Error::shape_mismatch(
             op,
@@ -3481,7 +3466,7 @@ fn typed_wrapping_add_with_pool<T>(
     rhs: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: WrappingIntegerElem,
+    T: WrappingIntegerElem + Mul<Output = T>,
 {
     typed_binary_with_pool("add", buffers, lhs, rhs, |x, y| x.wrapping_add_elem(y))
 }
@@ -3492,7 +3477,7 @@ fn typed_wrapping_add_view_with_pool<T, L, R>(
     rhs: &TypedTensorView<'_, T, R>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: WrappingIntegerElem,
+    T: WrappingIntegerElem + Mul<Output = T>,
     L: TensorRank,
     R: TensorRank,
 {
@@ -3511,38 +3496,38 @@ where
     R: TensorRank,
 {
     if lhs.shape() == rhs.shape() {
-        // SAFETY: zip_map2_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
         zip_map2_into(
-            &mut out.view_mut(),
+            &mut out.as_uninit_view_mut()?,
             &typed_view_from_view("add", lhs)?,
             &typed_view_from_view("add", rhs)?,
-            |x, y| x + y,
+            |x, y| MaybeUninit::new(x + y),
         )
         .map_err(|err| crate::Error::backend_source("add", err))?;
-        Ok(tensor_from_array(out))
+        // SAFETY: the successful multiplication kernel writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else if lhs.shape().is_empty() {
         let scalar = typed_view_from_view("add", lhs)?.get(&[]);
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, rhs.shape()) }?;
+        let mut out = PooledUninitOutput::<T>::new(buffers, rhs.shape().to_vec())?;
         map_into(
-            &mut out.view_mut(),
+            &mut out.as_uninit_view_mut()?,
             &typed_view_from_view("add", rhs)?,
-            |x| scalar + x,
+            |x| MaybeUninit::new(scalar + x),
         )
         .map_err(|err| crate::Error::backend_source("add", err))?;
-        Ok(tensor_from_array(out))
+        // SAFETY: the successful multiplication kernel writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else if rhs.shape().is_empty() {
         let scalar = typed_view_from_view("add", rhs)?.get(&[]);
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
         map_into(
-            &mut out.view_mut(),
+            &mut out.as_uninit_view_mut()?,
             &typed_view_from_view("add", lhs)?,
-            |x| x + scalar,
+            |x| MaybeUninit::new(x + scalar),
         )
         .map_err(|err| crate::Error::backend_source("add", err))?;
-        Ok(tensor_from_array(out))
+        // SAFETY: the successful add zip/map replay writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else {
         Err(crate::Error::shape_mismatch(
             "add",
@@ -3612,39 +3597,17 @@ where
     T: Copy + Clone + Zero + Mul<Output = T> + PoolScalar + 'static,
 {
     if lhs.shape() == rhs.shape() {
-        // SAFETY: mul_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
-        mul_into(
-            &mut out.view_mut(),
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
+        mul_into_uninit(
+            &mut out.as_uninit_view_mut()?,
             &typed_view("mul", lhs)?,
             &typed_view("mul", rhs)?,
         )
         .map_err(|err| crate::Error::backend_source("mul", err))?;
-        Ok(tensor_from_array(out))
-    } else if lhs.shape().is_empty() {
-        let scalar = typed_host_data("mul", lhs)?[0];
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, rhs.shape()) }?;
-        map_into(&mut out.view_mut(), &typed_view("mul", rhs)?, |x| {
-            scalar * x
-        })
-        .map_err(|err| crate::Error::backend_source("mul", err))?;
-        Ok(tensor_from_array(out))
-    } else if rhs.shape().is_empty() {
-        let scalar = typed_host_data("mul", rhs)?[0];
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
-        map_into(&mut out.view_mut(), &typed_view("mul", lhs)?, |x| {
-            x * scalar
-        })
-        .map_err(|err| crate::Error::backend_source("mul", err))?;
-        Ok(tensor_from_array(out))
+        // SAFETY: the successful multiplication kernel writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else {
-        Err(crate::Error::shape_mismatch(
-            "mul",
-            lhs.shape().to_vec(),
-            rhs.shape().to_vec(),
-        ))
+        typed_binary_with_pool("mul", buffers, lhs, rhs, |x, y| x * y)
     }
 }
 
@@ -3656,7 +3619,19 @@ fn typed_wrapping_mul_with_pool<T>(
 where
     T: WrappingIntegerElem,
 {
-    typed_binary_with_pool("mul", buffers, lhs, rhs, |x, y| x.wrapping_mul_elem(y))
+    if lhs.shape() == rhs.shape() {
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
+        mul_into_uninit(
+            &mut out.as_uninit_view_mut()?,
+            &typed_view("mul", lhs)?,
+            &typed_view("mul", rhs)?,
+        )
+        .map_err(|err| crate::Error::backend_source("mul", err))?;
+        // SAFETY: the successful wrapping multiplication kernel writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
+    } else {
+        typed_binary_with_pool("mul", buffers, lhs, rhs, |x, y| x.wrapping_mul_elem(y))
+    }
 }
 
 fn typed_wrapping_mul_view_with_pool<T, L, R>(
@@ -3669,7 +3644,19 @@ where
     L: TensorRank,
     R: TensorRank,
 {
-    typed_binary_view_with_pool("mul", buffers, lhs, rhs, |x, y| x.wrapping_mul_elem(y))
+    if lhs.shape() == rhs.shape() {
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
+        mul_into_uninit(
+            &mut out.as_uninit_view_mut()?,
+            &typed_view_from_view("mul", lhs)?,
+            &typed_view_from_view("mul", rhs)?,
+        )
+        .map_err(|err| crate::Error::backend_source("mul", err))?;
+        // SAFETY: the successful wrapping multiplication kernel writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
+    } else {
+        typed_binary_view_with_pool("mul", buffers, lhs, rhs, |x, y| x.wrapping_mul_elem(y))
+    }
 }
 
 #[doc(hidden)]
@@ -3684,43 +3671,17 @@ where
     R: TensorRank,
 {
     if lhs.shape() == rhs.shape() {
-        // SAFETY: mul_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
-        mul_into(
-            &mut out.view_mut(),
+        let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
+        mul_into_uninit(
+            &mut out.as_uninit_view_mut()?,
             &typed_view_from_view("mul", lhs)?,
             &typed_view_from_view("mul", rhs)?,
         )
         .map_err(|err| crate::Error::backend_source("mul", err))?;
-        Ok(tensor_from_array(out))
-    } else if lhs.shape().is_empty() {
-        let scalar = typed_view_from_view("mul", lhs)?.get(&[]);
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, rhs.shape()) }?;
-        map_into(
-            &mut out.view_mut(),
-            &typed_view_from_view("mul", rhs)?,
-            |x| scalar * x,
-        )
-        .map_err(|err| crate::Error::backend_source("mul", err))?;
-        Ok(tensor_from_array(out))
-    } else if rhs.shape().is_empty() {
-        let scalar = typed_view_from_view("mul", rhs)?.get(&[]);
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
-        map_into(
-            &mut out.view_mut(),
-            &typed_view_from_view("mul", lhs)?,
-            |x| x * scalar,
-        )
-        .map_err(|err| crate::Error::backend_source("mul", err))?;
-        Ok(tensor_from_array(out))
+        // SAFETY: the successful multiplication kernel writes every logical destination element and retains no destination view.
+        Ok(unsafe { out.assume_init()? })
     } else {
-        Err(crate::Error::shape_mismatch(
-            "mul",
-            lhs.shape().to_vec(),
-            rhs.shape().to_vec(),
-        ))
+        typed_binary_view_with_pool("mul", buffers, lhs, rhs, |x, y| x * y)
     }
 }
 
@@ -3731,44 +3692,9 @@ pub fn typed_div_with_pool<T>(
     rhs: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + Zero + Div<Output = T> + PoolScalar,
+    T: Copy + Clone + Zero + Div<Output = T> + PoolScalar + 'static,
 {
-    if lhs.shape() == rhs.shape() {
-        // SAFETY: zip_map2_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
-        zip_map2_into(
-            &mut out.view_mut(),
-            &typed_view("div", lhs)?,
-            &typed_view("div", rhs)?,
-            |x, y| x / y,
-        )
-        .map_err(|err| crate::Error::backend_source("div", err))?;
-        Ok(tensor_from_array(out))
-    } else if lhs.shape().is_empty() {
-        let scalar = typed_host_data("div", lhs)?[0];
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, rhs.shape()) }?;
-        map_into(&mut out.view_mut(), &typed_view("div", rhs)?, |x| {
-            scalar / x
-        })
-        .map_err(|err| crate::Error::backend_source("div", err))?;
-        Ok(tensor_from_array(out))
-    } else if rhs.shape().is_empty() {
-        let scalar = typed_host_data("div", rhs)?[0];
-        // SAFETY: map_into overwrites every output element.
-        let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
-        map_into(&mut out.view_mut(), &typed_view("div", lhs)?, |x| {
-            x / scalar
-        })
-        .map_err(|err| crate::Error::backend_source("div", err))?;
-        Ok(tensor_from_array(out))
-    } else {
-        Err(crate::Error::shape_mismatch(
-            "div",
-            lhs.shape().to_vec(),
-            rhs.shape().to_vec(),
-        ))
-    }
+    typed_binary_with_pool("div", buffers, lhs, rhs, |x, y| x / y)
 }
 
 fn typed_integer_div_with_pool<T>(
@@ -3839,18 +3765,36 @@ where
 }
 
 #[doc(hidden)]
+fn typed_map_with_pool<T, O>(
+    op: &'static str,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+    f: impl Fn(T) -> O + Copy + Sync,
+) -> crate::Result<TypedTensor<O>>
+where
+    T: Copy + Send + Sync + 'static,
+    O: Clone + PoolScalar,
+{
+    let mut out = PooledUninitOutput::<O>::new(buffers, input.shape().to_vec())?;
+    map_into(
+        &mut out.as_uninit_view_mut()?,
+        &typed_view(op, input)?,
+        |x| MaybeUninit::new(f(x)),
+    )
+    .map_err(|err| crate::Error::backend_source(op, err))?;
+    // SAFETY: the successful same-shape replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
+}
+
+#[doc(hidden)]
 pub fn typed_neg_with_pool<T>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + Zero + Neg<Output = T> + PoolScalar,
+    T: Copy + Clone + Zero + Neg<Output = T> + PoolScalar + 'static,
 {
-    // SAFETY: map_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
-    map_into(&mut out.view_mut(), &typed_view("neg", input)?, |x| -x)
-        .map_err(|err| crate::Error::backend_source("neg", err))?;
-    Ok(tensor_from_array(out))
+    typed_map_with_pool("neg", buffers, input, |x| -x)
 }
 
 fn typed_wrapping_unary_with_pool<T>(
@@ -3862,11 +3806,7 @@ fn typed_wrapping_unary_with_pool<T>(
 where
     T: WrappingIntegerElem,
 {
-    // SAFETY: map_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
-    map_into(&mut out.view_mut(), &typed_view(op, input)?, f)
-        .map_err(|err| crate::Error::backend_source(op, err))?;
-    Ok(tensor_from_array(out))
+    typed_map_with_pool(op, buffers, input, f)
 }
 
 fn typed_wrapping_neg_with_pool<T>(
@@ -3895,15 +3835,9 @@ pub fn typed_conj_with_pool<T>(
     input: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + Zero + ConjElem + PoolScalar,
+    T: Copy + Clone + Zero + ConjElem + PoolScalar + 'static,
 {
-    // SAFETY: map_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
-    map_into(&mut out.view_mut(), &typed_view("conj", input)?, |x| {
-        x.conj_elem()
-    })
-    .map_err(|err| crate::Error::backend_source("conj", err))?;
-    Ok(tensor_from_array(out))
+    typed_map_with_pool("conj", buffers, input, |x| x.conj_elem())
 }
 
 #[doc(hidden)]
@@ -3912,15 +3846,9 @@ pub fn typed_abs_with_pool<T>(
     input: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Tier2Elem + PoolScalar,
+    T: Tier2Elem + PoolScalar + 'static,
 {
-    // SAFETY: map_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
-    map_into(&mut out.view_mut(), &typed_view("abs", input)?, |x| {
-        x.abs_elem()
-    })
-    .map_err(|err| crate::Error::backend_source("abs", err))?;
-    Ok(tensor_from_array(out))
+    typed_map_with_pool("abs", buffers, input, |x| x.abs_elem())
 }
 
 fn typed_complex_abs_with_pool<T>(
@@ -3928,15 +3856,9 @@ fn typed_complex_abs_with_pool<T>(
     input: &TypedTensor<Complex<T>>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: num_traits::Float + PoolScalar,
+    T: num_traits::Float + PoolScalar + 'static,
 {
-    // SAFETY: the following kernel overwrites every output element before any read.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
-    map_into(&mut out.view_mut(), &typed_view("abs", input)?, |x| {
-        x.norm()
-    })
-    .map_err(|err| crate::Error::backend_source("abs", err))?;
-    Ok(tensor_from_array(out))
+    typed_map_with_pool("abs", buffers, input, |x| x.norm())
 }
 
 fn typed_complex_abs_view_with_pool<T, R>(
@@ -3947,15 +3869,15 @@ where
     T: num_traits::Float + PoolScalar + 'static,
     R: TensorRank,
 {
-    // SAFETY: the following kernel overwrites every output element before any read.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
+    let mut out = PooledUninitOutput::<T>::new(buffers, input.shape().to_vec())?;
     map_into(
-        &mut out.view_mut(),
+        &mut out.as_uninit_view_mut()?,
         &typed_view_from_view("abs", input)?,
-        |x| x.norm(),
+        |x| MaybeUninit::new(x.norm()),
     )
     .map_err(|err| crate::Error::backend_source("abs", err))?;
-    Ok(tensor_from_array(out))
+    // SAFETY: the successful unary map replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
 }
 
 #[doc(hidden)]
@@ -3964,15 +3886,9 @@ pub fn typed_sign_with_pool<T>(
     input: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Tier2Elem + PoolScalar,
+    T: Tier2Elem + PoolScalar + 'static,
 {
-    // SAFETY: map_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
-    map_into(&mut out.view_mut(), &typed_view("sign", input)?, |x| {
-        x.sign_elem()
-    })
-    .map_err(|err| crate::Error::backend_source("sign", err))?;
-    Ok(tensor_from_array(out))
+    typed_map_with_pool("sign", buffers, input, |x| x.sign_elem())
 }
 
 fn typed_integer_sign_with_pool<T>(
@@ -4001,16 +3917,16 @@ where
             rhs.shape().to_vec(),
         ));
     }
-    // SAFETY: zip_map2_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
+    let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
     zip_map2_into(
-        &mut out.view_mut(),
+        &mut out.as_uninit_view_mut()?,
         &typed_view("maximum", lhs)?,
         &typed_view("maximum", rhs)?,
-        |x, y| x.max_elem(y),
+        |x, y| MaybeUninit::new(x.max_elem(y)),
     )
     .map_err(|err| crate::Error::backend_source("maximum", err))?;
-    Ok(tensor_from_array(out))
+    // SAFETY: the successful binary zip replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
 }
 
 #[doc(hidden)]
@@ -4029,16 +3945,16 @@ where
             rhs.shape().to_vec(),
         ));
     }
-    // SAFETY: zip_map2_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
+    let mut out = PooledUninitOutput::<T>::new(buffers, lhs.shape().to_vec())?;
     zip_map2_into(
-        &mut out.view_mut(),
+        &mut out.as_uninit_view_mut()?,
         &typed_view("minimum", lhs)?,
         &typed_view("minimum", rhs)?,
-        |x, y| x.min_elem(y),
+        |x, y| MaybeUninit::new(x.min_elem(y)),
     )
     .map_err(|err| crate::Error::backend_source("minimum", err))?;
-    Ok(tensor_from_array(out))
+    // SAFETY: the successful binary zip replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
 }
 
 #[doc(hidden)]
@@ -4058,16 +3974,16 @@ where
             rhs.shape().to_vec(),
         ));
     }
-    // SAFETY: zip_map2_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
+    let mut out = PooledUninitOutput::<bool>::new(buffers, lhs.shape().to_vec())?;
     zip_map2_into(
-        &mut out.view_mut(),
+        &mut out.as_uninit_view_mut()?,
         &typed_view("compare", lhs)?,
         &typed_view("compare", rhs)?,
-        |x, y| x.compare_elem(y, dir),
+        |x, y| MaybeUninit::new(x.compare_elem(y, dir)),
     )
     .map_err(|err| crate::Error::backend_source("compare", err))?;
-    Ok(tensor_from_array(out))
+    // SAFETY: the successful compare replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
 }
 
 #[doc(hidden)]
@@ -4094,17 +4010,17 @@ where
             on_false.shape().to_vec(),
         ));
     }
-    // SAFETY: zip_map3_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, pred.shape()) }?;
+    let mut out = PooledUninitOutput::<T>::new(buffers, pred.shape().to_vec())?;
     zip_map3_into(
-        &mut out.view_mut(),
+        &mut out.as_uninit_view_mut()?,
         &typed_view("select", pred)?,
         &typed_view("select", on_true)?,
         &typed_view("select", on_false)?,
-        |p, t, f| if p { t } else { f },
+        |p, t, f| MaybeUninit::new(if p { t } else { f }),
     )
     .map_err(|err| crate::Error::backend_source("select", err))?;
-    Ok(tensor_from_array(out))
+    // SAFETY: the successful select replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
 }
 
 #[doc(hidden)]
@@ -4131,17 +4047,17 @@ where
             upper.shape().to_vec(),
         ));
     }
-    // SAFETY: zip_map3_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
+    let mut out = PooledUninitOutput::<T>::new(buffers, input.shape().to_vec())?;
     zip_map3_into(
-        &mut out.view_mut(),
+        &mut out.as_uninit_view_mut()?,
         &typed_view("clamp", input)?,
         &typed_view("clamp", lower)?,
         &typed_view("clamp", upper)?,
-        |x, lo, hi| hi.min_elem(lo.max_elem(x)),
+        |x, lo, hi| MaybeUninit::new(hi.min_elem(lo.max_elem(x))),
     )
     .map_err(|err| crate::Error::backend_source("clamp", err))?;
-    Ok(tensor_from_array(out))
+    // SAFETY: the successful clamp replay writes every logical destination element and retains no destination view.
+    Ok(unsafe { out.assume_init()? })
 }
 
 #[cfg(test)]

--- a/crates/tenferro-internal-cpu-kernels/src/elementwise/tests.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/elementwise/tests.rs
@@ -69,6 +69,132 @@ fn elementwise_fusion_validation_covers_descriptor_errors_and_empty_outputs() {
 }
 
 #[test]
+fn integer_multiplication_wraps_owned_view_and_scalar_broadcast_paths() {
+    let mut buffers = BufferPool::new();
+    macro_rules! check {
+        ($ty:ty, $variant:ident) => {{
+            let max: $ty = <$ty>::MAX;
+            let expected: $ty = -2;
+            let scalar = TypedTensor::<$ty>::from_vec_col_major(vec![], vec![max]).unwrap();
+            let other = TypedTensor::<$ty>::from_vec_col_major(vec![], vec![2]).unwrap();
+            let owned = mul_read_with_pool(
+                &mut buffers,
+                TensorRead::from_tensor(&Tensor::$variant(scalar.clone())),
+                TensorRead::from_tensor(&Tensor::$variant(other.clone())),
+            )
+            .unwrap();
+            assert_eq!(owned.as_slice::<$ty>().unwrap(), &[expected]);
+            let view = mul_read_with_pool(
+                &mut buffers,
+                TensorRead::from_view(TensorView::$variant(scalar.as_view())),
+                TensorRead::from_view(TensorView::$variant(other.as_view())),
+            )
+            .unwrap();
+            assert_eq!(view.as_slice::<$ty>().unwrap(), &[expected]);
+            let broadcast = broadcast_multiply_read_with_pool(
+                &mut buffers,
+                TensorRead::from_tensor(&Tensor::$variant(scalar.clone())),
+                &[],
+                &[],
+                TensorRead::from_tensor(&Tensor::$variant(other)),
+                &[],
+                &[],
+            )
+            .unwrap()
+            .unwrap();
+            assert_eq!(broadcast.as_slice::<$ty>().unwrap(), &[expected]);
+
+            let vector = TypedTensor::<$ty>::from_vec_col_major(vec![3], vec![2, 3, 4]).unwrap();
+            let expected_vector = [
+                max.wrapping_mul(2),
+                max.wrapping_mul(3),
+                max.wrapping_mul(4),
+            ];
+            let owned_scalar_vector = mul_read_with_pool(
+                &mut buffers,
+                TensorRead::from_tensor(&Tensor::$variant(scalar.clone())),
+                TensorRead::from_tensor(&Tensor::$variant(vector.clone())),
+            )
+            .unwrap();
+            assert_eq!(owned_scalar_vector.shape(), &[3]);
+            assert_eq!(
+                owned_scalar_vector.as_slice::<$ty>().unwrap(),
+                &expected_vector
+            );
+            let owned_vector_scalar = mul_read_with_pool(
+                &mut buffers,
+                TensorRead::from_tensor(&Tensor::$variant(vector.clone())),
+                TensorRead::from_tensor(&Tensor::$variant(scalar.clone())),
+            )
+            .unwrap();
+            assert_eq!(owned_vector_scalar.shape(), &[3]);
+            assert_eq!(
+                owned_vector_scalar.as_slice::<$ty>().unwrap(),
+                &expected_vector
+            );
+
+            let view_scalar_vector = mul_read_with_pool(
+                &mut buffers,
+                TensorRead::from_view(TensorView::$variant(scalar.as_view())),
+                TensorRead::from_view(TensorView::$variant(vector.as_view())),
+            )
+            .unwrap();
+            assert_eq!(view_scalar_vector.shape(), &[3]);
+            assert_eq!(
+                view_scalar_vector.as_slice::<$ty>().unwrap(),
+                &expected_vector
+            );
+            let view_vector_scalar = mul_read_with_pool(
+                &mut buffers,
+                TensorRead::from_view(TensorView::$variant(vector.as_view())),
+                TensorRead::from_view(TensorView::$variant(scalar.as_view())),
+            )
+            .unwrap();
+            assert_eq!(view_vector_scalar.shape(), &[3]);
+            assert_eq!(
+                view_vector_scalar.as_slice::<$ty>().unwrap(),
+                &expected_vector
+            );
+
+            let broadcast_scalar_vector = broadcast_multiply_read_with_pool(
+                &mut buffers,
+                TensorRead::from_tensor(&Tensor::$variant(scalar.clone())),
+                &[3],
+                &[],
+                TensorRead::from_tensor(&Tensor::$variant(vector.clone())),
+                &[3],
+                &[0],
+            )
+            .unwrap()
+            .unwrap();
+            assert_eq!(broadcast_scalar_vector.shape(), &[3]);
+            assert_eq!(
+                broadcast_scalar_vector.as_slice::<$ty>().unwrap(),
+                &expected_vector
+            );
+            let broadcast_vector_scalar = broadcast_multiply_read_with_pool(
+                &mut buffers,
+                TensorRead::from_tensor(&Tensor::$variant(vector)),
+                &[3],
+                &[0],
+                TensorRead::from_tensor(&Tensor::$variant(scalar)),
+                &[3],
+                &[],
+            )
+            .unwrap()
+            .unwrap();
+            assert_eq!(broadcast_vector_scalar.shape(), &[3]);
+            assert_eq!(
+                broadcast_vector_scalar.as_slice::<$ty>().unwrap(),
+                &expected_vector
+            );
+        }};
+    }
+    check!(i32, I32);
+    check!(i64, I64);
+}
+
+#[test]
 fn elementwise_fusion_executes_i32_add_multiply_plan() {
     use tenferro_tensor::backend::ElementwiseFusionInst;
 
@@ -1366,8 +1492,8 @@ fn ordered_compare_owned_and_read_routes_use_fixed_dispatch() {
         .map(|(body, _)| body)
         .expect("fixed comparison helper must remain defined");
     assert!(
-        helper.contains("compare_into("),
-        "fixed comparison helper must dispatch through strided compare_into"
+        helper.contains("compare_into_uninit("),
+        "fixed comparison helper must dispatch through strided compare_into_uninit"
     );
 
     for (start, end, route) in [
@@ -1555,6 +1681,7 @@ fn broadcast_multiply_read_and_value_cover_dtypes_and_error_paths() {
             &lhs_f32,
             &[2, 3, 5],
             &[0, 1],
+            |x, y| x * y,
         ),
         "broadcast_multiply",
     );

--- a/crates/tenferro-internal-cpu-kernels/src/lib.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/lib.rs
@@ -2,22 +2,31 @@
 
 //! Internal CPU kernel and scratch-pool implementation crate.
 
+#[cfg(test)]
+use std::mem::MaybeUninit;
+
 pub type Result<T> = tenferro_tensor::Result<T>;
 pub use tenferro_tensor::{CacheStats, Error, ErrorKind};
 
 pub mod buffer_pool;
+mod pooled_uninit_output;
+/// Canonical pooled full-overwrite owner shared with the sibling `tenferro-cpu`
+/// crate. This is the minimum cross-crate surface required for one ownership
+/// contract; `pub(crate)` cannot cross that crate boundary. Construction only
+/// exposes `MaybeUninit` storage, with initialization completed by an explicit
+/// unsafe handoff.
+pub use pooled_uninit_output::PooledUninitOutput;
 pub mod elementwise;
 
 use num_complex::{Complex32, Complex64};
-use strided_kernel::{col_major_strides as kernel_col_major_strides, StridedArray, StridedView};
+use strided_kernel::{col_major_strides as kernel_col_major_strides, StridedView};
 #[cfg(test)]
-use strided_kernel::{copy_into, Identity};
-use tenferro_tensor::{
-    validate::checked_shape_product, Buffer, DType, TensorRank, TypedTensor, TypedTensorView,
-};
+use strided_kernel::{map_into, Identity};
+use tenferro_tensor::{Buffer, DType, TensorRank, TypedTensor, TypedTensorView};
 #[cfg(test)]
 use tenferro_tensor::{Tensor, TensorRead, TensorView};
 
+#[cfg(test)]
 use crate::buffer_pool::{BufferPool, PoolScalar};
 
 pub(crate) fn cpu_backend_buffer_error(op: &'static str) -> Error {
@@ -111,34 +120,6 @@ pub(crate) fn typed_view_from_view<'a, T: Copy + 'static, R: TensorRank>(
     .map_err(|err| Error::backend_source(op, err))
 }
 
-/// Create an output array from the CPU buffer pool WITHOUT initializing values.
-///
-/// # Safety
-/// Caller must write every element before reading. The returned array contains
-/// uninitialized or stale data acquired from `buffers`.
-pub(crate) unsafe fn typed_array_uninit_from_pool<T>(
-    buffers: &mut BufferPool,
-    shape: &[usize],
-) -> Result<StridedArray<T>>
-where
-    T: PoolScalar,
-{
-    let total = checked_shape_product("typed_array_uninit_from_pool", "shape", shape)?;
-    let strides = kernel_col_major_strides(shape);
-    // SAFETY: callers use this only for operation outputs that fully overwrite every element.
-    let data = unsafe { T::pool_acquire(buffers, total) };
-    // Invariant: callers pass validated tensor-derived or prechecked output
-    // shapes, and `strides` is their compact column-major layout.
-    StridedArray::from_parts(data, shape, &strides, 0)
-        .map_err(|err| Error::backend_source("typed_array_uninit_from_pool", err))
-}
-
-pub(crate) fn tensor_from_array<T: Clone>(array: StridedArray<T>) -> TypedTensor<T> {
-    // Invariant: `StridedArray` owns data whose length matches its validated dimensions.
-    TypedTensor::from_vec_col_major(array.dims().to_vec(), array.into_data())
-        .expect("strided array dimensions match owned data length")
-}
-
 #[cfg(test)]
 pub(crate) fn materialize_tensor_read(
     buffers: &mut BufferPool,
@@ -216,14 +197,18 @@ where
         view.offset(),
     )
     .map_err(|err| Error::backend_source(op, err))?;
-    // SAFETY: copy_into overwrites every logical output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, view.shape()) }?;
-    copy_into(&mut out.view_mut(), &src).map_err(|err| Error::backend_source(op, err))?;
+    let mut out = PooledUninitOutput::<T>::new(buffers, view.shape().to_vec())?;
+    map_into(&mut out.as_uninit_view_mut()?, &src, |x| {
+        MaybeUninit::new(x)
+    })
+    .map_err(|err| Error::backend_source(op, err))?;
+    // SAFETY: the successful materialize map replay writes every logical destination element and retains no destination view.
+    let out = unsafe { out.assume_init_as::<R>()? };
     let shape = R::shape_from_vec(view.shape().to_vec().into())
         .map_err(|err| Error::backend_source(op, err))?;
     TypedTensor::from_buffer_col_major(
         shape,
-        Buffer::Host(out.into_data()),
+        Buffer::Host(out.into_vec_col_major()?.1),
         view.placement().clone(),
     )
 }

--- a/crates/tenferro-internal-cpu-kernels/src/pooled_uninit_output.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/pooled_uninit_output.rs
@@ -1,0 +1,245 @@
+use std::alloc::Layout;
+use std::mem::{ManuallyDrop, MaybeUninit};
+
+use strided_kernel::StridedViewMut;
+use tenferro_tensor::{validate::checked_shape_product, TensorRank, TypedTensor};
+
+use crate::buffer_pool::{BufferPool, PoolScalar, UninitCheckoutToken};
+use crate::{Error, Result};
+
+fn checked_compact_strides(shape: &[usize]) -> Result<Vec<isize>> {
+    let mut strides = Vec::with_capacity(shape.len());
+    let mut stride = 1isize;
+    for &dim in shape {
+        strides.push(stride);
+        let dim = isize::try_from(dim).map_err(|_| {
+            Error::invalid_argument("pooled_uninit_output", "shape", "dimension exceeds isize")
+        })?;
+        stride = stride.checked_mul(dim).ok_or_else(|| {
+            Error::invalid_argument("pooled_uninit_output", "shape", "compact stride overflow")
+        })?;
+    }
+    Ok(strides)
+}
+
+#[derive(Debug)]
+/// Owns a pooled full-overwrite destination until initialization is proven.
+///
+/// This type is public because `tenferro-cpu` is a sibling crate and must use
+/// the same canonical owner; `pub(crate)` would prevent that cross-crate
+/// ownership. Before the unsafe completion handoff, callers receive only
+/// `MaybeUninit` storage.
+pub struct PooledUninitOutput<'pool, T: PoolScalar> {
+    pool: &'pool mut BufferPool,
+    shape: Vec<usize>,
+    strides: Vec<isize>,
+    data: Vec<std::mem::MaybeUninit<T>>,
+    checkout: Option<UninitCheckoutToken>,
+    byte_len: usize,
+}
+
+impl<'pool, T: PoolScalar> PooledUninitOutput<'pool, T> {
+    /// Creates a compact, pooled full-overwrite destination.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_internal_cpu_kernels::{buffer_pool::BufferPool, PooledUninitOutput};
+    /// let mut pool = BufferPool::new();
+    /// let output = PooledUninitOutput::<f32>::new(&mut pool, vec![2, 3]).unwrap();
+    /// drop(output);
+    /// ```
+    /// # Errors
+    /// Returns `Error::Validation` for shape-product, layout, or stride
+    /// validation failures, or `Error::BackendSource` if allocation
+    /// reservation fails. No pool accounting is changed before validation.
+    pub fn new(pool: &'pool mut BufferPool, shape: Vec<usize>) -> Result<Self> {
+        let len = checked_shape_product("pooled_uninit_output", "shape", &shape)?;
+        let layout = Layout::array::<T>(len).map_err(|_| {
+            Error::invalid_argument(
+                "pooled_uninit_output",
+                "shape",
+                "element byte layout exceeds allocation limits",
+            )
+        })?;
+        let byte_len = layout.size();
+        let strides = checked_compact_strides(&shape)?;
+        let (data, checkout) =
+            <T as crate::buffer_pool::private::Sealed>::pool_acquire_uninit_tracked(pool, len)?;
+        debug_assert!(match checkout {
+            UninitCheckoutToken::Fresh { actual_capacity }
+            | UninitCheckoutToken::Reused { actual_capacity } => {
+                data.capacity() == actual_capacity
+            }
+        });
+        Ok(Self {
+            pool,
+            shape,
+            strides,
+            data,
+            checkout: Some(checkout),
+            byte_len,
+        })
+    }
+
+    /// Borrows the destination as `MaybeUninit` elements.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_internal_cpu_kernels::{buffer_pool::BufferPool, PooledUninitOutput};
+    /// let mut pool = BufferPool::new();
+    /// let mut output = PooledUninitOutput::<i32>::new(&mut pool, vec![1]).unwrap();
+    /// output.as_uninit_slice_mut()[0].write(7);
+    /// ```
+    ///
+    pub fn as_uninit_slice_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        self.data.as_mut_slice()
+    }
+
+    /// Borrows the validated compact destination for typed uninitialized kernels.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_internal_cpu_kernels::{buffer_pool::BufferPool, PooledUninitOutput};
+    /// let mut pool = BufferPool::new();
+    /// let mut output = PooledUninitOutput::<f32>::new(&mut pool, vec![2]).unwrap();
+    /// let view = output.as_uninit_view_mut().unwrap();
+    /// assert_eq!(view.dims(), &[2]);
+    /// ```
+    /// # Errors
+    /// Returns `Error::BackendSource` if validated strided-view metadata is
+    /// rejected.
+    pub fn as_uninit_view_mut(&mut self) -> Result<StridedViewMut<'_, MaybeUninit<T>>> {
+        let shape = &self.shape;
+        let strides = &self.strides;
+        let data = &mut self.data;
+        StridedViewMut::new(data, shape, strides, 0)
+            .map_err(|err| Error::backend_source("pooled_uninit_output", err))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn token_is_reused_with_capacity(&self, capacity: usize) -> bool {
+        matches!(self.checkout, Some(UninitCheckoutToken::Reused { actual_capacity }) if actual_capacity == capacity)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn token_is_fresh(&self) -> bool {
+        matches!(
+            self.checkout,
+            Some(UninitCheckoutToken::Fresh { actual_capacity })
+                if self.data.capacity() == actual_capacity
+        )
+    }
+
+    /// Returns the backing bytes for erased uninitialized kernel descriptors.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_internal_cpu_kernels::{buffer_pool::BufferPool, PooledUninitOutput};
+    /// let mut pool = BufferPool::new();
+    /// let mut output = PooledUninitOutput::<i32>::new(&mut pool, vec![1]).unwrap();
+    /// assert_eq!(output.as_uninit_bytes_mut().len(), 4);
+    /// ```
+    pub fn as_uninit_bytes_mut(&mut self) -> &mut [std::mem::MaybeUninit<u8>] {
+        let data = self.as_uninit_slice_mut();
+        // SAFETY: this creates only MaybeUninit byte elements over the same allocation.
+        unsafe {
+            std::slice::from_raw_parts_mut(
+                data.as_mut_ptr().cast::<std::mem::MaybeUninit<u8>>(),
+                self.byte_len,
+            )
+        }
+    }
+
+    /// Converts the allocation after a successful full-overwrite kernel.
+    ///
+    /// # Safety
+    /// Every logical element must have been initialized by the completed kernel.
+    /// The kernel must have completed all validation before writing, and must
+    /// not retain any destination view after returning.
+    /// Successful completion transfers success accounting to the owning
+    /// `BufferPoolLoan` context; direct internal callers must keep that context alive.
+    /// Completes the handoff as a dynamic-rank typed tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_internal_cpu_kernels::{buffer_pool::BufferPool, PooledUninitOutput};
+    /// let mut pool = BufferPool::new();
+    /// let mut output = PooledUninitOutput::<i32>::new(&mut pool, vec![1]).unwrap();
+    /// output.as_uninit_slice_mut()[0].write(7);
+    /// // SAFETY: the preceding write initializes every logical destination element.
+    /// // SAFETY: the example writes every logical destination element before completion.
+    /// let tensor = unsafe { output.assume_init() }.unwrap();
+    /// assert_eq!(tensor.as_slice().unwrap(), &[7]);
+    /// ```
+    ///
+    /// # Errors
+    /// Returns `Error::Validation` if tensor construction rejects the shape or
+    /// data length. Dynamic-rank conversion itself is infallible, so this
+    /// method does not produce a rank-conversion `Error::BackendSource`.
+    pub unsafe fn assume_init(self) -> Result<TypedTensor<T>> {
+        // SAFETY: this method has the same full-initialization precondition.
+        unsafe { self.assume_init_as::<tenferro_tensor::DynRank>() }
+    }
+
+    /// Completes the handoff with an explicitly selected tensor rank.
+    ///
+    /// # Safety
+    /// Every logical element must have been initialized by the completed kernel.
+    /// The destination must be fully initialized before this method is called;
+    /// otherwise reading or dropping the resulting tensor is undefined behavior.
+    ///
+    /// # Errors
+    /// Returns `Error::BackendSource` if rank conversion rejects the shape, or
+    /// `Error::Validation` if tensor construction rejects the shape or length.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_internal_cpu_kernels::{buffer_pool::BufferPool, PooledUninitOutput};
+    /// use tenferro_tensor::Rank;
+    /// let mut pool = BufferPool::new();
+    /// let mut output = PooledUninitOutput::<i32>::new(&mut pool, vec![1]).unwrap();
+    /// output.as_uninit_slice_mut()[0].write(7);
+    /// // SAFETY: the preceding write initializes every logical destination element.
+    /// let tensor = unsafe { output.assume_init_as::<Rank<1>>() }.unwrap();
+    /// assert_eq!(tensor.as_slice().unwrap(), &[7]);
+    /// ```
+    pub unsafe fn assume_init_as<R: TensorRank>(mut self) -> Result<TypedTensor<T, R>>
+    where
+        T: Clone,
+    {
+        let shape = R::shape_from_vec(std::mem::take(&mut self.shape).into())
+            .map_err(|err| Error::backend_source("pooled_uninit_output", err))?;
+        let data = std::mem::take(&mut self.data);
+        let mut data = ManuallyDrop::new(data);
+        // SAFETY: caller proves initialization and MaybeUninit<T> has identical layout.
+        let data = unsafe {
+            Vec::from_raw_parts(data.as_mut_ptr().cast::<T>(), data.len(), data.capacity())
+        };
+        let tensor = TypedTensor::from_vec_col_major(shape, data)?;
+        self.checkout = None;
+        Ok(tensor)
+    }
+}
+
+impl<T: PoolScalar> Drop for PooledUninitOutput<'_, T> {
+    fn drop(&mut self) {
+        let Some(checkout) = self.checkout.take() else {
+            return;
+        };
+        let data = std::mem::take(&mut self.data);
+        <T as crate::buffer_pool::private::Sealed>::pool_discard_uninit(
+            &mut *self.pool,
+            data,
+            checkout,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tenferro-internal-cpu-kernels/src/pooled_uninit_output/tests.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/pooled_uninit_output/tests.rs
@@ -1,0 +1,26 @@
+use super::{checked_compact_strides, PooledUninitOutput};
+use crate::buffer_pool::BufferPool;
+
+#[test]
+fn compact_stride_validation_reports_dimension_and_product_overflow() {
+    let dimension_error = checked_compact_strides(&[isize::MAX as usize + 1]).unwrap_err();
+    assert!(dimension_error
+        .to_string()
+        .contains("dimension exceeds isize"));
+
+    let stride_error = checked_compact_strides(&[isize::MAX as usize, 2]).unwrap_err();
+    assert!(stride_error.to_string().contains("compact stride overflow"));
+}
+
+#[test]
+fn pooled_uninit_output_public_contract_covers_zero_length_handoff() {
+    let mut pool = BufferPool::new();
+    let mut output = PooledUninitOutput::<i32>::new(&mut pool, vec![0]).unwrap();
+    assert!(output.as_uninit_slice_mut().is_empty());
+    assert!(output.as_uninit_bytes_mut().is_empty());
+    assert_eq!(output.as_uninit_view_mut().unwrap().dims(), &[0]);
+
+    let tensor = unsafe { output.assume_init() }.unwrap();
+    assert_eq!(tensor.shape(), &[0]);
+    assert!(pool.is_empty());
+}

--- a/docs/worklogs/2026-07-30-issue-1516a-pooled-uninit-guard.md
+++ b/docs/worklogs/2026-07-30-issue-1516a-pooled-uninit-guard.md
@@ -1,0 +1,112 @@
+# #1516A pooled uninitialized output guard
+
+## Scope and sources
+
+This work implements the accepted #1516A contract from issue #1516 and its
+final contract comment, under umbrella #1535. The starting point is
+`af9d566c`; strided uninitialized replay is consumed at pin `6885f52e`.
+Reviewed: `AGENTS.md`, `REPOSITORY_RULES.md`, the existing buffer-pool and
+indexing allocation code, issue #1516, issue #1535, and the merged strided
+full-overwrite APIs.
+
+## State-machine proof
+
+`Fresh { actual_capacity }` and `Reused { actual_capacity }` are non-Copy checkout tokens. Acquisition
+removes best-fit storage and subtracts its exact retained bytes; only Reused
+increments the exact in-flight bucket. The owner holds `Vec<MaybeUninit<T>>`
+and the token while incomplete. Drop discards the vector and decrements only
+that token, so it cannot replenish, reinsert partial storage, clear unrelated
+markers, or create typed references. `assume_init` consumes the owner and is
+the only unsafe transition; one `Vec::from_raw_parts` preserves length and
+capacity. Constructor failure or panic leaves the owner armed and Drop runs
+exactly once; successful handoff disarms it.
+
+## RED / GREEN
+
+RED: added the lifecycle contract test
+`pooled_uninit_guard_discards_partial_reused_storage_without_replacement`.
+The focused test failed because the canonical owner, tracked token, and exact
+discard inspection surface were absent.
+
+GREEN: the focused lifecycle test passes. The guard now uses a non-Copy
+`UninitCheckoutToken`, preserves the original vector allocation through
+`ManuallyDrop`/`as_mut_ptr`, and keeps the token armed through typed-tensor
+construction. Error and unwind cleanup pass an empty vector when ownership has
+already moved, so the precise marker is still decremented exactly once.
+
+## Upstream mapping
+
+The owner is in `tenferro-internal-cpu-kernels`, adjacent to the pool because
+the pool owns typed retention and in-flight accounting. Its pre-completion
+surface is limited to `MaybeUninit` slices and byte/erased handoff helpers.
+
+## Rejected alternatives
+
+Unconditional zero-fill is rejected because it changes the full-overwrite
+performance contract. Pool-wide `clear_in_flight_retained` and replacement
+replenishment are rejected because they lose exact ownership. A second guard
+in `tenferro-cpu` is rejected because the contract requires one cross-crate
+owner. `ExecContext::ambient`, temporary pools, and scalar replacement loops
+are out of scope and prohibited.
+
+## Unsafe delta, performance, and final verification
+
+Sol's high audit recorded the unsafe-count reduction as `671 -> 666` overall,
+`71 -> 69` for internal kernels, and `103 -> 100` for CPU. The specialized
+same-shape multiply paths retain pinned `mul_into_uninit`; scalar/broadcast
+routing, SIMD/planner selection, wrapping integer dispatch, explicit contexts,
+and one-time fused input-pointer conversion remain intact.
+
+Final verification: internal unit tests **53 passed**, internal doctests **26
+passed**, CPU library tests **506 passed**, nightly Miri guard-filter tests
+**7 passed, 46 filtered**, and `git diff --check` passed. The source contract
+checks every production source file in the internal crate, with the pool
+definition's legacy public acquire path explicitly allowlisted. Internal
+clippy with `-D warnings` passed. The pre-amend candidate `060527f`, based on
+`origin/main` at `185d1256`, passed
+`scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test
+-p tenferro-internal-cpu-kernels
+internal_full_overwrite_sources_use_the_guard_boundary'`. Its committed-head
+repository-rules review also passed with no findings.
+
+Fresh checkout tests assert the allocator-returned `actual_capacity` but do
+not synthesize a C>len seam; deterministic C>len success, error, panic, and
+invalid-byte cases are covered for Reused storage.
+
+Earlier committed-head review findings on `4ab58773` and `f0bf6803` covered
+scanner-sensitive receipt naming, concrete error documentation, and missing
+adjacent SAFETY proofs; all were remediated. The reported `typed_map_with_pool`
+hidden-public finding was verified false against `origin/main` and left
+unchanged.
+
+The valid committed-head review on `f0bf6803` then blocked every new internal
+`out.assume_init` handoff lacking an adjacent proof. Each production handoff
+now states the successful map, zip, compare, select, clamp, multiplication,
+broadcast, outer-product, fused, fill, or materialization replay proof, and a
+source-contract test rejects future omissions within the preceding two lines.
+
+
+## #1516B deferrals
+
+The remaining `tenferro-cpu` typed pooled callers, including strided dot/einsum,
+structural and analytic helpers, are deliberately deferred. The legacy typed
+`PoolScalar::pool_acquire` and typed-uninitialized helper remain until #1516B.
+Only the duplicate indexing guard is canonicalized in this PR; unrelated
+tenferro-cpu/linalg callers are not migrated.
+
+## Ownership extraction follow-up
+
+The guard owner and `checked_compact_strides` now live in the private
+`pooled_uninit_output` module. The root crate keeps only the public re-export;
+`UninitCheckoutToken` and all pool accounting remain owned by `buffer_pool`.
+Guard-only coverage for `pooled_uninit_output.rs` is 94/96 lines (97.9%) after
+the state simplification. `data` is always owned by the guard and the optional
+checkout token is the sole completion/Drop state.
+The root `lib.rs` remains a mixed-responsibility file and is not used as the
+guard coverage target.
+
+The public re-export is intentional: `tenferro-cpu` is a workspace sibling
+and imports this canonical owner directly. Narrowing it to `pub(crate)` would
+break the cross-crate ownership contract and invite a duplicate guard. The
+pre-completion API exposes only `MaybeUninit`; typed ownership is transferred
+only by the explicit unsafe completion methods.


### PR DESCRIPTION
## Summary
- add a canonical `PooledUninitOutput` guard with exact fresh/reused capacity receipts and failure/panic cleanup
- migrate internal CPU full-overwrite kernels and the already-safe indexing users to the shared guard
- preserve specialized uninitialized elementwise paths, explicit execution contexts, and wrapping integer multiplication
- keep allocation failures typed by preserving `TryReserveError` as the backend source

## Verification
- `cargo test -p tenferro-internal-cpu-kernels` (53 unit tests, 26 doctests)
- `cargo test -p tenferro-cpu --features cpu-faer --lib` (506 tests)
- `cargo +nightly miri test -p tenferro-internal-cpu-kernels pooled_uninit_guard` (7 tests)
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-internal-cpu-kernels pooled_uninit_guard'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD` (pass, no findings)
- Sol low/high final review: no Critical, Important, or Minor findings

## Worklog
- `docs/worklogs/2026-07-30-issue-1516a-pooled-uninit-guard.md`

Refs #1516
Refs #1535