### PR TITLE
test: activate phase 0 control-plane evidence

### DIFF
--- a/crates/tenferro-runtime/tests/integration.rs
+++ b/crates/tenferro-runtime/tests/integration.rs
@@ -1,5 +1,7 @@
 #[path = "integration/engine_registration_debug.rs"]
 mod engine_registration_debug;
+#[path = "integration/execution_engine_identity.rs"]
+mod execution_engine_identity;
 #[path = "integration/public_surface_contract.rs"]
 mod public_surface_contract;
 #[path = "integration/runtime_error_api.rs"]

--- a/crates/tenferro-runtime/tests/integration/execution_engine_identity.rs
+++ b/crates/tenferro-runtime/tests/integration/execution_engine_identity.rs
@@ -1,0 +1,236 @@
+use std::any::Any;
+use std::error::Error as StdError;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tenferro_runtime::{
+    assemble_preparation_only_engine_registration, CoreCapabilityBundle, EngineId,
+    EngineRegistration, EngineRegistrationMetadata, Error, EventDomainDriver, EventDomainError,
+    EventDomainId, EventDomainOperation, EventToken, ExecutionContextIdentity, HardwareClassId,
+    ImmediateEventDomainDriver, PreparationOnlyEngineRegistrationConfig, ProviderDeviceIdentity,
+    ProviderId, RegistrationKey, Runtime, RuntimeConfigBuilder, RuntimeConfigError, StorageClass,
+    TransferEndpoint, TransferProvider, TransferRequest,
+};
+
+#[derive(Debug)]
+struct TestProviderContext;
+
+fn registration(
+    engine_id: EngineId,
+    target: &str,
+    storage: StorageClass,
+) -> Result<EngineRegistration, RuntimeConfigError> {
+    let metadata = EngineRegistrationMetadata::new(
+        engine_id,
+        ProviderDeviceIdentity::new(ProviderId::new("tenferro.test.phase0")?, target)?,
+        HardwareClassId::new("tenferro.test.phase0")?,
+        Arc::from(vec![storage.clone()]),
+        storage,
+        CoreCapabilityBundle::default(),
+    );
+    assemble_preparation_only_engine_registration(PreparationOnlyEngineRegistrationConfig::new(
+        metadata,
+        ExecutionContextIdentity::of::<TestProviderContext>(),
+    ))
+}
+
+struct EngineFixture {
+    builder: RuntimeConfigBuilder,
+    first_id: EngineId,
+    second_id: EngineId,
+    third_id: EngineId,
+    storage: StorageClass,
+}
+
+fn engine_fixture() -> Result<EngineFixture, RuntimeConfigError> {
+    let first_id = EngineId::new("tenferro.test.phase0.device0")?;
+    let second_id = EngineId::new("tenferro.test.phase0.device1")?;
+    let third_id = EngineId::new("tenferro.test.phase0.device2")?;
+    let storage = StorageClass::new("tenferro.test.phase0.storage")?;
+    let mut builder = Runtime::builder();
+    builder.register_engine(registration(first_id.clone(), "device:0", storage.clone())?)?;
+    builder.register_engine(registration(
+        second_id.clone(),
+        "device:1",
+        storage.clone(),
+    )?)?;
+    builder.register_engine(registration(third_id.clone(), "device:2", storage.clone())?)?;
+    Ok(EngineFixture {
+        builder,
+        first_id,
+        second_id,
+        third_id,
+        storage,
+    })
+}
+
+#[derive(Debug)]
+struct UnusedTransferProvider;
+
+impl TransferProvider for UnusedTransferProvider {
+    fn transfer_blocking(
+        &self,
+        _request: TransferRequest<'_>,
+    ) -> tenferro_runtime::Result<tenferro_tensor::Tensor> {
+        Err(Error::Internal(
+            "the phase-0 routing contract does not execute transfers".to_owned(),
+        ))
+    }
+}
+
+#[derive(Debug)]
+struct ForeignToken {
+    origin: EventDomainId,
+    waits: Arc<AtomicUsize>,
+}
+
+impl EventToken for ForeignToken {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn origin(&self) -> EventDomainId {
+        self.origin
+    }
+
+    fn wait(&self) -> tenferro_runtime::Result<()> {
+        self.waits.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[test]
+fn caller_selected_engines_have_distinct_physical_and_event_identity(
+) -> Result<(), Box<dyn StdError>> {
+    let mut fixture = engine_fixture()?;
+    let error = fixture
+        .builder
+        .register_engine(registration(
+            fixture.first_id.clone(),
+            "replacement-device",
+            fixture.storage.clone(),
+        )?)
+        .expect_err("a conflicting engine ID must be rejected");
+    assert!(matches!(
+        error,
+        RuntimeConfigError::DuplicateEngine { engine_id } if engine_id == fixture.first_id
+    ));
+
+    let runtime = fixture.builder.build()?;
+    let snapshot = runtime.snapshot()?;
+    let first = snapshot
+        .engine(&fixture.first_id)
+        .expect("first caller-selected engine");
+    let second = snapshot
+        .engine(&fixture.second_id)
+        .expect("second caller-selected engine");
+    let third = snapshot
+        .engine(&fixture.third_id)
+        .expect("third caller-selected engine");
+
+    assert_eq!(first.engine_id(), &fixture.first_id);
+    assert_eq!(second.engine_id(), &fixture.second_id);
+    assert_eq!(third.engine_id(), &fixture.third_id);
+    assert_ne!(
+        first.provider_device_identity(),
+        second.provider_device_identity()
+    );
+    assert_ne!(first.event_domain_id(), second.event_domain_id());
+    assert_ne!(first.event_domain_id(), third.event_domain_id());
+    assert_ne!(second.event_domain_id(), third.event_domain_id());
+    Ok(())
+}
+
+#[test]
+fn transfer_routes_are_keyed_by_the_complete_endpoint_pair() -> Result<(), Box<dyn StdError>> {
+    let mut fixture = engine_fixture()?;
+    let first = TransferEndpoint::new(fixture.first_id.clone(), fixture.storage.clone());
+    let second = TransferEndpoint::new(fixture.second_id.clone(), fixture.storage.clone());
+    let third = TransferEndpoint::new(fixture.third_id.clone(), fixture.storage.clone());
+    fixture.builder.register_transfer_provider(
+        first.clone(),
+        second.clone(),
+        Arc::new(UnusedTransferProvider),
+    )?;
+    fixture.builder.register_transfer_provider(
+        first.clone(),
+        third.clone(),
+        Arc::new(UnusedTransferProvider),
+    )?;
+    fixture.builder.register_transfer_provider(
+        second.clone(),
+        first.clone(),
+        Arc::new(UnusedTransferProvider),
+    )?;
+    fixture.builder.register_transfer_provider(
+        third,
+        first.clone(),
+        Arc::new(UnusedTransferProvider),
+    )?;
+
+    let error = fixture
+        .builder
+        .register_transfer_provider(
+            first.clone(),
+            second.clone(),
+            Arc::new(UnusedTransferProvider),
+        )
+        .expect_err("only an exact duplicate endpoint pair must conflict");
+    assert!(matches!(
+        error,
+        RuntimeConfigError::ConflictingRegistration {
+            key: RegistrationKey::TransferProvider {
+                source,
+                destination,
+            }
+        } if source == first && destination == second
+    ));
+
+    let runtime = fixture.builder.build()?;
+    assert_eq!(runtime.snapshot()?.transfer_provider_count(), 4);
+    Ok(())
+}
+
+#[test]
+fn event_domain_rejects_a_foreign_dependency_before_launch() -> Result<(), Box<dyn StdError>> {
+    let fixture = engine_fixture()?;
+    let runtime = fixture.builder.build()?;
+    let snapshot = runtime.snapshot()?;
+    let destination = snapshot
+        .engine(&fixture.first_id)
+        .expect("destination engine")
+        .event_domain_id();
+    let foreign = snapshot
+        .engine(&fixture.second_id)
+        .expect("foreign engine")
+        .event_domain_id();
+    let waits = Arc::new(AtomicUsize::new(0));
+    let dependency: Arc<dyn EventToken> = Arc::new(ForeignToken {
+        origin: foreign,
+        waits: Arc::clone(&waits),
+    });
+    let launches = AtomicUsize::new(0);
+    let mut launch = || {
+        launches.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    };
+    let mut run = ImmediateEventDomainDriver::new().begin_run(destination)?;
+
+    let error = run
+        .enqueue(&[dependency], &mut launch)
+        .expect_err("foreign event dependency must be rejected");
+    assert!(matches!(
+        error,
+        Error::EventDomain {
+            source: EventDomainError::DependencyDomainMismatch {
+                operation: EventDomainOperation::Enqueue,
+                expected,
+                actual,
+                ..
+            }
+        } if expected == destination && actual == foreign
+    ));
+    assert_eq!(launches.load(Ordering::SeqCst), 0);
+    assert_eq!(waits.load(Ordering::SeqCst), 0);
+    Ok(())
+}

--- a/scripts/storage-ownership-contracts.toml
+++ b/scripts/storage-ownership-contracts.toml
@@ -200,7 +200,7 @@ unit = "P0"
 gates = ["G3"]
 artifact = { id = "artifact-control-plane", kind = "rust-test", path = "crates/tenferro-runtime/tests/integration/execution_engine_identity.rs" }
 command = { id = "cmd-control-plane", kind = "cargo-test", argv = ["cargo", "test", "-p", "tenferro-runtime", "--test", "integration"], cwd = ".", path_args = [], artifact_id = "artifact-control-plane" }
-state = { kind = "deferred", activation_unit = "P0", promotion = { mode = "activate-in-place" } }
+state = { kind = "active" }
 rationale = "The obligation is one immutable artifact-command contract owned by one graph unit."
 
 [[obligations]]

--- a/scripts/test-storage-ownership-contracts-v2.py
+++ b/scripts/test-storage-ownership-contracts-v2.py
@@ -25,6 +25,7 @@ DIAGNOSTICS_SCHEMA = "tenferro.storage-ownership-diagnostics.v1"
 
 ACTIVE_IDS = frozenset(
     {
+        "p0-control-plane",
         "p1-ledger",
         "p1-contract-document",
         "p1-api-parity",
@@ -32,7 +33,6 @@ ACTIVE_IDS = frozenset(
     }
 )
 DEFERRED_CORRECTIONS = {
-    "p0-control-plane": "P0",
     "p2-root-claims": "P2",
 }
 
@@ -469,7 +469,7 @@ class StorageOwnershipV2Tests(unittest.TestCase):
         for row in deferred:
             self.assertFalse((ROOT / row["artifact"]["path"]).exists(), row["id"])
 
-        row = next(row for row in deferred if row["id"] == "p0-control-plane")
+        row = next(row for row in deferred if row["id"] == "p2-root-claims")
         files = _fixture_files()
         files[row["artifact"]["path"]] = "not a fabricated production artifact\n"
         result = _run_checker(
@@ -781,11 +781,11 @@ class StorageOwnershipV2Tests(unittest.TestCase):
                 finally:
                     temporary.cleanup()
 
-        base_manifest = _manifest_text()
-        promoted = _replace_row_state(
-            base_manifest.replace("revision = 3", "revision = 4", 1),
+        promoted = _manifest_text()
+        base_manifest = _replace_row_state(
+            promoted.replace("revision = 3", "revision = 2", 1),
             "p0-control-plane",
-            '{ kind = "active" }',
+            '{ kind = "deferred", activation_unit = "P0", promotion = { mode = "activate-in-place" } }',
         )
         files = _fixture_files(promoted)
         row = next(row for row in _manifest_rows(promoted) if row["id"] == "p0-control-plane")
@@ -890,7 +890,7 @@ class StorageOwnershipV2Tests(unittest.TestCase):
                 self,
                 result,
                 "E_COMMAND_FAILED",
-                {"command_id": "cmd-api-parity", "exit_code": 17},
+                {"command_id": "cmd-control-plane", "exit_code": 17},
             )
             self.assertFalse(receipt_path.exists())
         finally:


### PR DESCRIPTION
## Summary

- Add the P0 control-plane evidence as a module of the existing consolidated tenferro-runtime integration target.
- Verify caller-selected engine identity, complete transfer endpoint-pair identity, typed duplicate rejection, and foreign event-domain rejection before launch.
- Promote only p0-control-plane from deferred to active.
- Preserve ledger revision 3 and every obligation identity field fixed by #1600.
- Add no production code or new safety machinery; P2 and later phases remain deferred.

Refs #1555 and #1556. Follows #1600.

## Verification

- python3 scripts/test-storage-ownership-contracts-v2.py — 24/24
- python3 scripts/check-storage-ownership-contracts.py --base-commit origin/main — pass
- cargo test -p tenferro-runtime --test integration — 122/122
- python3 -m unittest scripts.ci.tests.test_build_artifact_contracts -v — 6/6
- scripts/check-pr-fast.sh --coverage-reviewed --test cargo-test-runtime-integration — pass
- The three P0 tests were independently reviewed in the earlier exact-content candidate; endpoint-pair key mutation was proven to fail before restoration.