### PR TITLE
ci: make review-bot LLM execution observable in logs and report

### DIFF
--- a/scripts/check-pr-fast.sh
+++ b/scripts/check-pr-fast.sh
@@ -53,7 +53,7 @@ die() {
 has_ci_profile() {
   local wanted="$1"
   local profile
-  for profile in "${CI_PROFILES[@]}"; do
+  for profile in ${CI_PROFILES[@]+"${CI_PROFILES[@]}"}; do
     if [[ "$profile" == "$wanted" ]]; then
       return 0
     fi

--- a/scripts/repository-rules-review.py
+++ b/scripts/repository-rules-review.py
@@ -16,6 +16,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -772,6 +773,23 @@ def llm_skipped_finding(reason: str) -> Finding:
     )
 
 
+def summarize_llm_review(
+    *,
+    chunk_sizes: list[int],
+    elapsed_seconds: float,
+    returned_count: int,
+    kept_count: int,
+) -> str:
+    dropped = returned_count - kept_count
+    return (
+        f"LLM review: {len(chunk_sizes)} chunk(s) "
+        f"({', '.join(f'{size} chars' for size in chunk_sizes)}) "
+        f"in {elapsed_seconds:.1f}s; "
+        f"{returned_count} finding(s) returned, {kept_count} kept, "
+        f"{dropped} dropped by diff-anchor filtering."
+    )
+
+
 def format_report(
     *,
     base: str,
@@ -779,11 +797,14 @@ def format_report(
     verdict: str,
     findings: list[Finding],
     waived: bool,
+    llm_summary: str | None = None,
 ) -> str:
     lines = [
         f"Repository rules review ({base}...{head})",
         f"Verdict: {verdict}",
     ]
+    if llm_summary:
+        lines.append(llm_summary)
     if waived:
         lines.append("Waived by maintainer label.")
     if not findings:
@@ -1047,6 +1068,8 @@ def main(argv: list[str] | None = None) -> int:
             args.output_json.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         return 0
 
+    llm_summary: str | None = None
+    llm_stats: dict[str, Any] | None = None
     if not args.dry_run and not sensitive_finding:
         api_key = os.environ.get("DEEPSEEK_API_KEY")
         if not api_key:
@@ -1060,8 +1083,16 @@ def main(argv: list[str] | None = None) -> int:
             worktree=args.worktree,
         )
         chunks = split_diff_chunks(redact_file_diffs(file_diffs))
+        chunk_sizes = [len(chunk) for chunk in chunks]
+        print(
+            f"LLM review: model {args.model}, {len(chunks)} chunk(s), "
+            f"sizes {chunk_sizes} chars",
+            file=sys.stderr,
+        )
         llm_findings: list[Finding] = []
-        for chunk in chunks:
+        llm_started = time.monotonic()
+        for index, chunk in enumerate(chunks, start=1):
+            chunk_started = time.monotonic()
             try:
                 _, chunk_findings = review_chunk(
                     api_key=api_key,
@@ -1074,17 +1105,42 @@ def main(argv: list[str] | None = None) -> int:
                     timeout=args.timeout,
                 )
             except (KeyError, ValueError, urllib.error.URLError, TimeoutError) as exc:
+                print(
+                    f"LLM chunk {index}/{len(chunks)}: failed after "
+                    f"{time.monotonic() - chunk_started:.1f}s: "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
                 findings.append(llm_response_error_finding(exc))
                 break
-            llm_findings.extend(chunk_findings)
-        findings.extend(
-            filter_findings(
-                merge_findings(llm_findings),
-                files,
-                added_lines,
-                allow_global=False,
+            print(
+                f"LLM chunk {index}/{len(chunks)}: {len(chunk)} chars, "
+                f"{len(chunk_findings)} finding(s), "
+                f"{time.monotonic() - chunk_started:.1f}s",
+                file=sys.stderr,
             )
+            llm_findings.extend(chunk_findings)
+        merged_llm_findings = merge_findings(llm_findings)
+        kept_llm_findings = filter_findings(
+            merged_llm_findings,
+            files,
+            added_lines,
+            allow_global=False,
         )
+        llm_elapsed = time.monotonic() - llm_started
+        llm_summary = summarize_llm_review(
+            chunk_sizes=chunk_sizes,
+            elapsed_seconds=llm_elapsed,
+            returned_count=len(merged_llm_findings),
+            kept_count=len(kept_llm_findings),
+        )
+        llm_stats = {
+            "chunk_sizes": chunk_sizes,
+            "elapsed_seconds": round(llm_elapsed, 3),
+            "findings_returned": len(merged_llm_findings),
+            "findings_kept": len(kept_llm_findings),
+        }
+        findings.extend(kept_llm_findings)
 
     block_findings = [item for item in findings if item.severity == "block"]
     verdict = reconcile_verdict(block_findings)
@@ -1095,6 +1151,7 @@ def main(argv: list[str] | None = None) -> int:
         verdict=verdict,
         findings=findings,
         waived=False,
+        llm_summary=llm_summary,
     )
     print(report_body)
 
@@ -1106,6 +1163,7 @@ def main(argv: list[str] | None = None) -> int:
         "changed_files": files,
         "rule_sections": section_names,
         "prompt_version": PROMPT_VERSION,
+        "llm_review": llm_stats,
     }
     if args.output_json:
         args.output_json.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/scripts/test-repository-rules-review.py
+++ b/scripts/test-repository-rules-review.py
@@ -754,6 +754,46 @@ def test_contains_sensitive_text_ignores_env_lookup_code() -> None:
     assert not mod.contains_sensitive_text(text)
 
 
+def test_summarize_llm_review_computes_dropped_count() -> None:
+    mod = load_module()
+    summary = mod.summarize_llm_review(
+        chunk_sizes=[118923, 46296],
+        elapsed_seconds=4.56,
+        returned_count=3,
+        kept_count=1,
+    )
+    assert "2 dropped" in summary
+
+
+def test_format_report_includes_llm_summary_line() -> None:
+    mod = load_module()
+    report = mod.format_report(
+        base="base",
+        head="head",
+        verdict="pass",
+        findings=[],
+        waived=False,
+        llm_summary="LLM review: 1 chunk(s) (10 chars) in 0.5s; "
+        "0 finding(s) returned, 0 kept, 0 dropped by diff-anchor filtering.",
+    )
+    lines = report.splitlines()
+    assert lines[1] == "Verdict: pass"
+    assert lines[2].startswith("LLM review: 1 chunk(s)")
+    assert lines[3] == "No findings."
+
+
+def test_format_report_omits_llm_summary_when_absent() -> None:
+    mod = load_module()
+    report = mod.format_report(
+        base="base",
+        head="head",
+        verdict="pass",
+        findings=[],
+        waived=False,
+    )
+    assert "LLM review:" not in report
+
+
 def main() -> int:
     for test in [
         test_added_lines_by_file,
@@ -788,6 +828,9 @@ def main() -> int:
         test_redact_sensitive_text_masks_common_secret_forms,
         test_sensitive_diff_finding_checks_added_lines_only,
         test_contains_sensitive_text_ignores_env_lookup_code,
+        test_summarize_llm_review_computes_dropped_count,
+        test_format_report_includes_llm_summary_line,
+        test_format_report_omits_llm_summary_when_absent,
     ]:
         test()
     return 0


### PR DESCRIPTION
## Summary

Investigating https://github.com/tensor4all/tenferro-rs/actions/runs/28704302423/job/85127414374 showed the linked \`repository rules review\` job finishing in ~0s. That is by design (it only aggregates the results of the LLM / no-llm / waived jobs for branch protection), but the LLM job log gave no direct evidence that the DeepSeek calls actually ran: no chunk count, no per-call latency, and findings dropped by \`filter_findings\` diff-anchor filtering disappeared silently. A fast pass was therefore indistinguishable from a silent no-op.

- \`scripts/repository-rules-review.py\`: log model, chunk count/sizes, and per-chunk latency (including the failure path) to stderr so they appear in the Actions log; add an \`LLM review: N chunk(s) (...) in X.Xs; R finding(s) returned, K kept, D dropped by diff-anchor filtering.\` line to the report (and the PR comment); record the same stats as \`llm_review\` in the JSON payload. Dry-run/waived/sensitive paths keep the line absent.
- \`scripts/check-pr-fast.sh\`: fix a pre-existing bash-3.2 (\`set -u\` + empty \`CI_PROFILES\` expansion) failure in \`has_ci_profile\` that aborted the code-change gate on macOS before clippy could run.

## Verification

- \`python3 scripts/test-repository-rules-review.py\` (3 new tests: dropped-count arithmetic, report line placement, line absent without LLM stats)
- End-to-end smoke against a local dummy DeepSeek endpoint: stderr shows per-chunk logs, report shows the summary line, JSON contains \`llm_review\`
- \`bash scripts/check-pr-fast.sh --coverage-reviewed --test 'python3 scripts/test-repository-rules-review.py'\` passed (fmt + CI-parity clippy + focused test)
- \`python3 scripts/repository-rules-review.py --base origin/main --head HEAD --dry-run\`: pass, no findings. The LLM portion could not run locally (no \`DEEPSEEK_API_KEY\`); the review bot runs the trusted base (main) copy of the script under pull_request_target, so the new logging takes effect for PRs opened after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
