### PR TITLE
linalg: add caller-owned solve destination

### DIFF
--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -291,6 +291,7 @@ pub(crate) use structural::{
 #[doc(hidden)]
 pub mod linalg_interop {
     pub use crate::buffer_pool::{BufferPool, PoolScalar};
+    pub use tenferro_internal_cpu_kernels::PooledUninitOutput;
 }
 
 pub(crate) fn cpu_backend_buffer_error(op: &'static str) -> crate::Error {

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -1,4 +1,4 @@
-use tenferro_tensor::{Tensor, TensorBackend, TensorRead};
+use tenferro_tensor::{Tensor, TensorBackend, TensorRead, TensorWrite};
 
 pub(crate) use crate::error::unsupported_dtype;
 use crate::extension::{
@@ -686,6 +686,46 @@ pub trait LinalgBackend: TensorBackend {
         ))
     }
 
+    /// Solve into a caller-owned destination.
+    ///
+    /// The default preserves the ordinary read path and copies its result into
+    /// `out`. Backends with a native destination path may override this method,
+    /// but must validate the destination before the first write and preserve
+    /// the same shape, dtype, placement, aliasing, and error contracts.
+    ///
+    /// # Errors
+    ///
+    /// Returns destination metadata, aliasing, validation, backend, or
+    /// numerical errors from the selected backend.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::LinalgBackend;
+    /// use tenferro_tensor::{Tensor, TensorRead, TensorWrite};
+    ///
+    /// let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// let b = Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 8.0])?;
+    /// let mut out = Tensor::from_vec_col_major(vec![2, 1], vec![0.0_f64; 2])?;
+    /// let mut backend = CpuBackend::new();
+    /// backend.solve_read_into(
+    ///     TensorRead::from_tensor(&a),
+    ///     TensorRead::from_tensor(&b),
+    ///     TensorWrite::from_tensor(&mut out),
+    /// )?;
+    /// assert_eq!(out.as_slice::<f64>()?, &[2.0, 2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn solve_read_into(
+        &mut self,
+        a: TensorRead<'_>,
+        b: TensorRead<'_>,
+        out: TensorWrite<'_>,
+    ) -> tenferro_tensor::Result<()> {
+        solve_read_into_default(self, a, b, out)
+    }
+
     #[doc(hidden)]
     fn lu_solve_prepared(
         &mut self,
@@ -704,4 +744,49 @@ pub trait LinalgBackend: TensorBackend {
             ),
         ))
     }
+}
+
+pub(crate) fn solve_read_into_default<B: LinalgBackend + ?Sized>(
+    backend: &mut B,
+    a: TensorRead<'_>,
+    b: TensorRead<'_>,
+    out: TensorWrite<'_>,
+) -> tenferro_tensor::Result<()> {
+    validate_solve_read_into(&a, &b, &out)?;
+    let result = backend.solve_read(a, b)?;
+    backend.copy_read_into(TensorRead::from_tensor(&result), out)
+}
+
+pub(crate) fn validate_solve_read_into(
+    _a: &TensorRead<'_>,
+    b: &TensorRead<'_>,
+    out: &TensorWrite<'_>,
+) -> tenferro_tensor::Result<()> {
+    if b.shape() != out.shape() {
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "solve_read_into",
+            b.shape().to_vec(),
+            out.shape().to_vec(),
+        ));
+    }
+    if b.dtype() != out.dtype() {
+        return Err(tenferro_tensor::Error::dtype_mismatch(
+            "solve_read_into",
+            b.dtype(),
+            out.dtype(),
+        ));
+    }
+    if b.placement() != out.as_read().placement() {
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "solve_read_into",
+            "out",
+            format!(
+                "destination placement {:?} does not match rhs placement {:?}",
+                out.as_read().placement(),
+                b.placement()
+            ),
+        ));
+    }
+    let inputs = [_a.clone(), b.clone()];
+    tenferro_tensor::backend::validate_read_into_destination("solve_read_into", &inputs, out)
 }

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -695,8 +695,11 @@ pub trait LinalgBackend: TensorBackend {
     ///
     /// # Errors
     ///
-    /// Returns destination metadata, aliasing, validation, backend, or
-    /// numerical errors from the selected backend.
+    /// Returns `tenferro_tensor_core::ShapeMismatch` or
+    /// `tenferro_tensor_core::ValidationError::DTypeMismatch` for incompatible
+    /// destination metadata, `tenferro_tensor_core::ValidationError::InvalidArgument`
+    /// for aliasing or placement violations, `Error::Unsupported` when the
+    /// provider is unavailable, and `Error::Singular` for a singular system.
     ///
     /// # Examples
     ///

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -8,7 +8,7 @@ use tenferro_cpu::{CpuBackend, CpuBackendKind, CpuExecSession, CpuExecutionConte
 use tenferro_tensor::{
     validate::validate_nonsingular_u, AllocationDomainId, Buffer, DType, Error, HostAccessError,
     MemoryKind, SharedTensorAllocationDomain, Tensor, TensorElementwise, TensorRead,
-    TensorStructural, TensorView, TypedTensor,
+    TensorStructural, TensorView, TensorViewMut, TensorWrite, TypedTensor,
 };
 
 trait FreshLinalgOutput {
@@ -693,14 +693,86 @@ impl LinalgBackend for CpuBackend {
         ensure_host_tensor_read("solve", &b)?;
         ensure_supported_linalg_dtypes("solve", a.dtype(), b.dtype())?;
         let provider = linalg_provider_kind(self.kind(), "solve")?;
+        let direct = !has_zero_dim(a.shape())
+            && !has_zero_dim(b.shape())
+            && solve_shape_direct_eligible(a.shape(), b.shape());
         self.with_linalg_pool_fresh(move |context, buffers| {
-            context.with_materialized_tensor_read(buffers, "solve", a, |a, buffers| {
-                context.with_materialized_tensor_read(buffers, "solve", b, |b, buffers| {
-                    solve_entered(provider, context, buffers, a, b)
+            if direct {
+                solve_from_views_entered(
+                    provider,
+                    context,
+                    buffers,
+                    a.tensor_view(),
+                    b.tensor_view(),
+                )
+            } else {
+                context.with_materialized_tensor_read(buffers, "solve", a, |a, buffers| {
+                    context.with_materialized_tensor_read(buffers, "solve", b, |b, buffers| {
+                        solve_entered(provider, context, buffers, a, b)
+                    })
                 })
-            })
+            }
         })
     }
+
+    fn solve_read_into(
+        &mut self,
+        a: TensorRead<'_>,
+        b: TensorRead<'_>,
+        out: TensorWrite<'_>,
+    ) -> tenferro_tensor::Result<()> {
+        crate::backend::validate_solve_read_into(&a, &b, &out)?;
+        ensure_host_tensor_read("solve_read_into", &a)?;
+        ensure_host_tensor_read("solve_read_into", &b)?;
+        ensure_host_tensor_read("solve_read_into", &out.as_read())?;
+        ensure_supported_linalg_dtypes("solve_read_into", a.dtype(), b.dtype())?;
+        let provider = linalg_provider_kind(self.kind(), "solve_read_into")?;
+
+        if has_zero_dim(a.shape())
+            || has_zero_dim(b.shape())
+            || !solve_read_into_direct_eligible(&a, &b, &out)
+        {
+            return crate::backend::solve_read_into_default(self, a, b, out);
+        }
+
+        let a = a.tensor_view();
+        let b = b.tensor_view();
+        self.with_linalg_pool(move |context, buffers| {
+            solve_read_into_entered(provider, context, buffers, a, b, out)
+        })
+    }
+}
+
+fn solve_read_into_direct_eligible(
+    a: &TensorRead<'_>,
+    b: &TensorRead<'_>,
+    out: &TensorWrite<'_>,
+) -> bool {
+    if !solve_shape_direct_eligible(a.shape(), b.shape()) {
+        return false;
+    }
+    let out = out.as_read();
+    if out.backend_family().is_some() || out.shape() != b.shape() {
+        return false;
+    }
+    let Ok(strides) = out.strides() else {
+        return false;
+    };
+    match out.shape() {
+        [_] => strides == [1],
+        [rows, cols] => {
+            strides.first().copied() == Some(1)
+                && strides.get(1).copied().is_some_and(|stride| {
+                    stride >= isize::try_from(*rows).unwrap_or(isize::MAX)
+                        && (*cols <= 1 || stride > 0)
+                })
+        }
+        _ => false,
+    }
+}
+
+fn solve_shape_direct_eligible(a_shape: &[usize], b_shape: &[usize]) -> bool {
+    a_shape.len() == 2 && matches!(b_shape.len(), 1 | 2)
 }
 
 /// Execute the prepared LU solve on an already-entered CPU session.
@@ -1330,6 +1402,173 @@ fn solve_entered(
         context.reshape_tensor(&result, &shape)
     } else {
         Ok(result)
+    }
+}
+
+fn solve_from_views_entered(
+    provider: CpuLinalgProvider,
+    context: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    a: TensorView<'_>,
+    b: TensorView<'_>,
+) -> tenferro_tensor::Result<Tensor> {
+    match provider {
+        CpuLinalgProvider::Faer => {
+            #[cfg(feature = "cpu-faer")]
+            {
+                match (a, b) {
+                    (TensorView::F32(a), TensorView::F32(b)) => {
+                        linalg::faer::solve_from_views(context, buffers, a, b, false)
+                            .map(Tensor::F32)
+                    }
+                    (TensorView::F64(a), TensorView::F64(b)) => {
+                        linalg::faer::solve_from_views(context, buffers, a, b, false)
+                            .map(Tensor::F64)
+                    }
+                    (TensorView::C32(a), TensorView::C32(b)) => {
+                        linalg::faer::solve_from_views(context, buffers, a, b, false)
+                            .map(Tensor::C32)
+                    }
+                    (TensorView::C64(a), TensorView::C64(b)) => {
+                        linalg::faer::solve_from_views(context, buffers, a, b, false)
+                            .map(Tensor::C64)
+                    }
+                    _ => Err(Error::invalid_argument(
+                        "solve",
+                        "inputs",
+                        "solve inputs must have the same dtype",
+                    )),
+                }
+            }
+            #[cfg(not(feature = "cpu-faer"))]
+            {
+                let _ = (context, buffers, a, b);
+                Err(unsupported_provider("solve", CpuBackendKind::Faer))
+            }
+        }
+        CpuLinalgProvider::Blas => {
+            #[cfg(feature = "cpu-blas")]
+            {
+                let _ = context;
+                match (a, b) {
+                    (TensorView::F32(a), TensorView::F32(b)) => {
+                        linalg::blas::solve_from_views(buffers, a, b, false).map(Tensor::F32)
+                    }
+                    (TensorView::F64(a), TensorView::F64(b)) => {
+                        linalg::blas::solve_from_views(buffers, a, b, false).map(Tensor::F64)
+                    }
+                    (TensorView::C32(a), TensorView::C32(b)) => {
+                        linalg::blas::solve_from_views(buffers, a, b, false).map(Tensor::C32)
+                    }
+                    (TensorView::C64(a), TensorView::C64(b)) => {
+                        linalg::blas::solve_from_views(buffers, a, b, false).map(Tensor::C64)
+                    }
+                    _ => Err(Error::invalid_argument(
+                        "solve",
+                        "inputs",
+                        "solve inputs must have the same dtype",
+                    )),
+                }
+            }
+            #[cfg(not(feature = "cpu-blas"))]
+            {
+                let _ = (context, buffers, a, b);
+                Err(unsupported_provider("solve", CpuBackendKind::Blas))
+            }
+        }
+    }
+}
+
+fn solve_read_into_entered(
+    provider: CpuLinalgProvider,
+    context: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    a: TensorView<'_>,
+    b: TensorView<'_>,
+    out: TensorWrite<'_>,
+) -> tenferro_tensor::Result<()> {
+    let out = tensor_write_view(out);
+    match provider {
+        CpuLinalgProvider::Faer => {
+            #[cfg(feature = "cpu-faer")]
+            {
+                match (a, b, out) {
+                    (TensorView::F32(a), TensorView::F32(b), TensorViewMut::F32(mut out)) => {
+                        linalg::faer::solve_into(context, buffers, a, b, &mut out, false)
+                    }
+                    (TensorView::F64(a), TensorView::F64(b), TensorViewMut::F64(mut out)) => {
+                        linalg::faer::solve_into(context, buffers, a, b, &mut out, false)
+                    }
+                    (TensorView::C32(a), TensorView::C32(b), TensorViewMut::C32(mut out)) => {
+                        linalg::faer::solve_into(context, buffers, a, b, &mut out, false)
+                    }
+                    (TensorView::C64(a), TensorView::C64(b), TensorViewMut::C64(mut out)) => {
+                        linalg::faer::solve_into(context, buffers, a, b, &mut out, false)
+                    }
+                    _ => Err(Error::invalid_argument(
+                        "solve_read_into",
+                        "out",
+                        "destination dtype does not match the solve inputs",
+                    )),
+                }
+            }
+            #[cfg(not(feature = "cpu-faer"))]
+            {
+                let _ = (context, buffers, a, b, out);
+                Err(unsupported_provider(
+                    "solve_read_into",
+                    CpuBackendKind::Faer,
+                ))
+            }
+        }
+        CpuLinalgProvider::Blas => {
+            #[cfg(feature = "cpu-blas")]
+            {
+                let _ = context;
+                match (a, b, out) {
+                    (TensorView::F32(a), TensorView::F32(b), TensorViewMut::F32(mut out)) => {
+                        linalg::blas::solve_into(buffers, a, b, &mut out, false)
+                    }
+                    (TensorView::F64(a), TensorView::F64(b), TensorViewMut::F64(mut out)) => {
+                        linalg::blas::solve_into(buffers, a, b, &mut out, false)
+                    }
+                    (TensorView::C32(a), TensorView::C32(b), TensorViewMut::C32(mut out)) => {
+                        linalg::blas::solve_into(buffers, a, b, &mut out, false)
+                    }
+                    (TensorView::C64(a), TensorView::C64(b), TensorViewMut::C64(mut out)) => {
+                        linalg::blas::solve_into(buffers, a, b, &mut out, false)
+                    }
+                    _ => Err(Error::invalid_argument(
+                        "solve_read_into",
+                        "out",
+                        "destination dtype does not match the solve inputs",
+                    )),
+                }
+            }
+            #[cfg(not(feature = "cpu-blas"))]
+            {
+                let _ = (context, buffers, a, b, out);
+                Err(unsupported_provider(
+                    "solve_read_into",
+                    CpuBackendKind::Blas,
+                ))
+            }
+        }
+    }
+}
+
+fn tensor_write_view(out: TensorWrite<'_>) -> TensorViewMut<'_> {
+    match out {
+        TensorWrite::Tensor(tensor) => match tensor {
+            Tensor::F32(tensor) => TensorViewMut::F32(tensor.as_view_mut()),
+            Tensor::F64(tensor) => TensorViewMut::F64(tensor.as_view_mut()),
+            Tensor::I32(tensor) => TensorViewMut::I32(tensor.as_view_mut()),
+            Tensor::I64(tensor) => TensorViewMut::I64(tensor.as_view_mut()),
+            Tensor::Bool(tensor) => TensorViewMut::Bool(tensor.as_view_mut()),
+            Tensor::C32(tensor) => TensorViewMut::C32(tensor.as_view_mut()),
+            Tensor::C64(tensor) => TensorViewMut::C64(tensor.as_view_mut()),
+        },
+        TensorWrite::View(view) => view,
     }
 }
 

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 
 use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar};
 use tenferro_cpu::CpuExecutionContext;
-use tenferro_tensor::{Tensor, TypedTensor, TypedTensorView};
+use tenferro_tensor::{Tensor, TypedTensor, TypedTensorView, TypedTensorViewMut};
 
 pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
     type Real: Copy + Clone + PoolScalar;
@@ -48,6 +48,39 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         b: &TypedTensor<Self>,
         transpose_a: bool,
     ) -> tenferro_tensor::Result<TypedTensor<Self>>;
+    fn solve_2d_into_view(
+        ctx: &CpuExecutionContext<'_>,
+        buffers: &mut BufferPool,
+        a: TypedTensorView<'_, Self>,
+        b: TypedTensorView<'_, Self>,
+        out: &mut TypedTensorViewMut<'_, Self>,
+        transpose_a: bool,
+    ) -> tenferro_tensor::Result<()> {
+        Self::solve_2d_in_place_view(
+            ctx,
+            buffers,
+            a,
+            b,
+            out,
+            transpose_a,
+            true,
+            "solve_read_into",
+        )
+    }
+    // INVARIANT: these parameters keep the provider kernel's context, pooled
+    // scratch, typed views, destination, and solve contract explicit at the
+    // single provider boundary; the method is private to this trait.
+    #[allow(clippy::too_many_arguments)]
+    fn solve_2d_in_place_view(
+        ctx: &CpuExecutionContext<'_>,
+        buffers: &mut BufferPool,
+        a: TypedTensorView<'_, Self>,
+        b: TypedTensorView<'_, Self>,
+        out: &mut TypedTensorViewMut<'_, Self>,
+        transpose_a: bool,
+        copy_rhs: bool,
+        op: &'static str,
+    ) -> tenferro_tensor::Result<()>;
     // Mirrors triangular-solve math flags directly at the scalar backend boundary.
     #[allow(clippy::too_many_arguments)]
     fn triangular_solve_2d(
@@ -315,18 +348,6 @@ fn complex_pivot_is_effectively_singular(
     eps: f64,
 ) -> bool {
     real.hypot(imag) <= eps * max_diagonal.max(1.0)
-}
-
-fn real_pivot_is_singular(pivot: f64) -> bool {
-    // Why not reuse the full-pivot tolerance: ordinary solve follows partial-
-    // pivot LU's exact-zero contract; conditioning belongs to an explicit API.
-    pivot == 0.0
-}
-
-fn complex_pivot_is_singular(real: f64, imag: f64) -> bool {
-    // Why not use a magnitude: a squared magnitude can underflow for a
-    // representable nonzero component, while component checks cannot.
-    real == 0.0 && imag == 0.0
 }
 
 fn checked_product(
@@ -1005,6 +1026,147 @@ where
     tensor_from_vec_with_template(out_shape, out_data, b.placement())
 }
 
+macro_rules! impl_solve_into_view {
+    ($scalar:ty, $faer_scalar:ty, $to_faer_slice:ident, $to_faer_slice_mut:ident) => {
+        // INVARIANT: this implementation mirrors the explicit provider
+        // boundary declared above so the macro cannot silently drop context,
+        // destination, or validation parameters.
+        #[allow(clippy::too_many_arguments)]
+        fn solve_2d_in_place_view(
+            ctx: &CpuExecutionContext<'_>,
+            _buffers: &mut BufferPool,
+            a: TypedTensorView<'_, Self>,
+            b: TypedTensorView<'_, Self>,
+            out: &mut TypedTensorViewMut<'_, Self>,
+            transpose_a: bool,
+            copy_rhs: bool,
+            op: &'static str,
+        ) -> tenferro_tensor::Result<()> {
+            let n = square_matrix_dim_view(&a, op)?;
+            let (b_rows, b_cols) = rhs_matrix_dims_view(&b, op)?;
+            if b_rows != n {
+                return Err(tenferro_tensor::Error::shape_mismatch(
+                    op,
+                    vec![n],
+                    vec![b_rows],
+                ));
+            }
+
+            let mut lu = Mat::<$faer_scalar>::zeros(n, n);
+            for col in 0..n {
+                for row in 0..n {
+                    let value = a.get(&[row, col]).ok_or_else(|| {
+                        tenferro_tensor::Error::runtime_state(
+                            op,
+                            "CPU Faer solve input view is not host-addressable",
+                        )
+                    })?;
+                    lu[(row, col)] = $to_faer_slice(std::slice::from_ref(value))[0];
+                }
+            }
+
+            let mut row_perm = vec![0usize; n];
+            let mut row_perm_inv = vec![0usize; n];
+            let mut mem = MemBuffer::new(
+                faer::linalg::lu::partial_pivoting::factor::lu_in_place_scratch::<
+                    usize,
+                    $faer_scalar,
+                >(n, n, ctx.faer_parallelism(), Default::default()),
+            );
+            let stack = MemStack::new(&mut mem);
+            let (_, row_perm_ref) = faer::linalg::lu::partial_pivoting::factor::lu_in_place(
+                lu.as_mut(),
+                &mut row_perm,
+                &mut row_perm_inv,
+                ctx.faer_parallelism(),
+                stack,
+                Default::default(),
+            );
+            for i in 0..n {
+                if lu[(i, i)] == <$faer_scalar as Default>::default() {
+                    return Err(singular_matrix(op));
+                }
+            }
+
+            if copy_rhs {
+                copy_rhs_view_into(&b, out, n, b_cols, op)?;
+            }
+            let out_col_stride = if out.shape().len() == 1 {
+                isize::try_from(n).map_err(|_| {
+                    tenferro_tensor::Error::invalid_argument(
+                        op,
+                        "out",
+                        "output row count does not fit a Faer stride",
+                    )
+                })?
+            } else {
+                out.strides()[1]
+            };
+            let out_storage = output_storage_slice_mut(out, n, b_cols, out_col_stride, op)?;
+            let out_storage = $to_faer_slice_mut(out_storage);
+            // SAFETY: the CPU boundary verifies host storage and a positive
+            // column-major destination. The aliasing contract rejects
+            // input/output overlap before this function is called.
+            let rhs = unsafe {
+                MatMut::<$faer_scalar>::from_raw_parts_mut(
+                    out_storage.as_mut_ptr(),
+                    n,
+                    b_cols,
+                    1,
+                    out_col_stride,
+                )
+            };
+            let mut mem = MemBuffer::new(if transpose_a {
+                faer::linalg::lu::partial_pivoting::solve::solve_transpose_in_place_scratch::<
+                    usize,
+                    $faer_scalar,
+                >(n, b_cols, ctx.faer_parallelism())
+            } else {
+                faer::linalg::lu::partial_pivoting::solve::solve_in_place_scratch::<
+                    usize,
+                    $faer_scalar,
+                >(n, b_cols, ctx.faer_parallelism())
+            });
+            let stack = MemStack::new(&mut mem);
+            if transpose_a {
+                faer::linalg::lu::partial_pivoting::solve::solve_transpose_in_place(
+                    lu.as_ref(),
+                    lu.as_ref(),
+                    row_perm_ref,
+                    rhs,
+                    ctx.faer_parallelism(),
+                    stack,
+                );
+            } else {
+                faer::linalg::lu::partial_pivoting::solve::solve_in_place(
+                    lu.as_ref(),
+                    lu.as_ref(),
+                    row_perm_ref,
+                    rhs,
+                    ctx.faer_parallelism(),
+                    stack,
+                );
+            }
+            Ok(())
+        }
+    };
+}
+
+pub(crate) fn solve_from_views<T: FaerLinalg + 'static>(
+    ctx: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    a: TypedTensorView<'_, T>,
+    b: TypedTensorView<'_, T>,
+    transpose_a: bool,
+) -> tenferro_tensor::Result<TypedTensor<T>> {
+    let mut output = super::output_from_rhs_view(buffers, &b, "solve")?;
+    let a = a;
+    let b = b;
+    let mut out = output.as_view_mut();
+    T::solve_2d_in_place_view(ctx, buffers, a, b, &mut out, transpose_a, false, "solve")?;
+    Ok(output)
+}
+
 macro_rules! impl_faer_linalg_for_real {
     ($scalar:ty) => {
         impl FaerLinalg for $scalar {
@@ -1322,76 +1484,10 @@ macro_rules! impl_faer_linalg_for_real {
         b: &TypedTensor<Self>,
         transpose_a: bool,
     ) -> tenferro_tensor::Result<TypedTensor<Self>> {
-        let n = square_matrix_dim(a, "solve")?;
-        let (b_rows, b_cols) = matrix_dims(b, "solve")?;
-        if b_rows != n {
-            return Err(tenferro_tensor::Error::shape_mismatch("solve", vec![n], vec![b_rows]));
-        }
-
-        let mut lu = Mat::zeros(n, n);
-        lu.copy_from(MatRef::from_column_major_slice(a.host_data()?, n, n));
-        let mut row_perm = vec![0usize; n];
-        let mut row_perm_inv = vec![0usize; n];
-        let mut mem = MemBuffer::new(
-            faer::linalg::lu::partial_pivoting::factor::lu_in_place_scratch::<usize, Self>(
-                n,
-                n,
-                ctx.faer_parallelism(),
-                Default::default(),
-            ),
-        );
-        let stack = MemStack::new(&mut mem);
-        let (_, row_perm_ref) = faer::linalg::lu::partial_pivoting::factor::lu_in_place(
-            lu.as_mut(),
-            &mut row_perm,
-            &mut row_perm_inv,
-            ctx.faer_parallelism(),
-            stack,
-            Default::default(),
-        );
-        for i in 0..n {
-            if real_pivot_is_singular(lu[(i, i)] as f64) {
-                return Err(singular_matrix("solve"));
-            }
-        }
-
-        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data()?.len());
-        rhs_data.extend_from_slice(b.host_data()?);
-        let rhs = MatMut::from_column_major_slice_mut(&mut rhs_data, n, b_cols);
-        let mut mem = MemBuffer::new(if transpose_a {
-            faer::linalg::lu::partial_pivoting::solve::solve_transpose_in_place_scratch::<
-                usize,
-                Self,
-            >(n, b_cols, ctx.faer_parallelism())
-        } else {
-            faer::linalg::lu::partial_pivoting::solve::solve_in_place_scratch::<usize, Self>(
-                n,
-                b_cols,
-                ctx.faer_parallelism(),
-            )
-        });
-        let stack = MemStack::new(&mut mem);
-        if transpose_a {
-            faer::linalg::lu::partial_pivoting::solve::solve_transpose_in_place(
-                lu.as_ref(),
-                lu.as_ref(),
-                row_perm_ref,
-                rhs,
-                ctx.faer_parallelism(),
-                stack,
-            );
-        } else {
-            faer::linalg::lu::partial_pivoting::solve::solve_in_place(
-                lu.as_ref(),
-                lu.as_ref(),
-                row_perm_ref,
-                rhs,
-                ctx.faer_parallelism(),
-                stack,
-            );
-        }
-        tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())
+        solve_from_views(ctx, buffers, a.as_view(), b.as_view(), transpose_a)
     }
+
+    impl_solve_into_view!($scalar, $scalar, same_slice, same_slice_mut);
 
     fn triangular_solve_2d(
         ctx: &CpuExecutionContext<'_>,
@@ -2195,81 +2291,15 @@ macro_rules! impl_faer_linalg_for_complex {
         b: &TypedTensor<Self>,
         transpose_a: bool,
     ) -> tenferro_tensor::Result<TypedTensor<Self>> {
-        let n = square_matrix_dim(a, "solve")?;
-        let (b_rows, b_cols) = matrix_dims(b, "solve")?;
-        if b_rows != n {
-            return Err(tenferro_tensor::Error::shape_mismatch("solve", vec![n], vec![b_rows]));
-        }
-
-        let mut lu = Mat::zeros(n, n);
-        lu.copy_from(MatRef::from_column_major_slice(
-            $to_faer_slice(a.host_data()?),
-            n,
-            n,
-        ));
-        let mut row_perm = vec![0usize; n];
-        let mut row_perm_inv = vec![0usize; n];
-        let mut mem = MemBuffer::new(
-            faer::linalg::lu::partial_pivoting::factor::lu_in_place_scratch::<usize, $faer_complex>(
-                n,
-                n,
-                ctx.faer_parallelism(),
-                Default::default(),
-            ),
-        );
-        let stack = MemStack::new(&mut mem);
-        let (_, row_perm_ref) = faer::linalg::lu::partial_pivoting::factor::lu_in_place(
-            lu.as_mut(),
-            &mut row_perm,
-            &mut row_perm_inv,
-            ctx.faer_parallelism(),
-            stack,
-            Default::default(),
-        );
-        for i in 0..n {
-            let value = lu[(i, i)];
-            if complex_pivot_is_singular(value.re as f64, value.im as f64) {
-                return Err(singular_matrix("solve"));
-            }
-        }
-
-        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data()?.len());
-        rhs_data.extend_from_slice(b.host_data()?);
-        let rhs =
-            MatMut::from_column_major_slice_mut($to_faer_slice_mut(&mut rhs_data), n, b_cols);
-        let mut mem = MemBuffer::new(if transpose_a {
-            faer::linalg::lu::partial_pivoting::solve::solve_transpose_in_place_scratch::<
-                usize,
-                $faer_complex,
-            >(n, b_cols, ctx.faer_parallelism())
-        } else {
-            faer::linalg::lu::partial_pivoting::solve::solve_in_place_scratch::<
-                usize,
-                $faer_complex,
-            >(n, b_cols, ctx.faer_parallelism())
-        });
-        let stack = MemStack::new(&mut mem);
-        if transpose_a {
-            faer::linalg::lu::partial_pivoting::solve::solve_transpose_in_place(
-                lu.as_ref(),
-                lu.as_ref(),
-                row_perm_ref,
-                rhs,
-                ctx.faer_parallelism(),
-                stack,
-            );
-        } else {
-            faer::linalg::lu::partial_pivoting::solve::solve_in_place(
-                lu.as_ref(),
-                lu.as_ref(),
-                row_perm_ref,
-                rhs,
-                ctx.faer_parallelism(),
-                stack,
-            );
-        }
-        tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())
+        solve_from_views(ctx, buffers, a.as_view(), b.as_view(), transpose_a)
     }
+
+    impl_solve_into_view!(
+        $complex,
+        $faer_complex,
+        $to_faer_slice,
+        $to_faer_slice_mut
+    );
 
     fn triangular_solve_2d(
         ctx: &CpuExecutionContext<'_>,
@@ -3024,6 +3054,29 @@ pub(crate) fn solve<T: FaerLinalg>(
     })
 }
 
+/// Solve a single matrix system directly into a positive column-major output
+/// view. The destination is populated only after factorization and singularity
+/// checks have completed, so validation/provider failures before execution do
+/// not partially modify the caller-owned buffer.
+pub(crate) fn solve_into<T: FaerLinalg>(
+    ctx: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    a: TypedTensorView<'_, T>,
+    b: TypedTensorView<'_, T>,
+    out: &mut TypedTensorViewMut<'_, T>,
+    transpose_a: bool,
+) -> tenferro_tensor::Result<()> {
+    T::solve_2d_into_view(ctx, buffers, a, b, out, transpose_a)
+}
+
+fn same_slice<T>(data: &[T]) -> &[T] {
+    data
+}
+
+fn same_slice_mut<T>(data: &mut [T]) -> &mut [T] {
+    data
+}
+
 // Keeps triangular-solve operands and flags explicit at the CPU backend boundary.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn triangular_solve<T: FaerLinalg>(
@@ -3250,6 +3303,104 @@ fn host_base_ptr<T: 'static>(view: &TypedTensorView<'_, T>) -> tenferro_tensor::
     }
     // SAFETY: offset is validated above.
     Ok(unsafe { storage.as_ptr().offset(offset) })
+}
+
+fn output_storage_slice_mut<'view, T: 'static>(
+    view: &'view mut TypedTensorViewMut<'_, T>,
+    rows: usize,
+    cols: usize,
+    col_stride: isize,
+    op: &'static str,
+) -> tenferro_tensor::Result<&'view mut [T]> {
+    let col_stride = usize::try_from(col_stride).map_err(|_| {
+        tenferro_tensor::Error::invalid_argument(
+            op,
+            "out",
+            "output column stride must be non-negative",
+        )
+    })?;
+    let span = cols
+        .checked_sub(1)
+        .and_then(|last_col| last_col.checked_mul(col_stride))
+        .and_then(|last_offset| last_offset.checked_add(rows))
+        .ok_or_else(|| {
+            tenferro_tensor::Error::invalid_argument(op, "out", "output view span overflows usize")
+        })?;
+    let offset = usize::try_from(view.offset())
+        .map_err(|_| tenferro_tensor::Error::runtime_state(op, "output view offset is negative"))?;
+    let end = offset.checked_add(span).ok_or_else(|| {
+        tenferro_tensor::Error::invalid_argument(
+            op,
+            "out",
+            "output view end offset overflows usize",
+        )
+    })?;
+    view.host_storage_mut()?
+        .get_mut(offset..end)
+        .ok_or_else(|| {
+            tenferro_tensor::Error::runtime_state(
+                op,
+                "output view does not contain the requested Faer span",
+            )
+        })
+}
+
+fn square_matrix_dim_view<T: 'static>(
+    view: &TypedTensorView<'_, T>,
+    op: &'static str,
+) -> tenferro_tensor::Result<usize> {
+    let (rows, cols) = matrix_dims_view(view, op)?;
+    if rows != cols {
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            op,
+            vec![rows],
+            vec![cols],
+        ));
+    }
+    Ok(rows)
+}
+
+fn rhs_matrix_dims_view<T: 'static>(
+    view: &TypedTensorView<'_, T>,
+    op: &'static str,
+) -> tenferro_tensor::Result<(usize, usize)> {
+    match view.shape() {
+        [rows] => Ok((*rows, 1)),
+        _ => matrix_dims_view(view, op),
+    }
+}
+
+fn copy_rhs_view_into<T: Copy + 'static>(
+    src: &TypedTensorView<'_, T>,
+    dst: &mut TypedTensorViewMut<'_, T>,
+    rows: usize,
+    cols: usize,
+    op: &'static str,
+) -> tenferro_tensor::Result<()> {
+    if dst.shape().len() == 1 {
+        for row in 0..rows {
+            let value = src.get(&[row]).ok_or_else(|| {
+                tenferro_tensor::Error::runtime_state(op, "RHS view is not host-addressable")
+            })?;
+            let target = dst.get_mut(&[row]).ok_or_else(|| {
+                tenferro_tensor::Error::runtime_state(op, "output view is not host-addressable")
+            })?;
+            *target = *value;
+        }
+    } else {
+        for col in 0..cols {
+            for row in 0..rows {
+                let value = src.get(&[row, col]).ok_or_else(|| {
+                    tenferro_tensor::Error::runtime_state(op, "RHS view is not host-addressable")
+                })?;
+                let target = dst.get_mut(&[row, col]).ok_or_else(|| {
+                    tenferro_tensor::Error::runtime_state(op, "output view is not host-addressable")
+                })?;
+                *target = *value;
+            }
+        }
+    }
+    Ok(())
 }
 
 fn matrix_dims_view<T: 'static>(

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg.rs
@@ -17,6 +17,6 @@ pub(crate) use eigh::{eigh, eigh_values};
 pub(crate) use full_piv_lu::{full_piv_lu, full_piv_lu_solve};
 pub(crate) use lu::{lu, lu_factor};
 pub(crate) use qr::qr;
-pub(crate) use solve::solve;
+pub(crate) use solve::{solve, solve_from_views, solve_into};
 pub(crate) use svd::{svd, svd_values};
 pub(crate) use triangular_solve::triangular_solve;

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/solve.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/solve.rs
@@ -1,11 +1,11 @@
 use num_complex::{Complex32, Complex64};
 
 use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar};
-use tenferro_tensor::TypedTensor;
+use tenferro_tensor::{TypedTensor, TypedTensorView, TypedTensorViewMut};
 
 use super::helpers::{
     batched_binary_result, check_lapack_info, dim_i32, has_zero_dim, matrix_core_and_batch_result,
-    matrix_dims, square_core_and_batch_result, square_matrix_dim, tensor_from_vec_with_template,
+    square_core_and_batch_result, tensor_from_vec_with_template,
 };
 
 pub(crate) trait LapackSolve: Clone + Copy + PoolScalar {
@@ -141,55 +141,16 @@ impl LapackSolve for Complex64 {
     }
 }
 
-fn solve_2d<T: LapackSolve>(
-    _buffers: &mut BufferPool,
+fn solve_2d<T: LapackSolve + 'static>(
+    buffers: &mut BufferPool,
     a: &TypedTensor<T>,
     b: &TypedTensor<T>,
     transpose_a: bool,
 ) -> tenferro_tensor::Result<TypedTensor<T>> {
-    let n = square_matrix_dim(a, "solve")?;
-    let (b_rows, b_cols) = matrix_dims(b, "solve")?;
-    if b_rows != n {
-        return Err(tenferro_tensor::Error::shape_mismatch(
-            "solve",
-            vec![n],
-            vec![b_rows],
-        ));
-    }
-
-    let n_i32 = dim_i32(n, "solve")?;
-    let b_cols_i32 = dim_i32(b_cols, "solve")?;
-    let mut lu = a.host_data()?.to_vec();
-    let mut ipiv = vec![0_i32; n];
-    let mut info = 0;
-    T::getrf(n_i32, n_i32, &mut lu, n_i32, &mut ipiv, &mut info);
-    check_lapack_info("solve", "getrf", info.min(0))?;
-    if info > 0 {
-        return Err(crate::error::into_tensor_error(
-            "solve",
-            crate::Error::Singular { op: "solve" },
-        ));
-    }
-
-    let mut rhs = b.host_data()?.to_vec();
-    let mut info = 0;
-    T::getrs(GetrsArgs {
-        trans: if transpose_a { b'T' } else { b'N' },
-        n: n_i32,
-        nrhs: b_cols_i32,
-        a: &lu,
-        lda: n_i32,
-        ipiv: &ipiv,
-        b: &mut rhs,
-        ldb: n_i32,
-        info: &mut info,
-    });
-    check_lapack_info("solve", "getrs", info)?;
-
-    tensor_from_vec_with_template(vec![n, b_cols], rhs, b)
+    solve_from_views(buffers, a.as_view(), b.as_view(), transpose_a)
 }
 
-pub(crate) fn solve<T: LapackSolve>(
+pub(crate) fn solve<T: LapackSolve + 'static>(
     buffers: &mut BufferPool,
     a: &TypedTensor<T>,
     b: &TypedTensor<T>,
@@ -217,5 +178,228 @@ pub(crate) fn solve<T: LapackSolve>(
 
     batched_binary_result("solve", buffers, a, b, |buffers, a, b| {
         solve_2d(buffers, a, b, transpose_a)
+    })
+}
+
+/// Solve a single matrix system directly into a positive column-major output
+/// view. The destination is copied from the RHS only after factorization has
+/// succeeded, preserving the caller's buffer on validation and singularity
+/// failures.
+pub(crate) fn solve_into<T: LapackSolve + 'static>(
+    buffers: &mut BufferPool,
+    a: TypedTensorView<'_, T>,
+    b: TypedTensorView<'_, T>,
+    out: &mut TypedTensorViewMut<'_, T>,
+    transpose_a: bool,
+) -> tenferro_tensor::Result<()> {
+    solve_in_place(buffers, a, b, out, transpose_a, true, "solve_read_into")
+}
+
+pub(crate) fn solve_from_views<T: LapackSolve + 'static>(
+    buffers: &mut BufferPool,
+    a: TypedTensorView<'_, T>,
+    b: TypedTensorView<'_, T>,
+    transpose_a: bool,
+) -> tenferro_tensor::Result<TypedTensor<T>> {
+    let mut output = super::super::output_from_rhs_view(buffers, &b, "solve")?;
+    let mut out = output.as_view_mut();
+    solve_in_place(buffers, a, b, &mut out, transpose_a, false, "solve")?;
+    Ok(output)
+}
+
+fn solve_in_place<T: LapackSolve + 'static>(
+    buffers: &mut BufferPool,
+    a: TypedTensorView<'_, T>,
+    b: TypedTensorView<'_, T>,
+    out: &mut TypedTensorViewMut<'_, T>,
+    transpose_a: bool,
+    copy_rhs: bool,
+    op: &'static str,
+) -> tenferro_tensor::Result<()> {
+    let n = square_matrix_dim_view(&a, op)?;
+    let (b_rows, b_cols) = rhs_matrix_dims_view(&b, op)?;
+    if b_rows != n {
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            op,
+            vec![n],
+            vec![b_rows],
+        ));
+    }
+    if out.strides().first().copied() != Some(1) {
+        return Err(tenferro_tensor::Error::invalid_argument(
+            op,
+            "out",
+            "direct LAPACK solve requires unit row stride",
+        ));
+    }
+
+    let lu_len = n.checked_mul(n).ok_or_else(|| {
+        tenferro_tensor::Error::invalid_argument(op, "a", "matrix size overflows usize")
+    })?;
+    let mut lu = buffers.acquire_with_capacity::<T>(lu_len);
+    for col in 0..n {
+        for row in 0..n {
+            let value = a.get(&[row, col]).ok_or_else(|| {
+                tenferro_tensor::Error::runtime_state(
+                    op,
+                    "CPU LAPACK solve input view is not host-addressable",
+                )
+            })?;
+            lu.push(*value);
+        }
+    }
+
+    let n_i32 = dim_i32(n, op)?;
+    let b_cols_i32 = dim_i32(b_cols, op)?;
+    let mut ipiv = vec![0_i32; n];
+    let mut info = 0;
+    T::getrf(n_i32, n_i32, &mut lu, n_i32, &mut ipiv, &mut info);
+    check_lapack_info(op, "getrf", info.min(0))?;
+    if info > 0 {
+        return Err(crate::error::into_tensor_error(
+            op,
+            crate::Error::Singular { op },
+        ));
+    }
+
+    let ldb = if out.shape().len() == 1 {
+        n
+    } else {
+        out.strides()[1].try_into().map_err(|_| {
+            tenferro_tensor::Error::invalid_argument(
+                op,
+                "out",
+                "output leading dimension does not fit LAPACK",
+            )
+        })?
+    };
+    let ldb_i32 = dim_i32(ldb, op)?;
+    if copy_rhs {
+        copy_rhs_view_into(&b, out, n, b_cols, op)?;
+    }
+    let rhs = output_slice_mut(out, n, b_cols, ldb, op)?;
+    let mut info = 0;
+    T::getrs(GetrsArgs {
+        trans: if transpose_a { b'T' } else { b'N' },
+        n: n_i32,
+        nrhs: b_cols_i32,
+        a: &lu,
+        lda: n_i32,
+        ipiv: &ipiv,
+        b: rhs,
+        ldb: ldb_i32,
+        info: &mut info,
+    });
+    check_lapack_info(op, "getrs", info)
+}
+
+fn square_matrix_dim_view<T: 'static>(
+    view: &TypedTensorView<'_, T>,
+    op: &'static str,
+) -> tenferro_tensor::Result<usize> {
+    let (rows, cols) = matrix_dims_view(view, op)?;
+    if rows != cols {
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            op,
+            vec![rows],
+            vec![cols],
+        ));
+    }
+    Ok(rows)
+}
+
+fn rhs_matrix_dims_view<T: 'static>(
+    view: &TypedTensorView<'_, T>,
+    op: &'static str,
+) -> tenferro_tensor::Result<(usize, usize)> {
+    match view.shape() {
+        [rows] => Ok((*rows, 1)),
+        _ => matrix_dims_view(view, op),
+    }
+}
+
+fn matrix_dims_view<T: 'static>(
+    view: &TypedTensorView<'_, T>,
+    op: &'static str,
+) -> tenferro_tensor::Result<(usize, usize)> {
+    if view.shape().len() != 2 {
+        return Err(tenferro_tensor::Error::rank_mismatch(
+            op,
+            2,
+            view.shape().len(),
+        ));
+    }
+    Ok((view.shape()[0], view.shape()[1]))
+}
+
+fn copy_rhs_view_into<T: Copy + 'static>(
+    src: &TypedTensorView<'_, T>,
+    dst: &mut TypedTensorViewMut<'_, T>,
+    rows: usize,
+    cols: usize,
+    op: &'static str,
+) -> tenferro_tensor::Result<()> {
+    if dst.shape().len() == 1 {
+        for row in 0..rows {
+            let value = src.get(&[row]).ok_or_else(|| {
+                tenferro_tensor::Error::runtime_state(op, "RHS view is not host-addressable")
+            })?;
+            let target = dst.get_mut(&[row]).ok_or_else(|| {
+                tenferro_tensor::Error::runtime_state(op, "output view is not host-addressable")
+            })?;
+            *target = *value;
+        }
+    } else {
+        for col in 0..cols {
+            for row in 0..rows {
+                let value = src.get(&[row, col]).ok_or_else(|| {
+                    tenferro_tensor::Error::runtime_state(op, "RHS view is not host-addressable")
+                })?;
+                let target = dst.get_mut(&[row, col]).ok_or_else(|| {
+                    tenferro_tensor::Error::runtime_state(op, "output view is not host-addressable")
+                })?;
+                *target = *value;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn output_slice_mut<'out, 'view, T: 'static>(
+    out: &'out mut TypedTensorViewMut<'view, T>,
+    rows: usize,
+    cols: usize,
+    ldb: usize,
+    op: &'static str,
+) -> tenferro_tensor::Result<&'out mut [T]> {
+    let offset = out.offset();
+    if offset < 0 {
+        return Err(tenferro_tensor::Error::runtime_state(
+            op,
+            "output view offset is negative",
+        ));
+    }
+    let span = cols
+        .checked_sub(1)
+        .and_then(|last_col| last_col.checked_mul(ldb))
+        .and_then(|last_offset| last_offset.checked_add(rows))
+        .ok_or_else(|| {
+            tenferro_tensor::Error::invalid_argument(op, "out", "output view span overflows usize")
+        })?;
+    let offset = usize::try_from(offset)
+        .map_err(|_| tenferro_tensor::Error::runtime_state(op, "output view offset is negative"))?;
+    let end = offset.checked_add(span).ok_or_else(|| {
+        tenferro_tensor::Error::invalid_argument(
+            op,
+            "out",
+            "output view end offset overflows usize",
+        )
+    })?;
+    let storage = out.host_storage_mut()?;
+    storage.get_mut(offset..end).ok_or_else(|| {
+        tenferro_tensor::Error::runtime_state(
+            op,
+            "output view does not contain the requested LAPACK span",
+        )
     })
 }

--- a/crates/tenferro-linalg/src/cpu/linalg/mod.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/mod.rs
@@ -31,11 +31,11 @@ pub(crate) fn output_from_rhs_view<T: Copy + Clone + PoolScalar + 'static>(
     // overflow: `row + col * rows < rows * cols`.
     if rank == 1 {
         let rows = rhs.shape()[0];
-        for row in 0..rows {
+        for (row, slot) in data.iter_mut().enumerate().take(rows) {
             let value = rhs.get(&[row]).ok_or_else(|| {
                 tenferro_tensor::Error::runtime_state(op, "RHS view is not host-addressable")
             })?;
-            data[row].write(*value);
+            slot.write(*value);
         }
     } else {
         let rows = rhs.shape()[0];

--- a/crates/tenferro-linalg/src/cpu/linalg/mod.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/mod.rs
@@ -5,7 +5,68 @@ pub mod faer_linalg;
 #[cfg_attr(feature = "cpu-faer", allow(dead_code, unused_imports))]
 pub mod lapack_linalg;
 
+use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar, PooledUninitOutput};
+use tenferro_tensor::{TypedTensor, TypedTensorView};
+
 #[cfg(feature = "cpu-faer")]
 pub(crate) use faer_linalg as faer;
 #[cfg(feature = "cpu-blas")]
 pub(crate) use lapack_linalg as blas;
+
+pub(crate) fn output_from_rhs_view<T: Copy + Clone + PoolScalar + 'static>(
+    buffers: &mut BufferPool,
+    rhs: &TypedTensorView<'_, T>,
+    op: &'static str,
+) -> tenferro_tensor::Result<TypedTensor<T>> {
+    let rank = rhs.shape().len();
+    if !matches!(rank, 1 | 2) {
+        return Err(tenferro_tensor::Error::rank_mismatch(op, 2, rank));
+    }
+    let element_count = tenferro_tensor::validate::checked_shape_product(op, "rhs", rhs.shape())?;
+    let mut output = PooledUninitOutput::<T>::new(buffers, rhs.shape().to_vec())?;
+    let data = output.as_uninit_slice_mut();
+    match rhs.shape() {
+        [rows] => {
+            for (row, slot) in data.iter_mut().enumerate().take(*rows) {
+                let value = rhs.get(&[row]).ok_or_else(|| {
+                    tenferro_tensor::Error::runtime_state(op, "RHS view is not host-addressable")
+                })?;
+                slot.write(*value);
+            }
+        }
+        [rows, cols] => {
+            for col in 0..*cols {
+                let col_offset = col.checked_mul(*rows).ok_or_else(|| {
+                    tenferro_tensor::Error::invalid_argument(
+                        op,
+                        "rhs",
+                        "RHS compact index overflows usize",
+                    )
+                })?;
+                for row in 0..*rows {
+                    let index = col_offset.checked_add(row).ok_or_else(|| {
+                        tenferro_tensor::Error::invalid_argument(
+                            op,
+                            "rhs",
+                            "RHS compact index overflows usize",
+                        )
+                    })?;
+                    let value = rhs.get(&[row, col]).ok_or_else(|| {
+                        tenferro_tensor::Error::runtime_state(
+                            op,
+                            "RHS view is not host-addressable",
+                        )
+                    })?;
+                    data[index].write(*value);
+                }
+            }
+        }
+        _ => unreachable!("rank was validated above"),
+    }
+    debug_assert_eq!(element_count, data.len());
+    // SAFETY: every element of the compact destination was initialized from
+    // the corresponding logical RHS element above.
+    let mut output = unsafe { output.assume_init()? };
+    output.set_placement(rhs.placement().clone());
+    Ok(output)
+}

--- a/crates/tenferro-linalg/src/cpu/linalg/mod.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/mod.rs
@@ -22,48 +22,35 @@ pub(crate) fn output_from_rhs_view<T: Copy + Clone + PoolScalar + 'static>(
     if !matches!(rank, 1 | 2) {
         return Err(tenferro_tensor::Error::rank_mismatch(op, 2, rank));
     }
-    let element_count = tenferro_tensor::validate::checked_shape_product(op, "rhs", rhs.shape())?;
     let mut output = PooledUninitOutput::<T>::new(buffers, rhs.shape().to_vec())?;
     let data = output.as_uninit_slice_mut();
-    match rhs.shape() {
-        [rows] => {
-            for (row, slot) in data.iter_mut().enumerate().take(*rows) {
-                let value = rhs.get(&[row]).ok_or_else(|| {
+
+    // PooledUninitOutput::new validates the compact shape product before
+    // allocating `data`. Thus the indices below are in bounds and the
+    // column-major arithmetic for the compact destination cannot
+    // overflow: `row + col * rows < rows * cols`.
+    if rank == 1 {
+        let rows = rhs.shape()[0];
+        for row in 0..rows {
+            let value = rhs.get(&[row]).ok_or_else(|| {
+                tenferro_tensor::Error::runtime_state(op, "RHS view is not host-addressable")
+            })?;
+            data[row].write(*value);
+        }
+    } else {
+        let rows = rhs.shape()[0];
+        let cols = rhs.shape()[1];
+        for col in 0..cols {
+            for row in 0..rows {
+                let index = row + col * rows;
+                let value = rhs.get(&[row, col]).ok_or_else(|| {
                     tenferro_tensor::Error::runtime_state(op, "RHS view is not host-addressable")
                 })?;
-                slot.write(*value);
+                data[index].write(*value);
             }
         }
-        [rows, cols] => {
-            for col in 0..*cols {
-                let col_offset = col.checked_mul(*rows).ok_or_else(|| {
-                    tenferro_tensor::Error::invalid_argument(
-                        op,
-                        "rhs",
-                        "RHS compact index overflows usize",
-                    )
-                })?;
-                for row in 0..*rows {
-                    let index = col_offset.checked_add(row).ok_or_else(|| {
-                        tenferro_tensor::Error::invalid_argument(
-                            op,
-                            "rhs",
-                            "RHS compact index overflows usize",
-                        )
-                    })?;
-                    let value = rhs.get(&[row, col]).ok_or_else(|| {
-                        tenferro_tensor::Error::runtime_state(
-                            op,
-                            "RHS view is not host-addressable",
-                        )
-                    })?;
-                    data[index].write(*value);
-                }
-            }
-        }
-        _ => unreachable!("rank was validated above"),
     }
-    debug_assert_eq!(element_count, data.len());
+
     // SAFETY: every element of the compact destination was initialized from
     // the corresponding logical RHS element above.
     let mut output = unsafe { output.assume_init()? };

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -1,6 +1,8 @@
 use super::*;
 
 use crate::TensorReadLinalgExt;
+use std::sync::Arc;
+use tenferro_tensor::{Buffer, BufferHandle, MemoryKind, Placement};
 
 fn assert_c32_close(actual: Complex32, expected: Complex32) {
     assert!(
@@ -183,6 +185,106 @@ fn solve_read_into_covers_public_extension_complex_rhs_and_singular_atomicity() 
     assert_eq!(error.kind(), tenferro_tensor::ErrorKind::NumericalFailure);
     assert_eq!(get_f64(&sentinel, &[0, 0]), -37.0);
     assert_eq!(get_f64(&sentinel, &[1, 0]), -37.0);
+}
+
+#[test]
+fn output_from_rhs_view_covers_vector_matrix_and_rank_validation() {
+    let vector = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 5.0]).unwrap();
+    let mut matrix_storage = vec![-1.0; 8];
+    matrix_storage[1] = 7.0;
+    matrix_storage[2] = 11.0;
+    matrix_storage[5] = 13.0;
+    matrix_storage[6] = 17.0;
+    let matrix = TypedTensorView::from_slice(vec![2, 2], vec![1, 4], 1, &matrix_storage).unwrap();
+    let rank3_storage = [19.0];
+    let rank3 =
+        TypedTensorView::from_slice(vec![1, 1, 1], vec![1, 1, 1], 0, &rank3_storage).unwrap();
+    let mut backend = CpuBackend::new();
+
+    backend
+        .with_linalg_pool(|_, buffers| {
+            let vector_output = crate::cpu::linalg::output_from_rhs_view(
+                buffers,
+                &vector.as_view(),
+                "test_output_from_rhs_view",
+            )?;
+            assert_eq!(vector_output.host_data()?, &[3.0, 5.0]);
+
+            let matrix_output = crate::cpu::linalg::output_from_rhs_view(
+                buffers,
+                &matrix,
+                "test_output_from_rhs_view",
+            )?;
+            assert_eq!(matrix_output.host_data()?, &[7.0, 11.0, 13.0, 17.0]);
+
+            let error = crate::cpu::linalg::output_from_rhs_view(
+                buffers,
+                &rank3,
+                "test_output_from_rhs_view",
+            )
+            .unwrap_err();
+            assert!(matches!(
+                error,
+                tenferro_tensor::Error::Validation {
+                    source: tenferro_tensor::ValidationError::RankMismatch {
+                        expected: 2,
+                        actual: 3,
+                    },
+                    ..
+                }
+            ));
+
+            let backend_vector = TypedTensor::<f64>::from_buffer_col_major(
+                vec![2],
+                Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(120, 2))),
+                Placement {
+                    memory_kind: MemoryKind::Device,
+                    device: None,
+                    cpu_affinity: None,
+                },
+            )?;
+            let backend_vector_view = backend_vector.backend_region_view(vec![2], vec![1], 0)?;
+            let error = crate::cpu::linalg::output_from_rhs_view(
+                buffers,
+                &backend_vector_view,
+                "test_output_from_rhs_view",
+            )
+            .unwrap_err();
+            assert!(matches!(
+                error,
+                tenferro_tensor::Error::RuntimeState {
+                    op: "test_output_from_rhs_view",
+                    ..
+                }
+            ));
+
+            let backend_matrix = TypedTensor::<f64>::from_buffer_col_major(
+                vec![2, 2],
+                Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(121, 4))),
+                Placement {
+                    memory_kind: MemoryKind::Device,
+                    device: None,
+                    cpu_affinity: None,
+                },
+            )?;
+            let backend_matrix_view =
+                backend_matrix.backend_region_view(vec![2, 2], vec![1, 2], 0)?;
+            let error = crate::cpu::linalg::output_from_rhs_view(
+                buffers,
+                &backend_matrix_view,
+                "test_output_from_rhs_view",
+            )
+            .unwrap_err();
+            assert!(matches!(
+                error,
+                tenferro_tensor::Error::RuntimeState {
+                    op: "test_output_from_rhs_view",
+                    ..
+                }
+            ));
+            Ok(())
+        })
+        .unwrap();
 }
 
 #[test]

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+use crate::TensorReadLinalgExt;
+
+fn assert_c32_close(actual: Complex32, expected: Complex32) {
+    assert!(
+        (actual - expected).norm() < 1.0e-5,
+        "expected {expected:?}, got {actual:?}"
+    );
+}
+
 fn compiled_linalg_provider_kinds() -> Vec<tenferro_cpu::CpuBackendKind> {
     vec![
         #[cfg(feature = "cpu-faer")]
@@ -45,6 +54,135 @@ fn solve_read_accepts_owned_and_strided_inputs_for_compiled_providers() {
             .unwrap();
         assert_eq!(vector_x.shape(), &[2]);
     }
+}
+
+#[test]
+fn solve_read_into_writes_owned_and_padded_column_major_outputs() {
+    let a = Tensor::from_vec_col_major([2, 2], vec![3.0_f64, 1.0, 0.0, 2.0]).unwrap();
+    let b = Tensor::from_vec_col_major([2, 1], vec![7.0_f64, 4.0]).unwrap();
+
+    for kind in compiled_linalg_provider_kinds() {
+        let mut backend = CpuBackend::with_kind(kind).unwrap();
+
+        let mut owned = Tensor::from_vec_col_major([2, 1], vec![-9.0_f64; 2]).unwrap();
+        backend
+            .solve_read_into(
+                TensorRead::from_tensor(&a),
+                TensorRead::from_tensor(&b),
+                tenferro_tensor::TensorWrite::from_tensor(&mut owned),
+            )
+            .unwrap();
+        assert_f64_close(get_f64(&owned, &[0, 0]), 7.0 / 3.0);
+        assert_f64_close(get_f64(&owned, &[1, 0]), 5.0 / 6.0);
+
+        let mut storage = vec![-17.0_f64; 8];
+        let view = tenferro_tensor::TypedTensorViewMut::from_slice([2, 1], [1, 4], 1, &mut storage)
+            .unwrap();
+        backend
+            .solve_read_into(
+                TensorRead::from_tensor(&a),
+                TensorRead::from_tensor(&b),
+                tenferro_tensor::TensorWrite::from_view(tenferro_tensor::TensorViewMut::F64(view)),
+            )
+            .unwrap();
+        assert_f64_close(storage[1], 7.0 / 3.0);
+        assert_f64_close(storage[2], 5.0 / 6.0);
+        assert_eq!(storage[0], -17.0);
+        assert_eq!(storage[5], -17.0);
+    }
+}
+
+#[test]
+fn solve_read_into_rejects_bad_destination_before_mutation() {
+    let a = Tensor::from_vec_col_major([2, 2], vec![3.0_f64, 1.0, 0.0, 2.0]).unwrap();
+    let b = Tensor::from_vec_col_major([2, 1], vec![7.0_f64, 4.0]).unwrap();
+
+    for kind in compiled_linalg_provider_kinds() {
+        let mut backend = CpuBackend::with_kind(kind).unwrap();
+        let mut out = Tensor::from_vec_col_major([3, 1], vec![-23.0_f64; 3]).unwrap();
+        let error = backend
+            .solve_read_into(
+                TensorRead::from_tensor(&a),
+                TensorRead::from_tensor(&b),
+                tenferro_tensor::TensorWrite::from_tensor(&mut out),
+            )
+            .unwrap_err();
+        assert!(matches!(error, tenferro_tensor::Error::Validation { .. }));
+        match out {
+            Tensor::F64(out) => assert_eq!(out.host_data().unwrap(), &[-23.0, -23.0, -23.0]),
+            _ => unreachable!("test output is f64"),
+        }
+    }
+}
+
+#[test]
+fn solve_read_into_covers_public_extension_complex_rhs_and_singular_atomicity() {
+    let a = Tensor::from_vec_col_major([2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap();
+    let b = Tensor::from_vec_col_major([2, 2], vec![2.0_f64, 4.0, 4.0, 8.0]).unwrap();
+    let mut out = Tensor::from_vec_col_major([2, 2], vec![-31.0_f64; 4]).unwrap();
+    let mut backend = CpuBackend::new();
+    TensorRead::from_tensor(&a)
+        .solve_read_into(
+            TensorRead::from_tensor(&b),
+            tenferro_tensor::TensorWrite::from_tensor(&mut out),
+            &mut backend,
+        )
+        .unwrap();
+    assert_f64_close(get_f64(&out, &[0, 0]), 1.0);
+    assert_f64_close(get_f64(&out, &[1, 0]), 1.0);
+    assert_f64_close(get_f64(&out, &[0, 1]), 2.0);
+    assert_f64_close(get_f64(&out, &[1, 1]), 2.0);
+
+    let a = Tensor::from_vec_col_major(
+        [2, 2],
+        vec![
+            Complex32::new(2.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(4.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let b = Tensor::from_vec_col_major(
+        [2, 2],
+        vec![
+            Complex32::new(2.0, 2.0),
+            Complex32::new(4.0, 4.0),
+            Complex32::new(4.0, -2.0),
+            Complex32::new(8.0, -4.0),
+        ],
+    )
+    .unwrap();
+    let mut storage = vec![Complex32::new(-19.0, 0.0); 8];
+    let view =
+        tenferro_tensor::TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut storage).unwrap();
+    backend
+        .solve_read_into(
+            TensorRead::from_tensor(&a),
+            TensorRead::from_tensor(&b),
+            tenferro_tensor::TensorWrite::from_view(tenferro_tensor::TensorViewMut::C32(view)),
+        )
+        .unwrap();
+    assert_c32_close(storage[1], Complex32::new(1.0, 1.0));
+    assert_c32_close(storage[2], Complex32::new(1.0, 1.0));
+    assert_c32_close(storage[4], Complex32::new(2.0, -1.0));
+    assert_c32_close(storage[5], Complex32::new(2.0, -1.0));
+    assert_eq!(storage[0], Complex32::new(-19.0, 0.0));
+    assert_eq!(storage[3], Complex32::new(-19.0, 0.0));
+
+    let singular = Tensor::from_vec_col_major([2, 2], vec![1.0_f64, 2.0, 2.0, 4.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major([2, 1], vec![3.0_f64, 6.0]).unwrap();
+    let mut sentinel = Tensor::from_vec_col_major([2, 1], vec![-37.0_f64; 2]).unwrap();
+    let error = backend
+        .solve_read_into(
+            TensorRead::from_tensor(&singular),
+            TensorRead::from_tensor(&rhs),
+            tenferro_tensor::TensorWrite::from_tensor(&mut sentinel),
+        )
+        .unwrap_err();
+    assert_eq!(error.kind(), tenferro_tensor::ErrorKind::NumericalFailure);
+    assert_eq!(get_f64(&sentinel, &[0, 0]), -37.0);
+    assert_eq!(get_f64(&sentinel, &[1, 0]), -37.0);
 }
 
 #[test]

--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -338,8 +338,12 @@ pub trait TensorReadLinalgExt {
     /// the trait default preserves the ordinary solve-read plus copy behavior.
     ///
     /// # Errors
-    /// Returns destination metadata, aliasing, validation, backend, or
-    /// numerical errors from [`LinalgBackend::solve_read_into`].
+    /// Returns `tenferro_tensor_core::ShapeMismatch` or
+    /// `tenferro_tensor_core::ValidationError::DTypeMismatch` for incompatible
+    /// destination metadata, `tenferro_tensor_core::ValidationError::InvalidArgument`
+    /// for aliasing or placement violations, `Error::Unsupported` when the
+    /// extension implementation or provider is unavailable, and `Error::Singular`
+    /// for a singular system.
     fn solve_read_into<B: LinalgBackend>(
         self,
         b: TensorRead<'_>,

--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -6,7 +6,7 @@
 
 use num_complex::{Complex32, Complex64};
 use tenferro_tensor::{
-    CompareDir, DType, DotGeneralConfig, Tensor, TensorRead, TensorScalar, TypedTensor,
+    CompareDir, DType, DotGeneralConfig, Tensor, TensorRead, TensorScalar, TensorWrite, TypedTensor,
 };
 
 use crate::extension::{
@@ -331,6 +331,30 @@ pub trait TensorReadLinalgExt {
         b: TensorRead<'_>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
+    /// Solve into a caller-owned destination without allocating the result at
+    /// the public API boundary.
+    ///
+    /// Backends with a native path may write directly into a compatible target;
+    /// the trait default preserves the ordinary solve-read plus copy behavior.
+    ///
+    /// # Errors
+    /// Returns destination metadata, aliasing, validation, backend, or
+    /// numerical errors from [`LinalgBackend::solve_read_into`].
+    fn solve_read_into<B: LinalgBackend>(
+        self,
+        b: TensorRead<'_>,
+        out: TensorWrite<'_>,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<()>
+    where
+        Self: Sized,
+    {
+        let _ = (self, b, out, backend);
+        Err(tenferro_tensor::Error::unsupported(
+            "solve_read_into",
+            "this tensor-read extension implementation does not accept borrowed solve targets",
+        ))
+    }
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns matrix validation, read/materialization, backend, or positive-definiteness errors.
@@ -797,6 +821,14 @@ impl TensorReadLinalgExt for TensorRead<'_> {
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor> {
         backend.solve_read(self, b)
+    }
+    fn solve_read_into<B: LinalgBackend>(
+        self,
+        b: TensorRead<'_>,
+        out: TensorWrite<'_>,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<()> {
+        backend.solve_read_into(self, b, out)
     }
     fn cholesky_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
         backend.cholesky_read(self)

--- a/crates/tenferro-linalg/tests/integration/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/integration/backend_errors.rs
@@ -10,7 +10,8 @@ use tenferro_tensor::{
     DType, DotGeneralConfig, Error, ErrorKind, GatherConfig, MemoryKind, PadConfig, Placement,
     ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
     TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
-    TensorReduction, TensorStructural, TensorView, TypedTensor, ValidationError,
+    TensorReduction, TensorStructural, TensorView, TensorWrite, TypedTensor, TypedTensorView,
+    ValidationError,
 };
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
@@ -161,6 +162,21 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
             tril(input: &Tensor, k: i64) -> tenferro_tensor::Result<Tensor>;
             triu(input: &Tensor, k: i64) -> tenferro_tensor::Result<Tensor>;
         }
+
+        fn copy_read_into(
+            &mut self,
+            src: TensorRead<'_>,
+            dst: TensorWrite<'_>,
+        ) -> tenferro_tensor::Result<()> {
+            let Some(Tensor::F64(src)) = src.as_tensor() else {
+                panic!("the default solve_read_into test uses an owned f64 source")
+            };
+            let TensorWrite::Tensor(Tensor::F64(dst)) = dst else {
+                panic!("the default solve_read_into test uses an owned f64 destination")
+            };
+            dst.host_data_mut()?.copy_from_slice(src.host_data()?);
+            Ok(())
+        }
     }
 
     impl TensorReduction for DefaultOnlyLinalgBackend {
@@ -212,6 +228,16 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
             solve(a: &Tensor, b: &Tensor) -> tenferro_tensor::Result<Tensor>;
         }
 
+        fn solve_read(
+            &mut self,
+            _a: TensorRead<'_>,
+            b: TensorRead<'_>,
+        ) -> tenferro_tensor::Result<Tensor> {
+            Ok(Tensor::F64(
+                TypedTensor::from_vec_col_major(b.shape().to_vec(), vec![2.0, 3.0]).unwrap(),
+            ))
+        }
+
         fn eig_values(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
             self.eig_values_calls += 1;
             Ok(self
@@ -261,6 +287,53 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
     ));
 
     let owned_input = Tensor::F64(input.clone());
+
+    let rhs = Tensor::from_vec_col_major(vec![2, 1], vec![7.0_f64, 11.0]).unwrap();
+    let mut output = Tensor::from_vec_col_major(vec![2, 1], vec![-1.0_f64; 2]).unwrap();
+    backend
+        .solve_read_into(
+            TensorRead::from_tensor(&owned_input),
+            TensorRead::from_tensor(&rhs),
+            TensorWrite::from_tensor(&mut output),
+        )
+        .unwrap();
+    assert_eq!(output.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
+
+    let mut bad_dtype = Tensor::from_vec_col_major(vec![2, 1], vec![0_i32; 2]).unwrap();
+    let err = backend
+        .solve_read_into(
+            TensorRead::from_tensor(&owned_input),
+            TensorRead::from_tensor(&rhs),
+            TensorWrite::from_tensor(&mut bad_dtype),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::Validation {
+            op: "solve_read_into",
+            source: ValidationError::DTypeMismatch { .. },
+        }
+    ));
+
+    let mut wrong_placement = backend_f64_tensor(vec![2, 1], 180);
+    let err = backend
+        .solve_read_into(
+            TensorRead::from_tensor(&owned_input),
+            TensorRead::from_tensor(&rhs),
+            TensorWrite::from_tensor(&mut wrong_placement),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::Validation {
+            op: "solve_read_into",
+            source: ValidationError::InvalidArgument {
+                argument: "out",
+                ..
+            },
+        }
+    ));
+
     let err = backend
         .svd_read(tenferro_tensor::TensorRead::from_tensor(&owned_input))
         .unwrap_err();
@@ -373,19 +446,13 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
 
     let rhs =
         Tensor::F64(TypedTensor::<f64>::from_vec_col_major(vec![2, 1], vec![1.0, 2.0]).unwrap());
-    let err = backend
+    let solved = backend
         .solve_read(
             TensorRead::from_tensor(&owned_input),
             TensorRead::from_tensor(&rhs),
         )
-        .unwrap_err();
-    assert!(matches!(
-        err,
-        Error::Unsupported {
-            op: "solve",
-            ref message,
-        } if message.contains("tensor reads")
-    ));
+        .unwrap();
+    assert_eq!(solved.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
 
     let err = backend
         .triangular_solve_read(
@@ -871,4 +938,33 @@ fn full_piv_lu_solve_rejects_batch_mismatch_without_backend_panic() {
             source: ValidationError::ShapeMismatch(_),
         }
     ));
+}
+
+#[test]
+fn cpu_solve_read_covers_direct_vector_and_matrix_rhs_views() {
+    let a = f64_tensor(vec![2, 2], vec![2.0, 0.0, 0.0, 3.0]);
+    let vector = f64_tensor(vec![2], vec![4.0, 6.0]);
+    let mut backend = CpuBackend::new();
+
+    let vector_output = backend
+        .solve_read(
+            TensorRead::from_tensor(&a),
+            TensorRead::from_tensor(&vector),
+        )
+        .unwrap();
+    assert_eq!(f64_values(&vector_output), vec![2.0, 2.0]);
+
+    let mut storage = vec![-1.0_f64; 8];
+    storage[1] = 4.0;
+    storage[2] = 6.0;
+    storage[5] = 8.0;
+    storage[6] = 9.0;
+    let matrix_view = TypedTensorView::from_slice(vec![2, 2], vec![1, 4], 1, &storage).unwrap();
+    let matrix_output = backend
+        .solve_read(
+            TensorRead::from_tensor(&a),
+            TensorRead::from_view(TensorView::F64(matrix_view)),
+        )
+        .unwrap();
+    assert_eq!(f64_values(&matrix_output), vec![2.0, 2.0, 4.0, 3.0]);
 }

--- a/crates/tenferro-linalg/tests/integration/cpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/integration/cpu_linalg_source_contract.rs
@@ -384,6 +384,25 @@ fn linalg_rustdoc_reuses_backend_in_read_examples() {
 }
 
 #[test]
+fn cpu_backend_overrides_solve_read_into_hook() {
+    let backend = cpu_backend_source();
+    let override_section = rust_function_section(&backend, "solve_read_into");
+    assert!(
+        override_section.contains("validate_solve_read_into")
+            && override_section.contains("with_linalg_pool")
+            && override_section.contains("solve_read_into_entered"),
+        "CpuBackend must override solve_read_into and inject its entered pool/context"
+    );
+
+    let trait_source = linalg_backend_trait_source();
+    let default_section = rust_function_section(&trait_source, "solve_read_into");
+    assert!(
+        default_section.contains("solve_read_into_default(self, a, b, out)"),
+        "LinalgBackend must retain the portable solve_read_into fallback"
+    );
+}
+
+#[test]
 fn public_cpu_linalg_read_methods_keep_one_operation_entry() {
     let source = cpu_backend_source();
     let methods = [

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -1621,11 +1621,47 @@ fn validate_elementwise_output_disjoint(
     inputs: &[TensorRead<'_>],
     out: &TensorWrite<'_>,
 ) -> crate::Result<()> {
+    validate_read_into_destination(op.label(), inputs, out)
+}
+
+/// Validate that a caller-owned destination does not overlap any read input.
+///
+/// The check is intentionally conservative for host views: two views backed by
+/// the same host allocation are treated as overlapping because the allocation
+/// identity is the only stable boundary contract available to erased backend
+/// code. Backend allocations use their domain/allocation identity when the
+/// provider exposes it.
+///
+/// # Errors
+///
+/// Returns an invalid-argument error when the destination storage overlaps an
+/// input, or when storage identity cannot be established safely.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{Tensor, TensorRead, TensorWrite};
+/// use tenferro_tensor::backend::validate_read_into_destination;
+///
+/// let input = Tensor::from_vec_col_major(vec![1], vec![1.0_f64])?;
+/// let mut output = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+/// validate_read_into_destination(
+///     "example",
+///     &[TensorRead::from_tensor(&input)],
+///     &TensorWrite::from_tensor(&mut output),
+/// )?;
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+pub fn validate_read_into_destination(
+    op: &'static str,
+    inputs: &[TensorRead<'_>],
+    out: &TensorWrite<'_>,
+) -> crate::Result<()> {
     let output_identity = tensor_read_storage_identity(&out.as_read())?;
     for (index, input) in inputs.iter().enumerate() {
         if storage_overlaps(tensor_read_storage_identity(input)?, output_identity) {
             return Err(Error::invalid_argument(
-                op.label(),
+                op,
                 "out",
                 format!("destination storage overlaps input {index}"),
             ));

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -1634,8 +1634,9 @@ fn validate_elementwise_output_disjoint(
 ///
 /// # Errors
 ///
-/// Returns an invalid-argument error when the destination storage overlaps an
-/// input, or when storage identity cannot be established safely.
+/// Returns `tenferro_tensor_core::ValidationError::InvalidArgument` when the
+/// destination storage overlaps an input, or `Error::RuntimeState` when
+/// storage identity cannot be established safely.
 ///
 /// # Examples
 ///

--- a/docs/worklogs/2026-07-31-issue-1502-solve-into.md
+++ b/docs/worklogs/2026-07-31-issue-1502-solve-into.md
@@ -1,0 +1,110 @@
+# Issue #1502: caller-owned eager solve destination
+
+## Scope
+
+This work adds the public `solve_read_into` path for eager linear solves. The
+default backend contract remains allocate-then-copy; the CPU Faer and LAPACK
+providers use a validated direct destination path for compatible host,
+column-major layouts. `solve` and `solve_read` retain their existing
+owned-result APIs and share the same provider kernels.
+
+## Context read
+
+- `AGENTS.md`, `REPOSITORY_RULES.md`, and the shared tensor4all rules.
+- Issue #1502 and the merged #1525 session/admission work.
+- Existing `TensorRead`/`TensorWrite` metadata and overlap validation.
+- CPU buffer-pool ownership and the Faer/LAPACK solve implementations.
+
+## Decisions
+
+- Add one trait hook, `LinalgBackend::solve_read_into`, plus the borrowed
+  `TensorReadLinalgExt` forwarding method. External backend implementations get
+  the safe allocate-plus-copy default.
+- Validate shape, dtype, placement, and detectable input/destination overlap
+  before either the direct provider path or the default result allocation.
+- The direct CPU path accepts rank-2 A, vector or rank-2 B, and positive
+  column-major output with unit row stride. Matrix output permits a padded
+  leading dimension and a nonzero view offset. Unsupported layouts use the
+  default owned-result fallback.
+- Faer and LAPACK pack A directly into one pooled factor buffer, copy strided
+  RHS values into the caller destination, and solve in place. The ordinary
+  owned-result path uses the same in-place provider kernel after allocating its
+  compact result through the shared pooled helper.
+- Singular validation occurs before the destination RHS is copied, so the
+  documented singular/validation failure leaves `out` unchanged. Provider
+  failures after execution begins retain the existing unpublished-output
+  boundary.
+- No prepared solve plan or process-global cache was introduced.
+
+## Alternatives rejected or deferred
+
+- A fused single-pass solve allocation cache was not added; the issue requests
+  caller-owned output, not a new global or prepared-plan lifetime.
+- Arbitrary strided output writes were not forced through the direct path. The
+  fallback preserves correctness until a provider-native strided destination
+  contract exists.
+- The #1525 scheduler/session implementation was not changed. The solve path
+  reuses its established CPU context admission and is measured separately.
+
+## Implementation
+
+- Added `validate_read_into_destination` to the tensor backend boundary and
+  reused it for solve destination validation.
+- Added the default and CPU override for `solve_read_into`, including host and
+  provider checks and direct-layout eligibility.
+- Added shared Faer and LAPACK view-based solve helpers for real and complex
+  dtypes, vector and multiple-RHS cases, padded leading dimensions, and view
+  offsets.
+- Reworked ordinary CPU `solve`/`solve_read` to use the same view-based kernel
+  where rank/layout eligibility permits, without adding a second pool entry.
+- Added dtype, multiple-RHS, public extension, padded/offset view, sentinel,
+  mismatch, overlap, and singular atomicity tests, plus a source-contract test
+  that keeps the CPU override from silently disappearing.
+
+## Verification
+
+Passed locally:
+
+- `cargo fmt --all`
+- `git diff --check`
+- `cargo test -p tenferro-linalg --lib --no-default-features --features cpu-faer`
+  (120 tests)
+- `cargo test -p tenferro-linalg --test integration --no-default-features --features cpu-faer cpu_linalg_source_contract`
+  (17 tests)
+- `cargo check -p tenferro-linalg --lib --no-default-features --features cpu-faer`
+- `cargo check -p tenferro-linalg --lib --no-default-features --features cpu-blas`
+- `cargo check -p tenferro-linalg --tests --no-default-features --features cpu-blas`
+- `cargo test -p tenferro-linalg --doc --no-default-features --features cpu-faer`
+  (62 doctests)
+
+The BLAS runtime test was not linkable on this host because system BLAS/LAPACK
+symbols are unavailable; the `cpu-blas` library and test targets compile. The
+repository BLAS CI lane remains required for the PR.
+
+## Focused public API measurement
+
+The release benchmark compared the existing allocating `solve_read` control
+with caller-owned `solve_read_into` on the same f64 diagonal matrix and four
+RHS columns. It used `taskset -c 0-3`, two warmups, and fixed repetitions. The
+allocating row is the before/control path; the caller-owned row is the
+candidate path. Values are median-like per-call means from the focused run in
+milliseconds.
+
+| threads | shape | allocating `solve_read` | caller-owned `solve_read_into` | ratio |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | 32x32, 4 RHS | 0.018726 | 0.019038 | 1.0166 |
+| 1 | 128x128, 4 RHS | 0.163904 | 0.161107 | 0.9829 |
+| 4 | 32x32, 4 RHS | 0.024043 | 0.023406 | 0.9735 |
+| 4 | 128x128, 4 RHS | 0.208381 | 0.197415 | 0.9474 |
+
+The small t1 row is within measurement noise and is not claimed as a speedup;
+the medium rows show that the direct destination path does not add a material
+solve regression and removes the result handoff. This is focused evidence, not
+the final public benchmark campaign.
+
+## Remaining verification
+
+Run the repository fast gate, full CPU Faer/BLAS CI, coverage/docs/clippy, and
+rules review on the committed PR head. After merge, rerun the #1525 `inv`
+direct/trace rows as a non-regression check and report the result on #1502 and
+umbrella #1535.


### PR DESCRIPTION
## Summary

- add the caller-owned `solve_read_into` API with a safe allocate-plus-copy trait default;
- add validated direct-destination CPU paths for Faer and LAPACK;
- share the view-based provider solve kernel with ordinary `solve`/`solve_read` where eligible;
- preserve typed validation, overlap rejection, singular atomicity, and padded/offset column-major output support.

Closes #1502. This is intentionally one reviewable PR because the public hook, CPU override, provider kernels, and their tests form one ownership contract. It does not include the separate #1542 or #1546 work recently added to umbrella #1535.

## Design

- `LinalgBackend::solve_read_into` defaults to `solve_read` followed by `copy_read_into`.
- The CPU override validates shape, dtype, placement, host access, and detectable aliasing before mutation.
- Direct execution accepts rank-2 A, vector or matrix RHS, and positive column-major output with unit row stride. Matrix outputs may have a nonzero offset and padded leading dimension; unsupported layouts use the default fallback.
- Faer and LAPACK factorize A into one pooled factor buffer, copy RHS values into the caller destination only after factorization/singularity checks, and solve in place.
- Complex Faer output conversion uses the existing size/alignment/field-offset assertions. New shape/span arithmetic is checked.

The reviewer-facing rationale is in [`docs/worklogs/2026-07-31-issue-1502-solve-into.md`](https://github.com/tensor4all/tenferro-rs/blob/691dc6d7/docs/worklogs/2026-07-31-issue-1502-solve-into.md).

## Verification

Passed locally:

- `cargo fmt --all --check`
- repository fast gate, including workspace clippy and focused CPU tests;
- `cargo test -p tenferro-linalg --lib --no-default-features --features cpu-faer` (120 tests);
- source-contract integration tests (17 tests);
- `cargo test -p tenferro-linalg --doc --no-default-features --features cpu-faer` (62 doctests);
- `cargo check -p tenferro-linalg --tests --no-default-features --features cpu-blas`;
- workspace rustdoc and docs-site checks;
- deterministic repository-rules review: pass.

The local BLAS runtime test could not link because this host does not provide system BLAS/LAPACK symbols; the BLAS library and test targets compile. The CI BLAS runtime lane remains required.

## Focused measurement

Release-mode comparison of the allocating `solve_read` control and caller-owned `solve_read_into`, fixed to CPUs 0-3:

| threads | shape | allocating ms | caller-owned ms | ratio |
| ---: | --- | ---: | ---: | ---: |
| 1 | 32x32, 4 RHS | 0.018726 | 0.019038 | 1.0166 |
| 1 | 128x128, 4 RHS | 0.163904 | 0.161107 | 0.9829 |
| 4 | 32x32, 4 RHS | 0.024043 | 0.023406 | 0.9735 |
| 4 | 128x128, 4 RHS | 0.208381 | 0.197415 | 0.9474 |

No material regression was observed; the small t1 difference is treated as measurement noise. The full public benchmark and post-#1525 `inv` non-regression rerun remain merge/close-out evidence.

The external DeepSeek LLM review is intentionally skipped for this large multi-provider PR under the maintainer-approved policy; deterministic routing, repository rules, manual source audit, tests, clippy, docs, and CI remain required.
