### PR TITLE
ci: keep A100 benchmark out of correctness gate

### DIFF
--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -491,6 +491,7 @@ jobs:
             --workspace-remap "${GITHUB_WORKSPACE}" \
             --run-ignored all \
             --no-fail-fast \
+            -E 'not test(cuda_runtime_copy_into_1522_a100_destination_reuse_benchmark)' \
             -j 1
       - name: Run OpenXLA PJRT E2E tests from archive
         env:

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -1214,6 +1214,7 @@ jobs:
             --workspace-remap "${GITHUB_WORKSPACE}/tenferro-rs" \
             --run-ignored all \
             --no-fail-fast \
+            -E 'not test(cuda_runtime_copy_into_1522_a100_destination_reuse_benchmark)' \
             -j 1
 
       - name: Run OpenXLA PJRT E2E tests from archive

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -362,6 +362,26 @@ class WorkflowContractTests(unittest.TestCase):
                 for match in re.finditer(r"cargo nextest archive[\s\S]{0,280}", text):
                     self.assertNotIn("--release", match.group(0))
 
+    def test_cuda_correctness_gate_excludes_a100_performance_benchmark(self) -> None:
+        benchmark = "cuda_runtime_copy_into_1522_a100_destination_reuse_benchmark"
+        structural_tests = read(
+            "crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs"
+        )
+        self.assertIn(f"fn {benchmark}()", structural_tests)
+        for path in (
+            ".github/workflows/runpod-gpu-test.yml",
+            ".github/workflows/CI_gpu.yml",
+        ):
+            text = read(path)
+            cuda_tests = text[
+                text.index("      - name: Run CUDA tests from archive") :
+                text.index("      - name: Run OpenXLA PJRT E2E tests from archive")
+            ]
+            with self.subTest(path=path):
+                self.assertEqual(
+                    cuda_tests.count(f"-E 'not test({benchmark})'"), 1
+                )
+
     def test_pjrt_uses_hosted_archive_not_runpod_cargo(self) -> None:
         for path in (
             ".github/workflows/runpod-gpu-test.yml",


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs #1522; unblocks #1596 and #1598 GPU validation.

## Summary

The ordinary CUDA correctness gate ran every ignored test, including the explicitly A100-only destination-reuse performance benchmark. Its existing max-page-size check is not a capacity check, so smaller RunPod GPUs attempted several 4 GiB-class allocations and failed from resource exhaustion after the correctness suite had otherwise passed.

Exclude that one benchmark from both ordinary CUDA archive runs. It remains directly runnable for explicit A100 performance work. A workflow contract verifies the exact nextest filter once per CUDA step and verifies that the named benchmark still exists. No GPU correctness test is removed.

Same-root-cause scan covered both CUDA archive workflows; both are fixed. No other subsystem or benchmark policy was changed.

## Work log

Not required for this three-file CI-only correction; the root cause, decision, and residual scope are recorded above.

## Verification

- `python3 -m unittest scripts.ci.tests.test_workflow_contracts` (30 passed)
- `bash scripts/check-pr-fast.sh --test "python3 -m unittest scripts.ci.tests.test_workflow_contracts"`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/tenferro-ci-a100-rules-review.json` (pass, 0 findings)
- Sol-medium review confirmed nextest 0.9.129 syntax and positive/inverse matching (1 benchmark excluded, 241 tests retained); its test-strength finding was applied.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.