### PR TITLE
Record the pre-redesign element access baseline

### DIFF
--- a/crates/tenferro-tensor/benches/element_access.rs
+++ b/crates/tenferro-tensor/benches/element_access.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-use tenferro_tensor::{Tensor, TypedTensor};
+use tenferro_tensor::{Tensor, TypedTensor, TypedTensorView};
 
 const INDEX_COUNT: usize = 4096;
 
@@ -63,10 +63,12 @@ fn bench_rank<const R: usize>(c: &mut Criterion, name: &str, shape: [usize; R]) 
             || tensor.clone(),
             |mut tensor| {
                 let data = tensor.host_data_mut().unwrap();
+                let mut sum = 0.0;
                 for &offset in &offsets {
                     data[black_box(offset)] += black_box(1.0);
+                    sum += data[offset];
                 }
-                black_box(data[0])
+                black_box(sum)
             },
             BatchSize::SmallInput,
         );
@@ -108,10 +110,13 @@ fn bench_rank<const R: usize>(c: &mut Criterion, name: &str, shape: [usize; R]) 
         b.iter_batched(
             || tensor.clone(),
             |mut tensor| {
+                let mut sum = 0.0;
                 for index in &indices {
-                    *tensor.get_mut(black_box(index.as_slice())).unwrap() += black_box(1.0);
+                    let value = tensor.get_mut(black_box(index.as_slice())).unwrap();
+                    *value += black_box(1.0);
+                    sum += *value;
                 }
-                black_box(tensor.as_slice().unwrap()[0])
+                black_box(sum)
             },
             BatchSize::SmallInput,
         );
@@ -121,14 +126,17 @@ fn bench_rank<const R: usize>(c: &mut Criterion, name: &str, shape: [usize; R]) 
         b.iter_batched(
             || tensor.clone(),
             |mut tensor| {
+                let mut sum = 0.0;
                 for index in &indices {
                     unsafe {
-                        *tensor
+                        let value = tensor
                             .get_unchecked_mut(black_box(index.as_slice()))
-                            .unwrap() += black_box(1.0);
+                            .unwrap();
+                        *value += black_box(1.0);
+                        sum += *value;
                     }
                 }
-                black_box(tensor.as_slice().unwrap()[0])
+                black_box(sum)
             },
             BatchSize::SmallInput,
         );
@@ -144,6 +152,7 @@ fn element_access(c: &mut Criterion) {
     bench_rank2_fixed(c);
     bench_rank3_fixed(c);
     bench_linear_iteration(c);
+    bench_strided_traversal(c);
 }
 
 fn bench_rank2_fixed(c: &mut Criterion) {
@@ -177,10 +186,13 @@ fn bench_rank2_fixed(c: &mut Criterion) {
         b.iter_batched(
             || tensor.clone(),
             |mut tensor| {
+                let mut sum = 0.0;
                 for [i, j] in &indices {
-                    *tensor.get_mut2(black_box(*i), black_box(*j)).unwrap() += black_box(1.0);
+                    let value = tensor.get_mut2(black_box(*i), black_box(*j)).unwrap();
+                    *value += black_box(1.0);
+                    sum += *value;
                 }
-                black_box(tensor.as_slice().unwrap()[0])
+                black_box(sum)
             },
             BatchSize::SmallInput,
         );
@@ -227,12 +239,15 @@ fn bench_rank3_fixed(c: &mut Criterion) {
         b.iter_batched(
             || tensor.clone(),
             |mut tensor| {
+                let mut sum = 0.0;
                 for [i, j, k] in &indices {
-                    *tensor
+                    let value = tensor
                         .get_mut3(black_box(*i), black_box(*j), black_box(*k))
-                        .unwrap() += black_box(1.0);
+                        .unwrap();
+                    *value += black_box(1.0);
+                    sum += *value;
                 }
-                black_box(tensor.as_slice().unwrap()[0])
+                black_box(sum)
             },
             BatchSize::SmallInput,
         );
@@ -282,10 +297,12 @@ fn bench_linear_iteration(c: &mut Criterion) {
         b.iter_batched(
             || tensor.clone(),
             |mut tensor| {
+                let mut sum = 0.0;
                 for value in tensor.iter_mut().unwrap() {
                     *value += black_box(1.0);
+                    sum += *value;
                 }
-                black_box(tensor.as_slice().unwrap()[0])
+                black_box(sum)
             },
             BatchSize::SmallInput,
         );
@@ -295,13 +312,45 @@ fn bench_linear_iteration(c: &mut Criterion) {
         b.iter_batched(
             || dynamic_tensor.clone(),
             |mut tensor| {
+                let mut sum = 0.0;
                 for value in tensor.iter_mut::<f64>().unwrap() {
                     *value += black_box(1.0);
+                    sum += *value;
                 }
-                black_box(tensor.as_slice::<f64>().unwrap()[0])
+                black_box(sum)
             },
             BatchSize::SmallInput,
         );
+    });
+
+    group.finish();
+}
+
+fn bench_strided_traversal(c: &mut Criterion) {
+    let source_shape = [48usize, 80];
+    let view_shape = [source_shape[1], source_shape[0]];
+    let element_count = view_shape[0] * view_shape[1];
+    let mut indices = Vec::with_capacity(element_count);
+    for column in 0..view_shape[1] {
+        for row in 0..view_shape[0] {
+            indices.push([row, column]);
+        }
+    }
+    let tensor = typed_tensor(source_shape);
+    let view = TypedTensorView::from_col_major(&source_shape, tensor.as_slice().unwrap())
+        .unwrap()
+        .transpose_view([1, 0])
+        .unwrap();
+    let mut group = c.benchmark_group("strided_traversal/rectangular_transpose");
+
+    group.bench_function(BenchmarkId::new("logical_order_get", element_count), |b| {
+        b.iter(|| {
+            let mut sum = 0.0;
+            for index in &indices {
+                sum += *black_box(view.get(black_box(index.as_slice())).unwrap());
+            }
+            black_box(sum)
+        });
     });
 
     group.finish();

--- a/docs/design/storage-ownership-contracts.md
+++ b/docs/design/storage-ownership-contracts.md
@@ -108,11 +108,11 @@ contractual active/deferred IDs without becoming another production registry.
 The checker is v2-only, the old v1 test authority is deleted, and the retained
 v1 fixture contains only its schema marker so that an old manifest is rejected
 without a compatibility parser. The real design-document checker is an active
-P1 obligation. The current production state deliberately activates only
-`p1-ledger`, `p1-contract-document`, and `p1-api-parity`; P0 control-plane,
-the P1 element-access baseline, and P2 root claims remain deferred until their
-real artifacts and verifiers land. No missing deferred artifact is fabricated
-to make this phase terminal.
+P1 obligation. The current production state deliberately activates only these
+four P1 rows: `p1-ledger`, `p1-contract-document`, `p1-api-parity`, and
+`p1-element-access-baseline`. P0 control-plane and P2 root claims remain
+deferred until their real artifacts and verifiers land. No missing deferred
+artifact is fabricated to make this phase terminal.
 
 ### One canonical graph
 
@@ -401,11 +401,11 @@ The v2 suite uses temporary repositories for reachable path, graph, promotion,
 command, receipt, and exit-status mistakes, plus an integration case for the
 checked-in production manifest. Counts are derived from the parsed manifest;
 the suite does not preserve a migration-event registry or historical totals.
-It verifies that only the three currently implementable P1 rows are active.
-P0 control-plane, the real-measurement P1 baseline, and P2 root claims remain
-deferred, and the remaining future rows are not executed or materialized.
-Fake active artifacts are rejected because they would turn missing scientific
-evidence into a green lifecycle state rather than proving the underlying work.
+It verifies the four currently implementable P1 rows, including the measured
+element-access baseline. P0 control-plane and P2 root claims remain deferred,
+and the remaining future rows are not executed or materialized. Fake active
+artifacts are rejected because they would turn missing scientific evidence
+into a green lifecycle state rather than proving the underlying work.
 
 Command tests cover exact typed argv and repository path confinement, including
 the ordering rule that a path escape is reported before a later command-identity
@@ -1150,15 +1150,36 @@ report (`p10-storage-traversal-performance`). Timing alone is not a sound CI
 proof; the deterministic counters and structural checks are mandatory even
 when a machine-dependent benchmark comparison is reported.
 
-The P1 element-access baseline remains deferred in this phase. At the next P1
-checkpoint, the owner checks out the exact pre-redesign source commit and runs
-the release capture utility once. That command records `element_access`
-direct-slice, contiguous owner/view, and representative strided results in
-`docs/testing/storage-element-access-baseline.json`, then adds the measured
-report to the ledger. The report records the measured source commit,
-benchmark source path, capture command/tool path, optimized toolchain/profile,
-machine/CPU, pinned thread configuration, sample settings, and machine-readable
-results. The active canonical command is deliberately a read-only verifier:
+The P1 element-access baseline is active after one clean pre-redesign source
+measurement. The measured source commit is
+`da7b36e699f9f4731dec08de6a4e1ca93f20cd6f`; the benchmark source path is
+`crates/tenferro-tensor/benches/element_access.rs`; and the tracked report is
+`docs/testing/storage-element-access-baseline.json`. The capture utility was
+run with:
+
+```text
+python3 scripts/capture-storage-element-access-baseline.py \
+  --root . --output docs/testing/storage-element-access-baseline.json
+```
+
+Its exact Criterion command was:
+
+```text
+cargo bench --locked -p tenferro-tensor --bench element_access -- \
+  --warm-up-time 2 --measurement-time 5 --sample-size 100 --noplot
+```
+
+The command uses Cargo's optimized `bench` profile, records WallTime values
+as nanoseconds, and sets `MKL_NUM_THREADS`, `OMP_NUM_THREADS`,
+`OPENBLAS_NUM_THREADS`, `RAYON_NUM_THREADS`, and `VECLIB_MAXIMUM_THREADS` to
+`1`. It records the actual Cargo/rustc/toolchain, CPU/OS/affinity, and actual
+`RUSTFLAGS`/`CARGO_ENCODED_RUSTFLAGS` values (both were empty here). The
+report retains explicit warm-up, measurement, sample, and unit fields without
+duplicating Criterion arguments, version, provider, or a derivable thread
+count. Mutable cases aggregate touched values, and the strided case is a full
+logical-order traversal of a rectangular transpose. The required cases include
+fixed-rank 3D access, dynamic immutable iteration, and dynamic mutable
+iteration. The active canonical command is deliberately a read-only verifier:
 
 ```text
 python3 scripts/verify-storage-element-access-baseline.py \
@@ -1171,7 +1192,16 @@ measurement commit and source paths as provenance. The exact Git commit plus
 path identifies tracked bytes; no content checksum or saved baseline receipt
 is required. P10 consumes the baseline report and its commit/path provenance
 directly. A benchmark added after the redesign or an unmeasured `--no-run`
-build cannot replace the deferred measured artifact.
+build cannot replace the measured artifact.
+
+P10 may compare a candidate traversal with this baseline only in a compatible
+environment: the relevant CPU architecture/model and affinity, OS/kernel
+class, rustc/Cargo/toolchain and compilation target, optimized profile, thread
+environment, and provider/placement configuration where applicable must match
+or be explicitly justified as equivalent. On an incompatible environment the
+report remains useful provenance but the comparison is inconclusive; no
+machine-independent threshold is inferred and no threshold is transferred
+between environments.
 
 ### Ordering rules
 
@@ -1907,7 +1937,7 @@ The v2 ledger carries these executable obligations:
 
 | Obligation | Phase | Artifact and proof |
 |---|---|---|
-| `p1-element-access-baseline` | P1 | remain deferred until the real measured direct-slice/contiguous/strided report and verifier land; later candidates use its exact Git commit and repository-relative path |
+| `p1-element-access-baseline` | P1 | active measured direct-slice/contiguous/strided report and verifier; later candidates use its exact Git commit and repository-relative path, subject to P10 compatible-environment comparison |
 | `p3-static-rank-preservation` | P3 | compile/API contract for owner, immutable view, and mutable view preserving `R` |
 | `p3-as-view-zero-allocation` | P3 | warmed allocator/refcount/provider-clone/layout-clone counters plus borrow-only source contract for owner/view-mut reborrows, including dynamic rank |
 | `p4-traversal-resolution-counts` | P4 | fake provider counters proving resolve/map/lease/dispatch counts are independent of element count |
@@ -2280,10 +2310,11 @@ phase issues carry the full inventories; this index is the cross-reference.
 
 - #1556 and #1557 are independent roots of the canonical DAG; #1557 owns the
   v2 ledger and its executable test gate.
-- `p1-element-access-baseline` is deferred until the real measured report and
-  verifier exist. Its later tracked report will be identified by its measured
-  Git commit and repository-relative path; this task does not benchmark or
-  capture it.
+- `p1-element-access-baseline` is active with the tracked measured report and
+  verifier. The report is identified by measured commit
+  `da7b36e699f9f4731dec08de6a4e1ca93f20cd6f` and repository-relative path
+  `docs/testing/storage-element-access-baseline.json`; P10 may compare it only
+  under the compatible-environment rule above.
 - #1558 owns the root pin, non-`Clone` claim, and the single typed provider
   bridge. #1560 owns access/retirement. #1561 owns groups and generational
   descriptors. None waits for the public host cutover.

--- a/docs/testing/storage-element-access-baseline.json
+++ b/docs/testing/storage-element-access-baseline.json
@@ -1,0 +1,222 @@
+{
+  "benchmark": {
+    "cargo_features": "default",
+    "crate": "tenferro-tensor",
+    "measurement_seconds": 5.0,
+    "path": "crates/tenferro-tensor/benches/element_access.rs",
+    "profile": "bench",
+    "sample_size": 100,
+    "target": "element_access",
+    "time_unit": "ns",
+    "warm_up_seconds": 2.0
+  },
+  "cases": [
+    {
+      "confidence_interval_ns": {
+        "confidence_level": 0.95,
+        "lower_bound": 3417.1734804882385,
+        "upper_bound": 3480.6477768821946
+      },
+      "estimate_ns": 3446.9680582849355,
+      "id": "element_access/2d/col_major/direct_slice/4096",
+      "standard_error_ns": 16.248749081306062
+    },
+    {
+      "confidence_interval_ns": {
+        "confidence_level": 0.95,
+        "lower_bound": 5711.830805356244,
+        "upper_bound": 6038.007516363871
+      },
+      "estimate_ns": 5878.583031372881,
+      "id": "element_access/2d/col_major/direct_slice_mut/4096",
+      "standard_error_ns": 83.54404938805418
+    },
+    {
+      "confidence_interval_ns": {
+        "confidence_level": 0.95,
+        "lower_bound": 19160.085818449366,
+        "upper_bound": 19405.64551359517
+      },
+      "estimate_ns": 19272.227700764415,
+      "id": "element_access/2d/col_major/get/4096",
+      "standard_error_ns": 63.05517730682087
+    },
+    {
+      "confidence_interval_ns": {
+        "confidence_level": 0.95,
+        "lower_bound": 15728.582452813394,
+        "upper_bound": 15939.878010205519
+      },
+      "estimate_ns": 15825.074362984866,
+      "id": "element_access/2d/col_major/get_unchecked/4096",
+      "standard_error_ns": 54.33917848577749
+    },
+    {
+      "confidence_interval_ns": {
+        "confidence_level": 0.95,
+        "lower_bound": 21510.594556550812,
+        "upper_bound": 21965.719710305515
+      },
+      "estimate_ns": 21736.387090796437,
+      "id": "element_access/2d/col_major/get_mut/4096",
+      "standard_error_ns": 115.80057591465044
+    },
+    {
+      "confidence_interval_ns": {
+        "confidence_level": 0.95,
+        "lower_bound": 28341.129098757752,
+        "upper_bound": 28800.89204698429
+      },
+      "estimate_ns": 28555.716496630084,
+      "id": "rank_fixed/2d/col_major/get2/4096",
+      "standard_error_ns": 117.62519163968439
+    },
+    {
+      "confidence_interval_ns": {
+        "confidence_level": 0.95,
+        "lower_bound": 32713.614835163484,
+        "upper_bound": 33275.50096157766
+      },
+      "estimate_ns": 32972.593115872616,
+      "id": "rank_fixed/3d/col_major/get3/4096",
+      "standard_error_ns": 143.86028484942867
+    },
+    {
+      "confidence_interval_ns": {
+        "confidence_level": 0.95,
+        "lower_bound": 54660.56030043634,
+        "upper_bound": 55368.00601149718
+      },
+      "estimate_ns": 54986.53687097039,
+      "id": "linear_iteration/col_major/as_slice_iter",
+      "standard_error_ns": 180.72499985745281
+    },
+    {
+      "confidence_interval_ns": {
+        "confidence_level": 0.95,
+        "lower_bound": 54088.01991392263,
+        "upper_bound": 54815.12445840716
+      },
+      "estimate_ns": 54426.40404333462,
+      "id": "linear_iteration/col_major/dynamic_tensor_iter",
+      "standard_error_ns": 186.69629085919848
+    },
+    {
+      "confidence_interval_ns": {
+        "confidence_level": 0.95,
+        "lower_bound": 54800.86782475171,
+        "upper_bound": 55709.79757080186
+      },
+      "estimate_ns": 55222.94285625193,
+      "id": "linear_iteration/col_major/tensor_iter",
+      "standard_error_ns": 231.91255016084793
+    },
+    {
+      "confidence_interval_ns": {
+        "confidence_level": 0.95,
+        "lower_bound": 76013.27521487197,
+        "upper_bound": 80871.06716547244
+      },
+      "estimate_ns": 78523.80185112353,
+      "id": "linear_iteration/col_major/dynamic_tensor_iter_mut",
+      "standard_error_ns": 1239.4840050583357
+    },
+    {
+      "confidence_interval_ns": {
+        "confidence_level": 0.95,
+        "lower_bound": 14766.25467943027,
+        "upper_bound": 14947.772142631851
+      },
+      "estimate_ns": 14849.827750481152,
+      "id": "strided_traversal/rectangular_transpose/logical_order_get/3840",
+      "standard_error_ns": 46.3674903709109
+    }
+  ],
+  "environment": {
+    "CARGO_ENCODED_RUSTFLAGS": "",
+    "RUSTFLAGS": "",
+    "architecture": "x86_64",
+    "cargo_version": "cargo 1.97.1 (c980f4866 2026-06-30)",
+    "compilation_target": "x86_64-unknown-linux-gnu",
+    "cpu_affinity": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+      18,
+      19,
+      20,
+      21,
+      22,
+      23,
+      24,
+      25,
+      26,
+      27,
+      28,
+      29,
+      30,
+      31,
+      32,
+      33,
+      34,
+      35,
+      36,
+      37,
+      38,
+      39,
+      40,
+      41,
+      42,
+      43,
+      44,
+      45,
+      46,
+      47,
+      48,
+      49,
+      50,
+      51,
+      52,
+      53,
+      54,
+      55,
+      56,
+      57,
+      58,
+      59,
+      60,
+      61,
+      62,
+      63
+    ],
+    "cpu_model": "AMD EPYC 7713P 64-Core Processor",
+    "logical_cpu_count": 64,
+    "os": "Linux 6.8.0-101-generic",
+    "rustc_host": "x86_64-unknown-linux-gnu",
+    "rustc_version": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
+    "thread_environment": {
+      "MKL_NUM_THREADS": "1",
+      "OMP_NUM_THREADS": "1",
+      "OPENBLAS_NUM_THREADS": "1",
+      "RAYON_NUM_THREADS": "1",
+      "VECLIB_MAXIMUM_THREADS": "1"
+    }
+  },
+  "measured_commit": "da7b36e699f9f4731dec08de6a4e1ca93f20cd6f",
+  "schema": "tenferro.storage-element-access-baseline.v1"
+}

--- a/docs/worklogs/2026-08-01-issue-1557-storage-ownership-contracts.md
+++ b/docs/worklogs/2026-08-01-issue-1557-storage-ownership-contracts.md
@@ -54,23 +54,25 @@ implementation introduces no such boundary.
 
 ## State correction
 
-Only these rows are active:
+Before the baseline measurement, only these rows were active:
 
 - `p1-ledger`
 - `p1-contract-document`
 - `p1-api-parity`
 
-`p0-control-plane` is deferred to P0, `p1-element-access-baseline` is deferred
-to P1 until the real measured report and verifier exist, and `p2-root-claims`
-is deferred to P2. The remaining future rows stay deferred. Fake active
-artifacts were explicitly rejected: creating a placeholder would convert
-unfinished scientific evidence into a false lifecycle proof and would violate
-the single tagged-obligation authority.
+`p0-control-plane` is deferred to P0, `p1-element-access-baseline` was then
+deferred to P1 until the real measured report and verifier existed, and
+`p2-root-claims` is deferred to P2. The remaining future rows stay deferred.
+Fake active artifacts were explicitly rejected: creating a placeholder would
+convert unfinished scientific evidence into a false lifecycle proof and would
+violate the single tagged-obligation authority. The baseline row is now
+promoted in place after the real report was measured and verified below.
 
 The baseline command and the P10 traversal command use commit/path provenance.
-The P10 command no longer accepts or names a saved baseline receipt. This task
-does not benchmark or capture the P1 baseline. Prepared-access `CheckedLayout`,
-contiguous-path, and prevalidated traversal requirements remain unchanged.
+The P10 command no longer accepts or names a saved baseline receipt. The
+measured report uses the exact source commit and benchmark path described below.
+Prepared-access `CheckedLayout`, contiguous-path, and prevalidated traversal
+requirements remain unchanged.
 
 ## Implementation
 
@@ -117,7 +119,7 @@ Final pre-commit evidence:
 - `python3.12 -m unittest scripts.ci.tests.test_run_profile -v`: 24 tests, 0 failures (`Ran 24 tests in 0.009s`, `OK`).
 - `cargo test -p tenferro-tensor --test storage_api_parity`: 1 passed, 0 failed.
 - Checker and runner `--contract-schema` probes, the design-document checker, and the production checker summary passed; the summary was `{"terminal": false}`.
-- Manifest audit: exactly 3 active and 28 deferred obligations; no baseline-receipt command arguments.
+- Pre-baseline manifest audit: exactly 3 active and 28 deferred obligations; no baseline-receipt command arguments.
 - `git diff --check`: passed.
 - `bash scripts/check-pr-fast.sh --no-fetch --base e51551755f1a42324e966ceda49e11e4933ab800 --coverage-reviewed --skip-doc-snippets --test 'cargo test -p tenferro-tensor --test storage_api_parity'`: passed, including workspace/extension fmt and clippy checks.
 
@@ -125,10 +127,105 @@ The implementation commit ID is reported in the handoff rather than inserted
 here: adding its own ID to this worklog would require an unnecessary follow-up
 amendment.
 
+## P1 element-access baseline measurement
+
+Date: 2026-08-02. This section records the measured artifact and the correction
+that superseded the earlier source surface.
+
+The interrupted pre-correction measurements are discarded. One run exposed
+Criterion 0.5.1's sanitized group-directory names before any report was
+accepted; the subsequent pre-Sol-correction run was also interrupted. Neither
+run produced a retained report, and their `target/criterion` data was moved to
+trash. No measurement from `014b08ca` (or an intermediate source revision) is
+used.
+
+The corrected first source-surface commit is
+`da7b36e699f9f4731dec08de6a4e1ca93f20cd6f` (`da7b36e6`), rebuilt from merged
+main `eab65236d6fff7ae28b5ec700b83a97b81a77740`. The benchmark, capture script,
+and verifier were not modified after this commit. The report's canonical
+provenance is this full measured commit plus
+`crates/tenferro-tensor/benches/element_access.rs`.
+
+The capture command was:
+
+```text
+python3 scripts/capture-storage-element-access-baseline.py \
+  --root . --output docs/testing/storage-element-access-baseline.json
+```
+
+The script used these exact settings and command:
+
+```text
+cargo bench --locked -p tenferro-tensor --bench element_access -- \
+  --warm-up-time 2 --measurement-time 5 --sample-size 100 --noplot
+```
+
+Cargo's optimized `bench` profile was used (`cargo bench` does not accept a
+separate `--release` flag here). Criterion sample size was 100, warm-up was
+2.0 s, measurement was 5.0 s, and the report unit is `ns`. Criterion 0.5.1
+WallTime `estimates.json` values are already nanoseconds; the corrected capture
+keeps them as-is. All recorded thread environment variables were explicitly
+set to `1`: `MKL_NUM_THREADS`, `OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`,
+`RAYON_NUM_THREADS`, and `VECLIB_MAXIMUM_THREADS`. The report records actual
+values for `RUSTFLAGS` and `CARGO_ENCODED_RUSTFLAGS`; both were the empty
+string. No provider constant or redundant thread-count field is recorded.
+
+Environment metadata:
+
+| Field | Value |
+|---|---|
+| CPU | AMD EPYC 7713P 64-Core Processor; x86_64; 64 logical CPUs; affinity 0–63 |
+| OS | Linux 6.8.0-101-generic |
+| rustc | `rustc 1.97.1 (8bab26f4f 2026-07-14)`; host `x86_64-unknown-linux-gnu` |
+| cargo | `cargo 1.97.1 (c980f4866 2026-06-30)` |
+| target | `x86_64-unknown-linux-gnu` |
+| flags | `RUSTFLAGS=""`; `CARGO_ENCODED_RUSTFLAGS=""` |
+| thread environment | all five recorded variables set to `"1"` |
+
+The measured report contains these exact Criterion estimates, 95% confidence
+intervals, and standard errors. Standard error is the report's uncertainty
+statistic (and is finite and nonnegative); no separate machine-independent
+variance threshold is inferred from it.
+
+| Case | Estimate (ns) | 95% CI (ns) | Standard error (ns) |
+|---|---:|---:|---:|
+| `element_access/2d/col_major/direct_slice/4096` | 3446.968058 | 3417.173480–3480.647777 | 16.248749 |
+| `element_access/2d/col_major/direct_slice_mut/4096` | 5878.583031 | 5711.830805–6038.007516 | 83.544049 |
+| `element_access/2d/col_major/get/4096` | 19272.227701 | 19160.085818–19405.645514 | 63.055177 |
+| `element_access/2d/col_major/get_unchecked/4096` | 15825.074363 | 15728.582453–15939.878010 | 54.339178 |
+| `element_access/2d/col_major/get_mut/4096` | 21736.387091 | 21510.594557–21965.719710 | 115.800576 |
+| `rank_fixed/2d/col_major/get2/4096` | 28555.716497 | 28341.129099–28800.892047 | 117.625192 |
+| `rank_fixed/3d/col_major/get3/4096` | 32972.593116 | 32713.614835–33275.500962 | 143.860285 |
+| `linear_iteration/col_major/as_slice_iter` | 54986.536871 | 54660.560300–55368.006011 | 180.725000 |
+| `linear_iteration/col_major/dynamic_tensor_iter` | 54426.404043 | 54088.019914–54815.124458 | 186.696291 |
+| `linear_iteration/col_major/tensor_iter` | 55222.942856 | 54800.867825–55709.797571 | 231.912550 |
+| `linear_iteration/col_major/dynamic_tensor_iter_mut` | 78523.801851 | 76013.275215–80871.067165 | 1239.484005 |
+| `strided_traversal/rectangular_transpose/logical_order_get/3840` | 14849.827750 | 14766.254679–14947.772143 | 46.367490 |
+
+The benchmark surface preserves the contiguous/direct/checked/unchecked,
+mutable, and fixed-rank cases. The strided case is a complete logical-order
+traversal of a rectangular transpose, not a square random-get sample. The
+recorded set includes fixed-rank 3D access, dynamic immutable iteration, and
+dynamic mutable iteration. Mutable writes are observed through an aggregate of
+the touched values rather than a single sentinel element.
+
+`python3 scripts/verify-storage-element-access-baseline.py --root . --report
+docs/testing/storage-element-access-baseline.json` passed. The row is promoted
+by changing only its tagged state from deferred to active; artifact, command,
+unit, gate, and IDs remain unchanged.
+
+P10 may compare a candidate only when the relevant environment is compatible:
+CPU architecture/model and affinity, OS/kernel class, rustc/Cargo/toolchain,
+compilation target, optimized profile, thread environment, and provider/
+placement where applicable. Otherwise the report is provenance but the result
+is incompatible/inconclusive; no machine-independent threshold or cross-machine
+threshold transfer is allowed.
+
 ## Residual risk and next action
 
-The P1 baseline, P0 control-plane artifact, and P2 root-claims artifact remain
-genuine future work. The runner assumes the trusted local command environment;
+The P0 control-plane artifact and P2 root-claims artifact remain genuine future
+work. The P1 baseline is now measured, tracked, verified, and active. The runner
+assumes the trusted local command environment;
 it does not attest to a child process or defend against a runner that forges its
 own log. Full tracked-tree cleanliness can reject a candidate with unrelated
 tracked edits, which is intentional because tracked source and build metadata
@@ -140,8 +237,7 @@ passes exactly one event-derived base to its existing production checker:
 There is no second checker execution, v1 detection, fallback, or compatibility
 exception. Local `ci-config` runs remain structural when no base is supplied.
 
-This enforcement branch cannot be published until #1593 merges because its
-first hosted comparison must have a schema-v2 base. Once sequenced after that
-merge, the wiring closes the P1 CI-enforcement residual. The P1 baseline, P0
-control-plane artifact, and P2 root-claims artifact remain genuine future
-work.
+The hosted checker requires a schema-v2 base for promotion comparisons. The
+merged-main base used for this promotion is
+`eab65236d6fff7ae28b5ec700b83a97b81a77740`; P0 and P2 remain deferred until
+their own artifacts are real.

--- a/scripts/capture-storage-element-access-baseline.py
+++ b/scripts/capture-storage-element-access-baseline.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Capture the Criterion element-access baseline into the v1 report schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import platform
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "tenferro.storage-element-access-baseline.v1"
+BENCHMARK_PATH = "crates/tenferro-tensor/benches/element_access.rs"
+CRITERION_ARGS = (
+    "--warm-up-time",
+    "2",
+    "--measurement-time",
+    "5",
+    "--sample-size",
+    "100",
+    "--noplot",
+)
+WARM_UP_SECONDS = 2.0
+MEASUREMENT_SECONDS = 5.0
+SAMPLE_SIZE = 100
+THREAD_VARIABLES = (
+    "RAYON_NUM_THREADS",
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+)
+REQUIRED_CASES = (
+    "element_access/2d/col_major/direct_slice/4096",
+    "element_access/2d/col_major/direct_slice_mut/4096",
+    "element_access/2d/col_major/get/4096",
+    "element_access/2d/col_major/get_unchecked/4096",
+    "element_access/2d/col_major/get_mut/4096",
+    "rank_fixed/2d/col_major/get2/4096",
+    "rank_fixed/3d/col_major/get3/4096",
+    "linear_iteration/col_major/as_slice_iter",
+    "linear_iteration/col_major/dynamic_tensor_iter",
+    "linear_iteration/col_major/tensor_iter",
+    "linear_iteration/col_major/dynamic_tensor_iter_mut",
+    "strided_traversal/rectangular_transpose/logical_order_get/3840",
+)
+FILENAME_UNSAFE = set('?"/\\*<>:|^')
+
+
+def _run(root: Path, command: list[str], *, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(
+        command,
+        cwd=root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _canonical_commit(root: Path) -> str:
+    if subprocess.run(["git", "diff", "--quiet", "HEAD", "--"], cwd=root).returncode != 0:
+        raise RuntimeError("baseline capture requires a clean tracked worktree")
+    return _run(root, ["git", "rev-parse", "--verify", "HEAD^{commit}"]).strip()
+
+
+def _rustc_metadata(root: Path, env: dict[str, str]) -> tuple[str, str, str]:
+    version = _run(root, ["rustc", "--version"]).strip()
+    verbose = _run(root, ["rustc", "-vV"])
+    fields = dict(
+        line.split(": ", 1)
+        for line in verbose.splitlines()
+        if ": " in line
+    )
+    host = fields.get("host")
+    if not host:
+        raise RuntimeError("rustc -vV did not report a host target")
+    return version, host, env.get("CARGO_BUILD_TARGET") or host
+
+
+def _cpu_model() -> str:
+    if platform.system() == "Linux":
+        try:
+            for line in Path("/proc/cpuinfo").read_text(encoding="utf-8").splitlines():
+                if line.lower().startswith("model name") and ":" in line:
+                    return line.split(":", 1)[1].strip()
+        except OSError:
+            pass
+    if platform.system() == "Darwin":
+        try:
+            return subprocess.run(
+                ["sysctl", "-n", "machdep.cpu.brand_string"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        except (OSError, subprocess.CalledProcessError):
+            pass
+    return platform.processor() or platform.machine() or "unknown"
+
+
+def _environment(root: Path, env: dict[str, str]) -> dict[str, Any]:
+    rustc_version, rustc_host, compilation_target = _rustc_metadata(root, env)
+    logical_cpu_count = os.cpu_count() or 1
+    if hasattr(os, "sched_getaffinity"):
+        cpu_affinity = sorted(os.sched_getaffinity(0))
+    else:
+        cpu_affinity = list(range(logical_cpu_count))
+    thread_environment = {
+        name: env.get(name, "") for name in THREAD_VARIABLES
+    }
+    for name, value in thread_environment.items():
+        if not value.isdigit() or int(value) <= 0:
+            raise RuntimeError(f"{name} must be a positive integer for baseline capture")
+    return {
+        "rustc_version": rustc_version,
+        "rustc_host": rustc_host,
+        "compilation_target": compilation_target,
+        "os": f"{platform.system()} {platform.release()}".strip(),
+        "architecture": platform.machine() or "unknown",
+        "cpu_model": _cpu_model(),
+        "logical_cpu_count": logical_cpu_count,
+        "cpu_affinity": cpu_affinity,
+        "cargo_version": _run(root, ["cargo", "--version"]).strip(),
+        "RUSTFLAGS": env.get("RUSTFLAGS", ""),
+        "CARGO_ENCODED_RUSTFLAGS": env.get("CARGO_ENCODED_RUSTFLAGS", ""),
+        "thread_environment": thread_environment,
+    }
+
+
+def _positive(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RuntimeError(f"Criterion {field} is not numeric")
+    value = float(value)
+    if not math.isfinite(value) or value <= 0.0:
+        raise RuntimeError(f"Criterion {field} is not finite and positive")
+    return value
+
+
+def _nonnegative(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RuntimeError(f"Criterion {field} is not numeric")
+    value = float(value)
+    if not math.isfinite(value) or value < 0.0:
+        raise RuntimeError(f"Criterion {field} is not finite and nonnegative")
+    return value
+
+
+def _confidence_level(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RuntimeError(f"Criterion {field} is not numeric")
+    value = float(value)
+    if not math.isfinite(value) or value <= 0.0 or value >= 1.0:
+        raise RuntimeError(f"Criterion {field} is not a valid confidence level")
+    return value
+
+
+def _criterion_component(value: str) -> str:
+    return "".join("_" if character in FILENAME_UNSAFE else character for character in value)[:64]
+
+
+def _estimate_path(root: Path, case_id: str) -> Path:
+    parts = case_id.split("/")
+    if len(parts) < 2:
+        raise RuntimeError(f"invalid benchmark case ID: {case_id}")
+    if parts[-1].isdigit():
+        if len(parts) < 3:
+            raise RuntimeError(f"invalid valued benchmark case ID: {case_id}")
+        group = "/".join(parts[:-2])
+        function = parts[-2]
+        value = parts[-1]
+    else:
+        group = "/".join(parts[:-1])
+        function = parts[-1]
+        value = None
+    components = [_criterion_component(group), _criterion_component(function)]
+    if value is not None:
+        components.append(_criterion_component(value))
+    return root / "target" / "criterion" / Path(*components) / "new" / "estimates.json"
+
+
+def _estimate(root: Path, case_id: str) -> dict[str, Any]:
+    estimate_path = _estimate_path(root, case_id)
+    try:
+        estimate = json.loads(estimate_path.read_text(encoding="utf-8"))
+        mean = estimate["mean"]
+        interval = mean["confidence_interval"]
+        return {
+            "id": case_id,
+            "estimate_ns": _positive(mean["point_estimate"], f"{case_id}.point_estimate"),
+            "confidence_interval_ns": {
+                "confidence_level": _confidence_level(
+                    interval["confidence_level"], f"{case_id}.confidence_level"
+                ),
+                "lower_bound": _positive(
+                    interval["lower_bound"], f"{case_id}.lower_bound"
+                ),
+                "upper_bound": _positive(
+                    interval["upper_bound"], f"{case_id}.upper_bound"
+                ),
+            },
+            "standard_error_ns": _nonnegative(
+                mean["standard_error"], f"{case_id}.standard_error"
+            ),
+        }
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"cannot read Criterion estimate for {case_id}: {estimate_path}") from error
+
+
+def capture(root: Path, output: Path) -> None:
+    root = root.resolve()
+    output = output if output.is_absolute() else root / output
+    measured_commit = _canonical_commit(root)
+    bench_env = os.environ.copy()
+    for name in THREAD_VARIABLES:
+        bench_env[name] = "1"
+    command = [
+        "cargo",
+        "bench",
+        "--locked",
+        "-p",
+        "tenferro-tensor",
+        "--bench",
+        "element_access",
+        "--",
+        *CRITERION_ARGS,
+    ]
+    _run(root, command, env=bench_env)
+    cases = [_estimate(root, case_id) for case_id in REQUIRED_CASES]
+    report = {
+        "schema": SCHEMA,
+        "measured_commit": measured_commit,
+        "benchmark": {
+            "path": BENCHMARK_PATH,
+            "crate": "tenferro-tensor",
+            "target": "element_access",
+            "profile": "bench",
+            "cargo_features": "default",
+            "warm_up_seconds": WARM_UP_SECONDS,
+            "measurement_seconds": MEASUREMENT_SECONDS,
+            "sample_size": SAMPLE_SIZE,
+            "time_unit": "ns",
+        },
+        "environment": _environment(root, bench_env),
+        "cases": cases,
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote {output}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("docs/testing/storage-element-access-baseline.json"),
+    )
+    args = parser.parse_args()
+    capture(args.root, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/storage-ownership-contracts.toml
+++ b/scripts/storage-ownership-contracts.toml
@@ -208,7 +208,7 @@ unit = "P1"
 gates = ["G4"]
 artifact = { id = "artifact-element-access-baseline", kind = "benchmark-report", path = "docs/testing/storage-element-access-baseline.json" }
 command = { id = "cmd-element-access-baseline", kind = "benchmark-check", argv = ["python3", "scripts/verify-storage-element-access-baseline.py", "--report", "docs/testing/storage-element-access-baseline.json"], cwd = ".", path_args = ["scripts/verify-storage-element-access-baseline.py", "docs/testing/storage-element-access-baseline.json"], artifact_id = "artifact-element-access-baseline" }
-state = { kind = "deferred", activation_unit = "P1", promotion = { mode = "activate-in-place" } }
+state = { kind = "active" }
 rationale = "The obligation is one immutable artifact-command contract owned by one graph unit."
 
 [[obligations]]

--- a/scripts/test-storage-ownership-contracts-v2.py
+++ b/scripts/test-storage-ownership-contracts-v2.py
@@ -23,10 +23,16 @@ SCHEMA = "tenferro.storage-ownership-contracts.v2"
 RECEIPT_SCHEMA = "tenferro.storage-ownership-receipt.v1"
 DIAGNOSTICS_SCHEMA = "tenferro.storage-ownership-diagnostics.v1"
 
-ACTIVE_IDS = frozenset({"p1-ledger", "p1-contract-document", "p1-api-parity"})
+ACTIVE_IDS = frozenset(
+    {
+        "p1-ledger",
+        "p1-contract-document",
+        "p1-api-parity",
+        "p1-element-access-baseline",
+    }
+)
 DEFERRED_CORRECTIONS = {
     "p0-control-plane": "P0",
-    "p1-element-access-baseline": "P1",
     "p2-root-claims": "P2",
 }
 
@@ -243,6 +249,11 @@ def _runner_files() -> dict[str, str]:
     files.update({
         "scripts/check-storage-ownership-contracts.py": CHECKER.read_text(encoding="utf-8"),
         "scripts/check-storage-design-docs.py": DOC_CHECKER.read_text(encoding="utf-8"),
+        # This test exercises runner argv/receipt binding; the baseline verifier
+        # itself has a dedicated 8-case test suite.
+        "scripts/verify-storage-element-access-baseline.py": (
+            "raise SystemExit(0)\n"
+        ),
         "docs/design/storage-ownership-contracts.md": (
             ROOT / "docs/design/storage-ownership-contracts.md"
         ).read_text(encoding="utf-8"),
@@ -333,7 +344,7 @@ class StorageOwnershipV2Tests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("storage-design-docs-ok", result.stdout)
 
-    def test_production_manifest_has_only_current_p1_active(self) -> None:
+    def test_production_manifest_has_current_active_rows(self) -> None:
         data = tomllib.loads(_manifest_text())
         self.assertEqual(data["schema"], SCHEMA)
         rows = data["obligations"]
@@ -432,7 +443,13 @@ class StorageOwnershipV2Tests(unittest.TestCase):
 
     def test_active_unit_requires_all_direct_source_obligations_active(self) -> None:
         manifest = _replace_row_state(
-            _manifest_text(), "p2-root-claims", '{ kind = "active" }'
+            _replace_row_state(
+                _manifest_text(),
+                "p1-element-access-baseline",
+                '{ kind = "deferred", activation_unit = "P1", promotion = { mode = "activate-in-place" } }',
+            ),
+            "p2-root-claims",
+            '{ kind = "active" }',
         )
         result = _run_checker(manifest, extra=("--diagnostics-json",))
         _assert_error(

--- a/scripts/test-verify-storage-element-access-baseline.py
+++ b/scripts/test-verify-storage-element-access-baseline.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Focused tests for the storage element-access baseline verifier."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "scripts" / "verify-storage-element-access-baseline.py"
+BENCHMARK_PATH = "crates/tenferro-tensor/benches/element_access.rs"
+REQUIRED_CASES = (
+    "element_access/2d/col_major/direct_slice/4096",
+    "element_access/2d/col_major/direct_slice_mut/4096",
+    "element_access/2d/col_major/get/4096",
+    "element_access/2d/col_major/get_unchecked/4096",
+    "element_access/2d/col_major/get_mut/4096",
+    "rank_fixed/2d/col_major/get2/4096",
+    "rank_fixed/3d/col_major/get3/4096",
+    "linear_iteration/col_major/as_slice_iter",
+    "linear_iteration/col_major/dynamic_tensor_iter",
+    "linear_iteration/col_major/tensor_iter",
+    "linear_iteration/col_major/dynamic_tensor_iter_mut",
+    "strided_traversal/rectangular_transpose/logical_order_get/3840",
+)
+
+
+class BaselineVerifierTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temporary.name)
+        subprocess.run(["git", "init", "-q"], cwd=self.repo, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "tests@example.invalid"],
+            cwd=self.repo,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Baseline Tests"],
+            cwd=self.repo,
+            check=True,
+        )
+        benchmark = self.repo / BENCHMARK_PATH
+        benchmark.parent.mkdir(parents=True)
+        benchmark.write_text("fn main() {}\n", encoding="utf-8")
+        subprocess.run(["git", "add", BENCHMARK_PATH], cwd=self.repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "benchmark"],
+            cwd=self.repo,
+            check=True,
+        )
+        self.commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        self.report_path = self.repo / "baseline.json"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def report(self) -> dict[str, object]:
+        return {
+            "schema": "tenferro.storage-element-access-baseline.v1",
+            "measured_commit": self.commit,
+            "benchmark": {
+                "path": BENCHMARK_PATH,
+                "crate": "tenferro-tensor",
+                "target": "element_access",
+                "profile": "bench",
+                "cargo_features": "default",
+                "warm_up_seconds": 2.0,
+                "measurement_seconds": 5.0,
+                "sample_size": 100,
+                "time_unit": "ns",
+            },
+            "environment": {
+                "rustc_version": "rustc 1.97.1 (test)",
+                "rustc_host": "x86_64-unknown-linux-gnu",
+                "compilation_target": "x86_64-unknown-linux-gnu",
+                "cargo_version": "cargo 1.97.1 (test)",
+                "RUSTFLAGS": "",
+                "CARGO_ENCODED_RUSTFLAGS": "",
+                "os": "Linux 6.test",
+                "architecture": "x86_64",
+                "cpu_model": "Test CPU",
+                "logical_cpu_count": 8,
+                "cpu_affinity": [2],
+                "thread_environment": {
+                    "RAYON_NUM_THREADS": "1",
+                    "OMP_NUM_THREADS": "1",
+                    "OPENBLAS_NUM_THREADS": "1",
+                    "MKL_NUM_THREADS": "1",
+                    "VECLIB_MAXIMUM_THREADS": "1",
+                },
+            },
+            "cases": [
+                {
+                    "id": case_id,
+                    "estimate_ns": 100.0 + index,
+                    "confidence_interval_ns": {
+                        "confidence_level": 0.95,
+                        "lower_bound": 99.0 + index,
+                        "upper_bound": 101.0 + index,
+                    },
+                    "standard_error_ns": 0.5,
+                }
+                for index, case_id in enumerate(REQUIRED_CASES)
+            ],
+        }
+
+    def run_verifier(self, report: dict[str, object]) -> subprocess.CompletedProcess[str]:
+        self.report_path.write_text(
+            json.dumps(report, indent=2) + "\n", encoding="utf-8"
+        )
+        return subprocess.run(
+            [
+                sys.executable,
+                str(VERIFIER),
+                "--root",
+                str(self.repo),
+                "--report",
+                str(self.report_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_accepts_measured_report_with_tracked_commit_provenance(self) -> None:
+        result = self.run_verifier(self.report())
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "storage-element-access-baseline-ok\n")
+        self.assertEqual(result.stderr, "")
+
+    def test_rejects_revision_alias_instead_of_canonical_commit(self) -> None:
+        report = self.report()
+        report["measured_commit"] = "HEAD"
+
+        result = self.run_verifier(report)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("canonical Git object ID", result.stderr)
+
+    def test_rejects_benchmark_path_missing_at_measured_commit(self) -> None:
+        subprocess.run(["git", "rm", "-q", BENCHMARK_PATH], cwd=self.repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "remove benchmark"],
+            cwd=self.repo,
+            check=True,
+        )
+        self.commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        result = self.run_verifier(self.report())
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("not tracked at measured_commit", result.stderr)
+
+    def test_rejects_benchmark_path_that_is_not_a_file_blob(self) -> None:
+        benchmark = self.repo / BENCHMARK_PATH
+        benchmark.unlink()
+        benchmark.mkdir()
+        (benchmark / "source").write_text("not a benchmark file\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=self.repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "replace benchmark with directory"],
+            cwd=self.repo,
+            check=True,
+        )
+        self.commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        result = self.run_verifier(self.report())
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("must be a tracked file", result.stderr)
+
+    def test_rejects_missing_required_benchmark_case(self) -> None:
+        report = self.report()
+        cases = report["cases"]
+        assert isinstance(cases, list)
+        cases.pop()
+
+        result = self.run_verifier(report)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("missing required benchmark cases", result.stderr)
+
+    def test_rejects_non_finite_or_non_positive_timing_statistics(self) -> None:
+        mutations = (
+            ("estimate_ns", 0.0),
+            ("standard_error_ns", float("inf")),
+            ("confidence_interval_ns", {"confidence_level": 0.95, "lower_bound": -1.0, "upper_bound": 101.0}),
+        )
+        for field, value in mutations:
+            with self.subTest(field=field):
+                report = self.report()
+                case = report["cases"][0]
+                assert isinstance(case, dict)
+                case[field] = value
+
+                result = self.run_verifier(report)
+
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("finite", result.stderr)
+
+    def test_accepts_zero_standard_error(self) -> None:
+        report = self.report()
+        cases = report["cases"]
+        assert isinstance(cases, list)
+        case = cases[0]
+        assert isinstance(case, dict)
+        case["standard_error_ns"] = 0.0
+
+        result = self.run_verifier(report)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_missing_or_malformed_environment_metadata(self) -> None:
+        mutations = (
+            ("missing_cpu_model", lambda environment: environment.pop("cpu_model")),
+            ("zero_logical_cpu_count", lambda environment: environment.__setitem__("logical_cpu_count", 0)),
+        )
+        for name, mutate in mutations:
+            with self.subTest(name=name):
+                report = self.report()
+                environment = report["environment"]
+                assert isinstance(environment, dict)
+                mutate(environment)
+
+                result = self.run_verifier(report)
+
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("environment", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-storage-element-access-baseline.py
+++ b/scripts/verify-storage-element-access-baseline.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Verify the immutable pre-redesign element-access benchmark report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "tenferro.storage-element-access-baseline.v1"
+BENCHMARK_PATH = "crates/tenferro-tensor/benches/element_access.rs"
+REQUIRED_CASES = frozenset(
+    {
+        "element_access/2d/col_major/direct_slice/4096",
+        "element_access/2d/col_major/direct_slice_mut/4096",
+        "element_access/2d/col_major/get/4096",
+        "element_access/2d/col_major/get_unchecked/4096",
+        "element_access/2d/col_major/get_mut/4096",
+        "rank_fixed/2d/col_major/get2/4096",
+        "rank_fixed/3d/col_major/get3/4096",
+        "linear_iteration/col_major/as_slice_iter",
+        "linear_iteration/col_major/dynamic_tensor_iter",
+        "linear_iteration/col_major/tensor_iter",
+        "linear_iteration/col_major/dynamic_tensor_iter_mut",
+        "strided_traversal/rectangular_transpose/logical_order_get/3840",
+    }
+)
+
+TOP_LEVEL_FIELDS = frozenset({"schema", "measured_commit", "benchmark", "environment", "cases"})
+BENCHMARK_FIELDS = frozenset(
+    {
+        "path",
+        "crate",
+        "target",
+        "profile",
+        "cargo_features",
+        "warm_up_seconds",
+        "measurement_seconds",
+        "sample_size",
+        "time_unit",
+    }
+)
+ENVIRONMENT_FIELDS = frozenset(
+    {
+        "rustc_version",
+        "rustc_host",
+        "compilation_target",
+        "cargo_version",
+        "RUSTFLAGS",
+        "CARGO_ENCODED_RUSTFLAGS",
+        "os",
+        "architecture",
+        "cpu_model",
+        "logical_cpu_count",
+        "cpu_affinity",
+        "thread_environment",
+    }
+)
+CASE_FIELDS = frozenset(
+    {"id", "estimate_ns", "confidence_interval_ns", "standard_error_ns"}
+)
+INTERVAL_FIELDS = frozenset(
+    {"confidence_level", "lower_bound", "upper_bound"}
+)
+THREAD_ENVIRONMENT_FIELDS = frozenset(
+    {
+        "RAYON_NUM_THREADS",
+        "OMP_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+    }
+)
+
+
+class BaselineError(ValueError):
+    """A report field violates the baseline contract."""
+
+
+def _object(value: Any, field: str, expected_fields: frozenset[str]) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise BaselineError(f"{field} must be an object")
+    actual = frozenset(value)
+    if actual != expected_fields:
+        raise BaselineError(
+            f"{field} fields must be {sorted(expected_fields)}, got {sorted(actual)}"
+        )
+    return value
+
+
+def _string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise BaselineError(f"{field} must be a non-empty string")
+    return value
+
+
+def _positive_number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise BaselineError(f"{field} must be a finite positive number")
+    number = float(value)
+    if not math.isfinite(number) or number <= 0.0:
+        raise BaselineError(f"{field} must be a finite positive number")
+    return number
+
+
+def _nonnegative_number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise BaselineError(f"{field} must be a finite nonnegative number")
+    number = float(value)
+    if not math.isfinite(number) or number < 0.0:
+        raise BaselineError(f"{field} must be a finite nonnegative number")
+    return number
+
+
+def _positive_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise BaselineError(f"{field} must be a positive integer")
+    return value
+
+
+def _canonical_commit(root: Path, revision: str) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{revision}^{{commit}}"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise BaselineError(f"measured_commit does not resolve to a commit: {revision}")
+    return result.stdout.strip()
+
+
+def _verify_benchmark(root: Path, commit: str, value: Any) -> None:
+    benchmark = _object(value, "benchmark", BENCHMARK_FIELDS)
+    path = _string(benchmark["path"], "benchmark.path")
+    expected_strings = {
+        "path": BENCHMARK_PATH,
+        "crate": "tenferro-tensor",
+        "target": "element_access",
+        "profile": "bench",
+        "cargo_features": "default",
+        "time_unit": "ns",
+    }
+    for field, expected in expected_strings.items():
+        if benchmark[field] != expected:
+            raise BaselineError(f"benchmark.{field} must be {expected!r}")
+    warm_up_seconds = _positive_number(
+        benchmark["warm_up_seconds"], "benchmark.warm_up_seconds"
+    )
+    measurement_seconds = _positive_number(
+        benchmark["measurement_seconds"], "benchmark.measurement_seconds"
+    )
+    sample_size = _positive_integer(benchmark["sample_size"], "benchmark.sample_size")
+    tracked = subprocess.run(
+        ["git", "cat-file", "-t", f"{commit}:{path}"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    if tracked.returncode != 0:
+        raise BaselineError(
+            f"benchmark.path is not tracked at measured_commit: {path}"
+        )
+    if tracked.stdout.strip() != "blob":
+        raise BaselineError(f"benchmark.path must be a tracked file: {path}")
+
+
+def _verify_environment(value: Any) -> None:
+    environment = _object(value, "environment", ENVIRONMENT_FIELDS)
+    for field in (
+        "rustc_version",
+        "rustc_host",
+        "compilation_target",
+        "cargo_version",
+        "os",
+        "architecture",
+        "cpu_model",
+    ):
+        _string(environment[field], f"environment.{field}")
+    for field in ("RUSTFLAGS", "CARGO_ENCODED_RUSTFLAGS"):
+        if not isinstance(environment[field], str):
+            raise BaselineError(f"environment.{field} must be a string")
+    _positive_integer(environment["logical_cpu_count"], "environment.logical_cpu_count")
+    affinity = environment["cpu_affinity"]
+    if not isinstance(affinity, list) or not affinity:
+        raise BaselineError("environment.cpu_affinity must be a non-empty integer array")
+    if any(isinstance(cpu, bool) or not isinstance(cpu, int) or cpu < 0 for cpu in affinity):
+        raise BaselineError("environment.cpu_affinity must be a non-empty integer array")
+    thread_environment = _object(
+        environment["thread_environment"],
+        "environment.thread_environment",
+        THREAD_ENVIRONMENT_FIELDS,
+    )
+    for field, setting in thread_environment.items():
+        if not isinstance(setting, str) or not setting.isdigit() or int(setting) <= 0:
+            raise BaselineError(
+                f"environment.thread_environment.{field} must be a positive integer string"
+            )
+
+
+def _verify_cases(value: Any) -> None:
+    if not isinstance(value, list) or not value:
+        raise BaselineError("cases must be a non-empty array")
+    seen: set[str] = set()
+    for index, raw_case in enumerate(value):
+        case = _object(raw_case, f"cases[{index}]", CASE_FIELDS)
+        case_id = _string(case["id"], f"cases[{index}].id")
+        if case_id in seen:
+            raise BaselineError(f"duplicate case id: {case_id}")
+        seen.add(case_id)
+        estimate = _positive_number(case["estimate_ns"], f"cases[{index}].estimate_ns")
+        _nonnegative_number(
+            case["standard_error_ns"], f"cases[{index}].standard_error_ns"
+        )
+        interval = _object(
+            case["confidence_interval_ns"],
+            f"cases[{index}].confidence_interval_ns",
+            INTERVAL_FIELDS,
+        )
+        confidence = _positive_number(
+            interval["confidence_level"],
+            f"cases[{index}].confidence_interval_ns.confidence_level",
+        )
+        lower = _positive_number(
+            interval["lower_bound"],
+            f"cases[{index}].confidence_interval_ns.lower_bound",
+        )
+        upper = _positive_number(
+            interval["upper_bound"],
+            f"cases[{index}].confidence_interval_ns.upper_bound",
+        )
+        if confidence >= 1.0:
+            raise BaselineError("confidence level must be less than 1")
+        if not lower <= estimate <= upper:
+            raise BaselineError(
+                f"case {case_id} estimate must lie inside its confidence interval"
+            )
+    missing = sorted(REQUIRED_CASES - seen)
+    if missing:
+        raise BaselineError(f"missing required benchmark cases: {missing}")
+
+
+def verify_report(root: Path, report_path: Path) -> None:
+    try:
+        raw = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise BaselineError(f"cannot read baseline report: {error}") from error
+    report = _object(raw, "report", TOP_LEVEL_FIELDS)
+    if report["schema"] != SCHEMA:
+        raise BaselineError(f"schema must be {SCHEMA!r}")
+    measured_commit = _string(report["measured_commit"], "measured_commit")
+    canonical_commit = _canonical_commit(root, measured_commit)
+    if measured_commit != canonical_commit:
+        raise BaselineError(
+            "measured_commit must be the canonical Git object ID, not a revision alias"
+        )
+    _verify_benchmark(root, canonical_commit, report["benchmark"])
+    _verify_environment(report["environment"])
+    _verify_cases(report["cases"])
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--report", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        verify_report(args.root.resolve(), args.report.resolve())
+    except BaselineError as error:
+        print(f"storage-element-access-baseline-error: {error}", file=sys.stderr)
+        return 1
+    print("storage-element-access-baseline-ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #1557

## Summary

- add the pre-redesign element-access benchmark surface and capture script
- record measurements against exact source commit da7b36e699f9f4731dec08de6a4e1ca93f20cd6f
- cover direct slices, checked and unchecked access, static-rank indexing, contiguous and dynamic iterators, mutable traversal, and rectangular transposed traversal
- promote p1-element-access-baseline in the schema-v2 obligation ledger (4 active, 27 deferred)
- verify report structure, environment compatibility, and complete case coverage without cryptographic receipts, nonces, or attestation machinery

## Validation

- cargo bench --locked -p tenferro-tensor --bench element_access -- --warm-up-time 2 --measurement-time 5 --sample-size 100 --noplot
- python3 scripts/test-verify-storage-element-access-baseline.py
- python3 scripts/verify-storage-element-access-baseline.py
- python3 scripts/test-storage-ownership-contracts-v2.py
- python3 scripts/check-storage-ownership-design.py
- bash scripts/check-pr-fast.sh --coverage-reviewed --test "cargo bench -p tenferro-tensor --bench element_access --no-run"
- python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-element-baseline.json (pass, 0 findings)

## Design record

See docs/worklogs/2026-08-01-issue-1557-storage-ownership-contracts.md.