### PR TITLE
chore(cpu): remove stale strided-einsum2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "9d
 strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "9da9b9f63e688eaf1bf4a78b718a01ac858b1f9f", version = "0.3.0" }
 strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "9da9b9f63e688eaf1bf4a78b718a01ac858b1f9f", version = "0.3.0", features = ["parallel"] }
 strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "9da9b9f63e688eaf1bf4a78b718a01ac858b1f9f", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "9da9b9f63e688eaf1bf4a78b718a01ac858b1f9f", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -760,9 +760,10 @@ Tests follow implementation ownership.
   different compiled provider when needed.
 - Tensor-sized CPU kernels must run through the repository CPU threading
   policy. `strided-kernel` must be compiled with its `parallel` feature for
-  elementwise, reduction, and structural materialization kernels; CPU
-  contraction features that use `strided-einsum2` must propagate
-  `strided-einsum2/parallel`.
+  elementwise, reduction, and structural materialization kernels. CPU
+  contraction providers must receive their policy from the owning
+  `CpuExecutionContext`; Faer uses `Par::Seq` for one-thread contexts and
+  explicit `Par::rayon(n)` for bounded multi-thread contexts.
 - If a tensor-sized CPU operation remains a dedicated sequential loop because
   no strided-kernel/backend-native parallel primitive fits the indexing pattern
   yet, keep a nearby source comment naming that rationale. Do not let

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -16,33 +16,24 @@ name = "tenferro_cpu"
 
 [features]
 default = ["cpu-faer"]
-cpu-faer = ["dep:faer", "dep:strided-einsum2", "strided-einsum2/faer", "strided-einsum2/parallel"]
+cpu-faer = ["dep:faer"]
 cpu-blas = ["dep:cblas-sys", "dep:lapack"]
 provider-src = ["cpu-blas", "dep:blas-src", "dep:cblas-src", "dep:lapack-src"]
 provider-inject = ["cpu-blas", "dep:cblas-inject", "dep:lapack-inject"]
 blas-openblas = [
     "provider-src",
-    "dep:strided-einsum2",
     "blas-src/openblas",
     "lapack-src/openblas",
-    "strided-einsum2/blas-openblas",
-    "strided-einsum2/parallel",
 ]
 blas-accelerate = [
     "provider-src",
-    "dep:strided-einsum2",
     "blas-src/accelerate",
     "lapack-src/accelerate",
-    "strided-einsum2/blas-accelerate",
-    "strided-einsum2/parallel",
 ]
 blas-mkl = [
     "provider-src",
-    "dep:strided-einsum2",
     "blas-src/intel-mkl-dynamic-parallel",
     "lapack-src/intel-mkl-dynamic-parallel",
-    "strided-einsum2/blas-mkl",
-    "strided-einsum2/parallel",
 ]
 
 [dependencies]
@@ -55,7 +46,6 @@ num-traits.workspace = true
 rayon.workspace = true
 smallvec.workspace = true
 strided-kernel.workspace = true
-strided-einsum2 = { workspace = true, optional = true }
 thiserror.workspace = true
 faer = { workspace = true, optional = true }
 cblas-sys = { workspace = true, optional = true }

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -31,13 +31,10 @@ fn cpu_tensor_kernel_parallel_features_are_wired() {
         "workspace strided-kernel dependency must enable the parallel feature: {strided_kernel_line}"
     );
 
-    let cpu_faer_line = cpu_manifest
-        .lines()
-        .find(|line| line.trim_start().starts_with("cpu-faer ="))
-        .expect("tenferro-cpu manifest should declare cpu-faer");
     assert!(
-        cpu_faer_line.contains("strided-einsum2/parallel"),
-        "cpu-faer must propagate strided-einsum2/parallel: {cpu_faer_line}"
+        !workspace_manifest.contains("strided-einsum2")
+            && !cpu_manifest.contains("strided-einsum2"),
+        "tenferro-rs must not retain the removed strided-einsum2 dependency"
     );
 }
 

--- a/crates/tenferro-cpu/tests/integration/provider_feature_contract.rs
+++ b/crates/tenferro-cpu/tests/integration/provider_feature_contract.rs
@@ -3,32 +3,22 @@ use std::path::{Path, PathBuf};
 const PROVIDER_FEATURES: &[(&str, &[&str])] = &[
     (
         "blas-openblas",
-        &[
-            "provider-src",
-            "dep:strided-einsum2",
-            "blas-src/openblas",
-            "lapack-src/openblas",
-            "strided-einsum2/blas-openblas",
-        ],
+        &["provider-src", "blas-src/openblas", "lapack-src/openblas"],
     ),
     (
         "blas-accelerate",
         &[
             "provider-src",
-            "dep:strided-einsum2",
             "blas-src/accelerate",
             "lapack-src/accelerate",
-            "strided-einsum2/blas-accelerate",
         ],
     ),
     (
         "blas-mkl",
         &[
             "provider-src",
-            "dep:strided-einsum2",
             "blas-src/intel-mkl-dynamic-parallel",
             "lapack-src/intel-mkl-dynamic-parallel",
-            "strided-einsum2/blas-mkl",
         ],
     ),
 ];
@@ -102,7 +92,7 @@ fn feature_values(manifest: &str, feature: &str) -> String {
 }
 
 #[test]
-fn cpu_provider_features_select_matching_source_and_einsum_provider() {
+fn cpu_provider_features_select_matching_source_provider() {
     let manifest = manifest("tenferro-cpu");
 
     for (feature, required_values) in PROVIDER_FEATURES {

--- a/docs/design/einsum.md
+++ b/docs/design/einsum.md
@@ -240,8 +240,8 @@ contiguous block for the underlying tensor backend.
 For a whole-expression binary GEMM-compatible contraction such as
 `ij,jk->ik`, `einsum_into` and `ConcreteEinsumPlan::execute_into` dispatch to
 the backend `dot_general_read_into` hook before the owned-output fallback. The
-CPU faer path writes directly into caller-provided output storage through
-`strided_einsum2` and does not allocate the final output tensor. General
+CPU faer provider writes directly into caller-provided output storage through
+its validated `FaerGemm` path and does not allocate the final output tensor. General
 multi-step einsums may still allocate intermediates; their `*_into` contract is
 that the final result is copied into the preallocated destination after output
 validation.

--- a/docs/worklogs/2026-07-31-issue-1546-faer-policy.md
+++ b/docs/worklogs/2026-07-31-issue-1546-faer-policy.md
@@ -30,6 +30,8 @@ rules text. Those declarations were reintroduced by the later strided pin
 update even though the tenferro-cpu Faer/BLAS contraction implementation no
 longer uses the crate. This change removes that unused build graph and updates
 the active contract text to describe the current tenferro-owned Faer provider.
+The CI build-artifact contract had the same stale assumption; it now checks the
+remaining strided revisions and asserts that `strided-einsum2` stays absent.
 
 No strided-rs code change is required for #1546, and no `Par::rayon(0)` call is
 introduced in tenferro-cpu.

--- a/docs/worklogs/2026-07-31-issue-1546-faer-policy.md
+++ b/docs/worklogs/2026-07-31-issue-1546-faer-policy.md
@@ -1,0 +1,42 @@
+# Issue #1546: Faer dot-general policy audit
+
+Date: 2026-07-31
+
+## Scope
+
+Audit the reported `Par::rayon(0)` bypass in ordinary CPU Faer
+`dot_general`, including the cross-repository `strided-einsum2` dependency and
+the `CpuContext` thread-policy boundary.
+
+## Findings
+
+The issue body describes an older route that is not present at the current
+`main` revision. The active `tenferro-cpu` implementation uses its local
+validated `FaerGemm` provider. `execute_faer_request_typed` obtains
+`context.faer_parallelism()`, and `CpuExecutionContext::faer_parallelism`
+returns `faer::Par::Seq` for one-thread or non-inner execution and explicit
+`faer::Par::rayon(n)` for bounded inner Rayon execution. The enclosing session
+also enters `CpuExecutionContext::with_native_parallelism`, so the Faer policy
+does not inherit an unrelated ambient Rayon degree.
+
+Focused tests cover the policy mapping, native execution scope, and the source
+contract forbidding ambient/ad-hoc policy selection.
+
+## Remediation
+
+The current tree still carried a stale `strided-einsum2` workspace dependency,
+optional CPU features, feature-contract assertions, active design wording, and
+rules text. Those declarations were reintroduced by the later strided pin
+update even though the tenferro-cpu Faer/BLAS contraction implementation no
+longer uses the crate. This change removes that unused build graph and updates
+the active contract text to describe the current tenferro-owned Faer provider.
+
+No strided-rs code change is required for #1546, and no `Par::rayon(0)` call is
+introduced in tenferro-cpu.
+
+## Verification
+
+- Focused Faer policy mapping test.
+- Focused native-policy source-contract test.
+- Focused active documentation/rules contract test.
+- Full package and workspace checks are run on the committed PR head.

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -64,7 +64,7 @@ class BuildArtifactContracts(unittest.TestCase):
                 for selector in removed_selectors:
                     self.assertNotIn(selector, contents)
 
-    def test_workspace_faer_dependency_disables_broad_defaults(self) -> None:
+    def test_workspace_faer_and_strided_dependencies_follow_contract(self) -> None:
         manifest = tomllib.loads((ROOT / "Cargo.toml").read_text())
         dependencies = manifest["workspace"]["dependencies"]
 
@@ -78,12 +78,11 @@ class BuildArtifactContracts(unittest.TestCase):
             "strided-traits",
             "strided-perm",
             "strided-kernel",
-            "strided-einsum2",
         ):
             with self.subTest(dependency=name):
                 self.assertEqual(dependencies[name]["rev"], revision)
 
-        self.assertFalse(dependencies["strided-einsum2"]["default-features"])
+        self.assertNotIn("strided-einsum2", dependencies)
 
     def test_linalg_provider_dependencies_are_isolated(self) -> None:
         manifest = tomllib.loads(


### PR DESCRIPTION
## Summary

- Audit #1546 against the current `main` implementation and record that the reported `Par::rayon(0)` route is stale.
- Remove the unused `strided-einsum2` workspace/package dependency and its provider feature wiring, which was reintroduced by a later strided pin update.
- Update the active CPU threading rule, provider feature contract, and einsum design note to describe the current context-owned Faer policy.

The current Faer provider obtains `Par::Seq` for one-thread contexts and explicit `Par::rayon(n)` for bounded multi-thread contexts from `CpuExecutionContext`; no `strided-rs` code change is required for #1546.

Closes #1546.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p tenferro-cpu --lib` (500 passed)
- `cargo test -p tenferro-cpu --test integration` (46 passed)
- `cargo metadata --format-version 1 --no-deps` dependency assertion: no `strided-einsum2`
- `scripts/check-pr-fast.sh --base origin/main --no-fetch --coverage-reviewed` passed
- `scripts/repository-rules-review.py --base origin/main --head HEAD` passed with no findings
