### PR TITLE
runtime: make prepared cache poison recovery explicit

### DIFF
--- a/crates/tenferro-runtime/src/runtime/cache.rs
+++ b/crates/tenferro-runtime/src/runtime/cache.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::mem::size_of;
 use std::num::NonZeroUsize;
-use std::sync::{Arc, Condvar, Mutex, MutexGuard, PoisonError};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 
 use lru::LruCache;
 
@@ -846,7 +846,26 @@ impl<K: PreparedCacheKey, V: PreparedValue> PreparedPlanCache<K, V> {
     }
 
     fn recover_state(&self) -> MutexGuard<'_, CacheState<K, V>> {
-        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+        match self.state.lock() {
+            Ok(state) => state,
+            Err(error) => {
+                // INVARIANT: Guard Drop cannot return Result, so it must finish guard-owned
+                // accounting and notify waiters; the poison bit remains set, making later
+                // Result-returning cache APIs report `prepared-cache.state`.
+                error.into_inner()
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn poison_state_for_test(&self) {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _state = match self.state.lock() {
+                Ok(state) => state,
+                Err(_) => panic!("cache state should not already be poisoned in test setup"),
+            };
+            panic!("poison prepared cache state for test");
+        }));
     }
 }
 

--- a/crates/tenferro-runtime/src/runtime/tests/cache.rs
+++ b/crates/tenferro-runtime/src/runtime/tests/cache.rs
@@ -868,6 +868,116 @@ fn clear_during_active_attempt_advances_generation_and_prevents_reinsert() {
 }
 
 #[test]
+fn poisoned_state_stays_visible_after_producer_and_waiter_cleanup() {
+    let cache = Arc::new(PreparedPlanCache::<TestKey, TestValue>::new(limits(
+        8, 4096, 1, 4,
+    )));
+    let producer_entered = Arc::new(Barrier::new(2));
+    let producer_release = Arc::new(Barrier::new(2));
+
+    thread::scope(|scope| {
+        let producer = {
+            let cache = Arc::clone(&cache);
+            let producer_entered = Arc::clone(&producer_entered);
+            let producer_release = Arc::clone(&producer_release);
+            scope.spawn(move || {
+                let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                    cache.get_or_prepare(TestKey(41), CacheInFlightBehavior::Wait, 0, || {
+                        producer_entered.wait();
+                        producer_release.wait();
+                        panic!("abort producer for poisoned-cache cleanup test");
+                    })
+                }));
+                assert!(result.is_err());
+            })
+        };
+        producer_entered.wait();
+
+        let waiter = {
+            let cache = Arc::clone(&cache);
+            scope.spawn(move || {
+                cache.get_or_prepare(TestKey(41), CacheInFlightBehavior::Wait, 0, || {
+                    panic!("waiter must not become the producer");
+                })
+            })
+        };
+        eventually(|| {
+            cache
+                .stats()
+                .is_ok_and(|stats| stats.waits >= 1 && stats.in_flight == 1)
+        });
+
+        cache.poison_state_for_test();
+        producer_release.wait();
+
+        producer.join().unwrap();
+        assert!(waiter.join().unwrap().is_err());
+    });
+
+    assert!(matches!(
+        cache.stats(),
+        Err(RuntimeStateError::Poisoned {
+            lock: "prepared-cache.state"
+        })
+    ));
+}
+
+#[test]
+fn poisoned_state_stays_visible_after_queue_ticket_cleanup() {
+    let cache = Arc::new(PreparedPlanCache::<TestKey, TestValue>::new(limits(
+        8, 4096, 1, 4,
+    )));
+    let producer_entered = Arc::new(Barrier::new(2));
+    let producer_release = Arc::new(Barrier::new(2));
+
+    thread::scope(|scope| {
+        let producer = {
+            let cache = Arc::clone(&cache);
+            let producer_entered = Arc::clone(&producer_entered);
+            let producer_release = Arc::clone(&producer_release);
+            scope.spawn(move || {
+                cache.get_or_prepare(TestKey(42), CacheInFlightBehavior::Wait, 0, || {
+                    producer_entered.wait();
+                    producer_release.wait();
+                    CacheProduced::Ready {
+                        value: TestValue::new(8),
+                        shared: None,
+                    }
+                })
+            })
+        };
+        producer_entered.wait();
+
+        let queued = {
+            let cache = Arc::clone(&cache);
+            scope.spawn(move || {
+                cache.get_or_prepare(TestKey(43), CacheInFlightBehavior::Wait, 0, || {
+                    panic!("queued request must not become the producer");
+                })
+            })
+        };
+        eventually(|| {
+            cache
+                .stats()
+                .is_ok_and(|stats| stats.queued_distinct_keys == 1 && stats.in_flight == 1)
+        });
+
+        cache.poison_state_for_test();
+        producer_release.wait();
+
+        assert!(producer.join().unwrap().is_err());
+        assert!(queued.join().unwrap().is_err());
+    });
+
+    assert!(matches!(
+        cache.stats(),
+        Err(RuntimeStateError::Poisoned {
+            lock: "prepared-cache.state"
+        })
+    ));
+}
+
+#[test]
 fn shared_roots_are_charged_once_and_drop_with_cache() {
     let key_sentinel = Arc::new(());
     let value_sentinel = Arc::new(());

--- a/docs/worklogs/2026-07-31-issue-1542-cache-poison-visibility.md
+++ b/docs/worklogs/2026-07-31-issue-1542-cache-poison-visibility.md
@@ -1,0 +1,65 @@
+# Issue #1542: PreparedPlanCache poison visibility
+
+## Scope
+
+Make the `PreparedPlanCache` poison-recovery exception explicit and cover all
+three guard cleanup paths without changing the typed poison errors returned by
+normal cache operations.
+
+## Context read
+
+- `AGENTS.md`, `REPOSITORY_RULES.md`, and the shared Rust/cache rules.
+- Issue #1542 and umbrella issue #1535.
+- `crates/tenferro-runtime/src/runtime/cache.rs` and its module-local cache
+  tests.
+- The neighboring runtime lock-poison handling in `execution.rs` and the
+  existing snapshot poison regression test.
+
+## Decisions
+
+- Keep `recover_state` as a non-`Result` helper because it is used only from
+  `Drop` implementations, which cannot return a typed error. It recovers the
+  guard needed to remove guard-owned accounting and notify waiters.
+- Make the exception explicit with the repository-standard `// INVARIANT:`
+  marker. The mutex poison bit is deliberately not cleared, so later
+  `Result`-returning cache APIs continue to report `prepared-cache.state`.
+- Do not add a logging dependency or broaden poison recovery to unrelated
+  runtime or CPU locks. The existing typed failure surface is the visible
+  signal available after a `Drop` cleanup has completed.
+- Use a test-only poison helper following the existing runtime test-helper
+  pattern. It creates real `std::sync::Mutex` poison and exercises producer,
+  entry-waiter, and queue-ticket guard drops through cache behavior.
+
+## Implementation
+
+- Replaced the implicit `unwrap_or_else(PoisonError::into_inner)` expression
+  with an explicit match and invariant marker.
+- Added focused tests for producer/waiter cleanup and queued-ticket cleanup
+  under a poisoned state. Both assert that subsequent `stats()` calls return
+  the typed `RuntimeStateError::Poisoned` value.
+
+## Verification
+
+- `cargo fmt --all`
+- `git diff --check`
+- `cargo test -p tenferro-runtime poisoned_state_stays_visible --lib`
+- `cargo test -p tenferro-runtime` (unit, integration, and doctest targets)
+- `bash scripts/check-pr-fast.sh --base origin/main --no-fetch
+  --coverage-reviewed --test 'cargo test -p tenferro-runtime --lib'`
+- Workspace and extension clippy with the repository's `-D warnings`,
+  `missing_errors_doc`, and `missing_panics_doc` flags.
+- Committed-head deterministic repository-rules review: pass.
+- Committed-head external LLM repository-rules review: pass, no findings.
+- `python3 scripts/ci/run_profile.py coverage`: `203/203` files passed.
+- `python3 scripts/ci/run_profile.py docs`: rustdoc, docs consistency, site
+  rendering, links, and API inventory passed.
+
+The repository's hardware-specific GPU lanes are unaffected by this
+runtime-only safety change and were left to their normal CI policy.
+
+## Residual risk
+
+Other `into_inner` uses in `tenferro-cpu` are outside #1542 and retain their
+existing issue scope. Runtime execution lock handling was audited and already
+records poison as an explicit execution error rather than fabricating healthy
+state; no unrelated lock behavior is changed here.


### PR DESCRIPTION
## Summary

Fixes #1542.

`PreparedPlanCache::recover_state` is used only by the three guard `Drop`
implementations. The method now makes its non-`Result` poison-recovery
exception explicit with the repository `// INVARIANT:` contract.

The mutex poison bit is intentionally preserved. Normal cache APIs continue to
return the typed `RuntimeStateError::Poisoned` error instead of treating the
recovered state as healthy. No logging dependency or unrelated lock recovery
was added.

## Regression coverage

- Producer and same-key waiter cleanup under a poisoned cache mutex.
- Queued-key ticket cleanup under a poisoned cache mutex.
- Post-cleanup `stats()` visibility of `prepared-cache.state` poison.

The test-only poison helper creates real `std::sync::Mutex` poison and drives
the existing cache paths; it does not add a production failure seam.

## Verification

- `cargo test -p tenferro-runtime` passed.
- Workspace and extension clippy passed with the CI warning-deny flags.
- `python3 scripts/ci/run_profile.py coverage` passed: 203/203 files.
- `python3 scripts/ci/run_profile.py docs` passed.
- Fast checks and committed-head repository-rules review passed.
- External LLM repository-rules review passed with no findings.

Worklog: `docs/worklogs/2026-07-31-issue-1542-cache-poison-visibility.md`
