### PR TITLE
[CUDA] Route public copy_read_into through cuTENSOR

### DIFF
--- a/crates/tenferro-gpu/examples/cuda_quickstart.rs
+++ b/crates/tenferro-gpu/examples/cuda_quickstart.rs
@@ -1,5 +1,5 @@
 use tenferro_gpu::{download_tensor, upload_tensor, CudaBackend};
-use tenferro_tensor::{Tensor, TensorElementwise};
+use tenferro_tensor::{Tensor, TensorElementwise, TensorRead, TensorStructural, TensorWrite};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !tenferro_gpu::gpu_available() {
@@ -16,5 +16,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cpu_c = download_tensor(backend.runtime(), &gpu_c)?;
 
     assert_eq!(cpu_c.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+
+    let mut gpu_reuse = upload_tensor(backend.runtime(), &cpu_c)?;
+    backend.copy_read_into(
+        TensorRead::from_tensor(&gpu_c),
+        TensorWrite::from_tensor(&mut gpu_reuse),
+    )?;
+    let copied = download_tensor(backend.runtime(), &gpu_reuse)?;
+    assert_eq!(copied.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
     Ok(())
 }

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -1250,6 +1250,22 @@ impl CudaBackend {
         Ok(())
     }
 
+    fn copy_view_to_view_cutensor_or_cubecl<T, R>(
+        &self,
+        src: &TypedTensorView<'_, T, R>,
+        dst: &mut TypedTensorViewMut<'_, T, R>,
+        op: &'static str,
+    ) -> crate::Result<()>
+    where
+        T: permutation::CutensorPermutationScalar,
+        R: TensorRank,
+    {
+        if dst.strides().iter().any(|&stride| stride < 0) {
+            return self.copy_view_to_view_typed(src, dst, op);
+        }
+        permutation::copy_view_into(self, src, dst, op)
+    }
+
     fn convert_float_to_float<In, Out>(
         &self,
         input: &TypedTensor<In>,
@@ -4510,7 +4526,7 @@ impl TensorStructural for CudaBackend {
     fn copy_read_into(&mut self, src: TensorRead<'_>, dst: TensorWrite<'_>) -> crate::Result<()> {
         let src_dtype = src.dtype();
         let dst_dtype = dst.dtype();
-        macro_rules! copy_source {
+        macro_rules! copy_source_typed {
             ($variant:ident, $src:expr) => {{
                 let src = $src;
                 match dst {
@@ -4521,6 +4537,32 @@ impl TensorStructural for CudaBackend {
                     TensorWrite::View(TensorViewMut::$variant(mut dst)) => {
                         self.copy_view_to_view_typed(&src, &mut dst, "CudaBackend::copy_read_into")
                     }
+                    _ => Err(crate::Error::dtype_mismatch(
+                        "CudaBackend::copy_read_into",
+                        src_dtype,
+                        dst_dtype,
+                    )),
+                }
+            }};
+        }
+        macro_rules! copy_source_cutensor {
+            ($variant:ident, $src:expr) => {{
+                let src = $src;
+                match dst {
+                    TensorWrite::Tensor(Tensor::$variant(dst)) => {
+                        let mut dst = dst.as_view_mut();
+                        self.copy_view_to_view_cutensor_or_cubecl(
+                            &src,
+                            &mut dst,
+                            "CudaBackend::copy_read_into",
+                        )
+                    }
+                    TensorWrite::View(TensorViewMut::$variant(mut dst)) => self
+                        .copy_view_to_view_cutensor_or_cubecl(
+                            &src,
+                            &mut dst,
+                            "CudaBackend::copy_read_into",
+                        ),
                     _ => Err(crate::Error::dtype_mismatch(
                         "CudaBackend::copy_read_into",
                         src_dtype,
@@ -4547,20 +4589,20 @@ impl TensorStructural for CudaBackend {
         }
 
         match src {
-            TensorRead::Tensor(Tensor::F32(src)) => copy_source!(F32, src.as_view()),
-            TensorRead::Tensor(Tensor::F64(src)) => copy_source!(F64, src.as_view()),
-            TensorRead::Tensor(Tensor::I32(src)) => copy_source!(I32, src.as_view()),
-            TensorRead::Tensor(Tensor::I64(src)) => copy_source!(I64, src.as_view()),
+            TensorRead::Tensor(Tensor::F32(src)) => copy_source_cutensor!(F32, src.as_view()),
+            TensorRead::Tensor(Tensor::F64(src)) => copy_source_cutensor!(F64, src.as_view()),
+            TensorRead::Tensor(Tensor::I32(src)) => copy_source_typed!(I32, src.as_view()),
+            TensorRead::Tensor(Tensor::I64(src)) => copy_source_typed!(I64, src.as_view()),
             TensorRead::Tensor(Tensor::Bool(_)) => reject_bool_source!(),
-            TensorRead::Tensor(Tensor::C32(src)) => copy_source!(C32, src.as_view()),
-            TensorRead::Tensor(Tensor::C64(src)) => copy_source!(C64, src.as_view()),
-            TensorRead::View(TensorView::F32(src)) => copy_source!(F32, src),
-            TensorRead::View(TensorView::F64(src)) => copy_source!(F64, src),
-            TensorRead::View(TensorView::I32(src)) => copy_source!(I32, src),
-            TensorRead::View(TensorView::I64(src)) => copy_source!(I64, src),
+            TensorRead::Tensor(Tensor::C32(src)) => copy_source_cutensor!(C32, src.as_view()),
+            TensorRead::Tensor(Tensor::C64(src)) => copy_source_cutensor!(C64, src.as_view()),
+            TensorRead::View(TensorView::F32(src)) => copy_source_cutensor!(F32, src),
+            TensorRead::View(TensorView::F64(src)) => copy_source_cutensor!(F64, src),
+            TensorRead::View(TensorView::I32(src)) => copy_source_typed!(I32, src),
+            TensorRead::View(TensorView::I64(src)) => copy_source_typed!(I64, src),
             TensorRead::View(TensorView::Bool(_)) => reject_bool_source!(),
-            TensorRead::View(TensorView::C32(src)) => copy_source!(C32, src),
-            TensorRead::View(TensorView::C64(src)) => copy_source!(C64, src),
+            TensorRead::View(TensorView::C32(src)) => copy_source_cutensor!(C32, src),
+            TensorRead::View(TensorView::C64(src)) => copy_source_cutensor!(C64, src),
         }
     }
 

--- a/crates/tenferro-gpu/src/cubecl/permutation.rs
+++ b/crates/tenferro-gpu/src/cubecl/permutation.rs
@@ -6,10 +6,11 @@ use std::sync::{Arc, Mutex};
 use cubecl::prelude::{CubeElement, CubePrimitive};
 use num_complex::{Complex32, Complex64};
 use num_traits::One;
-use tenferro_tensor::{CacheStats, DType, TensorRank, TypedTensorView};
+use tenferro_tensor::{CacheStats, DType, TensorRank, TypedTensorView, TypedTensorViewMut};
 
 use super::dispatch::{
-    cubecl_buffer, cubecl_view_buffer, ensure_resident_on_runtime, ensure_view_resident_on_runtime,
+    cubecl_buffer, cubecl_view_buffer, cubecl_view_mut_buffer, ensure_resident_on_runtime,
+    ensure_view_mut_resident_on_runtime, ensure_view_resident_on_runtime,
 };
 use super::ffi::cutensor::{
     CudaDataType, CutensorComputeDescriptor, CutensorCudaStream, CutensorHandle, CutensorOperator,
@@ -395,6 +396,157 @@ where
     Ok(output)
 }
 
+/// Copy a compact source view into a caller-owned CUDA destination view using
+/// the same cached cuTENSOR permutation plan as allocating materialization.
+///
+/// The caller selects this path only for layouts supported by cuTENSOR. This
+/// function deliberately does not fall back when cuTENSOR loading or plan
+/// creation fails: supported CUDA permutation paths require the NVIDIA
+/// library stack.
+pub(super) fn copy_view_into<T, R>(
+    backend: &CudaBackend,
+    src: &TypedTensorView<'_, T, R>,
+    dst: &mut TypedTensorViewMut<'_, T, R>,
+    op: &'static str,
+) -> crate::Result<()>
+where
+    T: CutensorPermutationScalar,
+    R: TensorRank,
+{
+    ensure_view_resident_on_runtime(backend.runtime(), src, op)?;
+    ensure_view_mut_resident_on_runtime(backend.runtime(), dst, op)?;
+    if src.shape() != dst.shape() {
+        return Err(crate::Error::shape_mismatch(
+            op,
+            src.shape().to_vec(),
+            dst.shape().to_vec(),
+        ));
+    }
+    let source_storage = src
+        .backend_buffer()
+        .ok_or_else(|| Error::runtime_state(op, "expected a CUDA source view"))?;
+    let destination_storage = dst
+        .backend_buffer()
+        .ok_or_else(|| Error::runtime_state(op, "expected a CUDA destination view"))?;
+    if std::sync::Arc::ptr_eq(source_storage, destination_storage) {
+        return Err(crate::Error::invalid_argument(
+            op,
+            "source/destination",
+            "CUDA copy_into source and destination allocations must not alias",
+        ));
+    }
+    let source_buffer = cubecl_view_buffer(src, op)?;
+    let destination_buffer = cubecl_view_mut_buffer(dst, op)?;
+    if !src.is_col_major_contiguous()?
+        || src.offset() != 0
+        || source_buffer.element_len() != src.n_elements()
+    {
+        return Err(crate::Error::invalid_argument(
+            op,
+            "source",
+            "CUDA copy_into requires a compact source view covering its full allocation; arbitrary-stride source views are unsupported without explicit canonicalization",
+        ));
+    }
+    if dst.n_elements() == 0 {
+        return Ok(());
+    }
+
+    backend.runtime().set_current_cuda_context(op)?;
+    let input_extents = dims_to_i64(op, src.shape())?;
+    let input_strides = compact_strides_i64(op, src.shape())?;
+    let modes = identity_modes(op, src.shape().len())?;
+    // Describe the destination in physical stride order. This is equivalent
+    // to the logical-order view descriptor, but lets cuTENSOR see the same
+    // permutation layout as the direct destination-reuse control. In
+    // particular, a transposed 2D view becomes extents/strides `[n, m]` /
+    // `[1, n]` with modes `[1, 0]`, instead of an identity-mode descriptor
+    // with swapped strides that may select a slower plan.
+    let (output_extents, output_strides, output_modes) =
+        physical_output_descriptor(op, dst.shape(), dst.strides())?;
+    let input_res = resolve_device_region(
+        backend.runtime(),
+        source_buffer,
+        src.shape(),
+        src.strides(),
+        src.offset(),
+        op,
+    )?;
+    let output_res = resolve_device_region(
+        backend.runtime(),
+        destination_buffer,
+        dst.shape(),
+        dst.strides(),
+        dst.offset(),
+        op,
+    )?;
+    let input_alignment_requirement = input_res.alignment;
+    let output_alignment_requirement = output_res.alignment;
+    execute_permutation::<T>(
+        backend,
+        input_res,
+        output_res,
+        CutensorPermutationSpec {
+            input_extents: &input_extents,
+            input_strides: &input_strides,
+            input_modes: &modes,
+            output_extents: &output_extents,
+            output_strides: &output_strides,
+            output_modes: &output_modes,
+            // Use the resolved pointer alignment rather than the scalar size.
+            // The destination-reuse benchmark passes whole allocations with
+            // 256-byte alignment, and cuTENSOR may choose a materially
+            // different kernel when the descriptor advertises only 8-byte
+            // alignment for f64. The resolved values are also the alignment
+            // that the actual pointers can satisfy.
+            input_alignment_requirement,
+            output_alignment_requirement,
+            input_op: CutensorOperator::Identity,
+        },
+        op,
+    )
+}
+
+fn physical_output_descriptor(
+    op: &'static str,
+    shape: &[usize],
+    strides: &[isize],
+) -> crate::Result<(Vec<i64>, Vec<i64>, Vec<i32>)> {
+    if shape.len() != strides.len() {
+        return Err(Error::invalid_argument(
+            op,
+            "layout",
+            "destination shape and stride ranks must match",
+        ));
+    }
+    if strides.iter().any(|&stride| stride < 0) {
+        return Err(Error::invalid_argument(
+            op,
+            "layout",
+            "cuTENSOR destination descriptors do not support negative strides",
+        ));
+    }
+    let mut axes: Vec<usize> = (0..shape.len()).collect();
+    axes.sort_by_key(|&axis| (strides[axis], axis));
+    let extents = axes
+        .iter()
+        .map(|&axis| i64::try_from(shape[axis]))
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|_| Error::invalid_argument(op, "shape", "dimension exceeds i64 extent limit"))?;
+    let sorted_strides = axes
+        .iter()
+        .map(|&axis| i64::try_from(strides[axis]))
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|_| Error::invalid_argument(op, "layout", "stride exceeds i64 limit"))?;
+    let modes = axes
+        .iter()
+        .map(|&axis| {
+            i32::try_from(axis)
+                .map_err(|_| Error::invalid_argument(op, "rank", "rank exceeds i32 mode limit"))
+        })
+        .collect::<crate::Result<Vec<_>>>()?;
+    Ok((extents, sorted_strides, modes))
+}
+
 fn execute_permutation<T>(
     backend: &CudaBackend,
     input_res: ResolvedPermutationOperand,
@@ -753,4 +905,33 @@ fn address_alignment(addr: u64) -> u32 {
         return CUDA_ALLOCATION_ALIGNMENT;
     }
     1u32 << addr.trailing_zeros().min(8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::physical_output_descriptor;
+
+    #[test]
+    fn physical_output_descriptor_matches_transposed_destination() {
+        let (extents, strides, modes) =
+            physical_output_descriptor("test", &[4, 3], &[3, 1]).unwrap();
+        assert_eq!(extents, [3, 4]);
+        assert_eq!(strides, [1, 3]);
+        assert_eq!(modes, [1, 0]);
+    }
+
+    #[test]
+    fn physical_output_descriptor_preserves_identity_layout() {
+        let (extents, strides, modes) =
+            physical_output_descriptor("test", &[4, 3], &[1, 4]).unwrap();
+        assert_eq!(extents, [4, 3]);
+        assert_eq!(strides, [1, 4]);
+        assert_eq!(modes, [0, 1]);
+    }
+
+    #[test]
+    fn physical_output_descriptor_rejects_negative_strides() {
+        let err = physical_output_descriptor("test", &[4], &[-1]).unwrap_err();
+        assert!(err.to_string().contains("negative strides"));
+    }
 }

--- a/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
@@ -835,8 +835,17 @@ fn cuda_runtime_copy_into_cutensor_rejects_aliased_destination() {
 }
 
 #[test]
-#[ignore = "requires CUDA 12.8+ GPU and approximately 8 GiB of device storage"]
+#[ignore = "requires CUDA 12.8+ GPU with a max single allocation above 4 GiB"]
 fn cuda_runtime_copy_into_1522_a100_destination_reuse_benchmark() {
+    const MIN_MAX_PAGE_SIZE: u64 = 4 * 1024 * 1024 * 1024;
+
+    let mut gpu = gpu_backend();
+    let max_page_size = gpu.runtime().client().properties().memory.max_page_size;
+    if max_page_size <= MIN_MAX_PAGE_SIZE {
+        eprintln!("skipping #1522 A100 benchmark: max single allocation is {max_page_size} bytes");
+        return;
+    }
+
     fn measure(
         gpu: &mut CudaBackend,
         source: &Tensor,
@@ -866,7 +875,6 @@ fn cuda_runtime_copy_into_1522_a100_destination_reuse_benchmark() {
         samples
     }
 
-    let mut gpu = gpu_backend();
     let source_2d = upload(
         &gpu,
         &tensor_f64(vec![32_768, 16_384], vec![0.0; 32_768 * 16_384]),

--- a/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
@@ -1,4 +1,7 @@
 // Run with: cargo test --features cuda -- --ignored
+use std::hint::black_box;
+use std::time::Instant;
+
 use crate::{DType, DeviceId, DeviceKind, Error, MemoryKind, Placement, Tensor, TypedTensor};
 use num_complex::{Complex32, Complex64};
 use tenferro_tensor::{
@@ -6,6 +9,7 @@ use tenferro_tensor::{
     TensorView, TensorViewCanonicalization, TensorViewMut, TensorWrite,
 };
 
+use super::super::CudaBackend;
 use super::{
     assert_cuda_unsupported_dtype, assert_error_parity, assert_runtime_state,
     assert_shape_mismatch, assert_tensor_close, assert_validation_kind, cpu_backend, download,
@@ -703,6 +707,188 @@ fn cuda_runtime_copy_is_object_safe_and_updates_strided_destination() {
 
     let actual = download(&gpu, &gpu_dst);
     assert_eq!(actual.as_slice::<i32>().unwrap(), &[1, 3, 2, 4]);
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_runtime_copy_into_cutensor_matches_destination_reuse_and_survives_source_mutation() {
+    let mut gpu = gpu_backend();
+    let mut gpu_src = upload(
+        &gpu,
+        &tensor_f64(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+    );
+    let mut gpu_dst = upload(&gpu, &tensor_f64(vec![2, 3], vec![0.0; 6]));
+    let replacement = upload(&gpu, &tensor_f64(vec![3, 2], vec![9.0; 6]));
+
+    let Tensor::F64(dst) = &mut gpu_dst else {
+        panic!("expected f64 destination");
+    };
+    let dst_view = dst.as_view_mut().transpose_view([1, 0]).unwrap();
+    gpu.copy_read_into(
+        TensorRead::from_tensor(&gpu_src),
+        TensorWrite::from_view(TensorViewMut::F64(dst_view)),
+    )
+    .unwrap();
+
+    let actual = download(&gpu, &gpu_dst);
+    assert_eq!(
+        actual.as_slice::<f64>().unwrap(),
+        &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
+    );
+
+    let Tensor::F64(replacement) = &replacement else {
+        panic!("expected f64 replacement");
+    };
+    let Tensor::F64(src_mut) = &mut gpu_src else {
+        panic!("expected mutable f64 source");
+    };
+    gpu.copy_into(&replacement.as_view(), &mut src_mut.as_view_mut())
+        .unwrap();
+
+    let after_source_mutation = download(&gpu, &gpu_dst);
+    assert_eq!(
+        after_source_mutation.as_slice::<f64>().unwrap(),
+        &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
+    );
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_runtime_copy_into_cutensor_matches_complex_destination_reuse() {
+    let mut gpu = gpu_backend();
+    let gpu_src = upload(
+        &gpu,
+        &tensor_c32(
+            vec![2, 2, 2],
+            vec![
+                Complex32::new(1.0, 2.0),
+                Complex32::new(3.0, 4.0),
+                Complex32::new(5.0, 6.0),
+                Complex32::new(7.0, 8.0),
+                Complex32::new(9.0, 10.0),
+                Complex32::new(11.0, 12.0),
+                Complex32::new(13.0, 14.0),
+                Complex32::new(15.0, 16.0),
+            ],
+        ),
+    );
+    let mut gpu_dst = upload(
+        &gpu,
+        &tensor_c32(vec![2, 2, 2], vec![Complex32::new(0.0, 0.0); 8]),
+    );
+    let Tensor::C32(dst) = &mut gpu_dst else {
+        panic!("expected complex destination");
+    };
+    let dst_view = dst.as_view_mut().transpose_view([1, 0, 2]).unwrap();
+    gpu.copy_read_into(
+        TensorRead::from_tensor(&gpu_src),
+        TensorWrite::from_view(TensorViewMut::C32(dst_view)),
+    )
+    .unwrap();
+
+    let actual = download(&gpu, &gpu_dst);
+    assert_eq!(
+        actual.as_slice::<Complex32>().unwrap(),
+        &[
+            Complex32::new(1.0, 2.0),
+            Complex32::new(5.0, 6.0),
+            Complex32::new(3.0, 4.0),
+            Complex32::new(7.0, 8.0),
+            Complex32::new(9.0, 10.0),
+            Complex32::new(13.0, 14.0),
+            Complex32::new(11.0, 12.0),
+            Complex32::new(15.0, 16.0),
+        ]
+    );
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_runtime_copy_into_cutensor_rejects_aliased_destination() {
+    let mut gpu = gpu_backend();
+    let gpu_tensor = upload(&gpu, &tensor_f64(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
+    let Tensor::F64(src) = &gpu_tensor else {
+        panic!("expected f64 source");
+    };
+    let mut dst = src.clone();
+    let dst_view = dst.as_view_mut().transpose_view([1, 0]).unwrap();
+
+    let err = gpu
+        .copy_read_into(
+            TensorRead::from_tensor(&gpu_tensor),
+            TensorWrite::from_view(TensorViewMut::F64(dst_view)),
+        )
+        .unwrap_err();
+
+    assert_validation_kind(
+        &err,
+        "CudaBackend::copy_read_into",
+        ValidationKind::InvalidArgument,
+    );
+    assert!(matches!(
+        err,
+        Error::Validation {
+            source: ValidationError::InvalidArgument { argument: "source/destination", message },
+            ..
+        } if message.contains("alias")
+    ));
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU and approximately 8 GiB of device storage"]
+fn cuda_runtime_copy_into_1522_a100_destination_reuse_benchmark() {
+    fn measure(
+        gpu: &mut CudaBackend,
+        source: &Tensor,
+        destination: &mut Tensor,
+        permutation: &[usize],
+    ) -> Vec<f64> {
+        let mut run = || {
+            let Tensor::F64(dst) = destination else {
+                panic!("expected f64 destination");
+            };
+            let view = dst.as_view_mut().transpose_view(permutation).unwrap();
+            let start = Instant::now();
+            let result = gpu.copy_read_into(
+                TensorRead::from_tensor(black_box(source)),
+                TensorWrite::from_view(TensorViewMut::F64(view)),
+            );
+            black_box(result).unwrap();
+            gpu.runtime().synchronize().unwrap();
+            start.elapsed().as_secs_f64() * 1e3
+        };
+
+        for _ in 0..3 {
+            black_box(run());
+        }
+        let mut samples: Vec<f64> = (0..7).map(|_| run()).collect();
+        samples.sort_by(f64::total_cmp);
+        samples
+    }
+
+    let mut gpu = gpu_backend();
+    let source_2d = upload(
+        &gpu,
+        &tensor_f64(vec![32_768, 16_384], vec![0.0; 32_768 * 16_384]),
+    );
+    let mut destination_2d = upload(
+        &gpu,
+        &tensor_f64(vec![16_384, 32_768], vec![0.0; 32_768 * 16_384]),
+    );
+    let samples_2d = measure(&mut gpu, &source_2d, &mut destination_2d, &[1, 0]);
+
+    let source_3d = upload(
+        &gpu,
+        &tensor_f64(vec![1024, 1024, 512], vec![0.0; 1024 * 1024 * 512]),
+    );
+    let mut destination_3d = upload(
+        &gpu,
+        &tensor_f64(vec![512, 1024, 1024], vec![0.0; 1024 * 1024 * 512]),
+    );
+    let samples_3d = measure(&mut gpu, &source_3d, &mut destination_3d, &[1, 2, 0]);
+
+    println!("#1522 A100 2D sorted samples (ms): {samples_2d:?}");
+    println!("#1522 A100 3D sorted samples (ms): {samples_3d:?}");
 }
 
 #[test]

--- a/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
@@ -1628,8 +1628,9 @@ fn cuda_float_permutation_routes_through_cutensor_and_policy_is_recorded() {
     );
     assert!(
         cuda.contains("permutation::transpose(self, t, perm)")
-            && cuda.contains("permutation::to_contiguous_view("),
-        "CUDA f32/f64/c32/c64 structural permutation paths should route through cuTENSOR"
+            && cuda.contains("permutation::to_contiguous_view(")
+            && cuda.contains("permutation::copy_view_into(self, src, dst, op)"),
+        "CUDA f32/f64/c32/c64 structural permutation and copy paths should route through cuTENSOR"
     );
     for dtype in ["Tensor::F32", "Tensor::F64", "Tensor::C32", "Tensor::C64"] {
         assert!(

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -73,7 +73,7 @@ For a time-axis diagram, see [Execution Models](execution-models.md).
 <!-- snippet-source: crates/tenferro-gpu/examples/cuda_quickstart.rs -->
 ```rust
 use tenferro_gpu::{download_tensor, upload_tensor, CudaBackend};
-use tenferro_tensor::{Tensor, TensorElementwise};
+use tenferro_tensor::{Tensor, TensorElementwise, TensorRead, TensorStructural, TensorWrite};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !tenferro_gpu::gpu_available() {
@@ -90,6 +90,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cpu_c = download_tensor(backend.runtime(), &gpu_c)?;
 
     assert_eq!(cpu_c.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+
+    let mut gpu_reuse = upload_tensor(backend.runtime(), &cpu_c)?;
+    backend.copy_read_into(
+        TensorRead::from_tensor(&gpu_c),
+        TensorWrite::from_tensor(&mut gpu_reuse),
+    )?;
+    let copied = download_tensor(backend.runtime(), &gpu_reuse)?;
+    assert_eq!(copied.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
     Ok(())
 }
 ```

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -110,6 +110,12 @@ LD_LIBRARY_PATH=$CUDA_PATH/lib64:$LD_LIBRARY_PATH \
 ```
 
 The example downloads the result back to CPU and asserts the expected values.
+`TensorStructural::copy_read_into` can reuse an already allocated CUDA
+destination; for supported floating and complex permutation layouts it uses
+the backend-owned cuTENSOR permutation plan cache. The source and destination
+must be distinct allocations. CUDA does not silently fall back when the
+required NVIDIA library stack is unavailable; the operation returns a typed
+library/provider error instead.
 CUDA 12.4 is the minimum supported driver/NVRTC runtime. CUDA 12.8 or newer
 enables all CubeCL features supported by the GPU, including the 12.8 tensor-map
 extensions. tenferro compiles against CUDA 12.8 cudarc bindings, but resolves

--- a/docs/worklogs/2026-07-31-issue-1522-cuda-copy-into.md
+++ b/docs/worklogs/2026-07-31-issue-1522-cuda-copy-into.md
@@ -1,0 +1,89 @@
+# 2026-07-31 CUDA `copy_read_into` destination reuse (#1522)
+
+## Scope
+
+The public caller-owned-destination CUDA `copy_read_into` path now shares the
+existing cuTENSOR permutation executor and `CudaBackend`-owned permutation plan
+cache when the source is compact column-major and the destination is a valid
+nonnegative-stride view of a supported `F32`, `F64`, `C32`, or `C64` allocation.
+No new cache or pointer-global state was added.
+
+Integer and Bool copies continue to use the existing CubeCL path. Negative
+destination strides also continue to use that path because cuTENSOR 2.x does
+not accept negative-stride descriptors. This is a layout capability boundary,
+not a missing-library fallback. For supported cuTENSOR layouts, loader and plan
+errors remain typed errors and are never silently routed to CubeCL.
+
+The cuTENSOR path repeats the existing public contract checks: equal shape,
+device residency, distinct source/destination allocations, compact full-source
+coverage, and valid destination reachable range. Destination view construction
+continues to enforce internal non-overlap.
+
+## Tests
+
+- f64 2D destination reuse matches the expected column-major permutation.
+- C32 3D destination reuse matches the expected column-major permutation.
+- Mutating the source after `copy_read_into` leaves the caller-owned
+  destination unchanged.
+- Existing aliasing, noncompact-source, dtype, and typed cuTENSOR-loader tests
+  remain in place.
+
+Focused A100 command:
+
+```bash
+CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda \
+LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} \
+CUDA_VISIBLE_DEVICES=0 CARGO_BUILD_JOBS=64 \
+cargo test -p tenferro-gpu --features cuda \
+  cubecl::tests::structural_tests::cuda_runtime_copy_into_cutensor \
+  -- --ignored --nocapture
+```
+
+The focused f64/C32 differential and mutation tests passed on an NVIDIA A100
+80GB PCIe.
+
+## A100 measurement
+
+Machine: NVIDIA A100 80GB PCIe, CUDA device 0. The focused runner used three
+warmups and seven timed calls per row, with `CudaBackend::copy_read_into`
+followed immediately by `backend.runtime().synchronize()` in every timed call.
+The source and destination were allocated once outside the timed region.
+
+| row | origin/main public path | this worktree public path | raw cuTENSOR control from #1522 | new/raw |
+| --- | ---: | ---: | ---: | ---: |
+| 2D `[32768,16384]`, transpose | 25.893 ms | 5.593 ms | 5.403 ms | 1.035x |
+| 3D `[1024,1024,512]`, `[1,2,0]` | 84.692 ms | 5.577 ms | 5.340 ms | 1.044x |
+
+The origin/main values and this-worktree values were collected with the same
+fixture, three warmups, seven timed calls, and host synchronization after each
+call. The raw cuTENSOR values are the exact controls recorded by accepted issue
+#1522 under the same fixture and destination-reuse protocol. Both rows are
+within the 20% target.
+
+The first public-path run was 6.598 ms for 2D because the descriptor advertised
+only the scalar-size alignment (`8` for f64), producing a different cuTENSOR
+plan from the raw 256-byte-aligned control. The path now resolves the actual
+device-region pointer alignment and includes it in the existing cache key. The
+follow-up A100 run selected the aligned plan and reduced 2D to 5.593 ms and 3D
+to 5.577 ms; both rows are within the 20% raw-control target. Nsight Systems
+also showed that the steady-state public host-side lookup/validation is only
+about 0.1--0.25 ms, while the cuTENSOR kernel is about 6 ms, so the original
+gap was primarily plan/kernel selection rather than an unbounded public API
+overhead.
+
+The worktree's final A100 samples were 2D `[5.5621, 5.5738, 5.5894, 5.5928,
+5.6038, 5.6145, 5.6221]` ms and 3D `[5.4205, 5.4265, 5.5678, 5.5774,
+5.5893, 5.5906, 5.6091]` ms. The medians above are used for the gate.
+
+This focused test does not expose a CPU thread-count dimension: CUDA work is
+submitted to the backend stream and synchronized at the host boundary. The
+public API benchmark harness currently has no `copy_read_into` 2D/3D rows, so
+the required threads-1/threads-4 CPU publication gate is not applicable to this
+CUDA-only issue; no such result is being inferred here.
+
+## Public usage
+
+The CUDA quickstart example exercises `TensorStructural::copy_read_into` with
+an already allocated destination. CUDA requires the NVIDIA library stack for
+cuTENSOR-supported layouts and reports typed provider/load errors when it is
+not available.


### PR DESCRIPTION
## Summary

- route compatible CUDA `copy_read_into` F32/F64/C32/C64 paths through the existing runtime-owned cuTENSOR permutation executor and cache
- preserve typed NVIDIA-library errors, destination alias checks, negative-stride CubeCL capability boundary, and mutation-after-handoff coverage
- align cuTENSOR descriptors with physical destination stride order and resolved device-pointer alignment
- add ignored A100 destination-reuse benchmark and update GPU usage documentation

Closes #1522

## A100 evidence

NVIDIA A100 80GB PCIe, three warmups and seven synchronized timed calls, allocations outside the timed region:

| row | origin/main | candidate | raw cuTENSOR | candidate/raw |
| --- | ---: | ---: | ---: | ---: |
| 2D `[32768,16384]`, transpose | 25.893 ms | 5.593 ms | 5.403 ms | 1.035x |
| 3D `[1024,1024,512]`, `[1,2,0]` | 84.692 ms | 5.577 ms | 5.340 ms | 1.044x |

The candidate is within the issue's 20% raw-control gate for both rows. The initial 2D gap was caused by an alignment-dependent cuTENSOR plan choice; using resolved pointer alignment selects the aligned plan.

## Verification

- `bash scripts/check-pr-fast.sh --no-fetch --coverage-reviewed --skip-doc-snippets --test 'cargo test -p tenferro-gpu --features cuda --lib physical_output_descriptor' --test 'cargo test -p tenferro-gpu --features cuda --test integration'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1522.json`
- focused ignored CUDA differential/mutation/alias tests
- focused ignored A100 benchmark
