### PR TITLE
Enforce storage ownership promotion base in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         if: needs.policy.result == 'success' && needs.policy.outputs.run_ci_config == 'true'
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         if: needs.policy.result == 'success' && needs.policy.outputs.run_ci_config == 'true'
         with:
@@ -255,7 +257,21 @@ jobs:
         run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
       - name: Validate CI configuration
         if: needs.policy.result == 'success' && needs.policy.outputs.run_ci_config == 'true'
-        run: python3 scripts/ci/run_profile.py ci-config
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" = pull_request ]; then
+            BASE_SHA="${PR_BASE_SHA}"
+          elif [ "${EVENT_NAME}" = push ]; then
+            BASE_SHA="${PUSH_BASE_SHA}"
+          else
+            echo "Unsupported CI event: ${EVENT_NAME}" >&2
+            exit 1
+          fi
+          python3 scripts/ci/run_profile.py ci-config --storage-ownership-base "${BASE_SHA}"
       - name: Report CI configuration disposition
         if: always()
         env:

--- a/docs/design/storage-ownership-contracts.md
+++ b/docs/design/storage-ownership-contracts.md
@@ -302,6 +302,12 @@ alias. Neither tool may infer a different manifest or command target from the
 current working directory. A receipt written by the runner is the only
 execution proof consumed by the checker.
 
+Hosted `ci-config` checks fetch full Git history and pass exactly one canonical
+event base to the existing production checker: `pull_request.base.sha` for a
+pull request and `github.event.before` for a push. The local `ci-config`
+profile omits the base by default and remains a structural developer check.
+Supplying a storage-ownership base without selecting `ci-config` is invalid.
+
 Availability is an explicit CLI contract, not source inspection or path
 existence. Both tools accept `--contract-schema`, exit successfully
 without loading a manifest, write exactly one JSON object to stdout, and write

--- a/docs/worklogs/2026-08-01-issue-1557-storage-ownership-contracts.md
+++ b/docs/worklogs/2026-08-01-issue-1557-storage-ownership-contracts.md
@@ -134,8 +134,14 @@ own log. Full tracked-tree cleanliness can reject a candidate with unrelated
 tracked edits, which is intentional because tracked source and build metadata
 are transitive inputs to cargo commands.
 
-CI base wiring is intentionally not part of this bootstrap amendment because
-`origin/main` still contains the v1 ledger. Retaining a v1 exception would be a
-compatibility shim. Immediately after this v2 bootstrap merges, CI must wire
-promotion validation to a v2 base and enforce it without exceptions. P1 is not
-fully complete until that follow-up wiring lands.
+The post-bootstrap CI follow-up gives the `ci-config` checkout full history and
+passes exactly one event-derived base to its existing production checker:
+`pull_request.base.sha` for pull requests or `github.event.before` for pushes.
+There is no second checker execution, v1 detection, fallback, or compatibility
+exception. Local `ci-config` runs remain structural when no base is supplied.
+
+This enforcement branch cannot be published until #1593 merges because its
+first hosted comparison must have a schema-v2 base. Once sequenced after that
+merge, the wiring closes the P1 CI-enforcement residual. The P1 baseline, P0
+control-plane artifact, and P2 root-claims artifact remain genuine future
+work.

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import subprocess
 import sys
 from collections.abc import Sequence
@@ -17,6 +18,9 @@ _NEXTEST_PROFILE = f"--cargo-profile {_CARGO_PROFILE}"
 _CARGO_TEST_PROFILE = f"--profile {_CARGO_PROFILE}"
 _CLIPPY_FLAGS = (
     "-D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc"
+)
+_STORAGE_OWNERSHIP_CHECKER = (
+    "python3 scripts/check-storage-ownership-contracts.py"
 )
 
 PROFILE_COMMANDS: dict[str, tuple[str, ...]] = {
@@ -74,7 +78,7 @@ PROFILE_COMMANDS: dict[str, tuple[str, ...]] = {
     ),
     "ci-config": (
         "python3 scripts/test-storage-ownership-contracts-v2.py",
-        "python3 scripts/check-storage-ownership-contracts.py",
+        _STORAGE_OWNERSHIP_CHECKER,
         "python3 -m unittest discover -s scripts/ci/tests -v",
         "actionlint",
     ),
@@ -116,12 +120,30 @@ def expand_profiles(profiles: Sequence[str]) -> tuple[str, ...]:
 
 
 def run_profiles(
-    profiles: Sequence[str], *, dry_run: bool, output: TextIO = sys.stdout
+    profiles: Sequence[str],
+    *,
+    dry_run: bool,
+    output: TextIO = sys.stdout,
+    storage_ownership_base: str | None = None,
 ) -> None:
     """Run selected profiles in order, or print their commands in dry-run mode."""
 
-    for profile in expand_profiles(profiles):
+    expanded_profiles = expand_profiles(profiles)
+    if storage_ownership_base is not None and "ci-config" not in expanded_profiles:
+        raise ValueError(
+            "storage ownership base requires the ci-config profile"
+        )
+
+    for profile in expanded_profiles:
         for command in commands_for(profile):
+            if (
+                storage_ownership_base is not None
+                and profile == "ci-config"
+                and command == _STORAGE_OWNERSHIP_CHECKER
+            ):
+                command += (
+                    " --base-commit " + shlex.quote(storage_ownership_base)
+                )
             print(f"+ {command}", file=output, flush=True)
             if dry_run:
                 continue
@@ -144,6 +166,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("profiles", nargs="*")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--list", action="store_true")
+    parser.add_argument("--storage-ownership-base")
     args = parser.parse_args()
     if not args.list and not args.profiles:
         parser.error("provide at least one profile or --list")
@@ -159,7 +182,11 @@ def main() -> int:
         if not args.profiles:
             return 0
     try:
-        run_profiles(args.profiles, dry_run=args.dry_run)
+        run_profiles(
+            args.profiles,
+            dry_run=args.dry_run,
+            storage_ownership_base=args.storage_ownership_base,
+        )
     except (RuntimeError, ValueError) as error:
         print(error, file=sys.stderr)
         return 1

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -1,4 +1,5 @@
 import io
+import shlex
 import tomllib
 import unittest
 from pathlib import Path
@@ -146,6 +147,63 @@ class RunProfileTests(unittest.TestCase):
             lines.index("+ python3 scripts/test-storage-ownership-contracts-v2.py"),
             lines.index("+ python3 scripts/check-storage-ownership-contracts.py"),
         )
+
+    def test_ci_config_base_is_appended_once_and_shell_quoted(self) -> None:
+        output = io.StringIO()
+        base = "refs/heads/base branch;not-a-command"
+        try:
+            run_profiles(
+                ["ci-config"],
+                dry_run=True,
+                output=output,
+                storage_ownership_base=base,
+            )
+        except TypeError as error:
+            self.fail(f"run_profiles does not accept a storage ownership base: {error}")
+
+        checker_lines = [
+            line
+            for line in output.getvalue().splitlines()
+            if "scripts/check-storage-ownership-contracts.py" in line
+        ]
+        self.assertEqual(
+            checker_lines,
+            [
+                "+ python3 scripts/check-storage-ownership-contracts.py "
+                f"--base-commit {shlex.quote(base)}"
+            ],
+        )
+
+    def test_storage_ownership_base_requires_ci_config(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "storage ownership base requires the ci-config profile"
+        ):
+            run_profiles(
+                ["fmt"],
+                dry_run=True,
+                output=io.StringIO(),
+                storage_ownership_base="base-commit",
+            )
+
+    def test_hosted_ci_config_supplies_event_base_with_full_history(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
+        ci_config_job = workflow.split("\n  ci-config:\n", maxsplit=1)[1]
+
+        self.assertIn("fetch-depth: 0", ci_config_job)
+        self.assertIn("EVENT_NAME: ${{ github.event_name }}", ci_config_job)
+        self.assertIn(
+            "PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}", ci_config_job
+        )
+        self.assertIn("PUSH_BASE_SHA: ${{ github.event.before }}", ci_config_job)
+        self.assertIn('if [ "${EVENT_NAME}" = pull_request ]; then', ci_config_job)
+        self.assertIn('elif [ "${EVENT_NAME}" = push ]; then', ci_config_job)
+        self.assertIn('BASE_SHA="${PR_BASE_SHA}"', ci_config_job)
+        self.assertIn('BASE_SHA="${PUSH_BASE_SHA}"', ci_config_job)
+        invocation = (
+            "python3 scripts/ci/run_profile.py ci-config "
+            '--storage-ownership-base "${BASE_SHA}"'
+        )
+        self.assertEqual(ci_config_job.count(invocation), 1)
 
     def test_full_profile_expands_named_profiles_once(self) -> None:
         expanded = expand_profiles(["full"])


### PR DESCRIPTION
Completes the remaining #1557 CI enforcement after the schema-v2 bootstrap in #1593.

- supplies the actual pull-request base SHA or previous main SHA to the existing ledger checker
- fetches full history in the CI configuration job
- executes the checker once; no v1 fallback, compatibility exception, or duplicate validation path
- keeps local ci-config structural-only unless a base is explicitly supplied

Validation: 27 run-profile tests, 22 storage-ledger tests, design checker, production promotion check against current main, and diff checks pass.