### PR TITLE
Add native CUDA f64 zero allocation

### DIFF
--- a/crates/tenferro-gpu/src/cubecl/dispatch.rs
+++ b/crates/tenferro-gpu/src/cubecl/dispatch.rs
@@ -16,10 +16,14 @@ use tenferro_tensor::{
 pub(crate) const DEFAULT_CUBE_DIM_X: u32 = 256;
 
 pub(crate) fn cube_count_for_len(len: usize) -> crate::Result<CubeCount> {
+    cube_count_for_len_for_op(len, "cube_count_for_len")
+}
+
+pub(crate) fn cube_count_for_len_for_op(len: usize, op: &'static str) -> crate::Result<CubeCount> {
     let cubes = len.div_ceil(DEFAULT_CUBE_DIM_X as usize);
     let cubes = u32::try_from(cubes).map_err(|_| {
         crate::Error::invalid_argument(
-            "cube_count_for_len",
+            op,
             "length",
             format!(
                 "1D CubeCL launch for {len} elements requires {cubes} cubes, \
@@ -431,10 +435,18 @@ pub(crate) fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
     rt: &CudaRuntime,
     shape: &[usize],
 ) -> crate::Result<TypedTensor<T>> {
-    let len = checked_shape_product("cubecl_alloc_output", shape)?;
+    alloc_output_for_op(rt, shape, "cubecl_alloc_output")
+}
+
+pub(crate) fn alloc_output_for_op<T: CubeElement + Clone + Send + Sync + 'static>(
+    rt: &CudaRuntime,
+    shape: &[usize],
+    op: &'static str,
+) -> crate::Result<TypedTensor<T>> {
+    let len = checked_shape_product(op, shape)?;
     let byte_len = len.checked_mul(core::mem::size_of::<T>()).ok_or_else(|| {
         crate::Error::invalid_argument(
-            "cubecl_alloc_output",
+            op,
             "shape",
             format!("output byte length overflow for shape {shape:?}"),
         )

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -328,6 +328,34 @@ fn scatter_update_len(meta: &ScatterLaunchMeta) -> crate::Result<usize> {
     })
 }
 
+mod cuda_zero_scalar {
+    use cubecl::prelude::{CubeElement, CubePrimitive};
+
+    pub trait Sealed: CubeElement + CubePrimitive + Clone + Send + Sync + 'static {
+        // Marker trait; bounds are available to the CUDA implementation.
+    }
+
+    impl Sealed for f64 {}
+}
+
+/// Scalar types supported by [`CudaBackend::zeros`].
+///
+/// This capability is sealed; the initial CUDA constructor supports only
+/// `f64`. In particular, `f32` is not admitted:
+///
+/// ```compile_fail
+/// use tenferro_gpu::CudaBackend;
+///
+/// fn rejected(backend: &CudaBackend) {
+///     let _ = backend.zeros::<f32>(1);
+/// }
+/// ```
+pub trait CudaZeroScalar: tenferro_tensor::TensorScalar + cuda_zero_scalar::Sealed {
+    // Marker trait; implementations are fixed by the private supertrait.
+}
+
+impl CudaZeroScalar for f64 {}
+
 /// CubeCL-based GPU backend.
 ///
 /// # Examples
@@ -757,7 +785,7 @@ impl CudaBackend {
         &self.inner.rt
     }
 
-    /// Allocate a one-dimensional `f64` CUDA tensor initialized to positive zero.
+    /// Allocate a one-dimensional CUDA tensor initialized to positive zero.
     ///
     /// The initialization kernel is enqueued on this backend's current stream;
     /// this method does not synchronize or transfer data to the host.
@@ -766,9 +794,10 @@ impl CudaBackend {
     ///
     /// ```
     /// use tenferro_gpu::CudaBackend;
-    /// use tenferro_tensor::{Result, Tensor};
+    /// use tenferro_tensor::{Result, TypedTensor};
     ///
-    /// let _zeros: fn(&CudaBackend, usize) -> Result<Tensor> = CudaBackend::zeros_f64;
+    /// let _zeros: fn(&CudaBackend, usize) -> Result<TypedTensor<f64>> =
+    ///     CudaBackend::zeros::<f64>;
     /// ```
     ///
     /// # Errors
@@ -777,22 +806,29 @@ impl CudaBackend {
     /// requested length cannot be represented by the CUDA launch or allocation,
     /// or [`crate::Error::RuntimeState`] when the allocated tensor cannot be
     /// bound to this backend's runtime.
-    pub fn zeros_f64(&self, len: usize) -> crate::Result<Tensor> {
-        let count = cube_count_for_len_for_op(len, "zeros_f64")?;
-        let output = alloc_output_for_op::<f64>(self.runtime(), &[len], "zeros_f64")?;
+    pub fn zeros<T: CudaZeroScalar>(&self, len: usize) -> crate::Result<TypedTensor<T>> {
+        const OP: &str = "zeros";
+        let count = cube_count_for_len_for_op(len, OP)?;
+        let output = alloc_output_for_op::<T>(self.runtime(), &[len], OP)?;
         launch_nullary_into(
             self.runtime(),
             &output,
-            "zeros_f64",
+            OP,
             count,
             cube_dim_1d(),
-            |client, count, dim, out| unsafe {
-                structural::fill_zero_kernel::launch_unchecked::<f64, CubeclCudaRuntime>(
-                    client, count, dim, out,
-                );
+            |client, count, dim, out| {
+                // SAFETY: `output` is a fresh, unaliased dense allocation of exactly
+                // `len` elements. `launch_nullary_into` validates its runtime and
+                // backing length before binding it; the launch covers the domain, and
+                // the kernel guards every write with `ABSOLUTE_POS < out.len()`.
+                unsafe {
+                    structural::fill_zero_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
+                        client, count, dim, out,
+                    );
+                }
             },
         )?;
-        Ok(Tensor::F64(output))
+        Ok(output)
     }
 
     fn cutensor_handle(&self) -> crate::Result<&ffi::cutensor::CutensorHandle> {

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -131,9 +131,9 @@ mod runtime;
 mod runtime_adapter;
 
 use dispatch::{
-    alloc_bool_output, alloc_output, bool_tensor_array_arg, comptime_sequence, cube_count_for_len,
-    cube_dim_1d, dtype_mismatch, ensure_axes_unique, ensure_axis, ensure_rank,
-    ensure_resident_on_runtime, ensure_view_mut_resident_on_runtime,
+    alloc_bool_output, alloc_output, alloc_output_for_op, bool_tensor_array_arg, comptime_sequence,
+    cube_count_for_len, cube_count_for_len_for_op, cube_dim_1d, dtype_mismatch, ensure_axes_unique,
+    ensure_axis, ensure_rank, ensure_resident_on_runtime, ensure_view_mut_resident_on_runtime,
     ensure_view_resident_on_runtime, launch_binary, launch_binary_bool_tensor,
     launch_binary_tensor, launch_bool_tensor_into, launch_compare_bool, launch_nullary_bool_into,
     launch_nullary_into, launch_select_bool, launch_ternary, launch_unary,
@@ -778,14 +778,8 @@ impl CudaBackend {
     /// or [`crate::Error::RuntimeState`] when the allocated tensor cannot be
     /// bound to this backend's runtime.
     pub fn zeros_f64(&self, len: usize) -> crate::Result<Tensor> {
-        let stable_validation_op = |error| match error {
-            crate::Error::Validation { source, .. } => {
-                crate::Error::validation("zeros_f64", source)
-            }
-            error => error,
-        };
-        let count = cube_count_for_len(len).map_err(stable_validation_op)?;
-        let output = alloc_output::<f64>(self.runtime(), &[len]).map_err(stable_validation_op)?;
+        let count = cube_count_for_len_for_op(len, "zeros_f64")?;
+        let output = alloc_output_for_op::<f64>(self.runtime(), &[len], "zeros_f64")?;
         launch_nullary_into(
             self.runtime(),
             &output,

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -757,6 +757,50 @@ impl CudaBackend {
         &self.inner.rt
     }
 
+    /// Allocate a one-dimensional `f64` CUDA tensor initialized to positive zero.
+    ///
+    /// The initialization kernel is enqueued on this backend's current stream;
+    /// this method does not synchronize or transfer data to the host.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_gpu::CudaBackend;
+    /// use tenferro_tensor::{Result, Tensor};
+    ///
+    /// let _zeros: fn(&CudaBackend, usize) -> Result<Tensor> = CudaBackend::zeros_f64;
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with `InvalidArgument` when the
+    /// requested length cannot be represented by the CUDA launch or allocation,
+    /// or [`crate::Error::RuntimeState`] when the allocated tensor cannot be
+    /// bound to this backend's runtime.
+    pub fn zeros_f64(&self, len: usize) -> crate::Result<Tensor> {
+        let stable_validation_op = |error| match error {
+            crate::Error::Validation { source, .. } => {
+                crate::Error::validation("zeros_f64", source)
+            }
+            error => error,
+        };
+        let count = cube_count_for_len(len).map_err(stable_validation_op)?;
+        let output = alloc_output::<f64>(self.runtime(), &[len]).map_err(stable_validation_op)?;
+        launch_nullary_into(
+            self.runtime(),
+            &output,
+            "zeros_f64",
+            count,
+            cube_dim_1d(),
+            |client, count, dim, out| unsafe {
+                structural::fill_zero_kernel::launch_unchecked::<f64, CubeclCudaRuntime>(
+                    client, count, dim, out,
+                );
+            },
+        )?;
+        Ok(Tensor::F64(output))
+    }
+
     fn cutensor_handle(&self) -> crate::Result<&ffi::cutensor::CutensorHandle> {
         if let Some(handle) = self.inner.cutensor.get() {
             return Ok(handle);

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -340,6 +340,16 @@ mod cuda_zero_scalar {
 
 /// Scalar types supported by [`CudaBackend::zeros`].
 ///
+/// # Examples
+///
+/// ```
+/// use tenferro_gpu::CudaZeroScalar;
+///
+/// fn accepts_cuda_zero<T: CudaZeroScalar>() {}
+///
+/// accepts_cuda_zero::<f64>();
+/// ```
+///
 /// This capability is sealed; the initial CUDA constructor supports only
 /// `f64`. In particular, `f32` is not admitted:
 ///

--- a/crates/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
@@ -4,7 +4,7 @@ use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 
 use crate::cubecl::memory::{device_ptr, download_tensor, upload_tensor};
 use crate::cubecl::{gpu_available, CudaBackend, CudaRuntime};
-use crate::{Error, Tensor};
+use crate::{DeviceKind, Error, GpuBackendKind, MemoryKind, Tensor};
 use tenferro_tensor::TensorElementwise;
 
 #[cube(launch_unchecked)]
@@ -44,6 +44,43 @@ fn cube_count_for_len_rejects_u32_overflow() {
         }
     ));
 }
+
+#[test]
+fn zeros_f64_has_the_narrow_public_signature() {
+    let _zeros: fn(&CudaBackend, usize) -> crate::Result<Tensor> = CudaBackend::zeros_f64;
+}
+
+gpu_test!(test_zeros_f64_exact_values_placement_and_overflow, {
+    let backend = CudaBackend::new(0).unwrap();
+
+    for len in [0, 1, 17, 4097] {
+        let zeros = backend.zeros_f64(len).unwrap();
+        assert_eq!(zeros.shape(), &[len]);
+        assert_eq!(zeros.dtype(), crate::DType::F64);
+        assert_eq!(zeros.placement().memory_kind, MemoryKind::Device);
+        let device = zeros.placement().device.as_ref().unwrap();
+        assert_eq!(device.kind, DeviceKind::Gpu(GpuBackendKind::Cuda));
+        assert_eq!(device.ordinal, 0);
+
+        let host = download_tensor(backend.runtime(), &zeros).unwrap();
+        assert!(host
+            .as_slice::<f64>()
+            .unwrap()
+            .iter()
+            .all(|value| value.to_bits() == 0));
+    }
+
+    assert!(matches!(
+        backend.zeros_f64(usize::MAX),
+        Err(Error::Validation {
+            op: "zeros_f64",
+            source: tenferro_tensor::ValidationError::InvalidArgument {
+                argument: "length",
+                ..
+            },
+        })
+    ));
+});
 
 gpu_test!(test_runtime_init, {
     let rt = CudaRuntime::new(0);

--- a/crates/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
@@ -4,7 +4,7 @@ use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 
 use crate::cubecl::memory::{device_ptr, download_tensor, upload_tensor};
 use crate::cubecl::{gpu_available, CudaBackend, CudaRuntime};
-use crate::{DeviceKind, Error, GpuBackendKind, MemoryKind, Tensor};
+use crate::{DeviceKind, Error, GpuBackendKind, MemoryKind, Tensor, TypedTensor};
 use tenferro_tensor::TensorElementwise;
 
 #[cube(launch_unchecked)]
@@ -47,14 +47,15 @@ fn cube_count_for_len_rejects_u32_overflow() {
 
 #[test]
 fn zeros_f64_has_the_narrow_public_signature() {
-    let _zeros: fn(&CudaBackend, usize) -> crate::Result<Tensor> = CudaBackend::zeros_f64;
+    let _zeros: fn(&CudaBackend, usize) -> crate::Result<TypedTensor<f64>> =
+        CudaBackend::zeros::<f64>;
 }
 
 gpu_test!(test_zeros_f64_exact_values_placement_and_overflow, {
     let backend = CudaBackend::new(0).unwrap();
 
     for len in [0, 1, 17, 4097] {
-        let zeros = backend.zeros_f64(len).unwrap();
+        let zeros = Tensor::F64(backend.zeros::<f64>(len).unwrap());
         assert_eq!(zeros.shape(), &[len]);
         assert_eq!(zeros.dtype(), crate::DType::F64);
         assert_eq!(zeros.placement().memory_kind, MemoryKind::Device);
@@ -71,9 +72,9 @@ gpu_test!(test_zeros_f64_exact_values_placement_and_overflow, {
     }
 
     assert!(matches!(
-        backend.zeros_f64(usize::MAX),
+        backend.zeros::<f64>(usize::MAX),
         Err(Error::Validation {
-            op: "zeros_f64",
+            op: "zeros",
             source: tenferro_tensor::ValidationError::InvalidArgument {
                 argument: "length",
                 ..

--- a/crates/tenferro-gpu/src/lib.rs
+++ b/crates/tenferro-gpu/src/lib.rs
@@ -40,7 +40,7 @@ mod webgpu;
 pub use cubecl::{
     cuda_capabilities, cuda_runtime_engine_id, cuda_runtime_engine_registration,
     cuda_runtime_hardware_class, device_ptr, download_tensor, gpu_available, upload_tensor,
-    CudaBackend, CudaRuntime,
+    CudaBackend, CudaRuntime, CudaZeroScalar,
 };
 #[cfg(feature = "cuda")]
 #[doc(hidden)]

--- a/crates/tenferro-gpu/tests/integration/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/public_surface_contract.rs
@@ -262,7 +262,8 @@ fn webgpu_materialization_does_not_inherit_host_defaults() {
 fn cubecl_output_allocations_use_checked_shape_products() {
     let dispatch = repo_file("crates/tenferro-gpu/src/cubecl/dispatch.rs");
     assert!(
-        dispatch.contains("let len = checked_shape_product(\"cubecl_alloc_output\", shape)?;"),
+        dispatch.contains("alloc_output_for_op(rt, shape, \"cubecl_alloc_output\")")
+            && dispatch.contains("let len = checked_shape_product(op, shape)?;"),
         "CubeCL typed output allocation must reject shape-product overflow"
     );
     assert!(


### PR DESCRIPTION
## Summary

Add the narrow typed `CudaBackend::zeros<T: CudaZeroScalar>(len)` prerequisite required by [TeNeT #740](https://github.com/Ryo-wtnb11/TeNeT/issues/740).

`CudaZeroScalar` is a sealed `TensorScalar` capability implemented only for `f64`. The method allocates compact `[len]` storage on the backend runtime and enqueues the existing `fill_zero_kernel` on the current CubeCL stream. It performs no host upload/download or synchronization. Length zero returns placed empty storage without launching the kernel.

## Scope

- one generic typed constructor with an initially f64-only sealed capability;
- reuse the existing checked allocator, launch helper, and zero kernel;
- preserve existing helper diagnostic labels while the public operation reports stable `op = "zeros"`;
- no f32 admission, runtime dtype dispatch, raw allocator, stream, pointer, or synchronization API.

## Tests

- exact positive-zero bits for lengths `0`, `1`, `17`, and `4097`;
- compact shape, f64 dtype, CUDA placement and ordinal;
- `usize::MAX` rejects before allocation with stable `zeros` validation label;
- typed public signature compile test;
- compile-fail rustdoc proving `f32` is not admitted by `CudaZeroScalar`.

Local gates: fmt, diff check, public-error-docs, all CUDA rustdocs, API consistency audit, CUDA compile, source contract, and focused tests pass. The API consistency audit reports only the existing unrelated README jargon finding. Clippy remains red only on existing unrelated warnings. A non-skipped CUDA device run also passes.

## Review evidence

At `b45ded71`, allocation and fill use the same runtime/current stream; empty launch is skipped; no upload, download, sync, or new raw interop seam appears in production. The unchecked launch now has an adjacent SAFETY argument covering fresh output ownership, validated binding length/runtime, launch domain, and kernel bounds guard.