### PR TITLE
ci: rename review-bot gate check to 'repository rules review gate'

### DIFF
--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -69,7 +69,7 @@ jobs:
             // tensor core dependency boundary) still block merge via branch
             // protection, but do not need to hold up the GPU runner.
             const required = [
-              "repository rules review",
+              "repository rules review gate",
               "rustfmt",
               "clippy",
               "coverage",

--- a/.github/workflows/review_bot.yml
+++ b/.github/workflows/review_bot.yml
@@ -476,7 +476,7 @@ jobs:
             }
 
   review-bot-gate:
-    name: repository rules review
+    name: repository rules review gate
     needs: [review-bot, review-bot-no-llm, review-bot-waived]
     if: always() && !cancelled()
     runs-on: ubuntu-latest

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -337,7 +337,7 @@ jobs:
             // non-GPU workspace test aggregate. CUDA archive compilation still
             // runs on a cheap hosted runner in parallel.
             const required = [
-              "repository rules review",
+              "repository rules review gate",
               "rustfmt",
               "clippy",
               "coverage",

--- a/ai/repo-settings.json
+++ b/ai/repo-settings.json
@@ -11,7 +11,7 @@
       "docs-site",
       "CI gate (PR workspace tests)",
       "CI GPU gate",
-      "repository rules review"
+      "repository rules review gate"
     ]
   },
   "pages": {

--- a/scripts/test-doc-consistency.py
+++ b/scripts/test-doc-consistency.py
@@ -247,7 +247,7 @@ def test_review_bot_workflow_exists() -> None:
     text = read(".github/workflows/review_bot.yml")
 
     assert "name: review bot" in text
-    assert "repository rules review" in text
+    assert "name: repository rules review gate" in text
     assert "DEEPSEEK_API_KEY" in text
     assert "rules-review:waive" in text
 
@@ -263,13 +263,13 @@ def test_review_bot_uses_current_deepseek_model_fallback() -> None:
 def test_repo_settings_requires_repository_rules_review() -> None:
     text = read("ai/repo-settings.json")
 
-    assert '"repository rules review"' in text
+    assert '"repository rules review gate"' in text
 
 
 def test_gpu_ci_waits_for_review_bot_gate_before_cuda_work() -> None:
     text = read(".github/workflows/CI_gpu.yml")
 
-    assert '"repository rules review"' in text
+    assert '"repository rules review gate"' in text
     assert "repository rules review (LLM)" not in text
     assert text.index("pre-gpu-gate:") < text.index("cuda-archive:")
     assert text.index("pre-gpu-gate:") < text.index("runs-on: ubuntu-gpu")


### PR DESCRIPTION
## Summary

Follow-up to #1572. The branch-protection aggregation job was named plain `repository rules review`, which reads as the review itself — its by-design ~0s runtime therefore looked like a silently skipped review (the confusion investigated on run 28704302423). Other gate checks already carry the word "gate" (`CI gate (PR workspace tests)`, `CI GPU gate`); this aligns the review-bot gate with that convention. The actual review job keeps its `repository rules review (LLM)` name.

- `.github/workflows/review_bot.yml`: gate job display name → `repository rules review gate`
- `ai/repo-settings.json`: required-context declaration updated
- `.github/workflows/runpod-gpu-test.yml`, `.github/workflows/CI_gpu.yml`: GPU pre-gate wait lists updated
- `scripts/test-doc-consistency.py`: assertions track the new name

## Rollout

- This PR's own review-bot run still reports the old name (`pull_request_target` executes the base-branch workflow), which satisfies the current branch protection, so it merges normally.
- **After merge**, branch protection must be switched: `bash scripts/configure-repo-settings.sh`, then verified with `bash scripts/check-repo-settings.sh`.
- `runpod-gpu-test.yml` runs from the default branch (`workflow_run`), so its updated wait list also only takes effect after merge — consistent with when new-name checks start appearing.
- No PRs are open at rename time, so no in-flight PR needs a review-bot re-run.

## Verification

- `python3.11 scripts/test-doc-consistency.py` passed
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'python3.11 scripts/test-doc-consistency.py'` passed (fmt + CI-parity clippy + focused test)
- `repository-rules-review.py --dry-run`: pass, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)