### PR TITLE
docs: add backend selection and capability guide

### DIFF
--- a/crates/tenferro-cpu/examples/choosing_cpu_provider.rs
+++ b/crates/tenferro-cpu/examples/choosing_cpu_provider.rs
@@ -1,0 +1,9 @@
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let faer = CpuBackend::with_threads_and_kind(4, CpuBackendKind::Faer)?;
+    let blas = CpuBackend::with_threads_and_kind(4, CpuBackendKind::Blas)?;
+    assert_eq!(faer.kind(), CpuBackendKind::Faer);
+    assert_eq!(blas.kind(), CpuBackendKind::Blas);
+    Ok(())
+}

--- a/crates/tenferro-cpu/examples/multiple_cpu_engines.rs
+++ b/crates/tenferro-cpu/examples/multiple_cpu_engines.rs
@@ -1,0 +1,20 @@
+use tenferro_cpu::{runtime_engine_registration_with_id, CpuBackend, CpuBackendKind};
+use tenferro_runtime::{EngineId, Runtime};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let primary = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer)?;
+    let secondary = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Blas)?;
+
+    let mut builder = Runtime::builder();
+    builder.register_engine(runtime_engine_registration_with_id(
+        &primary,
+        EngineId::new("example.cpu.faer.v1")?,
+    )?)?;
+    builder.register_engine(runtime_engine_registration_with_id(
+        &secondary,
+        EngineId::new("example.cpu.blas.v1")?,
+    )?)?;
+    let runtime = builder.build()?;
+    assert_eq!(runtime.snapshot()?.engine_count(), 2);
+    Ok(())
+}

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -204,7 +204,10 @@ pub use provider_capability::{
     CpuThreadCountControl,
 };
 pub use resource_domain::{CpuDomainOwnership, ExternalCpuDomain, ExternalCpuDomainError};
-pub use runtime_adapter::{runtime_engine_id, runtime_engine_registration, runtime_hardware_class};
+pub use runtime_adapter::{
+    runtime_engine_id, runtime_engine_registration, runtime_engine_registration_with_id,
+    runtime_hardware_class,
+};
 pub use topology::{
     discover_cpu_topology, CpuId, CpuNode, CpuSet, CpuSetError, CpuTopology, CpuTopologyError,
     NumaNodeId,

--- a/crates/tenferro-cpu/src/runtime_adapter.rs
+++ b/crates/tenferro-cpu/src/runtime_adapter.rs
@@ -56,6 +56,39 @@ pub fn runtime_hardware_class() -> Result<HardwareClassId, RuntimeConfigError> {
 pub fn runtime_engine_registration(
     backend: &CpuBackend,
 ) -> Result<EngineRegistration, RuntimeConfigError> {
+    runtime_engine_registration_with_id(backend, runtime_engine_id()?)
+}
+
+/// Build a runtime engine registration for a [`CpuBackend`] with a
+/// caller-selected engine identifier.
+///
+/// Use this when one process registers more than one CPU backend, for example
+/// when separate CPU resource domains or provider bundles need distinct
+/// placement identities. The hardware and storage classes remain the
+/// canonical host CPU classes; only the engine identity is caller-selected.
+///
+/// # Errors
+///
+/// Returns [`RuntimeConfigError`] if the supplied engine identifier or one of
+/// the built-in CPU runtime identifiers fails runtime validation, or if the
+/// registration is internally invalid.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{runtime_engine_registration_with_id, CpuBackend};
+/// use tenferro_runtime::EngineId;
+///
+/// let backend = CpuBackend::new();
+/// let engine_id = EngineId::new("example.cpu.primary.v1")?;
+/// let registration = runtime_engine_registration_with_id(&backend, engine_id)?;
+/// assert_eq!(registration.engine_id().as_str(), "example.cpu.primary.v1");
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn runtime_engine_registration_with_id(
+    backend: &CpuBackend,
+    engine_id: EngineId,
+) -> Result<EngineRegistration, RuntimeConfigError> {
     let backend = Arc::new(backend.clone());
     let elementwise: Arc<dyn ElementwiseRuntime> = backend.clone();
     let reduction: Arc<dyn ReductionRuntime> = backend.clone();
@@ -80,7 +113,7 @@ pub fn runtime_engine_registration(
     let resident_storage = storage.clone();
     let allocation_domain = backend.allocation_domain();
     EngineRegistration::new(
-        runtime_engine_id()?,
+        engine_id,
         ExecutionContextIdentity::of::<CpuBackend>(),
         runtime_hardware_class()?,
         Arc::from(vec![storage.clone()]),

--- a/crates/tenferro-cpu/src/runtime_adapter/tests.rs
+++ b/crates/tenferro-cpu/src/runtime_adapter/tests.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 
 use tenferro_runtime::program::CoreSemanticOp;
 use tenferro_runtime::{
-    CompareDir, DType, DotGeneralConfig, DotGeneralPreparation, ElementwiseRuntime,
+    CompareDir, DType, DotGeneralConfig, DotGeneralPreparation, ElementwiseRuntime, EngineId,
     IndexingRuntime, InputSignature, InputSignatureEntry, InputSpecializationProjection,
     InputSpecializationRequirements, LayoutClass, LayoutRuntime, LayoutSpecialization,
-    PlacementSpecialization, ReductionRuntime, RuntimeCacheOwner, SpecializationError,
+    PlacementSpecialization, ReductionRuntime, Runtime, RuntimeCacheOwner, SpecializationError,
     SpecializationRequirements,
 };
 use tenferro_tensor::{
@@ -40,6 +40,74 @@ fn public_cpu_runtime_registration_includes_execution_bridge() {
 
     assert_eq!(registration.engine_id().as_str(), "tenferro-cpu.default.v1");
     assert!(registration.has_execution_engine());
+}
+
+#[test]
+fn public_cpu_runtime_registration_allows_two_engine_ids_in_one_runtime() {
+    let first_backend = CpuBackend::with_threads(1).expect("first CPU backend");
+    let second_backend = CpuBackend::with_threads(1).expect("second CPU backend");
+    let first_id = EngineId::new("tenferro-cpu.first.v1").expect("first engine ID");
+    let second_id = EngineId::new("tenferro-cpu.second.v1").expect("second engine ID");
+
+    let mut builder = Runtime::builder();
+    builder
+        .register_engine(
+            crate::runtime_engine_registration_with_id(&first_backend, first_id.clone())
+                .expect("first CPU registration"),
+        )
+        .expect("register first CPU engine");
+    builder
+        .register_engine(
+            crate::runtime_engine_registration_with_id(&second_backend, second_id.clone())
+                .expect("second CPU registration"),
+        )
+        .expect("register second CPU engine");
+    let runtime = builder.build().expect("runtime with two CPU engines");
+    let snapshot = runtime.snapshot().expect("runtime snapshot");
+
+    assert_eq!(snapshot.engine_count(), 2);
+    assert_eq!(snapshot.engine(&first_id).unwrap().engine_id(), &first_id);
+    assert_eq!(snapshot.engine(&second_id).unwrap().engine_id(), &second_id);
+}
+
+#[cfg(all(feature = "cpu-faer", feature = "cpu-blas"))]
+#[test]
+fn public_cpu_runtime_registration_supports_distinct_compiled_provider_kinds() {
+    let faer = CpuBackend::with_threads_and_kind(1, crate::CpuBackendKind::Faer)
+        .expect("faer CPU backend");
+    let blas = CpuBackend::with_threads_and_kind(1, crate::CpuBackendKind::Blas)
+        .expect("BLAS CPU backend");
+
+    assert_ne!(faer.kind(), blas.kind());
+
+    let mut builder = Runtime::builder();
+    builder
+        .register_engine(
+            crate::runtime_engine_registration_with_id(
+                &faer,
+                EngineId::new("tenferro-cpu.faer.v1").expect("faer engine ID"),
+            )
+            .expect("faer CPU registration"),
+        )
+        .expect("register faer CPU engine");
+    builder
+        .register_engine(
+            crate::runtime_engine_registration_with_id(
+                &blas,
+                EngineId::new("tenferro-cpu.blas.v1").expect("BLAS engine ID"),
+            )
+            .expect("BLAS CPU registration"),
+        )
+        .expect("register BLAS CPU engine");
+    assert_eq!(
+        builder
+            .build()
+            .expect("runtime")
+            .snapshot()
+            .unwrap()
+            .engine_count(),
+        2
+    );
 }
 
 #[test]

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -48,6 +48,7 @@ website:
         contents:
           - text: "Choosing a Tensor API"
             href: guides/choosing-an-api.md
+          - guides/choosing-a-backend.md
           - guides/execution-models.md
           - guides/eager-operations.md
           - guides/tensor-operations.md

--- a/docs/guides/choosing-a-backend.md
+++ b/docs/guides/choosing-a-backend.md
@@ -49,15 +49,19 @@ giving up tenferro's strict worker-placement and per-operation control.
 The CPU provider kind is selected per backend when both base provider kinds are
 compiled:
 
+<!-- snippet-source: crates/tenferro-cpu/examples/choosing_cpu_provider.rs -->
 ```rust
 use tenferro_cpu::{CpuBackend, CpuBackendKind};
 
-let faer = CpuBackend::with_threads_and_kind(4, CpuBackendKind::Faer)?;
-let blas = CpuBackend::with_threads_and_kind(4, CpuBackendKind::Blas)?;
-assert_eq!(faer.kind(), CpuBackendKind::Faer);
-assert_eq!(blas.kind(), CpuBackendKind::Blas);
-# Ok::<(), Box<dyn std::error::Error>>(())
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let faer = CpuBackend::with_threads_and_kind(4, CpuBackendKind::Faer)?;
+    let blas = CpuBackend::with_threads_and_kind(4, CpuBackendKind::Blas)?;
+    assert_eq!(faer.kind(), CpuBackendKind::Faer);
+    assert_eq!(blas.kind(), CpuBackendKind::Blas);
+    Ok(())
+}
 ```
+<!-- end-snippet-source -->
 
 This requires both `cpu-faer` and `cpu-blas` in the resolved Cargo feature
 set. It does not make OpenBLAS and MKL independently selectable at runtime:
@@ -142,28 +146,30 @@ When one process needs two CPU engine registrations, use distinct engine IDs.
 The canonical helper keeps `tenferro-cpu.default.v1` for the usual single
 backend case; the caller-selected helper avoids an ID collision:
 
+<!-- snippet-source: crates/tenferro-cpu/examples/multiple_cpu_engines.rs -->
 ```rust
-use tenferro_cpu::{
-    runtime_engine_registration_with_id, CpuBackend, CpuBackendKind,
-};
+use tenferro_cpu::{runtime_engine_registration_with_id, CpuBackend, CpuBackendKind};
 use tenferro_runtime::{EngineId, Runtime};
 
-let primary = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer)?;
-let secondary = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Blas)?;
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let primary = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer)?;
+    let secondary = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Blas)?;
 
-let mut builder = Runtime::builder();
-builder.register_engine(runtime_engine_registration_with_id(
-    &primary,
-    EngineId::new("example.cpu.faer.v1")?,
-)?)?;
-builder.register_engine(runtime_engine_registration_with_id(
-    &secondary,
-    EngineId::new("example.cpu.blas.v1")?,
-)?)?;
-let runtime = builder.build()?;
-assert_eq!(runtime.snapshot()?.engine_count(), 2);
-# Ok::<(), Box<dyn std::error::Error>>(())
+    let mut builder = Runtime::builder();
+    builder.register_engine(runtime_engine_registration_with_id(
+        &primary,
+        EngineId::new("example.cpu.faer.v1")?,
+    )?)?;
+    builder.register_engine(runtime_engine_registration_with_id(
+        &secondary,
+        EngineId::new("example.cpu.blas.v1")?,
+    )?)?;
+    let runtime = builder.build()?;
+    assert_eq!(runtime.snapshot()?.engine_count(), 2);
+    Ok(())
+}
 ```
+<!-- end-snippet-source -->
 
 Compile this example with both `cpu-faer` and `cpu-blas`. If the second
 backend uses OpenBLAS, MKL, or Accelerate, its library and thread settings are

--- a/docs/guides/choosing-a-backend.md
+++ b/docs/guides/choosing-a-backend.md
@@ -1,0 +1,184 @@
+# Choosing A Backend
+
+Choose a backend in two steps. First choose the execution backend that owns
+the device and its synchronization boundary. If that backend is CPU, choose a
+dense CPU provider separately. The important choice is control: a provider
+that owns its own workers can deliver peak library performance, but tenferro
+cannot make the same affinity, nesting, and thread-budget guarantees around
+it.
+
+## Execution Backend
+
+| Backend | Device | Hard requirements | Cargo feature | Threading and synchronization | Good fit |
+| --- | --- | --- | --- | --- | --- |
+| CPU | Host CPUs | At least one CPU provider; `cpu-faer` is the default | `tenferro-cpu` `cpu-faer` or `cpu-blas` | `CpuBackend` admits an operation to its selected domain. faer and native kernels use that domain; CPU calls return synchronously. | Controlled CPU and NUMA execution, dense linalg, and host pipelines |
+| CUDA | NVIDIA GPU | CUDA runtime plus the NVIDIA library stack required by the operation, including cuBLAS/cuSOLVER/cuTENSOR where applicable; missing libraries are typed errors | `tenferro-gpu` `cuda` | The CUDA runtime owns the stream and device work. Eager launches are asynchronous until an explicit synchronize, download, or host inspection. | NVIDIA production workloads and CUDA library-backed dense operations |
+| WebGPU | A WebGPU adapter/device and queue | A working wgpu/WebGPU implementation; coverage is experimental and operation-specific | `tenferro-gpu` `webgpu` | wgpu owns the device queue. Submissions are asynchronous; queue synchronization or download establishes a host-visible boundary. | Portable GPU experiments and Apple shared CPU/Metal paths |
+| XLA/PJRT | A PJRT addressable device | A PJRT plugin shared library; the `pjrt` loader returns a typed error when it is absent or invalid | `tenferro-xla` `pjrt` | The PJRT plugin owns device execution and intra-op scheduling. tenferro controls lowering and invocation, not the plugin's worker pool. | Static traced programs and deployments already using XLA plugins |
+
+CUDA does not use a native CubeCL kernel as a silent fallback when a required
+NVIDIA library is unavailable. The operation returns a typed library/provider
+error instead. XLA likewise rejects an unavailable plugin or unsupported
+lowering instead of changing execution backends behind the caller's back. See
+[Devices and GPU](devices-and-gpu.md) and [XLA and PJRT](xla.md) for setup and
+operation coverage.
+
+## CPU Provider Choice
+
+`CpuBackend::new()` uses the default provider compiled into the application.
+The faer provider is the default because it gives tenferro the most control:
+tenferro can inject `Par::Seq` or `Par::rayon(n)` from the selected backend
+context, and a managed CPU domain can own the corresponding Rayon executor and
+affinity contract.
+
+External BLAS providers own their worker pools. Their environment variables
+are generally process-wide, so a provider call can oversubscribe an outer
+tenferro fan-out unless its provider thread count is reduced, often to one.
+Choose an external provider when its peak dense-kernel performance is worth
+giving up tenferro's strict worker-placement and per-operation control.
+
+| Provider family | Required library | Cargo feature | Thread ownership and scope | Guidance |
+| --- | --- | --- | --- | --- |
+| faer | None beyond the Rust dependencies | `cpu-faer` | tenferro-managed `CpuDomainExecutor` and Rayon pool; budget is per selected CPU domain | Default choice when placement, reproducibility, and predictable nesting matter |
+| OpenBLAS | OpenBLAS and its CBLAS/LAPACK entry points | `cpu-blas`, `blas-openblas` | OpenBLAS-owned pool; settings such as `OPENBLAS_NUM_THREADS` are provider/process-wide | Use for peak BLAS/LAPACK throughput; use `CpuPlacement::Auto` and avoid outer oversubscription |
+| Intel MKL | MKL and its BLAS/LAPACK entry points | `cpu-blas`, `blas-mkl` | MKL-owned pool; `MKL_NUM_THREADS` and related OpenMP settings are provider/process-wide | Use when the deployment already standardizes on MKL; tenferro cannot verify worker affinity |
+| Apple Accelerate | Apple Accelerate BLAS/LAPACK | `cpu-blas`, `blas-accelerate` | Accelerate-owned pool; `VECLIB_MAXIMUM_THREADS` is provider/process-wide | Use for Apple-native deployments; explicit NUMA placement is not a tenferro guarantee |
+| BLIS | BLIS | Planned in [#1334](https://github.com/tensor4all/tenferro-rs/issues/1334) | Provider-owned; the final scope and controls are not part of the current API | Do not rely on a BLIS feature until the planned provider contract lands |
+| TBLIS external provider | TBLIS source or a separately supplied library | External example in [#1493](https://github.com/tensor4all/tenferro-rs/issues/1493) | The provider bundle owns the TBLIS call policy; the example clamps its call to one thread and restores the setting | A `dot_general` provider example, not a complete dense backend; other operations delegate to the default provider |
+
+The CPU provider kind is selected per backend when both base provider kinds are
+compiled:
+
+```rust
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+
+let faer = CpuBackend::with_threads_and_kind(4, CpuBackendKind::Faer)?;
+let blas = CpuBackend::with_threads_and_kind(4, CpuBackendKind::Blas)?;
+assert_eq!(faer.kind(), CpuBackendKind::Faer);
+assert_eq!(blas.kind(), CpuBackendKind::Blas);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+This requires both `cpu-faer` and `cpu-blas` in the resolved Cargo feature
+set. It does not make OpenBLAS and MKL independently selectable at runtime:
+the concrete external BLAS implementation is selected by the process's build
+and linked library configuration. Its worker environment remains a
+provider-owned process-wide concern.
+
+## Nested Parallelism
+
+The two common nesting models are intentionally different:
+
+```text
+Panel A: faer (tenferro-managed)
+caller thread
+  -> CpuOperationEntry::enter (permit + owned pool entry, budget N fixed)
+    -> with_native_parallelism (ExecutionPolicy::Rayon{max_threads: N})
+      -> strided-kernel fanout (<= N partitions on SAME owned pool;
+         nested strided ops inside partition sequential by fanout guard)
+      -> faer ops (Par::rayon(N) same budget/pool)
+
+Panel B: external BLAS (provider-owned)
+caller thread
+  -> CpuOperationEntry::enter (outer permit, tenferro budget N)
+    -> outer tenferro fanout (N partitions)
+      -> provider call -> provider-owned pool
+         possible workers: N partitions * OPENBLAS_NUM_THREADS
+  remedy: set the provider thread count to 1 when outer fanout is active
+```
+
+The faer model keeps outer and inner work inside one admitted domain and
+prevents a child operation from recursively fanning out on the same pool. The
+external model cannot provide that invariant because the library owns the
+inner pool. Do not infer a strict tenferro thread budget from a provider
+environment variable.
+
+## Backend Capability Catalog
+
+The catalog uses the same vocabulary as runtime engine registration. A future
+`EngineRegistration` can expose these properties as capabilities without
+changing the user-facing decision structure.
+
+| Backend/family | Control tier | Outer/inner parallelism and nesting | Worker, stream, or queue owner and scope | Managed or ExternalManaged | Synchronization | Storage and event domain | Unsupported behavior and dtype/op coverage |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| CPU/faer and native kernels | Tenferro-managed | Both: engine-owned outer fan-out and context-selected inner kernels; nested child fan-out is sequential | `CpuDomainExecutor` and Rayon pool owned per CPU domain/backend coordinator | `Managed` for the default pinned faer path; `ExternalManaged` only when the caller supplies a domain executor | Direct CPU operations complete before return | Host storage classes; the current CPU runtime uses an immediate event domain | Typed unsupported errors; see [CPU execution](cpu-execution.md) and [linear algebra](linear-algebra.md) |
+| CPU/BLAS or LAPACK | Provider-owned | Tenferro may own outer work, while BLAS/LAPACK owns inner work; nesting is not fully controllable | Linked provider pool and environment; usually process-wide | `ExternalManaged`/provider-default exclusive; no tenferro affinity proof | Provider call returns before the synchronous CPU API returns; worker synchronization is provider-owned | Host storage classes; CPU event domain | Unsupported placement and provider operations are errors, not faer fallback; see [CPU execution](cpu-execution.md) |
+| CUDA | Backend and NVIDIA-library managed | Device kernels use provider-selected grid/stream parallelism; host-side nesting is limited to explicit backend submissions | CUDA runtime stream, handles, and backend plan caches owned by the CUDA runtime/backend instance | GPU runtime managed; CPU `ExternalManaged` labels do not describe CUDA worker ownership | Launches may be asynchronous; synchronize, download, or host inspection is the boundary | CUDA device storage and CUDA stream/event domain | Unsupported CUDA operation or dtype, and missing NVIDIA library, return typed errors; see [GPU coverage](devices-and-gpu.md) |
+| WebGPU | Queue/provider managed | Device parallelism is inside the submitted shader; independent work may share the queue, with no tenferro CPU-style nested budget | wgpu device and queue owned by the WebGPU runtime/backend | GPU runtime managed; no CPU NUMA contract | Queue submission is asynchronous; explicit runtime synchronization or download makes results host-visible | WebGPU storage and queue/event domain | Unsupported operation or dtype returns an error; no implicit CPU fallback; see [GPU coverage](devices-and-gpu.md) |
+| XLA/PJRT | Plugin-managed | XLA decides intra-op decomposition; tenferro does not add a second hidden inner pool | PJRT plugin owns its client, device, streams, and worker scope | Plugin-managed; not a tenferro CPU `Managed` or `ExternalManaged` domain | PJRT execution and transfers define the host-visible boundary | PJRT device buffers and plugin event domain | Unsupported lowering, dtype, shape, or missing plugin is rejected; see [XLA subset](xla.md) |
+
+The dtype and operation links above are the sources of truth for coverage.
+This page describes ownership and failure behavior, not a second operation
+catalog.
+
+## Ownership Contracts
+
+`Managed` and `ExternalManaged` are resource-domain contracts, not performance
+labels:
+
+- `Managed` means tenferro constructs and owns the executor, can enforce the
+  declared worker budget and supported affinity guarantee, and owns shutdown
+  for that executor. The faer path is the primary CPU example.
+- `ExternalManaged` means the caller or provider owns the executor and its
+  shutdown. tenferro retains the owner for dependent work and arbitrates the
+  declared domain, but it does not repin external workers or claim live OS
+  affinity verification. External BLAS uses this conservative contract.
+
+GPU runtimes and PJRT plugins have their own stream, queue, and client
+lifetimes. They should be described by explicit engine capabilities rather
+than being forced into a CPU NUMA label.
+
+## Placement
+
+An ordinary tensor is single-device. Placement selects one registered engine
+and storage class for an operation; it does not create a distributed tensor.
+The current multi-device work schedules independent single-device tensors and
+inserts explicit transfers. Cross-device transfer providers, event domains,
+and asynchronous submission are tracked in [execution substrate issue
+#1471](https://github.com/tensor4all/tenferro-rs/issues/1471). Distributed tensors
+and collectives are outside this contract.
+
+When one process needs two CPU engine registrations, use distinct engine IDs.
+The canonical helper keeps `tenferro-cpu.default.v1` for the usual single
+backend case; the caller-selected helper avoids an ID collision:
+
+```rust
+use tenferro_cpu::{
+    runtime_engine_registration_with_id, CpuBackend, CpuBackendKind,
+};
+use tenferro_runtime::{EngineId, Runtime};
+
+let primary = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer)?;
+let secondary = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Blas)?;
+
+let mut builder = Runtime::builder();
+builder.register_engine(runtime_engine_registration_with_id(
+    &primary,
+    EngineId::new("example.cpu.faer.v1")?,
+)?)?;
+builder.register_engine(runtime_engine_registration_with_id(
+    &secondary,
+    EngineId::new("example.cpu.blas.v1")?,
+)?)?;
+let runtime = builder.build()?;
+assert_eq!(runtime.snapshot()?.engine_count(), 2);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Compile this example with both `cpu-faer` and `cpu-blas`. If the second
+backend uses OpenBLAS, MKL, or Accelerate, its library and thread settings are
+still process-wide provider settings. Separate processes are required when
+the application needs mutually incompatible external BLAS installations or
+independent provider environment pools.
+
+## Policy Selection
+
+Use `CpuBackend::with_threads`, `CpuBackend::with_kind`, and explicit placement
+when tenferro should own the policy. Use a provider bundle or an external
+domain only when the provider's own controls are part of the application's
+deployment contract. In either case, an unsupported request must produce a
+typed error; a backend must not silently switch to another provider or device.
+
+See [Parallelism and Caching](parallelism-and-caching.md) for thread-budget
+mechanics, provider environment variables, cache lifetime, and
+oversubscription diagnostics.

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -76,6 +76,26 @@ CUDA is a backend/device choice for supported `Tensor`, `EagerTensor`, and
 Concrete, read, typed, eager, and traced tensor APIs are crate-root extension
 traits. `LinalgBackend` remains the provider contract passed to concrete methods.
 
+## Batch And Inner Parallelism
+
+Batched decompositions have two independent kinds of parallel work:
+
+- **Outer batch parallelism** runs independent matrices from the batch on the
+  selected CPU domain or device execution context. The engine owns this
+  scheduling and its resource budget.
+- **Inner decomposition parallelism** partitions the factorization of one
+  matrix. The selected provider owns this algorithmic decomposition, subject
+  to the execution context passed by the engine.
+
+For SVD, QR, Hermitian eigenvalue, and other batched linalg calls, the engine
+must choose the outer fan-out and the provider must respect the selected inner
+policy. A faer-backed CPU context can pass `Par::Seq` or `Par::rayon(n)` while
+preserving one domain budget. A BLAS/LAPACK provider may use its own worker
+pool, so its environment-controlled inner threads can oversubscribe an outer
+batch; see [Choosing A Backend](choosing-a-backend.md) before combining the
+two. Providers must report unsupported decomposition or dtype requests rather
+than silently changing the algorithm or execution backend.
+
 ## Concrete Solve
 
 ```rust

--- a/docs/guides/parallelism-and-caching.md
+++ b/docs/guides/parallelism-and-caching.md
@@ -14,55 +14,10 @@ parallelism contract.
 
 ## CPU Backend Provider
 
-At least one CPU provider feature must be compiled. `cpu-faer` is the default.
-`cpu-blas` can be compiled by itself or together with `cpu-faer`. External CPU
-providers can replace optional provider bundle slots, such as the complete
-general `dot_general` contraction path, but still require at least one of
-`cpu-faer` or `cpu-blas` for fallback and linalg coverage.
-`blas-openblas`, `blas-accelerate`, and `blas-mkl` are explicit BLAS/LAPACK
-source-provider features that also enable `cpu-blas`; enable at most one of
-them in a single resolved Cargo feature graph.
-
-`CpuBackend::new()` chooses a provider from the features compiled into the
-current binary:
-
-| Compiled CPU provider features | `CpuBackend::new()` provider |
-| --- | --- |
-| `cpu-faer` only | faer |
-| `cpu-blas` only | BLAS/LAPACK |
-| `cpu-faer` and `cpu-blas` | BLAS/LAPACK |
-
-This is the default provider for that backend instance. If multiple complete
-CPU providers are compiled, select `CpuBackendKind::Faer` or
-`CpuBackendKind::Blas` explicitly when a specific call path should use one of
-them. TBLIS is not a complete backend kind; the unpublished
-`ext/tenferro-cpu-tblis` crate demonstrates installing it as an external
-general-contraction provider through `CpuProviderBundleBuilder`. Explicit
-base-provider selection returns a
-configuration error if the requested provider was not compiled into the binary:
-
-```rust
-use tenferro_cpu::CpuBackend;
-use tenferro_cpu::CpuBackendKind;
-
-let backend = CpuBackend::with_threads_and_kind(4, CpuBackendKind::Faer).unwrap();
-assert_eq!(backend.num_threads(), 4);
-assert_eq!(backend.kind(), CpuBackendKind::Faer);
-```
-
-An external provider installs through the provider bundle, not through a
-`tenferro-cpu` feature. The TBLIS example under `ext/tenferro-cpu-tblis` is not
-published from this repository; its `source-build` feature uses the local
-`third_party/t4a-tblis-src` path unless that source package is separately
-released in a later maintainer-approved release.
-
-The compiled source of truth is the crate-level doctest in
-`ext/tenferro-cpu-tblis/src/lib.rs` plus the provider behavior tests in
-`ext/tenferro-cpu-tblis/tests/provider.rs`:
-
-```bash
-cargo test --manifest-path ext/tenferro-cpu-tblis/Cargo.toml -- --nocapture
-```
+Provider choice, feature combinations, thread ownership, and the external
+TBLIS example are maintained in [Choosing A Backend](choosing-a-backend.md).
+Use that guide for the decision and capability matrix; this page keeps the
+runtime mechanics below for users who have already selected a provider.
 
 ## CPU Thread Count
 

--- a/docs/guides/xla.md
+++ b/docs/guides/xla.md
@@ -78,6 +78,24 @@ With the `pjrt` feature enabled, `XlaExecutor::from_env()` reads
 unset, empty, points to a missing file, or the library does not export
 `GetPjrtApi`, tenferro returns an explicit error.
 
+## Threading And Synchronization
+
+PJRT owns the plugin client, device streams, and intra-op thread pool. A
+`CpuBackend::with_threads(n)` setting does not change the number of workers
+used inside a PJRT CPU plugin, and tenferro does not infer a PJRT affinity or
+NUMA guarantee from that setting. Configure intra-op parallelism through the
+selected PJRT/XLA deployment, such as the plugin's documented environment or
+XLA flags, and treat those controls as plugin-owned and generally
+process-scoped.
+
+The tenferro runtime controls graph lowering, engine selection, and the
+explicit call into PJRT. It does not insert a hidden CPU fallback or a second
+inner pool. PJRT execution and device-to-host transfer establish the
+host-visible synchronization boundary; use the executor's documented
+synchronization behavior when a host-side barrier is required. Unsupported
+shapes, dtypes, operations, and plugin capabilities are rejected before or by
+the PJRT call with an error.
+
 ```bash
 TENFERRO_PJRT_PLUGIN=/path/to/pjrt_c_api_cpu_plugin.so \
   cargo test -p tenferro-xla --features pjrt --test integration pjrt_env

--- a/docs/worklogs/2026-07-31-issue-1538-backend-selection.md
+++ b/docs/worklogs/2026-07-31-issue-1538-backend-selection.md
@@ -1,0 +1,39 @@
+# Worklog: #1538 Backend Selection And Capability Documentation
+
+This worklog records the documentation and runtime-registration changes for
+[tenferro-rs issue #1538](https://github.com/tensor4all/tenferro-rs/issues/1538).
+
+## Scope
+
+- Added `docs/guides/choosing-a-backend.md` as the owner for execution-backend
+  and CPU-provider selection, capability ownership, nested parallelism,
+  placement, and unsupported-operation policy.
+- Added the required SVD/QR batch-versus-inner parallelism section and PJRT
+  threading/synchronization section to the existing guides.
+- Replaced the duplicated provider-selection block in
+  `parallelism-and-caching.md` with a link to the choosing guide.
+- Added a documentation-consistency check mapping every item in the design
+  document's Documentation Requirements section to a named guide heading.
+
+## Runtime API decision
+
+`runtime_engine_registration` keeps the canonical
+`tenferro-cpu.default.v1` identity. The new
+`runtime_engine_registration_with_id` helper accepts a validated caller-chosen
+`EngineId`, so distinct CPU backends can be registered in one `Runtime`
+without colliding. `CpuBackendKind::Faer` and `CpuBackendKind::Blas` remain
+per-backend choices when both base features are compiled. Concrete external
+BLAS implementations and their worker environment remain build/provider
+process-wide; the guide documents that limitation rather than implying
+runtime selection between OpenBLAS and MKL.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo test -p tenferro-cpu --lib runtime_adapter::tests::public_cpu_runtime_registration`
+- `python3 scripts/test-doc-consistency.py`
+- `git diff --check`
+- The conditional faer-plus-BLAS provider test was compiled with
+  `--features cpu-faer,cpu-blas`; linking could not complete in this
+  environment because no CBLAS symbols (`cblas_*gemm`) were installed. The
+  normal CI BLAS profile remains the environment for the linked-provider run.

--- a/docs/worklogs/2026-07-31-issue-1538-backend-selection.md
+++ b/docs/worklogs/2026-07-31-issue-1538-backend-selection.md
@@ -8,6 +8,8 @@ This worklog records the documentation and runtime-registration changes for
 - Added `docs/guides/choosing-a-backend.md` as the owner for execution-backend
   and CPU-provider selection, capability ownership, nested parallelism,
   placement, and unsupported-operation policy.
+- Added executable `tenferro-cpu` examples as the source of truth for the
+  provider-selection and multi-engine snippets in the guide.
 - Added the required SVD/QR batch-versus-inner parallelism section and PJRT
   threading/synchronization section to the existing guides.
 - Replaced the duplicated provider-selection block in

--- a/scripts/test-doc-consistency.py
+++ b/scripts/test-doc-consistency.py
@@ -15,6 +15,60 @@ import xml.etree.ElementTree as ET
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 
+DOCUMENTATION_REQUIREMENT_HOMES = (
+    (
+        "whether parallelism is outer, inner, or both;",
+        "docs/guides/choosing-a-backend.md",
+        "## Backend Capability Catalog",
+    ),
+    (
+        "which object owns the thread pool, stream, or queue;",
+        "docs/guides/choosing-a-backend.md",
+        "## Backend Capability Catalog",
+    ),
+    (
+        "whether thread counts are per-runtime, per-domain, per-provider, or global;",
+        "docs/guides/choosing-a-backend.md",
+        "## CPU Provider Choice",
+    ),
+    (
+        "what `Managed` and `ExternalManaged` guarantee;",
+        "docs/guides/choosing-a-backend.md",
+        "## Ownership Contracts",
+    ),
+    (
+        "how faer differs from general BLAS/LAPACK;",
+        "docs/guides/choosing-a-backend.md",
+        "## CPU Provider Choice",
+    ),
+    (
+        "when synchronization occurs;",
+        "docs/guides/choosing-a-backend.md",
+        "## Backend Capability Catalog",
+    ),
+    (
+        "what single-device and multi-device placement mean;",
+        "docs/guides/choosing-a-backend.md",
+        "## Placement",
+    ),
+    (
+        "which behavior is unsupported rather than silently degraded.",
+        "docs/guides/choosing-a-backend.md",
+        "## Backend Capability Catalog",
+    ),
+    (
+        "SVD, QR, and other batched linalg documentation must explicitly describe outer",
+        "docs/guides/linear-algebra.md",
+        "## Batch And Inner Parallelism",
+    ),
+    (
+        "different policy select or implement providers;",
+        "docs/guides/choosing-a-backend.md",
+        "## CPU Provider Choice",
+    ),
+)
+
+
 def read(relative: str) -> str:
     return (ROOT / relative).read_text(encoding="utf-8")
 
@@ -160,6 +214,21 @@ def test_docs_ci_runs_docs_script_tests() -> None:
         "python3 \"$ROOT_DIR/scripts/check-operation-categories.py\" --fail-on-findings --include-rendered"
         in build_docs_site
     )
+
+
+def test_design_documentation_requirements_have_named_rendered_homes() -> None:
+    design = read("docs/design/execution-engine-provider-architecture.md")
+    start = design.index("## Documentation Requirements")
+    next_section = re.search(r"(?m)^##[ \t]+", design[start + 1 :])
+    end = start + 1 + next_section.start() if next_section else len(design)
+    requirements = design[start:end]
+
+    for requirement, guide_path, heading in DOCUMENTATION_REQUIREMENT_HOMES:
+        assert requirement in requirements, requirement
+        guide = read(guide_path)
+        assert heading in guide, (guide_path, heading)
+
+    assert "guides/choosing-a-backend.md" in read("docs/_quarto.yml")
 
 
 def test_ci_enforces_public_error_docs_and_extension_clippy() -> None:
@@ -529,6 +598,7 @@ def main() -> int:
         test_architecture_svg_lists_cpu_crate_xla_boundary_and_background,
         test_agents_layer_diagram_lists_cpu_crate,
         test_docs_ci_runs_docs_script_tests,
+        test_design_documentation_requirements_have_named_rendered_homes,
         test_ci_enforces_public_error_docs_and_extension_clippy,
         test_review_bot_workflow_exists,
         test_review_bot_uses_current_deepseek_model_fallback,


### PR DESCRIPTION
Fixes #1538\n\n## Summary\n\n- Add the Choosing A Backend guide with execution-backend and CPU-provider decision tables.\n- Document managed versus external ownership, nested parallelism, synchronization, placement, capability links, and typed unsupported behavior.\n- Add caller-selected CPU engine IDs through runtime_engine_registration_with_id and verify two CPU engines can coexist in one Runtime.\n- Add the SVD/QR batch-versus-inner parallelism and PJRT threading sections.\n- Add a design-documentation requirement-to-guide drift check and worklog.\n\n## Verification\n\n- bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-cpu --lib runtime_adapter::tests::public_cpu_runtime_registration'\n- cargo test -p tenferro-cpu --lib\n- cargo test -p tenferro-cpu --doc\n- python3 scripts/test-doc-consistency.py\n- bash scripts/build_docs_site.sh\n- python3 scripts/repository-rules-review.py --base origin/main --head HEAD\n\nWorklog: docs/worklogs/2026-07-31-issue-1538-backend-selection.md