### PR TITLE
Use CUDA memset for zero allocation

### DIFF
--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -92,6 +92,7 @@ use cubecl::prelude::{
 };
 use cubecl::prelude::{CubeCount, Int as CubeInt, StorageType, TensorBinding, Type};
 use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
+use cudarc::runtime::{result as cuda_result, sys::cudaStream_t};
 use num_complex::{Complex32, Complex64};
 use tenferro_core_ops::PrimitiveOpKind;
 use tenferro_tensor::CacheStats;
@@ -132,8 +133,8 @@ mod runtime_adapter;
 
 use dispatch::{
     alloc_bool_output, alloc_output, alloc_output_for_op, bool_tensor_array_arg, comptime_sequence,
-    cube_count_for_len, cube_count_for_len_for_op, cube_dim_1d, dtype_mismatch, ensure_axes_unique,
-    ensure_axis, ensure_rank, ensure_resident_on_runtime, ensure_view_mut_resident_on_runtime,
+    cube_count_for_len, cube_dim_1d, dtype_mismatch, ensure_axes_unique, ensure_axis, ensure_rank,
+    ensure_resident_on_runtime, ensure_view_mut_resident_on_runtime,
     ensure_view_resident_on_runtime, launch_binary, launch_binary_bool_tensor,
     launch_binary_tensor, launch_bool_tensor_into, launch_compare_bool, launch_nullary_bool_into,
     launch_nullary_into, launch_select_bool, launch_ternary, launch_unary,
@@ -330,15 +331,21 @@ fn scatter_update_len(meta: &ScatterLaunchMeta) -> crate::Result<usize> {
 
 mod cuda_zero_scalar {
     use cubecl::prelude::{CubeElement, CubePrimitive};
+    use cudarc::driver::ValidAsZeroBits;
 
-    pub trait Sealed: CubeElement + CubePrimitive + Clone + Send + Sync + 'static {
-        // Marker trait; bounds are available to the CUDA implementation.
+    pub trait Sealed:
+        CubeElement + CubePrimitive + ValidAsZeroBits + Clone + Send + Sync + 'static
+    {
+        // Marker trait; all-zero bits are valid for every admitted scalar.
     }
 
     impl Sealed for f64 {}
 }
 
 /// Scalar types supported by [`CudaBackend::zeros`].
+///
+/// Every admitted scalar has a valid all-zero bit pattern. For the initial
+/// `f64` implementation, that pattern is IEEE 754 positive zero.
 ///
 /// # Examples
 ///
@@ -797,7 +804,7 @@ impl CudaBackend {
 
     /// Allocate a one-dimensional CUDA tensor initialized to positive zero.
     ///
-    /// The initialization kernel is enqueued on this backend's current stream;
+    /// The asynchronous byte memset is enqueued on this backend's current stream;
     /// this method does not synchronize or transfer data to the host.
     ///
     /// # Examples
@@ -813,31 +820,32 @@ impl CudaBackend {
     /// # Errors
     ///
     /// Returns [`crate::Error::Validation`] with `InvalidArgument` when the
-    /// requested length cannot be represented by the CUDA launch or allocation,
+    /// requested allocation byte length cannot be represented,
     /// or [`crate::Error::RuntimeState`] when the allocated tensor cannot be
     /// bound to this backend's runtime.
     pub fn zeros<T: CudaZeroScalar>(&self, len: usize) -> crate::Result<TypedTensor<T>> {
         const OP: &str = "zeros";
-        let count = cube_count_for_len_for_op(len, OP)?;
+        let byte_len = len.checked_mul(core::mem::size_of::<T>()).ok_or_else(|| {
+            crate::Error::invalid_argument(
+                OP,
+                "length",
+                format!("CUDA allocation byte length overflows usize for {len} elements"),
+            )
+        })?;
         let output = alloc_output_for_op::<T>(self.runtime(), &[len], OP)?;
-        launch_nullary_into(
-            self.runtime(),
-            &output,
-            OP,
-            count,
-            cube_dim_1d(),
-            |client, count, dim, out| {
-                // SAFETY: `output` is a fresh, unaliased dense allocation of exactly
-                // `len` elements. `launch_nullary_into` validates its runtime and
-                // backing length before binding it; the launch covers the domain, and
-                // the kernel guards every write with `ABSOLUTE_POS < out.len()`.
-                unsafe {
-                    structural::fill_zero_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
-                        client, count, dim, out,
-                    );
-                }
-            },
-        )?;
+        if len == 0 {
+            return Ok(output);
+        }
+
+        self.runtime().set_current_cuda_context(OP)?;
+        let ptr = interop::typed_device_ptr(self.runtime(), &output, OP)?;
+        let stream = interop::raw_cuda_stream(self.runtime(), OP)? as usize as cudaStream_t;
+        // SAFETY: `output` owns a fresh CubeCL allocation of `byte_len` bytes and
+        // keeps it alive after this call. `CudaZeroScalar` is sealed to types for
+        // which all-zero bits are valid, and the memset is ordered on CubeCL's
+        // current stream before any subsequent use of the returned tensor.
+        unsafe { cuda_result::memset_d8_async(ptr, 0, byte_len, stream) }
+            .map_err(|err| crate::Error::backend_source(OP, err))?;
         Ok(output)
     }
 

--- a/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
@@ -1449,6 +1449,47 @@ fn cubecl_gemm_zero_contracting_path_stays_device_native() {
 }
 
 #[test]
+fn cuda_zeros_uses_stream_ordered_byte_memset() {
+    let source = cubecl_source("mod.rs");
+    let scalar = source_section(
+        &source,
+        "mod cuda_zero_scalar",
+        "impl CudaZeroScalar for f64",
+    );
+    let zeros = source_section(
+        &source,
+        "    pub fn zeros<T: CudaZeroScalar>",
+        "    fn cutensor_handle",
+    );
+
+    assert!(scalar.contains("ValidAsZeroBits"));
+    assert_ordered_needles(
+        "CudaBackend::zeros",
+        zeros,
+        &[
+            "checked_mul(core::mem::size_of::<T>())",
+            "alloc_output_for_op::<T>",
+            "if len == 0",
+            "set_current_cuda_context(OP)",
+            "interop::typed_device_ptr",
+            "interop::raw_cuda_stream",
+            "cuda_result::memset_d8_async",
+        ],
+    );
+    for banned in [
+        "fill_zero_kernel",
+        "launch_nullary_into",
+        "create_from_slice",
+        "synchronize",
+    ] {
+        assert!(
+            !zeros.contains(banned),
+            "CudaBackend::zeros must stay asynchronous and device-native: {banned}"
+        );
+    }
+}
+
+#[test]
 fn cubecl_raw_device_pointer_paths_use_exposed_provenance() {
     for (name, source) in [
         ("cubecl/interop.rs", cubecl_source("interop.rs")),

--- a/docs/worklogs/2026-08-01-cuda-zero-memset.md
+++ b/docs/worklogs/2026-08-01-cuda-zero-memset.md
@@ -1,0 +1,48 @@
+# CUDA zero allocation byte memset
+
+## Summary
+
+The existing `CudaBackend::zeros::<f64>` path launched a generic CubeCL fill
+kernel. A downstream A100 comparison reported about a 5.6% warmed median
+regression versus the previous host-zero upload path. This change keeps zero
+construction device-native but enqueues `cudaMemsetAsync` on CubeCL's current
+CUDA stream instead.
+
+## Context read
+
+- `AGENTS.md`, `REPOSITORY_RULES.md`, and
+  `docs/design/gpu-backend-design.md`
+- `crates/tenferro-gpu/src/cubecl/{mod,runtime,memory,interop,gemm}.rs`
+- CubeCL's pinned `ComputeClient::get_resource`, `CudaServer::raw_stream`, and
+  managed-allocation implementation
+- cudarc 0.19.8 `memset_d8_async` and `ValidAsZeroBits` contracts
+
+## Decisions
+
+- Reuse the existing CubeCL raw pointer/current-stream interop; no new public
+  API, dependency, synchronization, or transfer boundary is needed.
+- Keep `CudaZeroScalar` sealed and add cudarc's `ValidAsZeroBits` as its private
+  proof that byte zeroing produces a valid scalar. The only admitted type
+  remains `f64`, for which all-zero bits are positive zero.
+- Return an empty allocation before context, pointer, or stream lookup.
+- Retain checked byte-length overflow with operation name `zeros`. Remove the
+  obsolete CubeCL workgroup-count limit because byte memset has no launch grid.
+
+The output tensor's CubeCL handle retains the allocation, and the memset is
+submitted to the same current stream used by subsequent CubeCL work. A host
+zero buffer, a new CUDA abstraction, and an internal synchronization were
+rejected because each would either restore the measured cost or broaden the
+change without improving the established interop contract.
+
+## Verification
+
+- `cargo test -p tenferro-gpu --test integration cuda_zeros_uses_stream_ordered_byte_memset`
+- `cargo check -p tenferro-gpu --features cuda`
+- `cargo test -p tenferro-gpu --features cuda --no-run`
+- `cargo fmt --all --check`
+- `git diff --check`
+
+The existing ignored CUDA runtime test covers lengths 0, 1, 17, and 4097,
+exact positive-zero bits after download, placement metadata, and overflow.
+Runtime execution and the downstream paired latency comparison remain an A100
+hardware gate.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs #1583

## Summary

`CudaBackend::zeros::<f64>` used a generic CubeCL fill kernel. A downstream
A100 paired comparison found that path about 5.6% slower at warmed median than
the prior host-zero H2D baseline.

This follow-up replaces only that fill launch with `cudaMemsetAsync` on
CubeCL's current CUDA stream. It keeps allocation and initialization
device-native and asynchronous, preserves the public `zeros` operation name,
f64-only sealed API, exact positive-zero bits, checked byte-size errors, and
the len=0 path. The obsolete u32 workgroup-count limit is removed because
memset has no launch grid.

The private sealed scalar bound now includes cudarc's `ValidAsZeroBits`, making
the byte-zero safety condition explicit. Existing CubeCL pointer/current-stream
interop supplies residency, device ordinal, allocation lifetime, and stream
ordering; no public API, dependency, host transfer, synchronization, or new
interop abstraction was added.

The AI-assisted bug-fix scope gate was applied. The neighborhood scan covered
all `CudaBackend::zeros` callers and the existing raw CUDA pointer/stream users.
The separate generic `gemm::zero_alloc` path remains unchanged because it is a
different generic dtype contract and was not part of the measured regression.

## Work log

- [CUDA zero allocation byte memset](docs/worklogs/2026-08-01-cuda-zero-memset.md)

## Verification

- `bash scripts/check-pr-fast.sh --base upstream/main --no-fetch --coverage-reviewed --test 'cargo test -p tenferro-gpu --test integration cuda_zeros_uses_stream_ordered_byte_memset'`
- `cargo check -p tenferro-gpu --features cuda`
- `cargo test -p tenferro-gpu --features cuda --no-run`
- `python3 scripts/repository-rules-review.py --base upstream/main --head HEAD --dry-run --output-json /private/tmp/tenferro-cuda-zero-memset-review.json`
- `cargo fmt --all --check`
- `git diff --check upstream/main...HEAD`

The ignored CUDA semantic test already checks len 0/1/17/4097, exact +0 bits,
placement, and overflow; runtime execution and paired latency remain for the
A100 gate. An additional CUDA-feature Clippy run reached pre-existing deny-
warning failures outside this diff; the required default CI-parity Clippy
profiles passed in `check-pr-fast.sh`. The LLM-backed repository-rules review
could not run because `DEEPSEEK_API_KEY` is unavailable; its committed-diff
deterministic review passed with no findings.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [ ] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
