### PR TITLE
Fix large-wide CUDA SVD fallback orientation

### DIFF
--- a/crates/tenferro-linalg/src/gpu/kernels.rs
+++ b/crates/tenferro-linalg/src/gpu/kernels.rs
@@ -48,7 +48,7 @@ fn matching_work_offset<Work: CubePrimitive, Out: CubePrimitive>(
 }
 
 #[cube]
-fn svd_v_to_vt_offset<E: CubePrimitive>(
+fn matrix_adjoint_offset<E: CubePrimitive>(
     out: &Tensor<E>,
     v: &Tensor<E>,
     flat: usize,
@@ -74,26 +74,26 @@ pub fn fill_one_kernel<E: CubePrimitive>(out: &mut Tensor<E>) {
 }
 
 #[cube(launch_unchecked)]
-pub fn svd_v_to_vt_real<E: CubePrimitive>(
+pub fn matrix_adjoint_real<E: CubePrimitive>(
     out: &mut Tensor<E>,
     v: &Tensor<E>,
     #[comptime] rank: usize,
 ) {
     let pos = ABSOLUTE_POS as usize;
     if pos < out.len() {
-        out[pos] = v[svd_v_to_vt_offset(out, v, pos, rank)];
+        out[pos] = v[matrix_adjoint_offset(out, v, pos, rank)];
     }
 }
 
 #[cube(launch_unchecked)]
-pub fn svd_v_to_vt_complex<C: ComplexCore>(
+pub fn matrix_adjoint_complex<C: ComplexCore>(
     out: &mut Tensor<C>,
     v: &Tensor<C>,
     #[comptime] rank: usize,
 ) {
     let pos = ABSOLUTE_POS as usize;
     if pos < out.len() {
-        out[pos] = v[svd_v_to_vt_offset(out, v, pos, rank)].conj();
+        out[pos] = v[matrix_adjoint_offset(out, v, pos, rank)].conj();
     }
 }
 

--- a/crates/tenferro-linalg/src/gpu/linalg.rs
+++ b/crates/tenferro-linalg/src/gpu/linalg.rs
@@ -39,7 +39,7 @@ trait LinalgScalar:
     const DATA_TYPE: CudaDataType;
     const NEEDS_RWORK: bool;
 
-    fn copy_svd_v_to_vt(
+    fn copy_matrix_adjoint(
         rt: &CudaRuntime,
         v: &TypedTensor<Self>,
         vt_shape: &[usize],
@@ -53,13 +53,13 @@ impl LinalgScalar for f32 {
     const DATA_TYPE: CudaDataType = CudaDataType::F32;
     const NEEDS_RWORK: bool = false;
 
-    fn copy_svd_v_to_vt(
+    fn copy_matrix_adjoint(
         rt: &CudaRuntime,
         v: &TypedTensor<Self>,
         vt_shape: &[usize],
         op: &'static str,
     ) -> Result<TypedTensor<Self>> {
-        copy_svd_v_to_vt_real(rt, v, vt_shape, op)
+        copy_matrix_adjoint_real(rt, v, vt_shape, op)
     }
 }
 
@@ -69,13 +69,13 @@ impl LinalgScalar for f64 {
     const DATA_TYPE: CudaDataType = CudaDataType::F64;
     const NEEDS_RWORK: bool = false;
 
-    fn copy_svd_v_to_vt(
+    fn copy_matrix_adjoint(
         rt: &CudaRuntime,
         v: &TypedTensor<Self>,
         vt_shape: &[usize],
         op: &'static str,
     ) -> Result<TypedTensor<Self>> {
-        copy_svd_v_to_vt_real(rt, v, vt_shape, op)
+        copy_matrix_adjoint_real(rt, v, vt_shape, op)
     }
 }
 
@@ -85,13 +85,13 @@ impl LinalgScalar for Complex32 {
     const DATA_TYPE: CudaDataType = CudaDataType::Complex32;
     const NEEDS_RWORK: bool = true;
 
-    fn copy_svd_v_to_vt(
+    fn copy_matrix_adjoint(
         rt: &CudaRuntime,
         v: &TypedTensor<Self>,
         vt_shape: &[usize],
         op: &'static str,
     ) -> Result<TypedTensor<Self>> {
-        copy_svd_v_to_vt_complex(rt, v, vt_shape, op)
+        copy_matrix_adjoint_complex(rt, v, vt_shape, op)
     }
 }
 
@@ -101,13 +101,13 @@ impl LinalgScalar for Complex64 {
     const DATA_TYPE: CudaDataType = CudaDataType::Complex64;
     const NEEDS_RWORK: bool = true;
 
-    fn copy_svd_v_to_vt(
+    fn copy_matrix_adjoint(
         rt: &CudaRuntime,
         v: &TypedTensor<Self>,
         vt_shape: &[usize],
         op: &'static str,
     ) -> Result<TypedTensor<Self>> {
-        copy_svd_v_to_vt_complex(rt, v, vt_shape, op)
+        copy_matrix_adjoint_complex(rt, v, vt_shape, op)
     }
 }
 
@@ -904,7 +904,7 @@ where
     }
 }
 
-fn copy_svd_v_to_vt_real<T>(
+fn copy_matrix_adjoint_real<T>(
     rt: &CudaRuntime,
     v: &TypedTensor<T>,
     vt_shape: &[usize],
@@ -914,11 +914,11 @@ where
     T: LinalgScalar,
 {
     let vt = alloc_output::<T>(rt, vt_shape)?;
-    launch_svd_v_to_vt_real(rt, v, &vt, op)?;
+    launch_matrix_adjoint_real(rt, v, &vt, op)?;
     Ok(vt)
 }
 
-fn copy_svd_v_to_vt_complex<T>(
+fn copy_matrix_adjoint_complex<T>(
     rt: &CudaRuntime,
     v: &TypedTensor<T>,
     vt_shape: &[usize],
@@ -928,11 +928,11 @@ where
     T: LinalgScalar + ComplexCore,
 {
     let vt = alloc_output::<T>(rt, vt_shape)?;
-    launch_svd_v_to_vt_complex(rt, v, &vt, op)?;
+    launch_matrix_adjoint_complex(rt, v, &vt, op)?;
     Ok(vt)
 }
 
-fn launch_svd_v_to_vt_real<T>(
+fn launch_matrix_adjoint_real<T>(
     rt: &CudaRuntime,
     v: &TypedTensor<T>,
     vt: &TypedTensor<T>,
@@ -948,9 +948,9 @@ where
     let v_arg = typed_tensor_binding(v, op)?;
     let launch_count = cube_count_for_len(vt.n_elements())?;
     // SAFETY: tensor bindings describe live CUDA tensors, and `launch_count`
-    // covers exactly the output domain for the V-to-VT copy kernel.
+    // covers exactly the output domain for the matrix-adjoint copy kernel.
     with_cubecl_client(rt, |client| unsafe {
-        cubecl_linalg::svd_v_to_vt_real::launch_unchecked::<T, CubeclCudaRuntime>(
+        cubecl_linalg::matrix_adjoint_real::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
             launch_count,
             cube_dim_1d(),
@@ -962,7 +962,7 @@ where
     flush_cubecl_client(rt, op)
 }
 
-fn launch_svd_v_to_vt_complex<T>(
+fn launch_matrix_adjoint_complex<T>(
     rt: &CudaRuntime,
     v: &TypedTensor<T>,
     vt: &TypedTensor<T>,
@@ -978,9 +978,9 @@ where
     let v_arg = typed_tensor_binding(v, op)?;
     let launch_count = cube_count_for_len(vt.n_elements())?;
     // SAFETY: tensor bindings describe live CUDA tensors, and `launch_count`
-    // covers exactly the output domain for the conjugating V-to-VT copy kernel.
+    // covers exactly the output domain for the conjugating matrix-adjoint kernel.
     with_cubecl_client(rt, |client| unsafe {
-        cubecl_linalg::svd_v_to_vt_complex::launch_unchecked::<T, CubeclCudaRuntime>(
+        cubecl_linalg::matrix_adjoint_complex::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
             launch_count,
             cube_dim_1d(),
@@ -1024,20 +1024,15 @@ where
         ));
     }
 
-    let work = clone_device_tensor(backend.runtime(), input, OP)?;
-    let u = alloc_output::<T>(backend.runtime(), &u_shape)?;
     let s = alloc_output::<<T as LinalgScalar>::Real>(backend.runtime(), &s_shape)?;
-    let m_i32 = as_i32(m, OP, "m")?;
-    let n_i32 = as_i32(n, OP, "n")?;
-    let lda = as_i32(m, OP, "lda")?;
-    let ldu = as_i32(m, OP, "ldu")?;
     let batch_total = batch_count(OP, batch_shape)?;
     let a_stride = checked_mul_usize(OP, "svd input stride", m, n)?;
-    let u_stride = checked_mul_usize(OP, "svd u stride", m, k)?;
     let s_stride = k;
 
     match select_svd_driver(m, n) {
         SvdDriver::Gesvdj => {
+            let work = clone_device_tensor(backend.runtime(), input, OP)?;
+            let u = alloc_output::<T>(backend.runtime(), &u_shape)?;
             let mut v_shape = vec![n, k];
             v_shape.extend_from_slice(batch_shape);
             let v = alloc_output::<T>(backend.runtime(), &v_shape)?;
@@ -1050,6 +1045,10 @@ where
                 let u_ptr = typed_device_ptr(backend.runtime(), &u, OP)?;
                 let s_ptr = typed_device_ptr(backend.runtime(), &s, OP)?;
                 let v_ptr = typed_device_ptr(backend.runtime(), &v, OP)?;
+                let m_i32 = as_i32(m, OP, "m")?;
+                let n_i32 = as_i32(n, OP, "n")?;
+                let lda = as_i32(m, OP, "lda")?;
+                let ldu = as_i32(m, OP, "ldu")?;
                 let ldv = as_i32(n, OP, "ldv")?;
                 let params = handles.cusolver().create_gesvdj_info(OP)?;
                 let lwork = handles.cusolver().gesvdj_buffer_size(
@@ -1071,6 +1070,7 @@ where
                 let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
                 let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
                 let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
+                let u_stride = checked_mul_usize(OP, "svd u stride", m, k)?;
                 let v_stride = checked_mul_usize(OP, "svd v stride", n, k)?;
 
                 for batch in 0..batch_total {
@@ -1121,23 +1121,45 @@ where
                 }
                 check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*gesvdj")?;
             }
-            let vt = T::copy_svd_v_to_vt(backend.runtime(), &v, &vt_shape, OP)?;
+            let vt = T::copy_matrix_adjoint(backend.runtime(), &v, &vt_shape, OP)?;
             Ok((u, s, vt))
         }
         SvdDriver::Gesvd => {
-            let vt = alloc_output::<T>(backend.runtime(), &vt_shape)?;
+            let transpose_for_gesvd = m < n;
+            let (work, gesvd_m, gesvd_n) = if transpose_for_gesvd {
+                let mut work_shape = vec![n, m];
+                work_shape.extend_from_slice(batch_shape);
+                (
+                    T::copy_matrix_adjoint(backend.runtime(), input, &work_shape, OP)?,
+                    n,
+                    m,
+                )
+            } else {
+                (clone_device_tensor(backend.runtime(), input, OP)?, m, n)
+            };
+            let mut gesvd_u_shape = vec![gesvd_m, k];
+            gesvd_u_shape.extend_from_slice(batch_shape);
+            let mut gesvd_vt_shape = vec![k, gesvd_n];
+            gesvd_vt_shape.extend_from_slice(batch_shape);
+            let gesvd_u = alloc_output::<T>(backend.runtime(), &gesvd_u_shape)?;
+            let gesvd_vt = alloc_output::<T>(backend.runtime(), &gesvd_vt_shape)?;
             let handles = linalg_handles(backend)?;
             let stream = raw_stream(backend.runtime(), OP)?;
             handles.cusolver().set_stream(stream, OP)?;
 
             let a_ptr = typed_device_ptr(backend.runtime(), &work, OP)?;
-            let u_ptr = typed_device_ptr(backend.runtime(), &u, OP)?;
+            let u_ptr = typed_device_ptr(backend.runtime(), &gesvd_u, OP)?;
             let s_ptr = typed_device_ptr(backend.runtime(), &s, OP)?;
-            let vt_ptr = typed_device_ptr(backend.runtime(), &vt, OP)?;
+            let vt_ptr = typed_device_ptr(backend.runtime(), &gesvd_vt, OP)?;
+            let gesvd_m_i32 = as_i32(gesvd_m, OP, "gesvd m")?;
+            let gesvd_n_i32 = as_i32(gesvd_n, OP, "gesvd n")?;
+            let lda = gesvd_m_i32;
+            let ldu = gesvd_m_i32;
             let ldvt = as_i32(k, OP, "ldvt")?;
-            let lwork = handles
-                .cusolver()
-                .gesvd_buffer_size(T::DATA_TYPE, m_i32, n_i32, OP)?;
+            let lwork =
+                handles
+                    .cusolver()
+                    .gesvd_buffer_size(T::DATA_TYPE, gesvd_m_i32, gesvd_n_i32, OP)?;
             let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
             let rwork = if T::NEEDS_RWORK {
                 alloc_workspace_elems::<<T as LinalgScalar>::Real>(
@@ -1154,7 +1176,8 @@ where
             };
             let info = alloc_output::<i32>(backend.runtime(), &[batch_total])?;
             let info_ptr = typed_device_ptr(backend.runtime(), &info, OP)?;
-            let vt_stride = checked_mul_usize(OP, "svd vt stride", k, n)?;
+            let u_stride = checked_mul_usize(OP, "svd gesvd u stride", gesvd_m, k)?;
+            let vt_stride = checked_mul_usize(OP, "svd gesvd vt stride", k, gesvd_n)?;
             let job = b'S' as c_char;
 
             for batch in 0..batch_total {
@@ -1181,8 +1204,8 @@ where
                         T::DATA_TYPE,
                         job,
                         job,
-                        m_i32,
-                        n_i32,
+                        gesvd_m_i32,
+                        gesvd_n_i32,
                         batch_a,
                         lda,
                         batch_s,
@@ -1199,7 +1222,13 @@ where
                 }
             }
             check_solver_info_tensor(backend.runtime(), &info, OP, "cusolverDn*gesvd")?;
-            Ok((u, s, vt))
+            if transpose_for_gesvd {
+                let u = T::copy_matrix_adjoint(backend.runtime(), &gesvd_vt, &u_shape, OP)?;
+                let vt = T::copy_matrix_adjoint(backend.runtime(), &gesvd_u, &vt_shape, OP)?;
+                Ok((u, s, vt))
+            } else {
+                Ok((gesvd_u, s, gesvd_vt))
+            }
         }
     }
 }
@@ -1224,17 +1253,14 @@ where
         return Ok(alloc_output(backend.runtime(), &s_shape)?);
     }
 
-    let work = clone_device_tensor(backend.runtime(), input, OP)?;
     let s = alloc_output::<T::Real>(backend.runtime(), &s_shape)?;
-    let m_i32 = as_i32(m, OP, "m")?;
-    let n_i32 = as_i32(n, OP, "n")?;
-    let lda = as_i32(m, OP, "lda")?;
     let batch_total = batch_count(OP, batch_shape)?;
     let a_stride = checked_mul_usize(OP, "svd_values input stride", m, n)?;
     let s_stride = k;
 
     match select_svd_driver(m, n) {
         SvdDriver::Gesvdj => {
+            let work = clone_device_tensor(backend.runtime(), input, OP)?;
             let mut u_shape = vec![m, k];
             u_shape.extend_from_slice(batch_shape);
             let mut v_shape = vec![n, k];
@@ -1249,6 +1275,9 @@ where
             let s_ptr = typed_device_ptr(backend.runtime(), &s, OP)?;
             let u_ptr = typed_device_ptr(backend.runtime(), &u, OP)?;
             let v_ptr = typed_device_ptr(backend.runtime(), &v, OP)?;
+            let m_i32 = as_i32(m, OP, "m")?;
+            let n_i32 = as_i32(n, OP, "n")?;
+            let lda = as_i32(m, OP, "lda")?;
             let params = handles.cusolver().create_gesvdj_info(OP)?;
             let lwork = handles.cusolver().gesvdj_buffer_size(
                 T::DATA_TYPE,
@@ -1324,15 +1353,30 @@ where
             Ok(s)
         }
         SvdDriver::Gesvd => {
+            let (work, gesvd_m, gesvd_n) = if m < n {
+                let mut work_shape = vec![n, m];
+                work_shape.extend_from_slice(batch_shape);
+                (
+                    T::copy_matrix_adjoint(backend.runtime(), input, &work_shape, OP)?,
+                    n,
+                    m,
+                )
+            } else {
+                (clone_device_tensor(backend.runtime(), input, OP)?, m, n)
+            };
             let handles = linalg_handles(backend)?;
             let stream = raw_stream(backend.runtime(), OP)?;
             handles.cusolver().set_stream(stream, OP)?;
 
             let a_ptr = typed_device_ptr(backend.runtime(), &work, OP)?;
             let s_ptr = typed_device_ptr(backend.runtime(), &s, OP)?;
-            let lwork = handles
-                .cusolver()
-                .gesvd_buffer_size(T::DATA_TYPE, m_i32, n_i32, OP)?;
+            let gesvd_m_i32 = as_i32(gesvd_m, OP, "gesvd m")?;
+            let gesvd_n_i32 = as_i32(gesvd_n, OP, "gesvd n")?;
+            let lda = gesvd_m_i32;
+            let lwork =
+                handles
+                    .cusolver()
+                    .gesvd_buffer_size(T::DATA_TYPE, gesvd_m_i32, gesvd_n_i32, OP)?;
             let workspace = alloc_workspace_elems::<T>(backend.runtime(), lwork, OP)?;
             let rwork = if T::NEEDS_RWORK {
                 alloc_workspace_elems::<T::Real>(
@@ -1376,8 +1420,8 @@ where
                         T::DATA_TYPE,
                         job,
                         job,
-                        m_i32,
-                        n_i32,
+                        gesvd_m_i32,
+                        gesvd_n_i32,
                         batch_a,
                         lda,
                         batch_s,

--- a/crates/tenferro-linalg/tests/integration/gpu_linalg.rs
+++ b/crates/tenferro-linalg/tests/integration/gpu_linalg.rs
@@ -255,6 +255,80 @@ fn assert_slice_close_c64(actual: &[Complex64], expected: &[Complex64], tol: f64
     }
 }
 
+fn assert_relative_error_f64(actual: &[f64], expected: &[f64], tol: f64) {
+    assert_eq!(actual.len(), expected.len());
+    let error_sq = actual
+        .iter()
+        .zip(expected)
+        .map(|(lhs, rhs)| (lhs - rhs).powi(2))
+        .sum::<f64>();
+    let expected_sq = expected.iter().map(|value| value.powi(2)).sum::<f64>();
+    let relative_error = error_sq.sqrt() / expected_sq.sqrt().max(1.0);
+    assert!(
+        relative_error <= tol,
+        "relative error {relative_error:e} exceeds tolerance {tol:e}"
+    );
+}
+
+fn assert_relative_error_c64(actual: &[Complex64], expected: &[Complex64], tol: f64) {
+    assert_eq!(actual.len(), expected.len());
+    let error_sq = actual
+        .iter()
+        .zip(expected)
+        .map(|(lhs, rhs)| (*lhs - *rhs).norm_sqr())
+        .sum::<f64>();
+    let expected_sq = expected.iter().map(|value| value.norm_sqr()).sum::<f64>();
+    let relative_error = error_sq.sqrt() / expected_sq.sqrt().max(1.0);
+    assert!(
+        relative_error <= tol,
+        "relative error {relative_error:e} exceeds tolerance {tol:e}"
+    );
+}
+
+fn assert_identity_f64(matrix: &[f64], n: usize, tol: f64) {
+    for col in 0..n {
+        for row in 0..n {
+            let expected = if row == col { 1.0 } else { 0.0 };
+            let actual = matrix[col_major_index(n, row, col)];
+            assert!(
+                (actual - expected).abs() <= tol,
+                "isometry residual at ({row}, {col}) is {:e}",
+                actual - expected
+            );
+        }
+    }
+}
+
+fn assert_identity_c64(matrix: &[Complex64], n: usize, tol: f64) {
+    for col in 0..n {
+        for row in 0..n {
+            let expected = if row == col {
+                Complex64::new(1.0, 0.0)
+            } else {
+                Complex64::new(0.0, 0.0)
+            };
+            let residual = matrix[col_major_index(n, row, col)] - expected;
+            assert!(
+                residual.norm() <= tol,
+                "isometry residual at ({row}, {col}) is {residual:?}"
+            );
+        }
+    }
+}
+
+fn assert_singular_values(s: &[f64]) {
+    for (index, value) in s.iter().enumerate() {
+        assert!(*value >= 0.0, "singular value {index} is negative: {value}");
+    }
+    for (index, pair) in s.windows(2).enumerate() {
+        assert!(
+            pair[0] >= pair[1],
+            "singular values are not descending at {index}: {:?}",
+            pair
+        );
+    }
+}
+
 #[test]
 #[ignore]
 fn test_cubecl_cholesky_batched_f64_matches_cpu() {
@@ -450,6 +524,150 @@ fn test_cubecl_svd_values_f64_matches_cpu() {
     let actual = gpu.svd_values(&upload(&gpu, &input)).unwrap();
     let actual = download(&gpu, &actual);
     assert_tensor_close(&actual, &expected, 1e-9);
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU and exercises legacy gesvd above 1024"]
+fn test_cubecl_svd_gesvd_wide_f64_reconstructs_and_matches_values() {
+    const M: usize = 8;
+    const N: usize = 1025;
+    let data = (0..N)
+        .flat_map(|col| {
+            (0..M).map(move |row| {
+                let patterned = ((row * 17 + col * 13 + 3) % 31) as f64 / 31.0 - 0.5;
+                patterned + if col == row { 2.0 } else { 0.0 }
+            })
+        })
+        .collect::<Vec<_>>();
+    let input = tensor_f64(vec![M, N], data);
+
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &input);
+    let outputs = gpu.svd(&gpu_input).unwrap();
+    let u = download(&gpu, &outputs[0]);
+    let s = download(&gpu, &outputs[1]);
+    let vt = download(&gpu, &outputs[2]);
+    let gpu_values = gpu.svd_values(&gpu_input).unwrap();
+    let values = download(&gpu, &gpu_values);
+
+    assert_eq!(u.shape(), &[M, M]);
+    assert_eq!(s.shape(), &[M]);
+    assert_eq!(vt.shape(), &[M, N]);
+    let u_data = u.as_slice::<f64>().unwrap();
+    let s_data = s.as_slice::<f64>().unwrap();
+    let vt_data = vt.as_slice::<f64>().unwrap();
+    assert_singular_values(s_data);
+    assert_tensor_close(&values, &s, 1e-10);
+
+    let mut scaled_u = u_data.to_vec();
+    for col in 0..M {
+        for row in 0..M {
+            scaled_u[col_major_index(M, row, col)] *= s_data[col];
+        }
+    }
+    let reconstruction = matmul_f64(&scaled_u, vt_data, M, M, N);
+    assert_relative_error_f64(&reconstruction, input.as_slice::<f64>().unwrap(), 1e-10);
+    let utu = matmul_f64(&transpose_f64(u_data, M, M), u_data, M, M, M);
+    assert_identity_f64(&utu, M, 1e-10);
+    let vvt = matmul_f64(vt_data, &transpose_f64(vt_data, M, N), M, N, M);
+    assert_identity_f64(&vvt, M, 1e-10);
+
+    let mut cpu = cpu_backend();
+    let expected_values = cpu.svd_values(&input).unwrap();
+    assert_tensor_close(&values, &expected_values, 1e-9);
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU and exercises complex legacy gesvd above 1024"]
+fn test_cubecl_svd_gesvd_wide_c64_preserves_adjoint_mapping() {
+    const M: usize = 8;
+    const N: usize = 1025;
+    let data = (0..N)
+        .flat_map(|col| {
+            (0..M).map(move |row| {
+                let real = ((row * 11 + col * 7 + 5) % 29) as f64 / 29.0 - 0.5;
+                let imag = ((row * 19 + col * 3 + 1) % 23) as f64 / 23.0 - 0.5;
+                Complex64::new(real + if col == row { 2.0 } else { 0.0 }, imag)
+            })
+        })
+        .collect::<Vec<_>>();
+    let input = tensor_c64(vec![M, N], data);
+
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &input);
+    let outputs = gpu.svd(&gpu_input).unwrap();
+    let u = download(&gpu, &outputs[0]);
+    let s = download(&gpu, &outputs[1]);
+    let vt = download(&gpu, &outputs[2]);
+    let gpu_values = gpu.svd_values(&gpu_input).unwrap();
+    let values = download(&gpu, &gpu_values);
+
+    let u_data = u.as_slice::<Complex64>().unwrap();
+    let s_data = s.as_slice::<f64>().unwrap();
+    let vt_data = vt.as_slice::<Complex64>().unwrap();
+    assert_singular_values(s_data);
+    assert_tensor_close(&values, &s, 1e-10);
+
+    let mut scaled_u = u_data.to_vec();
+    for col in 0..M {
+        for row in 0..M {
+            scaled_u[col_major_index(M, row, col)] *= s_data[col];
+        }
+    }
+    let reconstruction = matmul_c64(&scaled_u, vt_data, M, M, N);
+    assert_relative_error_c64(
+        &reconstruction,
+        input.as_slice::<Complex64>().unwrap(),
+        1e-10,
+    );
+    let uhu = matmul_c64(&conj_transpose_c64(u_data, M, M), u_data, M, M, M);
+    assert_identity_c64(&uhu, M, 1e-10);
+    let vvh = matmul_c64(vt_data, &conj_transpose_c64(vt_data, M, N), M, N, M);
+    assert_identity_c64(&vvh, M, 1e-10);
+
+    let mut cpu = cpu_backend();
+    let expected_values = cpu.svd_values(&input).unwrap();
+    assert_tensor_close(&values, &expected_values, 1e-9);
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU and exercises legacy gesvd above 1024"]
+fn test_cubecl_svd_gesvd_tall_f64_retains_direct_route() {
+    const M: usize = 1025;
+    const N: usize = 8;
+    let data = (0..N)
+        .flat_map(|col| {
+            (0..M).map(move |row| {
+                let patterned = ((row * 13 + col * 17 + 3) % 31) as f64 / 31.0 - 0.5;
+                patterned + if row == col { 2.0 } else { 0.0 }
+            })
+        })
+        .collect::<Vec<_>>();
+    let input = tensor_f64(vec![M, N], data);
+
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &input);
+    let outputs = gpu.svd(&gpu_input).unwrap();
+    let u = download(&gpu, &outputs[0]);
+    let s = download(&gpu, &outputs[1]);
+    let vt = download(&gpu, &outputs[2]);
+    let u_data = u.as_slice::<f64>().unwrap();
+    let s_data = s.as_slice::<f64>().unwrap();
+    let vt_data = vt.as_slice::<f64>().unwrap();
+    assert_singular_values(s_data);
+
+    let mut scaled_u = u_data.to_vec();
+    for col in 0..N {
+        for row in 0..M {
+            scaled_u[col_major_index(M, row, col)] *= s_data[col];
+        }
+    }
+    let reconstruction = matmul_f64(&scaled_u, vt_data, M, N, N);
+    assert_relative_error_f64(&reconstruction, input.as_slice::<f64>().unwrap(), 1e-10);
+
+    let mut cpu = cpu_backend();
+    let expected_values = cpu.svd_values(&input).unwrap();
+    assert_tensor_close(&s, &expected_values, 1e-9);
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/integration/gpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/integration/gpu_linalg_source_contract.rs
@@ -496,9 +496,9 @@ fn gpu_svd_uses_jax_compatible_default_driver_selection() {
     }
 
     for needle in [
-        "T::copy_svd_v_to_vt(backend.runtime(), &v, &vt_shape, OP)",
-        "copy_svd_v_to_vt_real",
-        "copy_svd_v_to_vt_complex",
+        "T::copy_matrix_adjoint(backend.runtime(), &v, &vt_shape, OP)",
+        "copy_matrix_adjoint_real",
+        "copy_matrix_adjoint_complex",
     ] {
         assert!(
             source.contains(needle),
@@ -511,13 +511,42 @@ fn gpu_svd_uses_jax_compatible_default_driver_selection() {
     );
 
     for needle in [
-        "pub fn svd_v_to_vt_real",
-        "pub fn svd_v_to_vt_complex",
+        "pub fn matrix_adjoint_real",
+        "pub fn matrix_adjoint_complex",
         ".conj()",
     ] {
         assert!(
             kernels.contains(needle),
             "GPU SVD kernels should expose real and complex V-to-VT copies: missing {needle}"
+        );
+    }
+
+    for needle in [
+        "let transpose_for_gesvd = m < n;",
+        "T::copy_matrix_adjoint(backend.runtime(), input, &work_shape, OP)?",
+        "gesvd_buffer_size(T::DATA_TYPE, gesvd_m_i32, gesvd_n_i32, OP)",
+        "T::copy_matrix_adjoint(backend.runtime(), &gesvd_vt, &u_shape, OP)?",
+        "T::copy_matrix_adjoint(backend.runtime(), &gesvd_u, &vt_shape, OP)?",
+    ] {
+        assert!(
+            svd.contains(needle),
+            "wide factor gesvd should solve the device adjoint and map factors back: missing {needle}"
+        );
+    }
+    for needle in [
+        "let (work, gesvd_m, gesvd_n) = if m < n",
+        "T::copy_matrix_adjoint(backend.runtime(), input, &work_shape, OP)?",
+        "gesvd_buffer_size(T::DATA_TYPE, gesvd_m_i32, gesvd_n_i32, OP)",
+    ] {
+        assert!(
+            svd_values.contains(needle),
+            "wide values-only gesvd should solve the device adjoint: missing {needle}"
+        );
+    }
+    for banned in ["download_tensor", "download_typed_tensor"] {
+        assert!(
+            !svd.contains(banned) && !svd_values.contains(banned),
+            "wide gesvd orientation must not download factor data: found {banned}"
         );
     }
 

--- a/docs/worklogs/2026-08-02-issue-1589-cuda-wide-svd.md
+++ b/docs/worklogs/2026-08-02-issue-1589-cuda-wide-svd.md
@@ -1,0 +1,51 @@
+# Issue 1589 CUDA wide SVD
+
+## Session summary
+
+Fixed the CUDA legacy `gesvd` fallback for wide matrices. cuSOLVER's legacy
+driver requires `m >= n`, while tenferro previously passed large wide matrices
+with their original dimensions.
+
+## Context read
+
+- issue #1589 and its linked cuSOLVER contract;
+- `REPOSITORY_RULES.md` and `docs/design/gpu-backend-design.md`;
+- the CUDA SVD factor, values-only, FFI, device-adjoint kernel, source-contract,
+  and ignored hardware-test paths.
+
+## Decisions made
+
+- Keep the existing 1024 `gesvdj` selection threshold unchanged.
+- Only for the legacy `gesvd` branch with `m < n`, factor `A^H` on CUDA.
+- Reuse the existing one-pass real transpose / complex adjoint device kernel.
+- For `A^H = U_B S V_B^H`, return `U_A = V_B` and `V_A^H = U_B^H` by
+  adjointing the thin device factors. The values-only route needs only the
+  adjointed input.
+- Keep the original direct legacy route for tall matrices and preserve solver
+  `info` checking and typed errors.
+
+## Rejected alternatives
+
+- Raising the Jacobi threshold would change numerical algorithm selection.
+- Passing a wide matrix directly to legacy `gesvd` violates its shape contract.
+- A host transpose or CPU SVD fallback would introduce a hidden device transfer.
+- Composing separate transpose and conjugation allocations for complex inputs
+  is unnecessary because the existing CUDA kernel performs the adjoint in one
+  pass.
+
+## Verification performed
+
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-linalg`
+- `cargo test -p tenferro-linalg --test gpu_linalg_source_contract`
+- `cargo test -p tenferro-linalg --features cuda --test gpu_linalg --no-run`
+- `git diff --check`
+
+Portable source contracts verify orientation in both SVD routes and reject host
+downloads. Ignored CUDA tests cover real and complex `8 x 1025` matrices with
+reconstruction, thin-factor isometry, singular-value ordering, factor/value
+parity, and a CPU values oracle. A `1025 x 8` test guards the direct tall route.
+
+## Remaining risk
+
+The CUDA tests compile locally but require a CUDA 12.8+ host for execution.


### PR DESCRIPTION
Closes #1589.

## What

- orient large wide CUDA SVD inputs as `A^H` before the legacy cuSOLVER
  `gesvd` fallback;
- map thin factors back entirely on device, including complex conjugation;
- apply the same safe orientation to `svd_values`;
- retain the existing `gesvdj` threshold and direct tall `gesvd` route;
- add real/complex `8 x 1025` and tall `1025 x 8` real-device gates.

## Why

NVIDIA documents legacy `cusolverDn<t>gesvd` as supporting only `m >= n`.
The existing driver selected it whenever either dimension exceeded 1024 but
passed large wide `(m,n)` unchanged. This fixes the shared backend root cause;
downstream TeNeT #760 then does not need a permanent shape rejection.

## Validation

- `cargo test -p tenferro-linalg`
- `cargo test -p tenferro-linalg --test gpu_linalg_source_contract`
- `cargo check -p tenferro-linalg --features cuda`
- `cargo test -p tenferro-linalg --features cuda --test gpu_linalg --no-run`
- `cargo fmt --all --check`
- `git diff --check`

The named CUDA tests compile. Real A100 execution is a merge gate and will be
recorded on this PR before merge. Auto-merge is not enabled.
