### PR TITLE
docs: harden storage ownership contracts

### DIFF
--- a/docs/design/storage-ownership-contracts.md
+++ b/docs/design/storage-ownership-contracts.md
@@ -25,6 +25,29 @@ Authority and change control:
   and later). Phase 0 (#1556, engine identity) is independent and may proceed
   at any time.
 
+Long-term architecture quality gate:
+
+- The redesign has one ownership kernel shared by CPU, CUDA, WebGPU, Apple/
+  Metal, runtime submission, and AD. Providers may differ in synchronization,
+  mapping, and endpoint capabilities, but not in the meaning of owner,
+  shared/exclusive capability, descriptor, claim, or lease.
+- Owner claims, Rust access capabilities, provider-resource pins, and
+  descriptor-liveness roots are four separate concepts. No implementation
+  may merge them for convenience or recover one from another through a
+  reference count, downcast, raw handle, or provider-specific shortcut.
+- New APIs are derived from ownership and lifetime requirements in this
+  document, not shaped around preserving legacy call sites. Backward
+  compatibility is not a requirement for #1555.
+- A phase that introduces a temporary bridge must inventory it, keep it
+  crate-private and non-authoritative, name the phase that deletes it, and
+  remove it at that phase's exit gate. The completed redesign has no dual
+  storage stack, permanent compatibility adapter, or provider-specific
+  authority escape hatch.
+- A phase is incomplete when it merely adds the new path: it must also delete
+  the replaced path and update contract tests, documentation, and source
+  inventories. Exceptions require a contract change reviewed before the
+  implementation PR, never an ad hoc implementation waiver.
+
 ## Conventions
 
 Terminology:
@@ -86,6 +109,38 @@ pub struct AllocationSpan {
     guaranteed_alignment: usize, // power of two, describes the span start
 }
 
+// Private representation shape. Names remain provisional.
+pub struct OwnedStorage {
+    resource: ProviderResourcePin, // lifetime/deallocator pin; no access authority
+    claim: OwnedSpanClaim,         // unique, non-Clone authority for span()
+}
+
+struct OwnedSpanClaim {
+    resource: RootResourceId,
+    span: AllocationSpan,
+    provenance: ClaimProvenance, // private, non-Clone proof token
+}
+
+struct ProviderResourcePin {
+    resource: RootResourceId,
+    key: AllocationKey,
+    // provider state plus the exactly-once root deallocator
+}
+
+impl OwnedStorage {
+    fn split_claim(
+        self,
+        children: &[ByteRange],
+    ) -> Result<Vec<Self>, (Self, ClaimSplitError)>;
+}
+
+// Provider allocator/import boundary only.
+unsafe fn import_unique_claim(
+    resource: ProviderResourcePin,
+    span: AllocationSpan,
+    proof: ProviderUniqueImportProof,
+) -> OwnedStorage;
+
 unsafe trait BackendAllocation: Debug + Send + Sync + 'static {
     fn span(&self) -> AllocationSpan;
     fn provider(&self) -> ProviderKind;
@@ -122,6 +177,24 @@ Contract points:
   the exclusive capability (`&mut`); read acquisition requires shared. This
   is the provider-side counterpart of "write mapping and write enqueue
   require the mutable capability" in #1555.
+- Physical-resource lifetime and span authority are separate. An
+  `OwnedSpanClaim` is the unique, non-cloneable authority for its byte span.
+  A `ProviderResourcePin` may be shared internally to keep the provider root
+  resource and its deallocator alive, but it authorizes neither reads nor
+  writes and cannot create a claim. `OwnedStorage` combines exactly one
+  claim with such a pin; all safe access starts from that claim through the
+  borrow-taking methods above.
+- The claim and pin carry the same private, non-forgeable `RootResourceId`.
+  `OwnedStorage` construction checks that relation. `split_claim` consumes
+  the parent provenance token before creating children; failure returns the
+  unchanged parent. `import_unique_claim` is the only route that accepts an
+  allocator/provider uniqueness proof not derived from a parent claim.
+- Allocation-resource pins do not float unaccounted: every live pin is held
+  by an owner claim, an acquired lease/binding, or a retirement/quarantine
+  record. Provider endpoint/context handles that are cached independently do
+  not own this allocation's deallocator. This makes "last claim and lease"
+  an auditable deallocation condition rather than an incidental strong-count
+  observation.
 
 ### Span rules
 
@@ -136,6 +209,19 @@ Contract points:
 - Two owners whose spans overlap for the same key must not exist. Group
   construction and provider constructors reject overlapping owner claims.
   Distinct non-overlapping suballocations sharing a key are valid.
+- A safe provider constructor creates a claim only for a freshly allocated
+  root resource. Further claims for that resource arise only by consuming a
+  parent claim and splitting it into proven-disjoint children. Provider
+  import or allocator code that cannot establish this provenance statically
+  is one audited `unsafe` boundary whose safety contract requires global
+  non-overlap for the imported `(key, byte range)`. Cloning a resource pin is
+  never a claim-creation mechanism.
+- The root provider resource is deallocated exactly once, after the last
+  span claim has been released and every lease covering that resource has
+  retired. Releasing one child claim never deallocates a root still covered
+  by sibling claims. The shared pin may hold the deallocator internally, but
+  its reference count is lifetime bookkeeping only, not evidence of access
+  uniqueness.
 - Zero-length spans: canonically valid when `byte_len == 0` and the offset
   passes checked arithmetic. Guards over empty spans return empty slices.
   Empty access acquires no provider resources and imposes no ordering. No
@@ -184,15 +270,33 @@ if an internal invariant was violated upstream.
 
 | Transition | cap | borrow | sync | fail | panic/drop | reclaim |
 |---|---|---|---|---|---|---|
+| allocate fresh root and claim | provider allocator returns owning claim | none | provider allocation rules | no claim and provider cleans up unpublished resource | no partially published claim | root is live under its first claim |
+| reject overlapping/imported claim | none until audited construction succeeds | none | none | structured overlap/provenance error; existing claims unchanged | no claim published | unchanged |
 | `acquire_host_read` | shared | allocation for guard lifetime | wait: overlapping device writes (plus reads where provider requires) | no guard, no state change | guard drop unregisters host use | not while guard alive |
 | `acquire_host_write` | exclusive | allocation, exclusively, for guard lifetime | wait: all overlapping device uses | no guard, no state change | drop unregisters; writes made so far are visible bytes, no rollback | not while guard alive |
 | `acquire_device_read` | shared | none beyond the call (lease is a pin) | event dependency on last overlapping write | no lease, no state change | lease drop before submission releases pin | not while lease outstanding |
 | `acquire_device_write` | exclusive | `&mut` for the call; lease pins after | event dependencies for RAW/WAR/WAW | no lease, no state change | same as device read | not while lease outstanding |
 | lease submitted with work | owning (runtime owns inputs) | none (pins) | none at submit; retirement via events | enqueue prep failure releases only unsubmitted leases | admitted leases survive handle drop and panic until retirement | after all covering events complete |
 | guard leaked (`mem::forget`) | n/a | borrow ends without `Drop` | none | n/a | provider host-use registration may persist until owner drop; soundness is preserved (access is gone), liveness may degrade; this is documented, not UB | owner drop path below |
-| owner drop, no outstanding use | owning | none | none | n/a | n/a | immediately, exactly once, via the original deallocator |
-| owner drop, outstanding leases | owning | none | none | n/a | deallocator and pins move into a retirement record | after the record's events complete, exactly once |
+| split owner claim | owning (consumes parent claim) | none | none | original owner returned unchanged | no child is observable until all disjoint claims are built | parent is replaced by children; root resource remains pinned |
+| drop one of several sibling claims | owning | none | covering leases for that claim follow the next row | n/a | only that claim is released or retired | root remains live under sibling claims/pins |
+| owner drop, no outstanding use | owning | none | none | n/a | releases exactly that span claim | root deallocated exactly once only if this was the last claim and no lease remains |
+| owner drop, outstanding leases | owning | none | none | n/a | claim, deallocator pin, and leases move into a retirement record | claim releases after its events; root deallocates exactly once after the last claim and lease |
+| last root pin/claim release | owning/provider-internal | none | all covering events already retired | n/a | exactly-once deallocator runs or the resource remains quarantined | now, and only now |
 | retirement wait fails | n/a | none | attempted wait/poll | error reported on the runtime/provider error channel | resources quarantined: retained and reported | never speculatively; only if a later drain proves completion |
+
+Persistent owner-claim splitting above is distinct from G2 `split_mut`.
+Claim splitting consumes one owner and changes the persistent ownership set;
+`split_mut` only derives temporary disjoint Rust borrows from an unchanged
+owner/group and cannot create a claim or affect root-resource lifetime.
+
+Quarantine is root-resource state, not merely a runtime log entry. Marking a
+root quarantined is atomic and visible to every claim sharing its private
+`RootResourceId`. All safe acquisition and extraction paths revalidate this
+state and fail before exposing bytes or raw bindings. A quarantine record
+retains the root pin/deallocator and provider context even after every public
+claim is dropped; only a later provider-specific proof of retirement may
+release it.
 
 ## G2. AllocationGroup
 
@@ -204,7 +308,7 @@ values (#1555, "Disjoint views and allocation groups"; #1561).
 ```rust
 pub struct AllocationGroup {
     allocations: Vec<OwnedStorage>,   // private: each owned span exactly once
-    values: Vec<TensorDescriptor>,    // private: interpretation + slot
+    values: GenerationalDescriptors,  // private: interpretation + slot
 }
 
 pub struct TensorDescriptor {
@@ -214,7 +318,22 @@ pub struct TensorDescriptor {
     placement: Placement,
 }
 
-pub struct ValueId(/* stable index for the group's lifetime */);
+pub struct ValueId {
+    group: GroupId,
+    slot: u32,
+    generation: u32,
+}
+
+struct GenerationalDescriptors {
+    group: GroupId,
+    slots: SlotMap<DescriptorSlot>,
+}
+
+struct DescriptorSlot {
+    generation: u32,
+    descriptor: Option<TensorDescriptor>,
+    roots: DescriptorRoots, // handles, tape, checkpoint, execution
+}
 ```
 
 Construction preconditions (safe constructors):
@@ -224,6 +343,20 @@ Construction preconditions (safe constructors):
 - every descriptor is validated against its slot's span (G1 revalidation
   rules) at construction;
 - descriptors may alias freely, including exact duplicates.
+- A `ValueId` is stable only while its descriptor slot and generation are
+  live. Removing a descriptor tombstones the slot; reuse increments the
+  generation. Stale IDs fail with a structured error and can never resolve
+  to a later value. The group component prevents an ID from resolving in a
+  different group even when slot and generation happen to match. Slot
+  indices, vector addresses, and provider handles are not public identity.
+- `GroupId` is opaque, non-forgeable outside the registry, and is never
+  reused while a stale `ValueId` could exist. Exhaustion is a structured
+  construction error, never wraparound. Group identity is descriptor-table
+  identity only and cannot authorize allocation access.
+- `GenerationalDescriptors` is the sole authoritative descriptor-liveness
+  registry. Root registration/release and descriptor lookup are atomic with
+  respect to slot tombstoning. G2 extraction and G7 handle operations consult
+  this registry; no side table or provider reference count may override it.
 
 ### Operation contracts
 
@@ -244,9 +377,11 @@ fn into_tensor(self, id: ValueId) -> Result<Tensor, (Self, ExtractError)>;
   exclusive borrow of the group; the root is inaccessible while any child
   lives.
 - `try_extract` removes descriptor `id` and moves its allocation out as a
-  standalone owner only when no remaining descriptor references the same
-  slot. On failure the group is unchanged and the error carries a typed
-  reason. There is no copy or materialization fallback (I4).
+  standalone owner only when no remaining descriptor or registered external
+  descriptor handle references the same allocation slot. On failure the
+  group is unchanged and the error carries a typed reason. Removing the
+  descriptor invalidates its generation. There is no copy or materialization
+  fallback (I4).
 - `into_tensor` consumes the group, selecting one descriptor and explicitly
   discarding the rest; it never duplicates ownership to preserve them. On
   failure it returns the unchanged group.
@@ -283,7 +418,8 @@ unsupported provider span. Every error leaves the group unchanged.
 ## G3. Submission
 
 Two complementary APIs (#1555, "Runtime ownership and asynchronous
-execution"; #1565). Both return group-based results.
+execution"; #1565). Detached execution returns an owned group-based result;
+scoped execution returns the hybrid borrowed/owned result defined below.
 
 ### Signatures
 
@@ -304,66 +440,220 @@ pub struct SubmitRejected {
     inputs: ExecutionInputs, // the exact unaccepted package
 }
 
+pub struct ExecutionFailure {
+    cause: ExecutionError,
+    inputs: ExecutionInputs,
+}
+
+pub struct CancelledExecution {
+    inputs: ExecutionInputs,
+}
+
+pub struct QuarantinedExecution {
+    cause: RetirementError,
+    quarantine: QuarantineId,
+    affected: Box<[AllocationKey]>, // diagnostic identity, never owners
+}
+
 pub enum ExecutionOutcome {
     Completed(ExecutionBundle),
     Failed(ExecutionFailure),       // recovered inputs, typed cause
     Cancelled(CancelledExecution),  // recovered inputs
+    Quarantined(QuarantinedExecution), // runtime registry retains resources
 }
 
 pub struct ExecutionBundle {
     group: AllocationGroup,
-    outputs: Box<[ValueId]>,
+    outputs: Box<[ExecutionOutput]>,
     retained_inputs: Box<[Option<ValueId>]>,
+}
+
+pub enum ExecutionOutput {
+    Tensor(ValueId),
+    Metadata(OutputMetadata),
+}
+
+impl SubmitRejected {
+    pub fn into_parts(self) -> (Error, ExecutionInputs);
+}
+
+impl ExecutionFailure {
+    pub fn into_parts(self) -> (ExecutionError, ExecutionInputs);
+}
+
+impl CancelledExecution {
+    pub fn into_inputs(self) -> ExecutionInputs;
+}
+
+impl QuarantinedExecution {
+    pub fn into_parts(self) -> (RetirementError, QuarantineId, Box<[AllocationKey]>);
 }
 
 pub fn scope<'env, R>(
     &self,
     f: impl for<'s> FnOnce(&'s SubmitScope<'s, 'env>) -> R,
-) -> R;
+) -> Result<R, ScopeExitError<R>>;
 
 impl<'s, 'env> SubmitScope<'s, 'env> {
     pub fn submit_read_only(
         &'s self,
         program: &CompiledGraph,
         inputs: ScopedReadInputs<'env>,
-    ) -> Result<ScopedHandle<'s>, ScopedSubmitError>;
+    ) -> Result<ScopedHandle<'s, 'env>, ScopedSubmitRejected<'env>>;
+}
+
+impl<'s, 'env> ScopedHandle<'s, 'env> {
+    pub fn wait(self) -> ScopedExecutionOutcome<'env>;
+}
+
+pub enum ScopedExecutionOutcome<'env> {
+    Completed(ScopedExecutionBundle<'env>),
+    Failed(ScopedExecutionFailure<'env>),
+    Cancelled(ScopedCancelledExecution<'env>),
+    Quarantined(ScopedQuarantinedExecution<'env>),
+}
+
+pub struct ScopedExecutionBundle<'env> {
+    allocations: Box<[ScopedAllocation<'env>]>,
+    values: GenerationalDescriptors,
+    outputs: Box<[ScopedOutput]>,
+}
+
+pub enum ScopedOutput {
+    Tensor(ValueId),
+    Metadata(OutputMetadata), // genuinely storage-free graph result
+}
+
+enum ScopedAllocation<'env> {
+    Borrowed(StorageRef<'env>),
+    Owned(OwnedStorage),
+}
+
+pub struct ScopedSubmitRejected<'env> {
+    error: Error,
+    inputs: ScopedReadInputs<'env>,
+}
+
+pub struct ScopedExecutionFailure<'env> {
+    cause: ExecutionError,
+    inputs: ScopedReadInputs<'env>,
+}
+
+pub struct ScopedCancelledExecution<'env> {
+    inputs: ScopedReadInputs<'env>,
+}
+
+pub struct ScopedQuarantinedExecution<'env> {
+    cause: RetirementError,
+    quarantine: QuarantineId,
+    inputs: ScopedReadInputs<'env>,
+}
+
+pub struct ScopeExitError<R> {
+    value: R,
+    unobserved: Box<[ScopedTaskFailure]>,
+}
+
+impl<'env> ScopedSubmitRejected<'env> {
+    pub fn into_parts(self) -> (Error, ScopedReadInputs<'env>);
+}
+
+impl<'env> ScopedExecutionFailure<'env> {
+    pub fn into_parts(self) -> (ExecutionError, ScopedReadInputs<'env>);
+}
+
+impl<'env> ScopedCancelledExecution<'env> {
+    pub fn into_inputs(self) -> ScopedReadInputs<'env>;
+}
+
+impl<'env> ScopedQuarantinedExecution<'env> {
+    pub fn into_parts(
+        self,
+    ) -> (RetirementError, QuarantineId, ScopedReadInputs<'env>);
+}
+
+impl<R> ScopeExitError<R> {
+    pub fn into_parts(self) -> (R, Box<[ScopedTaskFailure]>);
 }
 ```
 
 - Repeated or aliased bindings reference descriptors; they never duplicate
   owners.
-- `ExecutionBundle` fields are private. `output()` returns a borrowed view;
-  `output_mut()` exclusively borrows the whole bundle; extraction follows G2.
-  Identity, metadata-only, repeated-input, and duplicate-output graphs keep
-  exactly one owner per physical allocation, with no hidden copy.
+- `ExecutionBundle` fields are private. Tensor `output()` returns a borrowed
+  view; `output_mut()` exclusively borrows the whole bundle; extraction
+  follows G2. Identity, metadata-only tensor transforms, repeated-input, and
+  duplicate-output graphs keep exactly one owner per physical allocation,
+  with no hidden copy. A genuinely storage-free output uses
+  `ExecutionOutput::Metadata`, parallel to scoped execution.
 - `ScopedReadInputs` borrows immutable tensor/group views for `'env` and
   declares its access mode explicitly. Provider read leases are still
   acquired (G1), because logically read-only host and device uses can
   conflict on some providers. Mutable scoped inputs are out of scope for the
   redesign; a future mutable-input graph requires an exclusive borrow and a
   separate signature contract.
-- `ScopedHandle<'s>` cannot escape the scope (higher-ranked lifetime), and
-  scope exit joins and retires every admitted task before returning.
+- `ScopedHandle<'s, 'env>` cannot escape the scope (higher-ranked `'s`). Its
+  `wait` result contains no `'s` borrow and may leave the scope, but remains
+  bounded by the original input lifetime `'env`.
+- A completed scoped bundle is deliberately hybrid. Identity,
+  metadata-only, repeated-input, and duplicate-output results are
+  tensor descriptors whose slot is `ScopedAllocation::Borrowed`; newly
+  computed tensor results use `ScopedAllocation::Owned`. A genuinely
+  storage-free result is `ScopedOutput::Metadata` and never receives a fake
+  allocation slot. `output()` borrows the bundle and returns a view bounded
+  by both that borrow and `'env`. Extraction is available only for an
+  `Owned` slot satisfying G2; requesting extraction from a `Borrowed` slot
+  returns `BorrowedOutput` and never copies.
+- `ScopedSubmitRejected<'env>` returns the exact unadmitted
+  `ScopedReadInputs<'env>` package with its typed cause. After admission,
+  `ScopedExecutionFailure<'env>` and `ScopedCancelledExecution<'env>` retain
+  the exact borrowed input descriptors for diagnosis; caller ownership was
+  never transferred. Partial or uninitialized owned outputs remain private
+  and are retired and dropped or quarantined before either outcome becomes
+  observable. Consuming accessors return the error and exact input package;
+  private fields are not the recovery contract.
+- Scope exit joins and retires every admitted task whose handle was not
+  waited. Dropping a handle abandons observation, not execution. A waited
+  `ScopedExecutionBundle<'env>` may be returned from the closure because it
+  contains only `'env` borrows plus its own fresh owners, never a scope
+  borrow.
+- A normal scope exit reports every unobserved task failure through
+  `ScopeExitError<R>` while preserving the closure result. If the closure
+  panics, the scope guard still drains, records secondary failures in the
+  documented runtime error sink, and resumes the original panic; it never
+  replaces that panic with a second one.
+- If retirement cannot be proven, `Quarantined` is a distinct terminal
+  outcome, not `Retired`. Before a scoped borrow can end, provider state for
+  every affected root is atomically marked quarantined. All later safe map,
+  enqueue, extraction, and deallocation attempts return `Quarantined`; the
+  quarantine registry retains the root resource and context. Thus dropping
+  a scoped error cannot expose borrowed storage to work of unknown status.
 
 ### Lifecycle
 
 States: `Prepared` (validation/planning), `Admitted` (worker owns inputs),
 `Running`, `Draining` (event domains drain after completion, error, panic,
-or cancellation), `Retired(outcome)`.
+or cancellation), then either `Retired(outcome)` or
+`Quarantined(quarantine_id)`.
 
 | Transition | cap | borrow | sync | fail | panic/drop | reclaim |
 |---|---|---|---|---|---|---|
 | `submit` validation/preparation/spawn | owning (consumes `ExecutionInputs`) | none | none | `SubmitRejected` returns the exact unaccepted package | no worker exists yet; nothing retained | inputs back with caller; G1 rules |
 | admitted, running | owning (worker) | none | leases per G1 acquired before each enqueue | execution error leads to Draining then `Failed` | worker panic leads to Draining/quarantine then `Failed` with a typed panic cause | only after retirement |
-| `ExecutionHandle::wait` | none | none | blocks until Retired | returns `ExecutionOutcome` (all variants are post-retirement) | n/a | per outcome: bundle owns allocations |
+| `ExecutionHandle::wait` | none | none | blocks until Retired or Quarantined | returns explicit terminal `ExecutionOutcome`; quarantined resources are not recovered | n/a | per retired outcome; quarantine registry otherwise |
 | handle drop before completion | none | none | none | n/a | detach: reaper retains owners and leases until retirement; completion is not cancelled | after retirement, by the reaper |
 | cancellation request | none | none | none | n/a | cooperative: honored at pre-enqueue boundaries only; already enqueued device work is never revoked | after retirement |
 | unobserved failure (detached, handle dropped) | none | none | none | reported through the documented runtime error sink/callback; never silent | n/a | after retirement |
-| scoped submit | shared borrows of inputs for `'env` | inputs until scope exit | leases per G1 | error carrier returns without admitting | dropping a `ScopedHandle` abandons observation only; scope exit still joins and retires every admitted task | after scope join |
+| scoped submit rejected | shared borrows packaged for `'env` | no runtime borrow admitted | none | exact `ScopedReadInputs<'env>` returned with cause | no worker or partial bundle exists | caller-owned inputs unaffected |
+| scoped admitted and `wait`ed | shared borrows of inputs for `'env` | input storage for `'env`; handle for `'s` only | leases per G1; `wait` observes post-retirement outcome | typed scoped outcome; borrowed descriptors retained, partial owned outputs private | panic enters draining/quarantine before outcome | fresh owners after retirement; borrowed slots never reclaimed by bundle |
+| scoped handle dropped | none beyond admitted shared input borrows | inputs remain borrowed for `'env`; handle observation ends | none at drop | n/a | scope registry retains task, owners, and leases | only after scope join/retirement |
+| scope exit with unobserved tasks | none | ends `'s`, not `'env` | joins and drains every admitted task | `ScopeExitError<R>` preserves closure result and aggregates failures/quarantine IDs | panic during closure still drains, reports secondary failures, and resumes original panic | after proven retirement; quarantine registry otherwise |
 
-Recovered inputs on `Failed`/`Cancelled` are exposed read-only and only
-after all relevant event domains retire. Possibly partial or uninitialized
-outputs stay private and are dropped after retirement or quarantine.
+Detached `Failed`/`Cancelled` outcomes return the exact owning input package
+only after all relevant event domains retire; normal shared, exclusive, and
+extraction APIs are then available again. A `Quarantined` outcome returns no
+owner: the runtime quarantine registry retains affected resources. Possibly
+partial or uninitialized outputs stay private and are dropped after
+retirement or retained by quarantine.
 
 ## G4. Method distribution
 
@@ -427,8 +717,14 @@ Method-home table:
   ```rust
   session.read(TensorRead<'_>)   -> Result<ReadBinding<'_>>;
   session.write(TensorWrite<'_>) -> Result<WriteBinding<'_>>;
-  session.enqueue(...)           -> Result<Completion>;
+  session.enqueue(...)           -> Result<Completion, (Self, EnqueueError)>;
   ```
+
+  `TensorRead` and `TensorWrite` are sealed capability wrappers, not public
+  descriptor constructors. `TensorRead` is built only from `StorageRef` plus
+  a validated descriptor; `TensorWrite` is built only from `StorageMut` plus
+  a validated, injective descriptor. Their fields and constructors remain in
+  the audited ownership module.
 
   Bindings expose raw pointers only for the session lifetime; every binding
   revalidates domain/endpoint, span, layout arithmetic, alignment, access
@@ -436,18 +732,57 @@ Method-home table:
   `device_ptr(&Tensor) -> u64` does not exist; any escaping raw-pointer API
   is explicitly `unsafe` and documents its retirement obligations, and it
   stays provider-specific (no false parity).
-- Shared-internal to exclusive transitions funnel through one crate-internal
-  `unsafe fn` (working name `lease_unique`) with a documented uniqueness
-  argument per call site. The call-site inventory is enforced by a
-  source-contract test. `debug_assert!` on strong counts at hand-offs is
-  diagnostics only, never the proof (I3).
-- Stream-ordered reclamation (I6): a retirement record holds the deallocator
-  and all pins for an allocation whose owner dropped with outstanding work.
+- There is no shared-internal-to-exclusive transition. In particular, a
+  provider pin, `Arc`, raw handle, lease, reference count, or completion
+  token cannot be converted into `StorageMut`, an owner claim, or a write
+  binding. Raw write binding starts with an exclusive capability already
+  proven by Rust ownership. The sole audited unsafe boundary has this shape:
+
+  ```rust
+  unsafe fn bind_raw_write<'a>(
+      capability: StorageMut<'a>,
+      request: ValidatedWriteRequest,
+  ) -> Result<WriteBinding<'a>, AccessError>;
+  ```
+
+  `StorageMut` carries the exclusively borrowed claim and its matching
+  resource pin together, so the binder cannot be given an unrelated pin.
+  The binder rechecks request key/range against that capability before
+  exposing raw state. Its safety proof covers only conversion of an existing
+  exclusive capability into provider raw state; it does not establish
+  uniqueness.
+  The call-site inventory is enforced by a source-contract test. Strong
+  counts may be diagnostics for leaked pins or retirement latency, never a
+  precondition or proof for access authority (I3).
+- Successful enqueue consumes the launch session. For detached execution,
+  the runtime task continues to own the containing `OwnedStorage` and makes
+  it unreachable to callers until event retirement; the encoding borrow may
+  end, but no safe reborrow is possible. The completion lease and root pin
+  move to the retirement record. Scoped submission in G3 is read-only; any
+  future scoped write API must keep its exclusive input borrow live through
+  scope join in its signature. No other async write mode is permitted.
+- Enqueue failure returns the unchanged session and all unadmitted
+  capabilities in `(Self, EnqueueError)`. No raw binding or lease remains
+  active, and the owning task/borrow can retry or recover without inference.
+- Stream-ordered reclamation (I6): a retirement record holds the root-resource
+  deallocator and all pins for a resource whose claim dropped with
+  outstanding work. It never owns a deallocator for an individual subspan.
   Records are keyed by event domain. Completion tokens visible to users are
   never the sole owner of a lease, because users may drop them. Runtime
   drop drains only its own retirement queue before releasing its context.
   A failed drain quarantines (retains and reports); it never frees early and
   never releases a provider context that pending work may still use.
+
+### Raw-binding state table
+
+| Transition | cap | borrow | sync | fail | panic/drop | reclaim |
+|---|---|---|---|---|---|---|
+| request write from shared pin/handle/lease | shared or none (insufficient) | none | none | structured capability error; no binding or state change | n/a | unchanged |
+| bind raw read | `StorageRef<'a>` | shared capability and resource for binding/session lifetime | dependencies from G1 | no binding; capability remains valid | session retains lease after admitted enqueue | after covering read retires |
+| bind raw write | sealed `TensorWrite<'a>` from matching `StorageMut<'a>` | exclusive claim+pin capability for binding/session lifetime | RAW/WAR/WAW dependencies from G1 | no binding; exclusive capability remains valid | no shared state can recover the consumed exclusivity; admitted lease retires normally | after covering write retires |
+| enqueue validated bindings | consumes session; detached task retains owners | capabilities cannot be reused during admission or before retirement | provider enqueue/event registration | returns unchanged session and all capabilities in `(Self, EnqueueError)` | admitted leases and root pins move to runtime retirement even if completion handle is dropped | after event-domain retirement |
+| drop last claim with provider pins in flight | owning claim | none | none at drop | n/a | claim, root pin, and leases enter retirement record | root deallocator only after all sibling claims and pins retire |
+| retirement proof fails | provider-internal retirement record | none | attempted wait/poll | error reported | resource and context are quarantined | never speculatively |
 
 ## G6. Documentation ownership
 
@@ -508,13 +843,25 @@ not an accepted migration.
   storage owner or a write capability. Handle types may remain `Clone`
   because they are not owner-like; the non-`Clone` rule (I1) applies to
   owners and capabilities.
+- Every descriptor reference is registered against a generational `ValueId`.
+  The liveness set includes the tape, checkpoint records, execution bundles,
+  and every public handle clone. This bookkeeping may use reference counts,
+  but those counts govern descriptor-slot liveness only; they never prove
+  storage uniqueness or authorize a write. A slot is reclaimed or reused
+  only after all liveness roots are gone, and reuse increments the generation
+  so stale handles fail rather than resolving to a new value.
+- Public handles pin the retention table and its group as liveness roots,
+  without gaining access authority. Dropping a tape/context releases only
+  its own root; owners needed by surviving public handles remain in the table
+  until those handles are dropped or one last handle successfully extracts
+  the value.
 - Retention policy: an operation output is retained iff a registered
   VJP/JVP rule declares it needed for backward, or the user explicitly
   requests retention. Values nobody declares needed are not retained.
 - When the caller wants a standalone owner of a retained value, the paths
-  are exactly the G2 paths: `try_extract` once the tape no longer references
-  the slot, or an explicit duplicate (classified below). There is no hidden
-  copy path.
+  are exactly the G2 paths: `try_extract` after every other registered root
+  (tape, checkpoint, execution, and sibling public handles) is absent, or an
+  explicit duplicate (classified below). There is no hidden copy path.
 
 ### Public API replacement
 
@@ -525,7 +872,7 @@ adapter must not appear in any public signature.
 |---|---|---|
 | `materialized(&self) -> Result<Arc<Tensor>>` | `value(&self) -> Result<ValueGuard<'_>>` | materializes if lazy, then exposes a borrowed `TensorView`; host bytes go through G1 guards |
 | owned copy of a value | `duplicate_value(&self) -> Result<Tensor>` | explicit copy, reason `ExplicitDuplicate` |
-| owned move of a value | `into_value(self) -> Result<Tensor, RetainedByTape>` | extraction via G2; fails while the tape still references the slot |
+| owned move of a value | `into_value(self) -> Result<Tensor, (Self, ValueStillReferenced)>` | extraction via G2; succeeds only after consuming the last public handle and when tape, checkpoint, execution bundle, and sibling-handle liveness roots are absent; failure returns the handle |
 | backward result `Vec<Arc<Tensor>>`, `GradSlot = Arc<Mutex<Option<Arc<Tensor>>>>` | `Gradients` bundle (a G2 group specialization) with `grad(&self, key) -> Option<TensorView<'_>>` and `take_grad(&mut self, key) -> Option<Tensor>` | one owner per gradient allocation; extraction when unique |
 | traced attached-data maps `HashMap<ValueKey, Arc<Tensor>>` | `ExecutionInputs` bindings over group descriptors (G3) | no shared owners in the runtime boundary |
 
@@ -535,10 +882,13 @@ adapter must not appear in any public signature.
   descriptors in the checkpoint group.
 - Interior values are deliberately discarded at record time; checkpointing
   must not accidentally retain every intermediate. A contract test asserts
-  interior allocations are released after the boundary is recorded.
+  the checkpoint adds no liveness root for an interior value. Its allocation
+  is released after the boundary is recorded only when no tape, execution,
+  or external handle root independently keeps it live.
 - Backward recomputation executes the stored subgraph and produces fresh
-  owners; its allocations are classified `CheckpointRecompute`, distinct
-  from retention (which allocates nothing) and from explicit duplicates.
+  owners; its allocations are classified `CheckpointRecomputeOutput`,
+  distinct from retention (which allocates nothing) and from explicit
+  duplicates.
 
 ### Reinterpretation and aliases
 
@@ -546,25 +896,50 @@ adapter must not appear in any public signature.
   descriptor of the same slot in the same group (G2 duplicate-descriptor
   semantics), never a second owner.
 - Mutable reinterpretation requires an exclusive or owning capability. While
-  any tape or checkpoint descriptor references a span, the owner lives in
-  the retention group, so no caller can hold the owner: consuming or mutable
-  reinterpretation of that allocation is unreachable, and `try_extract`
-  fails with `RetainedByTape`. This exclusion is structural (borrow/owner
-  placement), verified by compile-fail plus runtime extraction tests.
+  any tape, checkpoint, execution bundle, or sibling handle descriptor
+  references a span, the owner lives in the retention group, so no caller can
+  hold the owner: consuming or mutable reinterpretation of that allocation
+  is unreachable, and `try_extract` fails with a typed
+  `ValueStillReferenced` reason (`Tape`, `Checkpoint`, `Execution`, or
+  `SiblingHandle`). This exclusion is structural (borrow/owner placement),
+  verified by compile-fail plus runtime extraction and stale-generation
+  tests.
 
-### Copy accounting
+### Copy and allocation accounting
 
-Copy and allocation events carry a reason:
+Copy events and allocation events are distinct ledgers:
 
 ```rust
-enum CopyReason { ExplicitDuplicate, Transfer, CheckpointRecompute, OperationOutput }
+enum CopyReason {
+    ExplicitDuplicate,
+    Transfer,
+}
+
+enum AllocationReason {
+    OperationOutput,
+    CheckpointRecomputeOutput,
+    ExplicitDuplicateDestination,
+    TransferDestination,
+}
 ```
 
-- Retention itself has no reason variant because retention performs no copy.
+- A byte-preserving duplicate or transfer records a `CopyReason`; allocating
+  its destination independently records the matching `AllocationReason`.
+  An operation kernel records an allocation reason for a fresh output but is
+  not thereby a copy. Checkpoint recomputation records fresh allocations as
+  `CheckpointRecomputeOutput`; it is not reclassified as a copy merely
+  because the values reproduce prior results.
+- Retention has neither a copy nor an allocation reason because retaining a
+  descriptor performs neither operation.
+- Every physical allocation emits exactly one allocation event. Every
+  physical data movement emits exactly one copy event, whether or not a new
+  destination was allocated. Descriptor aliasing, metadata-only outputs,
+  and public-handle cloning emit neither event.
 - Acceptance for an AD scenario (forward plus backward, with and without
-  checkpointing): every observed copy carries one of the enumerated reasons
-  and matches the scenario's expected multiset; copies attributable to
-  retention are therefore exactly zero.
+  checkpointing): every observed copy and every observed allocation carries
+  a reason from its own enum and each ledger matches the scenario's expected
+  multiset. Copies and allocations attributable to retention are therefore
+  both exactly zero.
 - Aggregate pre-migration versus post-migration copy counts are not an
   acceptance criterion.
 
@@ -585,7 +960,7 @@ Between the Phase 3 cutover and the Phase 9 group representation:
 
 - CPU is mandatory: eager and traced forward plus backward, and a
   checkpoint boundary-retention/recomputation case, with reason-classified
-  copy counters.
+  copy and allocation counters compared as separate expected multisets.
 - One supported asynchronous accelerator lane is designated before the
   Stage A freeze (CUDA preferred, else WebGPU or Apple/Metal) and runs the
   same retention contract with allocation, copy-reason, and retirement
@@ -597,15 +972,22 @@ Between the Phase 3 cutover and the Phase 9 group representation:
 
 | Transition | cap | borrow | sync | fail | panic/drop | reclaim |
 |---|---|---|---|---|---|---|
-| record op output into tape | owning (tape takes the output owner into its group) | none | none | op error: no retention entry | tape unwind drops group per G1/G2 | via tape drop |
-| clone `EagerTensor` handle | none | none | none | n/a | handle drop is free | n/a |
+| record op output into tape | owning (retention table takes the output owner into its group) | none | none | op error: no retention entry | unwind releases the tape root but preserves independent roots | after the last liveness root, via G1/G2 |
+| clone `EagerTensor` handle | none (descriptor liveness only) | none | none | n/a; clone does not resolve storage | clone registers another liveness root; drop unregisters it | descriptor slot only after all roots disappear; never storage authority |
+| drop last descriptor handle while tape/checkpoint retains | none | none | none | n/a | public-handle root disappears; retention root remains | not until all remaining roots disappear |
+| tape/context drop while public handle remains | owning tape root only | none | outstanding work follows G1 | n/a | table/group pin transfers no authority; public-handle root remains | not until last independent root disappears |
+| tape retains/releases descriptor | owning tape bookkeeping / none on release | none | none | invalid or stale ID is typed error | update is atomic; release cannot invalidate sibling roots | only after all roots disappear |
+| checkpoint retains/releases boundary descriptor | owning checkpoint bookkeeping / none on release | none | none | invalid or stale ID is typed error | no interior root is added implicitly | only after all roots disappear |
 | `value()` guard | shared | tape group (shared) for guard lifetime | G1 host-read rules if host bytes requested | error, tape unchanged | guard drop ends borrow | n/a |
 | backward execution | shared reads of retained descriptors; new owners for grads | tape group shared during execution | G3 rules | typed failure, tape unchanged, grads dropped after retirement | per G3 panic row | grads owned by `Gradients` bundle |
 | `take_grad` | exclusive on `Gradients` | none after return | none | `None`/typed reason, bundle unchanged | n/a | extracted owner per G1 |
-| `into_value` while retained | owning attempt | none | none | `RetainedByTape`, value usable, tape unchanged | n/a | n/a |
-| checkpoint record | owning (boundary owners into checkpoint group) | none | none | error: no partial checkpoint | interior values already released | boundary owners via checkpoint drop |
+| `into_value` while any other root remains | owning attempt (consumes one handle) | none | none | `ValueStillReferenced` identifies tape/checkpoint/execution/sibling handle; consumed handle is returned or remains usable | no liveness root is lost on failure | n/a |
+| `into_value` as last root | owning (consumes last handle and group slot) | none | none | stale/invalid descriptor leaves group unchanged | generation tombstoned; owner moves exactly once | extracted owner per G1 |
+| stale-handle access after tombstone/reuse | none | none | none | deterministic `StaleValueId`; no storage is touched | no state change | unchanged |
+| reuse descriptor slot | owning group bookkeeping | none | none | n/a | generation increments before publication | new slot follows its own roots; old IDs remain stale |
+| checkpoint record | owning (boundary owners/descriptors into checkpoint group) | none | none | error: no partial checkpoint | no checkpoint root is added for interiors; independent roots remain valid | boundary owners after last liveness root |
 | checkpoint recompute (backward) | shared reads of boundary; fresh owners for recomputed values | checkpoint group shared | G3 rules | typed failure after retirement | per G3 | recomputed owners dropped after use |
-| tape drop | owning | none | retirement per G1 for every owner with in-flight work | n/a | quarantine path per G1 | after retirement, exactly once |
+| tape drop | owning tape root | none | retirement per G1 for owners with no other roots and in-flight work | n/a | quarantine path per G1; independent handle/checkpoint roots remain | after retirement and the last liveness root, exactly once |
 
 ## Contract test index
 
@@ -614,13 +996,13 @@ phase issues carry the full inventories; this index is the cross-reference.
 
 | Gate | Enforcement | Owning phases |
 |---|---|---|
-| G1 ordering, guards, revalidation, retirement | deterministic fake-timeline transition tests; compile-fail (guard across consuming submit, write guard from shared); corrupt-descriptor rejection at map and enqueue; immediate-drop-after-enqueue; Miri on host guard slices | #1560, providers in #1563/#1564 |
-| G2 group, splitting, extraction | N-way split cases (N=0,1,>2, empty, reverse-stride, overflow); permutation-independence property tests; compile-fail (root access while children live); extraction counters | #1561 |
-| G3 submission terminal semantics | rejection carriers return identical allocation keys; cancellation/panic/detach/unobserved-error suites; compile-fail (scoped handle escape, host guard across submit) | #1565, hardware in #1568 |
+| G1 ordering, guards, revalidation, retirement | deterministic fake-timeline transition tests; claim provenance/split/overlap and exactly-once root-deallocator tests; compile-fail (guard across consuming submit, write guard from shared); corrupt-descriptor rejection at map and enqueue; immediate-drop-after-enqueue; quarantine poisoning; Miri on host guard slices | #1560, providers in #1563/#1564 |
+| G2 group, splitting, extraction | N-way split cases (N=0,1,>2, empty, reverse-stride, overflow); permutation-independence property tests; group-qualified stale-generation tests; compile-fail (root access while children live); extraction counters | #1561 |
+| G3 submission terminal semantics | rejection carriers return identical allocation keys; hybrid scoped identity/metadata/new-output bundles; borrowed-output extraction rejection; scoped result bounded by `'env` but not `'s`; explicit scope-exit and quarantine outcomes; cancellation/panic/detach/unobserved-error suites; compile-fail (scoped handle escape, host guard across submit) | #1565, hardware in #1568 |
 | G4 method distribution | API-parity contract with one canonical method list; compile-fail (no `Clone` on owners/capabilities); source scan (no mutable owner projections) | #1557 harness, #1559 |
-| G5 raw handles, reclamation | fake backend proving internal `Arc` clones cannot write or mint owners; `lease_unique` call-site inventory; retirement/quarantine tests; source scan (no safe unleased pointer) | #1558, #1563, #1564 |
+| G5 raw handles, reclamation | fake backend proving internal `Arc` clones cannot write or mint owners; sealed `TensorWrite` construction and audited raw-write binder inventory proving `StorageMut` input; enqueue-failure capability recovery; retirement/quarantine tests; source scans (no shared-to-exclusive transition, no safe unleased pointer) | #1558, #1563, #1564 |
 | G6 documentation | rendered stale-language checker; doctests; tutorial-code checks; source-blind audit | #1569, #1567 |
-| G7 AD retention | reason-classified copy counters (zero retention copies); extraction-blocked tests; checkpoint interior-release test; mutable-reinterpret exclusion; CPU plus designated async accelerator lanes | #1557 contract, #1559 interim, #1565 final, #1568 evidence |
+| G7 AD retention | separate reason-classified copy/allocation counters (zero retention events in both); generational stale-handle and all-liveness-root extraction tests; checkpoint interior-release test; mutable-reinterpret exclusion; CPU plus designated async accelerator lanes | #1557 contract, #1559 interim, #1565 final, #1568 evidence |
 
 ## Relationship to phase issues
 

--- a/docs/worklogs/2026-08-01-issue-1557-storage-ownership-contracts.md
+++ b/docs/worklogs/2026-08-01-issue-1557-storage-ownership-contracts.md
@@ -48,10 +48,38 @@ for the storage ownership redesign tracked by
   owners and capabilities, and gate 7 defines handles as read-only
   descriptor references. This resolves the apparent conflict between
   "remove shallow `Clone`" (#1559) and existing `EagerTensor` cloning.
-- Copy accounting has no retention reason variant at all; acceptance asserts
-  every copy in an AD scenario carries one of the enumerated reasons. This
-  encodes "retention performs no copy" structurally instead of comparing
-  aggregate counts.
+- Copy and allocation accounting use separate reason enums and ledgers.
+  Retention has no variant in either ledger, encoding that retention performs
+  neither a copy nor an allocation instead of relying on aggregate counts.
+- Follow-up contract review after #1570 merged separated a unique
+  `OwnedSpanClaim` from a non-authoritative shared provider-resource pin.
+  Child claims can only be produced by consuming and proving a split of the
+  parent (or at an audited unsafe import boundary), and root deallocation
+  waits for every claim and lease.
+- Scoped execution now has an exact hybrid result shape: borrowed
+  identity/metadata outputs remain `'env`-bounded slots, fresh outputs are
+  owned slots, and `wait` returns an outcome that is independent of the
+  scope lifetime `'s`. Borrowed slots reject extraction without copying.
+- The earlier `lease_unique` sketch was rejected. No transition from a
+  shared pin or handle to exclusive authority exists; the unsafe raw-write
+  binder consumes an already-proven `StorageMut` capability.
+- AD descriptor liveness covers tape, checkpoint, execution, and every
+  sibling public handle. Generational IDs prevent a stale handle from
+  resolving to a reused descriptor slot, and extraction requires the caller
+  to consume the last liveness root.
+- The architecture quality gate rejects ad hoc provider or legacy-API
+  exceptions. All backends and AD/runtime use one ownership kernel; each
+  implementation phase deletes the path it replaces, and every temporary
+  bridge has an explicit removal phase.
+- Scoped retirement failure is an explicit quarantine outcome. Before a
+  borrowed scope can end, the affected root is atomically poisoned so later
+  safe access fails and the quarantine registry retains the resource. This
+  avoids both hidden copies and unsound return of a borrow whose device use
+  has unknown completion.
+- `ValueId` is group-qualified and generational, with
+  `GenerationalDescriptors` as the only liveness registry. Root claims carry
+  private provenance linked to the same root-resource identity as their
+  non-authoritative pin.
 
 ## Alternatives rejected
 
@@ -68,6 +96,13 @@ for the storage ownership redesign tracked by
 - `python3 scripts/repository-rules-review.py --base origin/main --head HEAD`.
 - Manual cross-check of every contract clause against the #1555 body and the
   phase issues it cites; no contradiction found at authoring time.
+- Follow-up amendment: `bash scripts/check-pr-fast.sh` passed after the final
+  edits.
+- Follow-up amendment: `python3 scripts/ci/run_profile.py docs` passed,
+  including rustdoc and the rendered 84-page docs site. The optional
+  dependency graph was skipped because Graphviz `dot` is not installed.
+- Independent contract reviews were repeated after each amendment round;
+  blockers were incorporated before submission.
 
 ## Remaining risks
 
@@ -78,3 +113,5 @@ for the storage ownership redesign tracked by
 - The AD `ValueGuard`/`Gradients` sketches are the least implementation-
   tested part of the contract; Phase 3 and Phase 9 may need to refine them
   through the documented change-control path.
+- The five follow-up decisions above require executable enforcement in the
+  remaining #1557 harness before G1 through G7 are considered frozen.


### PR DESCRIPTION
## Summary

Follow-up to #1570 before the #1555 implementation phases begin. This hardens the normative storage ownership contract around five review findings:

- separates root-resource lifetime/deallocation from unique subspan claims, with provenance-carrying claim splits;
- defines hybrid scoped borrowed/owned/metadata outcomes, exact recovery carriers, scope-exit errors, and quarantine-safe borrowed lifetimes;
- removes every shared-pin-to-exclusive transition and requires sealed write capabilities derived from Rust-exclusive ownership;
- separates copy and allocation event ledgers, with retention emitting neither;
- makes descriptor identity group-qualified and generational, with one authoritative liveness registry across handles, tape, checkpoint, and execution.

It also adds a long-term architecture gate: one ownership kernel across CPU, CUDA, WebGPU/Metal, runtime, and AD; no permanent compatibility stack or provider-specific authority exception.

## Validation

- `bash scripts/check-pr-fast.sh`
- `python3 scripts/ci/run_profile.py docs`
  - rustdoc and rendered 84-page docs site passed
  - optional dependency graph skipped because Graphviz `dot` is unavailable

Refs #1555
Refs #1557
