### PR TITLE
Revert CUDA zeros until CubeCL publishes output writes

### DIFF
--- a/crates/tenferro-gpu/src/cubecl/dispatch.rs
+++ b/crates/tenferro-gpu/src/cubecl/dispatch.rs
@@ -16,14 +16,10 @@ use tenferro_tensor::{
 pub(crate) const DEFAULT_CUBE_DIM_X: u32 = 256;
 
 pub(crate) fn cube_count_for_len(len: usize) -> crate::Result<CubeCount> {
-    cube_count_for_len_for_op(len, "cube_count_for_len")
-}
-
-pub(crate) fn cube_count_for_len_for_op(len: usize, op: &'static str) -> crate::Result<CubeCount> {
     let cubes = len.div_ceil(DEFAULT_CUBE_DIM_X as usize);
     let cubes = u32::try_from(cubes).map_err(|_| {
         crate::Error::invalid_argument(
-            op,
+            "cube_count_for_len",
             "length",
             format!(
                 "1D CubeCL launch for {len} elements requires {cubes} cubes, \
@@ -435,18 +431,10 @@ pub(crate) fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
     rt: &CudaRuntime,
     shape: &[usize],
 ) -> crate::Result<TypedTensor<T>> {
-    alloc_output_for_op(rt, shape, "cubecl_alloc_output")
-}
-
-pub(crate) fn alloc_output_for_op<T: CubeElement + Clone + Send + Sync + 'static>(
-    rt: &CudaRuntime,
-    shape: &[usize],
-    op: &'static str,
-) -> crate::Result<TypedTensor<T>> {
-    let len = checked_shape_product(op, shape)?;
+    let len = checked_shape_product("cubecl_alloc_output", shape)?;
     let byte_len = len.checked_mul(core::mem::size_of::<T>()).ok_or_else(|| {
         crate::Error::invalid_argument(
-            op,
+            "cubecl_alloc_output",
             "shape",
             format!("output byte length overflow for shape {shape:?}"),
         )

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -131,9 +131,9 @@ mod runtime;
 mod runtime_adapter;
 
 use dispatch::{
-    alloc_bool_output, alloc_output, alloc_output_for_op, bool_tensor_array_arg, comptime_sequence,
-    cube_count_for_len, cube_count_for_len_for_op, cube_dim_1d, dtype_mismatch, ensure_axes_unique,
-    ensure_axis, ensure_rank, ensure_resident_on_runtime, ensure_view_mut_resident_on_runtime,
+    alloc_bool_output, alloc_output, bool_tensor_array_arg, comptime_sequence, cube_count_for_len,
+    cube_dim_1d, dtype_mismatch, ensure_axes_unique, ensure_axis, ensure_rank,
+    ensure_resident_on_runtime, ensure_view_mut_resident_on_runtime,
     ensure_view_resident_on_runtime, launch_binary, launch_binary_bool_tensor,
     launch_binary_tensor, launch_bool_tensor_into, launch_compare_bool, launch_nullary_bool_into,
     launch_nullary_into, launch_select_bool, launch_ternary, launch_unary,
@@ -327,44 +327,6 @@ fn scatter_update_len(meta: &ScatterLaunchMeta) -> crate::Result<usize> {
         )
     })
 }
-
-mod cuda_zero_scalar {
-    use cubecl::prelude::{CubeElement, CubePrimitive};
-
-    pub trait Sealed: CubeElement + CubePrimitive + Clone + Send + Sync + 'static {
-        // Marker trait; bounds are available to the CUDA implementation.
-    }
-
-    impl Sealed for f64 {}
-}
-
-/// Scalar types supported by [`CudaBackend::zeros`].
-///
-/// # Examples
-///
-/// ```
-/// use tenferro_gpu::CudaZeroScalar;
-///
-/// fn accepts_cuda_zero<T: CudaZeroScalar>() {}
-///
-/// accepts_cuda_zero::<f64>();
-/// ```
-///
-/// This capability is sealed; the initial CUDA constructor supports only
-/// `f64`. In particular, `f32` is not admitted:
-///
-/// ```compile_fail
-/// use tenferro_gpu::CudaBackend;
-///
-/// fn rejected(backend: &CudaBackend) {
-///     let _ = backend.zeros::<f32>(1);
-/// }
-/// ```
-pub trait CudaZeroScalar: tenferro_tensor::TensorScalar + cuda_zero_scalar::Sealed {
-    // Marker trait; implementations are fixed by the private supertrait.
-}
-
-impl CudaZeroScalar for f64 {}
 
 /// CubeCL-based GPU backend.
 ///
@@ -793,52 +755,6 @@ impl CudaBackend {
     /// ```
     pub fn runtime(&self) -> &CudaRuntime {
         &self.inner.rt
-    }
-
-    /// Allocate a one-dimensional CUDA tensor initialized to positive zero.
-    ///
-    /// The initialization kernel is enqueued on this backend's current stream;
-    /// this method does not synchronize or transfer data to the host.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_gpu::CudaBackend;
-    /// use tenferro_tensor::{Result, TypedTensor};
-    ///
-    /// let _zeros: fn(&CudaBackend, usize) -> Result<TypedTensor<f64>> =
-    ///     CudaBackend::zeros::<f64>;
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns [`crate::Error::Validation`] with `InvalidArgument` when the
-    /// requested length cannot be represented by the CUDA launch or allocation,
-    /// or [`crate::Error::RuntimeState`] when the allocated tensor cannot be
-    /// bound to this backend's runtime.
-    pub fn zeros<T: CudaZeroScalar>(&self, len: usize) -> crate::Result<TypedTensor<T>> {
-        const OP: &str = "zeros";
-        let count = cube_count_for_len_for_op(len, OP)?;
-        let output = alloc_output_for_op::<T>(self.runtime(), &[len], OP)?;
-        launch_nullary_into(
-            self.runtime(),
-            &output,
-            OP,
-            count,
-            cube_dim_1d(),
-            |client, count, dim, out| {
-                // SAFETY: `output` is a fresh, unaliased dense allocation of exactly
-                // `len` elements. `launch_nullary_into` validates its runtime and
-                // backing length before binding it; the launch covers the domain, and
-                // the kernel guards every write with `ABSOLUTE_POS < out.len()`.
-                unsafe {
-                    structural::fill_zero_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
-                        client, count, dim, out,
-                    );
-                }
-            },
-        )?;
-        Ok(output)
     }
 
     fn cutensor_handle(&self) -> crate::Result<&ffi::cutensor::CutensorHandle> {

--- a/crates/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
@@ -4,7 +4,7 @@ use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 
 use crate::cubecl::memory::{device_ptr, download_tensor, upload_tensor};
 use crate::cubecl::{gpu_available, CudaBackend, CudaRuntime};
-use crate::{DeviceKind, Error, GpuBackendKind, MemoryKind, Tensor, TypedTensor};
+use crate::{Error, Tensor};
 use tenferro_tensor::TensorElementwise;
 
 #[cube(launch_unchecked)]
@@ -44,44 +44,6 @@ fn cube_count_for_len_rejects_u32_overflow() {
         }
     ));
 }
-
-#[test]
-fn zeros_f64_has_the_narrow_public_signature() {
-    let _zeros: fn(&CudaBackend, usize) -> crate::Result<TypedTensor<f64>> =
-        CudaBackend::zeros::<f64>;
-}
-
-gpu_test!(test_zeros_f64_exact_values_placement_and_overflow, {
-    let backend = CudaBackend::new(0).unwrap();
-
-    for len in [0, 1, 17, 4097] {
-        let zeros = Tensor::F64(backend.zeros::<f64>(len).unwrap());
-        assert_eq!(zeros.shape(), &[len]);
-        assert_eq!(zeros.dtype(), crate::DType::F64);
-        assert_eq!(zeros.placement().memory_kind, MemoryKind::Device);
-        let device = zeros.placement().device.as_ref().unwrap();
-        assert_eq!(device.kind, DeviceKind::Gpu(GpuBackendKind::Cuda));
-        assert_eq!(device.ordinal, 0);
-
-        let host = download_tensor(backend.runtime(), &zeros).unwrap();
-        assert!(host
-            .as_slice::<f64>()
-            .unwrap()
-            .iter()
-            .all(|value| value.to_bits() == 0));
-    }
-
-    assert!(matches!(
-        backend.zeros::<f64>(usize::MAX),
-        Err(Error::Validation {
-            op: "zeros",
-            source: tenferro_tensor::ValidationError::InvalidArgument {
-                argument: "length",
-                ..
-            },
-        })
-    ));
-});
 
 gpu_test!(test_runtime_init, {
     let rt = CudaRuntime::new(0);

--- a/crates/tenferro-gpu/src/lib.rs
+++ b/crates/tenferro-gpu/src/lib.rs
@@ -40,7 +40,7 @@ mod webgpu;
 pub use cubecl::{
     cuda_capabilities, cuda_runtime_engine_id, cuda_runtime_engine_registration,
     cuda_runtime_hardware_class, device_ptr, download_tensor, gpu_available, upload_tensor,
-    CudaBackend, CudaRuntime, CudaZeroScalar,
+    CudaBackend, CudaRuntime,
 };
 #[cfg(feature = "cuda")]
 #[doc(hidden)]

--- a/crates/tenferro-gpu/tests/integration/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/public_surface_contract.rs
@@ -262,8 +262,7 @@ fn webgpu_materialization_does_not_inherit_host_defaults() {
 fn cubecl_output_allocations_use_checked_shape_products() {
     let dispatch = repo_file("crates/tenferro-gpu/src/cubecl/dispatch.rs");
     assert!(
-        dispatch.contains("alloc_output_for_op(rt, shape, \"cubecl_alloc_output\")")
-            && dispatch.contains("let len = checked_shape_product(op, shape)?;"),
+        dispatch.contains("let len = checked_shape_product(\"cubecl_alloc_output\", shape)?;"),
         "CubeCL typed output allocation must reject shape-product overflow"
     );
     assert!(

--- a/docs/worklogs/2026-08-01-issue-1586-revert-cuda-zeros.md
+++ b/docs/worklogs/2026-08-01-issue-1586-revert-cuda-zeros.md
@@ -1,0 +1,43 @@
+# 2026-08-01 Revert CUDA zero allocation (#1586)
+
+## Scope
+
+Revert the public `CudaBackend::zeros` API added by #1583 because CubeCL does
+not yet publish a kernel output write as a new managed binding cursor. The
+allocate-then-fill sequence can therefore return an output whose initialization
+is not ordered before a later first use from another thread and stream.
+
+The revert removes `CudaZeroScalar`, `CudaBackend::zeros`, their tests and
+exports, and the two operation-aware helper generalizations that had no other
+callers. The remaining five source and test files match the parent of #1583;
+unrelated CUDA allocation and kernel paths are unchanged.
+
+## Context reviewed
+
+- issue #1586 and the rejected raw-memset follow-up #1585;
+- CubeCL issue #16 and the pinned CubeCL binding-cursor behavior summarized in
+  #1586;
+- #1583's complete diff and all current repository references to the removed
+  API and generalized helpers;
+- `AGENTS.md`, `CONTRIBUTING.md`, `REPOSITORY_RULES.md`, and the shared Rust,
+  performance, documentation, and test rules.
+
+## Decision
+
+Remove the unsafe-to-publish public constructor until CubeCL provides
+scheduler-managed binding write-version publication covering both ordinary
+kernel outputs and external writes. A future raw-memset path additionally needs
+external write registration and stream enqueue to be atomic. Do not add a
+Tenferro-wide lock, synchronize before returning, reconstruct CubeCL allocation
+internals, or modify adjacent CUDA operations in this leaf.
+
+## Verification
+
+- repository search contains no `CudaZeroScalar`, `CudaBackend::zeros`, or
+  caller of the removed helper generalizations;
+- the focused CubeCL checked-allocation source contract passes;
+- the required local PR gate, repository-rules review, default build, and CUDA
+  build are recorded in the PR.
+
+Hardware concurrency validation is not applicable to the removal. The systemic
+cursor contract remains tracked by CubeCL #16.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [x] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Closes #1586

## Summary

Revert the public CUDA zero constructor added by #1583. CubeCL's pinned
multi-stream scheduler does not publish an output write as a new managed
binding version, so the allocate-then-fill sequence can expose initialization
without the required cross-stream dependency.

This removes the public scalar capability, constructor, export, and associated
tests. It also restores the two operation-aware helper generalizations because
repository-wide caller search found no remaining users. The five affected
source/test files exactly match the parent of #1583; unrelated CUDA paths are
unchanged. #1583's squashed mainline commit contains no worklog to remove; the
#1585 memset worklog remains confined to that rejected, closed branch.

Same-root-cause search covered the CUDA module, crate exports, runtime tests,
integration source contracts, active docs, examples, and all workspace Rust
callers. The systemic scheduler contract remains tracked by tensor4all/cubecl#16
and is intentionally not repaired in this Tenferro leaf.

The AI-assisted bug-fix scope gate was applied: this removes a known-racy new
public surface without adding an API, dependency, feature, backend, or
architectural layer.

## Work log

- [2026-08-01 issue #1586 revert](docs/worklogs/2026-08-01-issue-1586-revert-cuda-zeros.md)

## Verification

- `cargo test -p tenferro-gpu --test integration cubecl_output_allocations_use_checked_shape_products`
- `cargo check -p tenferro-gpu`
- `cargo check -p tenferro-gpu --features cuda`
- `bash scripts/check-pr-fast.sh --base upstream/main --no-fetch --coverage-reviewed --test 'cargo test -p tenferro-gpu --test integration cubecl_output_allocations_use_checked_shape_products'`
  - passed formatting, doc-snippet checks, root and standalone-extension clippy,
    and the focused test
- committed-diff inspection and `git diff --check`

The repository-rules review command was attempted on the committed head but the
local LLM review was unavailable because `DEEPSEEK_API_KEY` is not set. The
repository rules and routed GPU/public-surface/worklog sections were reviewed
manually; no residual finding was identified.

Hardware concurrency validation is not applicable to an API removal. Hosted CI
retains ownership of the full workspace, CUDA matrix, and coverage gates.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules review and documented that its LLM backend
      was unavailable.
- [x] If this implements a new feature, the linked issue has been accepted by
      maintainers. (Not applicable: bug-fix removal.)
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from
      `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and
      linked it above.
