### PR TITLE
fix(linalg): restore column-major real eig pairs

### DIFF
--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -552,6 +552,8 @@ macro_rules! impl_real_eig_to_complex_outputs {
                     s.push(<$complex>::new(s_re[j], -s_im[j]));
                     for i in 0..n {
                         u.push(<$complex>::new(u_real[(i, j)], u_real[(i, j + 1)]));
+                    }
+                    for i in 0..n {
                         u.push(<$complex>::new(u_real[(i, j)], -u_real[(i, j + 1)]));
                     }
                     j += 2;

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -745,6 +745,62 @@ fn eig_read_returns_correct_outputs_for_diagonal_matrix() {
     assert_eq!(outputs[1].shape(), &[2, 2]);
 }
 
+macro_rules! real_rotation_eig_residual_test {
+    ($name:ident, $real:ty, $real_variant:ident, $get_complex:ident, $tol:expr) => {
+        #[test]
+        fn $name() {
+            let input = Tensor::$real_variant(
+                TypedTensor::<$real>::from_vec_col_major(
+                    vec![2, 2],
+                    vec![0.0 as $real, 1.0 as $real, -1.0 as $real, 0.0 as $real],
+                )
+                .unwrap(),
+            );
+
+            for kind in compiled_linalg_provider_kinds() {
+                let mut backend = CpuBackend::with_threads_and_kind(1, kind).unwrap();
+                let outputs = backend.eig(&input).unwrap();
+                let mut residual_squared = 0.0_f64;
+                let mut vector_squared = 0.0_f64;
+                let mut diagonal_squared = 0.0_f64;
+                for column in 0..2 {
+                    let v0 = $get_complex(&outputs[1], &[0, column]);
+                    let v1 = $get_complex(&outputs[1], &[1, column]);
+                    let lambda = $get_complex(&outputs[0], &[column]);
+                    residual_squared +=
+                        ((-v1 - v0 * lambda).norm_sqr() + (v0 - v1 * lambda).norm_sqr()) as f64;
+                    vector_squared += (v0.norm_sqr() + v1.norm_sqr()) as f64;
+                    diagonal_squared += lambda.norm_sqr() as f64;
+                }
+                let vector_norm = vector_squared.sqrt();
+                let relative_residual = residual_squared.sqrt()
+                    / (2.0_f64.sqrt() * vector_norm + vector_norm * diagonal_squared.sqrt());
+
+                assert!(
+                    relative_residual.is_finite() && relative_residual <= $tol,
+                    "{kind:?} relative AV-VD residual {relative_residual:e} exceeds {}",
+                    $tol
+                );
+            }
+        }
+    };
+}
+
+real_rotation_eig_residual_test!(
+    real_f32_rotation_eig_has_column_major_eigenvectors,
+    f32,
+    F32,
+    get_c32,
+    1.0e-6
+);
+real_rotation_eig_residual_test!(
+    real_f64_rotation_eig_has_column_major_eigenvectors,
+    f64,
+    F64,
+    get_c64,
+    1.0e-14
+);
+
 #[test]
 fn cholesky_read_accepts_all_supported_linalg_view_dtypes() {
     let mut backend = CpuBackend::new();

--- a/docs/worklogs/2026-07-31-issue-1548-faer-real-eig.md
+++ b/docs/worklogs/2026-07-31-issue-1548-faer-real-eig.md
@@ -1,0 +1,66 @@
+# 2026-07-31 Faer real eigendecomposition layout fix (#1548)
+
+## Session summary
+
+The Faer real-input `eig` conversion now appends each conjugate eigenvector as
+a complete column. Commit `cb388a8` had changed the previous indexed
+column-major writes into alternating `push` calls, which interleaved the two
+columns by row and broke the returned `A V = V D` relation.
+
+## Context read
+
+- `AGENTS.md`, `REPOSITORY_RULES.md`, `CONTRIBUTING.md`
+- `ai/contribution-workflows/bugfix-pr.md`
+- `ai/contribution-workflows/repository-remediation.md`
+- Current shared repository, performance, documentation/test, and Rust
+  numerical rules
+
+## Reference code consulted
+
+- The parent of `cb388a8`, where the two conjugate vectors were written through
+  `u[i + j * n]` and `u[i + (j + 1) * n]`
+- The LAPACK real-eigenvalue conversion, which still writes complete
+  column-major conjugate-pair columns
+- The Faer and LAPACK values-only paths; neither constructs eigenvectors and
+  neither needs a corresponding change
+
+## Decision
+
+Keep the pooled append-only initialization introduced by `cb388a8`, but use
+one loop for column `j` and a second loop for column `j + 1`. This is the
+smallest change that preserves both the initialized-length contract and the
+public column-major tensor layout.
+
+## Rejected alternatives
+
+- Restoring indexed writes would conflict with the current pooled buffer
+  initialization contract.
+- Transposing or repairing the tensor after construction would add unnecessary
+  work and would hide the incorrect write order.
+- Changing the values-only or LAPACK paths was rejected because their existing
+  ordering is already correct.
+
+## Verification
+
+Public `CpuBackend::eig` regression tests use the real rotation
+`A = [[0, -1], [1, 0]]` for both `f32` and `f64` and every compiled CPU linear
+algebra provider. They assert a finite relative residual for `A V - V D`. With
+the interleaved Faer ordering restored temporarily, both Faer tests fail with
+residual `5e-1`; with the fix, both residuals are exactly `0`. The same tests
+also preserve Faer/BLAS provider parity when both providers are compiled.
+
+```text
+cargo test -p tenferro-linalg rotation_eig -- --nocapture
+2 passed; f32 residual 0e0; f64 residual 0e0
+cargo test -p tenferro-linalg --lib
+118 passed
+cargo fmt --all --check
+passed
+```
+
+## Remaining risks
+
+The regression covers the minimal two-dimensional conjugate pair directly.
+Larger mixed real/conjugate spectra are not covered by a runnable regression
+test and remain a residual risk. Add that matrix family if this minimal case
+fails to protect later layout changes.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1548

## Summary

Restore column-major eigenvector output for real-input Faer `eig` when a
complex-conjugate eigenpair is returned. The MaybeUninit migration appended
each row's `v` and `conj(v)` entries together, but the returned `[n, n]` tensor
is column-major. This change appends the complete `v` column followed by the
complete conjugate column.

The public `CpuBackend::eig` regression tests exercise both `f32` and `f64`
with `A = [[0, -1], [1, 0]]` for every compiled CPU linear-algebra provider
and check the relative residual of `A V - V D`. The regressed Faer ordering
gives residual `0.5`; the corrected ordering gives `0`. The BLAS/LAPACK path
already writes the two eigenvector columns by column-major index and is covered
by the same test when `cpu-blas` is enabled.

## Work log

[Issue #1548 Faer real EIG column layout](docs/worklogs/2026-07-31-issue-1548-faer-real-eig.md)

The work log records the root cause, same-root scan, rejected alternatives,
verification, and the remaining lack of a larger mixed real/conjugate-spectrum
regression.

## Verification

- `cargo test -p tenferro-linalg rotation_eig -- --nocapture` — 2 passed
- `cargo test -p tenferro-linalg --lib` — 118 passed
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/check-pr-fast.sh` with the focused test and `clippy` CI profile
  (root/ext fmt, docs snippets, focused tests, workspace/tropical/sparse/TBLIS
  clippy all passed)
- Independent read-only review of the production patch: no P0/P1 findings; its
  documentation P2 was resolved before push
- The regression was subsequently moved from the private Faer helper to the
  public provider-dispatch path. The updated Faer test and fast gate pass.

The repository-rules LLM review could not run because `DEEPSEEK_API_KEY` is not
available in the local environment. The local BLAS test could not link because
OpenBLAS is not installed on the macOS host; the `workspace-blas` CI profile
owns that execution.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [ ] I ran local repository-rules LLM review and resolved or documented its
      findings.
- [x] If this implements a new feature, the linked issue has been accepted by
      maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from
      `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and
      linked it above.
