### PR TITLE
Fix three remaining review-bot gaps

### DIFF
--- a/docs/worklogs/2026-08-04-review-bot-transport-and-guard-hardening.md
+++ b/docs/worklogs/2026-08-04-review-bot-transport-and-guard-hardening.md
@@ -222,3 +222,38 @@ Coverage: `test_sensitive_diff_ignores_a_field_access_continuation` and
 `test_files_with_unanchorable_deletions_keeps_a_mixed_hunk_deletion`, alongside
 the existing replacement-edit and whole-file-deletion cases which pin that the
 per-hunk rule did not widen the exception back out.
+
+## Review Follow-ups, Round 3 (Codex on PR #1604)
+
+Both reproduced against `f1c2cd37` first.
+
+- **P1 — plain identifiers still read as bare secret literals.** After the
+  expression and field-access narrowings, the class still accepted every
+  identifier-only continuation of eight or more characters, so `let api_key =`
+  followed by `configured_token;` or `ENV_API_KEY;` blocked the required gate
+  with no credential in the diff. An identifier is spelled from the same
+  alphabet as a credential, so shape alone cannot separate them; two further
+  discriminators do:
+  * the bare floor rises from 8 to **20** characters — the threshold this file
+    already uses for bare credentials (`github_pat_…{20,}`, `gh[pousr]_…{20,}`,
+    `sk-…{20,}`). The reported identifiers are 16 and 11.
+  * `IDENTIFIER_WORD_SHAPE` rejects snake_case / SCREAMING_SNAKE_CASE past the
+    floor, since that is an identifier convention base64/hex credentials do not
+    follow. This covers `configured_authentication_token` (31).
+  `is_standalone_secret_value` composes the two so the call site reads as one
+  decision. Residual: a long single-word identifier with no underscore still
+  trips; it is waivable, whereas the reverse error would upload a secret.
+- **P2 — diff body lines mistaken for file headers.** Deleting a source line
+  reading `-- validation` produces the body line `--- validation`, which the
+  parser read as an old-file header: it closed the hunk, reset the flags and
+  cleared the path, so a deletion-only hunk returned nothing (measured:
+  `set()` instead of `{"a.rs"}`) and the unanchored block was discarded after
+  all. Header parsing now happens only OUTSIDE a hunk — `@@` enters the hunk
+  state and `diff --git` returns to the header state — which fixes the `+++`
+  twin at the same time.
+
+Coverage: `test_sensitive_diff_ignores_an_identifier_continuation`,
+`test_is_standalone_secret_value_keeps_credential_shapes` (positive control for
+the shapes the guard exists for), and
+`test_files_with_unanchorable_deletions_reads_headers_outside_hunks`. The
+round-1/2 replacement-edit, whole-file-deletion and mixed-hunk tests still pass.

--- a/docs/worklogs/2026-08-04-review-bot-transport-and-guard-hardening.md
+++ b/docs/worklogs/2026-08-04-review-bot-transport-and-guard-hardening.md
@@ -196,3 +196,29 @@ Three findings, each reproduced against the pre-fix script first.
 Coverage: `test_sensitive_diff_ignores_an_expression_continuation`,
 `test_files_with_unanchorable_deletions_keeps_a_fully_deleted_file`, and
 `test_files_with_unanchorable_deletions_skips_replacement_edits`.
+
+## Review Follow-ups, Round 2 (Codex on PR #1604)
+
+Two findings, both reproduced against `f1c2cd37` first.
+
+- **P1 — field accesses still read as credential values.** Narrowing the bare
+  continuation class to `[A-Za-z0-9._~+/=-]` excluded call and path syntax but
+  kept `.`, so `let api_key =` continued by `settings.api_key;` still matched
+  and credential-LOADING code still could not pass the required gate. `.` is
+  now out of the class. The cost is the unquoted-JWT continuation shape; a
+  quoted JWT still matches the quoted alternatives and the `Bearer` form is
+  covered by `SECRET_VALUE_PATTERNS`, whereas a dotted bare token on a
+  continuation line is far more often a field access. Blocking valid code on
+  the required gate is the worse of the two errors.
+- **P2 — mixed-hunk deletions lost the exception.** Additions and deletions
+  were aggregated per FILE, so an unrelated addition anywhere in the file
+  removed a deletion-only hunk from the set and `filter_findings` dropped the
+  real block. The unit of "nothing to anchor to" is the HUNK: a file now
+  qualifies when at least one hunk removes lines and adds none. This keeps
+  round 1's narrowing intact — a pure replacement edit has both in the same
+  hunk, so it still does not qualify.
+
+Coverage: `test_sensitive_diff_ignores_a_field_access_continuation` and
+`test_files_with_unanchorable_deletions_keeps_a_mixed_hunk_deletion`, alongside
+the existing replacement-edit and whole-file-deletion cases which pin that the
+per-hunk rule did not widen the exception back out.

--- a/docs/worklogs/2026-08-04-review-bot-transport-and-guard-hardening.md
+++ b/docs/worklogs/2026-08-04-review-bot-transport-and-guard-hardening.md
@@ -167,3 +167,32 @@ invocations now pass `-c core.quotePath=false`.
 - `CONTENT_TRIGGERS` is a heuristic keyed on source text. It will miss a rule
   signal expressed differently and will occasionally supply a section that
   turns out to be irrelevant, costing tokens rather than correctness.
+
+## Review Follow-ups (Codex on PR #1604)
+
+Three findings, each reproduced against the pre-fix script first.
+
+- **P1 — expression continuations blocked the gate.** The new bare
+  continuation alternative `[^\s"'#][^\s#]{7,}` matched a whole EXPRESSION,
+  so `let api_key =` continued by `std::env::var("API_KEY")?;` was reported as
+  a leaked credential and a valid credential-LOADING change could not pass the
+  required review-bot gate. The alternative is now `BARE_SECRET_VALUE`,
+  restricted to the characters a credential literal is made of
+  (`[A-Za-z0-9][A-Za-z0-9._~+/=-]{7,}` — base64/hex/JWT alphabets plus URL-safe
+  punctuation). Call, path and index syntax falls outside the class. The
+  motivating unquoted-secret case and JWT-shaped values still match.
+- **P2 — a fully deleted file was omitted.** `+++ /dev/null` cleared
+  `current_file`, so a whole-file deletion never entered the set that exists to
+  retain unanchored blocks about deletions. The parser now falls back to the
+  old-side path from the preceding `--- a/...` header — the path a finding
+  about the removal names.
+- **P2 — the exception was too wide.** Any patch removing even one line put
+  the file in the set, which disabled the anti-generalization filter for most
+  modified files. The rule is now "removes lines and adds none": a replacement
+  edit supplies the lines that took the deleted ones' place, so a real finding
+  about it can and should name one of them. The helper is renamed
+  `files_with_unanchorable_deletions` to state that condition.
+
+Coverage: `test_sensitive_diff_ignores_an_expression_continuation`,
+`test_files_with_unanchorable_deletions_keeps_a_fully_deleted_file`, and
+`test_files_with_unanchorable_deletions_skips_replacement_edits`.

--- a/scripts/repository-rules-review.py
+++ b/scripts/repository-rules-review.py
@@ -85,13 +85,18 @@ OPEN_SECRET_ASSIGNMENT = re.compile(
 # bare tokens here cannot fire on ordinary continuations.
 #
 # The bare alternative is restricted to the characters a credential literal is
-# actually made of (base64/hex/JWT alphabets plus the URL-safe punctuation).
-# An unrestricted `[^\s#]+` also matched an EXPRESSION, so
+# actually made of. An unrestricted `[^\s#]+` also matched an EXPRESSION, so
 # `let api_key =` continued by `std::env::var("API_KEY")?;` was reported as a
 # leaked credential and a valid credential-LOADING change could not pass the
 # required gate. Call, path, and index syntax (`(`, `)`, `::`, `?`, `[`, `"`)
 # is outside the class, so such continuations no longer match.
-BARE_SECRET_VALUE = r"[A-Za-z0-9][A-Za-z0-9._~+/=-]{7,}"
+#
+# `.` is excluded too, which costs the unquoted-JWT continuation shape (a
+# quoted one still matches the alternatives above, and the `Bearer` form is
+# covered by SECRET_VALUE_PATTERNS). A dotted token is far more often a FIELD
+# ACCESS — `let api_key =` continued by `settings.api_key;` — and blocking
+# credential-loading code on the required gate is the worse error of the two.
+BARE_SECRET_VALUE = r"[A-Za-z0-9][A-Za-z0-9_~+/=-]{7,}"
 STANDALONE_VALUE = re.compile(
     r"""^[ \t]*(?:"[^"\r\n]{4,}"|'[^'\r\n]{4,}'|"""
     + BARE_SECRET_VALUE
@@ -542,28 +547,42 @@ def added_lines_by_file(diff_text: str) -> dict[str, set[int]]:
 
 
 def files_with_unanchorable_deletions(diff_text: str) -> set[str]:
-    """Files this diff removes lines from without adding any.
+    """Files containing at least one hunk that removes lines and adds none.
 
     A finding about a deletion has no new-file line to point at, so the model
     is obliged to return ``line: null`` and `filter_findings` must keep the
-    block. That obligation only holds when the diff gives it nothing to anchor
-    to: a replacement edit adds the lines that took the deleted ones' place, so
-    a real finding about that edit can and should name one of them. Requiring
-    "no added lines" keeps the anti-generalization filter in force for ordinary
-    modified files instead of disabling it for any patch that happens to remove
-    a line.
+    block. That obligation holds exactly where the diff gives it nothing to
+    anchor to, and the unit of "nothing to anchor to" is the HUNK, not the
+    file:
+
+    * a replacement edit adds the lines that took the deleted ones' place, so
+      a real finding about it can and should name one of them — judging this
+      per file would disable the anti-generalization filter for any patch that
+      happens to remove a line;
+    * but an unrelated addition elsewhere in the same file is not a valid
+      anchor for a deletion-only hunk — judging this per file would drop a
+      real block about validation or a ``// SAFETY:`` comment removed in a
+      mixed-hunk diff.
 
     Keyed by the new-side path, falling back to the old-side path when the file
     is deleted outright (``+++ /dev/null``) — that is the path a finding about
     the removal names, and without the fallback a whole-file deletion was
     omitted from the very set that exists to retain it.
     """
-    deleted: set[str] = set()
-    added: set[str] = set()
+    result: set[str] = set()
     current_file: str | None = None
     old_file: str | None = None
+    hunk_deleted = False
+    hunk_added = False
+
+    def close_hunk() -> None:
+        if current_file and hunk_deleted and not hunk_added:
+            result.add(current_file)
+
     for line in diff_text.splitlines():
         if line.startswith("--- "):
+            close_hunk()
+            hunk_deleted = hunk_added = False
             raw = line.removeprefix("--- a/").removeprefix("--- ")
             old_file = None if raw == "/dev/null" else raw
             continue
@@ -571,13 +590,18 @@ def files_with_unanchorable_deletions(diff_text: str) -> set[str]:
             raw = line.removeprefix("+++ b/").removeprefix("+++ ")
             current_file = old_file if raw == "/dev/null" else raw
             continue
-        if current_file is None or line.startswith("@@"):
+        if line.startswith("@@"):
+            close_hunk()
+            hunk_deleted = hunk_added = False
+            continue
+        if current_file is None:
             continue
         if line.startswith("-") and not line.startswith("---"):
-            deleted.add(current_file)
+            hunk_deleted = True
         elif line.startswith("+") and not line.startswith("+++"):
-            added.add(current_file)
-    return deleted - added
+            hunk_added = True
+    close_hunk()
+    return result
 
 
 def added_lines_with_text(diff_text: str) -> dict[str, list[tuple[int, str]]]:

--- a/scripts/repository-rules-review.py
+++ b/scripts/repository-rules-review.py
@@ -122,12 +122,36 @@ OPEN_SECRET_ASSIGNMENT = re.compile(
 # covered by SECRET_VALUE_PATTERNS). A dotted token is far more often a FIELD
 # ACCESS — `let api_key =` continued by `settings.api_key;` — and blocking
 # credential-loading code on the required gate is the worse error of the two.
-BARE_SECRET_VALUE = r"[A-Za-z0-9][A-Za-z0-9_~+/=-]{7,}"
+#
+# Length and word-shape carry the rest of the discrimination, because a plain
+# IDENTIFIER is spelled from the same alphabet as a credential:
+# `let api_key =` continued by `configured_token;` or `ENV_API_KEY;` is
+# ordinary code with no secret in the diff.
+#   * 20 characters is the floor the file already uses for a bare credential
+#     (`github_pat_…{20,}`, `gh[pousr]_…{20,}`, `sk-…{20,}`); the reported
+#     identifiers are 16 and 11.
+#   * a snake_case / SCREAMING_SNAKE_CASE token is an identifier by
+#     convention, while base64/hex credentials mix case and digits, so
+#     `IDENTIFIER_WORD_SHAPE` rejects the former even past the length floor.
+# A long single-word identifier with no underscore remains a residual false
+# positive; it is waivable, whereas the reverse error would upload a secret.
+BARE_SECRET_VALUE = r"[A-Za-z0-9][A-Za-z0-9_~+/=-]{19,}"
+IDENTIFIER_WORD_SHAPE = re.compile(
+    r"^(?:[a-z][a-z0-9]*(?:_[a-z0-9]+)+|[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)$"
+)
 STANDALONE_VALUE = re.compile(
-    r"""^[ \t]*(?:"[^"\r\n]{4,}"|'[^'\r\n]{4,}'|"""
+    r"""^[ \t]*(?P<value>"[^"\r\n]{4,}"|'[^'\r\n]{4,}'|"""
     + BARE_SECRET_VALUE
     + r""")[ \t]*[,;]?[ \t]*$"""
 )
+
+
+def is_standalone_secret_value(body: str) -> bool:
+    """Whether a continuation line carries a credential value rather than code."""
+    match = STANDALONE_VALUE.match(body)
+    if not match:
+        return False
+    return not IDENTIFIER_WORD_SHAPE.match(match.group("value"))
 # A quote opened on this line and closed on a later one hides the value from
 # any single-line pattern, so treat the opening alone as disqualifying.
 UNTERMINATED_SECRET_ASSIGNMENT = re.compile(
@@ -613,10 +637,16 @@ def files_with_unanchorable_deletions(diff_text: str) -> set[str]:
     is deleted outright (``+++ /dev/null``) — that is the path a finding about
     the removal names, and without the fallback a whole-file deletion was
     omitted from the very set that exists to retain it.
+
+    File headers are only read OUTSIDE a hunk. Inside one, ``--- validation``
+    is the deletion of a source line reading ``-- validation``, not an
+    old-file header; treating it as a header reset the hunk flags and lost the
+    file. ``diff --git`` returns the parser to the header state.
     """
     result: set[str] = set()
     current_file: str | None = None
     old_file: str | None = None
+    in_hunk = False
     hunk_deleted = False
     hunk_added = False
 
@@ -625,25 +655,32 @@ def files_with_unanchorable_deletions(diff_text: str) -> set[str]:
             result.add(current_file)
 
     for line in diff_text.splitlines():
-        if line.startswith("--- "):
+        if line.startswith("diff --git"):
             close_hunk()
+            in_hunk = False
             hunk_deleted = hunk_added = False
-            raw = line.removeprefix("--- a/").removeprefix("--- ")
-            old_file = None if raw == "/dev/null" else raw
-            continue
-        if line.startswith("+++ "):
-            raw = line.removeprefix("+++ b/").removeprefix("+++ ")
-            current_file = old_file if raw == "/dev/null" else raw
+            current_file = old_file = None
             continue
         if line.startswith("@@"):
             close_hunk()
+            in_hunk = True
             hunk_deleted = hunk_added = False
+            continue
+        if not in_hunk:
+            if line.startswith("--- "):
+                raw = line.removeprefix("--- a/").removeprefix("--- ")
+                old_file = None if raw == "/dev/null" else raw
+                continue
+            if line.startswith("+++ "):
+                raw = line.removeprefix("+++ b/").removeprefix("+++ ")
+                current_file = old_file if raw == "/dev/null" else raw
+                continue
             continue
         if current_file is None:
             continue
-        if line.startswith("-") and not line.startswith("---"):
+        if line.startswith("-"):
             hunk_deleted = True
-        elif line.startswith("+") and not line.startswith("+++"):
+        elif line.startswith("+"):
             hunk_added = True
     close_hunk()
     return result
@@ -979,7 +1016,7 @@ def sensitive_diff_location(diff_text: str) -> tuple[str, int] | None:
 
         if is_added and contains_sensitive_text(body):
             return current_file, new_line
-        if is_added and awaiting_value and STANDALONE_VALUE.match(body):
+        if is_added and awaiting_value and is_standalone_secret_value(body):
             return current_file, new_line
 
         opener = OPEN_SECRET_ASSIGNMENT.search(body)

--- a/scripts/repository-rules-review.py
+++ b/scripts/repository-rules-review.py
@@ -83,8 +83,19 @@ OPEN_SECRET_ASSIGNMENT = re.compile(
 # The value may be a bare token: `API_KEY =` followed by an unquoted secret.
 # `awaiting_value` is only set for credential-named assignments, so accepting
 # bare tokens here cannot fire on ordinary continuations.
+#
+# The bare alternative is restricted to the characters a credential literal is
+# actually made of (base64/hex/JWT alphabets plus the URL-safe punctuation).
+# An unrestricted `[^\s#]+` also matched an EXPRESSION, so
+# `let api_key =` continued by `std::env::var("API_KEY")?;` was reported as a
+# leaked credential and a valid credential-LOADING change could not pass the
+# required gate. Call, path, and index syntax (`(`, `)`, `::`, `?`, `[`, `"`)
+# is outside the class, so such continuations no longer match.
+BARE_SECRET_VALUE = r"[A-Za-z0-9][A-Za-z0-9._~+/=-]{7,}"
 STANDALONE_VALUE = re.compile(
-    r"""^[ \t]*(?:"[^"\r\n]{4,}"|'[^'\r\n]{4,}'|[^\s"'#][^\s#]{7,})[ \t]*[,;]?[ \t]*$"""
+    r"""^[ \t]*(?:"[^"\r\n]{4,}"|'[^'\r\n]{4,}'|"""
+    + BARE_SECRET_VALUE
+    + r""")[ \t]*[,;]?[ \t]*$"""
 )
 # A quote opened on this line and closed on a later one hides the value from
 # any single-line pattern, so treat the opening alone as disqualifying.
@@ -530,20 +541,43 @@ def added_lines_by_file(diff_text: str) -> dict[str, set[int]]:
     return result
 
 
-def files_with_deleted_lines(diff_text: str) -> set[str]:
-    """Files this diff removes lines from, keyed by their new-side path."""
-    result: set[str] = set()
+def files_with_unanchorable_deletions(diff_text: str) -> set[str]:
+    """Files this diff removes lines from without adding any.
+
+    A finding about a deletion has no new-file line to point at, so the model
+    is obliged to return ``line: null`` and `filter_findings` must keep the
+    block. That obligation only holds when the diff gives it nothing to anchor
+    to: a replacement edit adds the lines that took the deleted ones' place, so
+    a real finding about that edit can and should name one of them. Requiring
+    "no added lines" keeps the anti-generalization filter in force for ordinary
+    modified files instead of disabling it for any patch that happens to remove
+    a line.
+
+    Keyed by the new-side path, falling back to the old-side path when the file
+    is deleted outright (``+++ /dev/null``) — that is the path a finding about
+    the removal names, and without the fallback a whole-file deletion was
+    omitted from the very set that exists to retain it.
+    """
+    deleted: set[str] = set()
+    added: set[str] = set()
     current_file: str | None = None
+    old_file: str | None = None
     for line in diff_text.splitlines():
+        if line.startswith("--- "):
+            raw = line.removeprefix("--- a/").removeprefix("--- ")
+            old_file = None if raw == "/dev/null" else raw
+            continue
         if line.startswith("+++ "):
             raw = line.removeprefix("+++ b/").removeprefix("+++ ")
-            current_file = None if raw == "/dev/null" else raw
+            current_file = old_file if raw == "/dev/null" else raw
             continue
-        if line.startswith("--- ") or line.startswith("@@"):
+        if current_file is None or line.startswith("@@"):
             continue
-        if current_file and line.startswith("-") and not line.startswith("---"):
-            result.add(current_file)
-    return result
+        if line.startswith("-") and not line.startswith("---"):
+            deleted.add(current_file)
+        elif line.startswith("+") and not line.startswith("+++"):
+            added.add(current_file)
+    return deleted - added
 
 
 def added_lines_with_text(diff_text: str) -> dict[str, list[tuple[int, str]]]:
@@ -1498,7 +1532,7 @@ def main(argv: list[str] | None = None) -> int:
     diff_text = unified_diff(args.base, args.head, worktree=args.worktree)
     added_lines = added_lines_by_file(diff_text)
     added_text = added_lines_with_text(diff_text)
-    deleted_from = files_with_deleted_lines(diff_text)
+    deleted_from = files_with_unanchorable_deletions(diff_text)
     section_names = select_rule_sections(files, added_text)
     rules_text = build_rules_payload(section_names)
     system_prompt = PROMPT_PATH.read_text(encoding="utf-8")

--- a/scripts/repository-rules-review.py
+++ b/scripts/repository-rules-review.py
@@ -80,7 +80,12 @@ OPEN_SECRET_ASSIGNMENT = re.compile(
     r"(?i)\b(?P<name>" + SECRET_NAME + r")" + SECRET_ANNOTATION + r"[ \t]*[:=][ \t]*$"
 )
 # A value standing alone on its own line, as the continuation of the above.
-STANDALONE_VALUE = re.compile(r"""^[ \t]*(?:"[^"\r\n]{4,}"|'[^'\r\n]{4,}')[ \t]*[,;]?[ \t]*$""")
+# The value may be a bare token: `API_KEY =` followed by an unquoted secret.
+# `awaiting_value` is only set for credential-named assignments, so accepting
+# bare tokens here cannot fire on ordinary continuations.
+STANDALONE_VALUE = re.compile(
+    r"""^[ \t]*(?:"[^"\r\n]{4,}"|'[^'\r\n]{4,}'|[^\s"'#][^\s#]{7,})[ \t]*[,;]?[ \t]*$"""
+)
 # A quote opened on this line and closed on a later one hides the value from
 # any single-line pattern, so treat the opening alone as disqualifying.
 UNTERMINATED_SECRET_ASSIGNMENT = re.compile(
@@ -522,6 +527,22 @@ def added_lines_by_file(diff_text: str) -> dict[str, set[int]]:
         elif line.startswith(" "):
             new_line += 1
 
+    return result
+
+
+def files_with_deleted_lines(diff_text: str) -> set[str]:
+    """Files this diff removes lines from, keyed by their new-side path."""
+    result: set[str] = set()
+    current_file: str | None = None
+    for line in diff_text.splitlines():
+        if line.startswith("+++ "):
+            raw = line.removeprefix("+++ b/").removeprefix("+++ ")
+            current_file = None if raw == "/dev/null" else raw
+            continue
+        if line.startswith("--- ") or line.startswith("@@"):
+            continue
+        if current_file and line.startswith("-") and not line.startswith("---"):
+            result.add(current_file)
     return result
 
 
@@ -1012,8 +1033,19 @@ def filter_findings(
     added_lines: dict[str, set[int]],
     *,
     allow_global: bool = True,
+    files_with_deletions: set[str] | None = None,
 ) -> list[Finding]:
+    """Keep only findings anchored to something this diff actually changed.
+
+    A file-level `block` is normally dropped, because an unanchored block is
+    usually the model generalising about the file rather than about the diff.
+    The exception is a violation introduced by *deleting* required validation,
+    coverage, or a safety comment: there is no new-file line to point at, so
+    the model must return `line: null`, and dropping it would let a
+    deletion-only diff pass the gate.
+    """
     allowed_files = set(files)
+    deletions = files_with_deletions or set()
     kept: list[Finding] = []
     for finding in findings:
         if not finding.file:
@@ -1022,7 +1054,11 @@ def filter_findings(
             continue
         if finding.file and finding.file not in allowed_files:
             continue
-        if finding.line is None and finding.severity == "block":
+        if (
+            finding.line is None
+            and finding.severity == "block"
+            and finding.file not in deletions
+        ):
             continue
         if finding.line is not None:
             if finding.line not in added_lines.get(finding.file, set()):
@@ -1462,6 +1498,7 @@ def main(argv: list[str] | None = None) -> int:
     diff_text = unified_diff(args.base, args.head, worktree=args.worktree)
     added_lines = added_lines_by_file(diff_text)
     added_text = added_lines_with_text(diff_text)
+    deleted_from = files_with_deleted_lines(diff_text)
     section_names = select_rule_sections(files, added_text)
     rules_text = build_rules_payload(section_names)
     system_prompt = PROMPT_PATH.read_text(encoding="utf-8")
@@ -1562,7 +1599,20 @@ def main(argv: list[str] | None = None) -> int:
                     f"{type(exc).__name__}: {exc}",
                     file=sys.stderr,
                 )
-                findings.append(llm_response_error_finding(exc))
+                # A transport failure at the cumulative deadline is the budget
+                # running out, not an unusable model. Reporting it as a block
+                # would fail the gate for exactly the case the budget exists
+                # to degrade gracefully.
+                if isinstance(exc, TRANSPORT_ERRORS) and (
+                    time.monotonic() >= llm_deadline
+                ):
+                    findings.append(
+                        budget_exhausted_finding(
+                            reviewed, len(chunks), args.budget_seconds
+                        )
+                    )
+                else:
+                    findings.append(llm_response_error_finding(exc))
                 break
             print(
                 f"LLM chunk {index}/{len(chunks)}: {len(chunk)} chars, "
@@ -1578,6 +1628,7 @@ def main(argv: list[str] | None = None) -> int:
             files,
             added_lines,
             allow_global=False,
+            files_with_deletions=deleted_from,
         )
         llm_elapsed = time.monotonic() - llm_started
         llm_summary = summarize_llm_review(

--- a/scripts/test-repository-rules-review.py
+++ b/scripts/test-repository-rules-review.py
@@ -1267,7 +1267,7 @@ def test_filter_findings_keeps_file_level_block_for_deletions() -> None:
     assert kept == [block]
 
 
-def test_files_with_deleted_lines_reads_the_new_side_path() -> None:
+def test_files_with_unanchorable_deletions_reads_the_new_side_path() -> None:
     mod = load_module()
     diff = "\n".join(
         [
@@ -1285,7 +1285,80 @@ def test_files_with_deleted_lines_reads_the_new_side_path() -> None:
             "+added",
         ]
     )
-    assert mod.files_with_deleted_lines(diff) == {"a.rs"}
+    assert mod.files_with_unanchorable_deletions(diff) == {"a.rs"}
+
+
+def test_files_with_unanchorable_deletions_keeps_a_fully_deleted_file() -> None:
+    """A whole-file deletion has `+++ /dev/null`; keep its old-side path.
+
+    Clearing `current_file` on the `/dev/null` header omitted the deleted file
+    from the very set that exists to retain unanchored blocks about deletions.
+    """
+    mod = load_module()
+    diff = "\n".join(
+        [
+            "diff --git a/crates/x/src/old.rs b/crates/x/src/old.rs",
+            "deleted file mode 100644",
+            "--- a/crates/x/src/old.rs",
+            "+++ /dev/null",
+            "@@ -1,2 +0,0 @@",
+            "-fn validate() {}",
+            "-// SAFETY: checked above",
+        ]
+    )
+    assert mod.files_with_unanchorable_deletions(diff) == {"crates/x/src/old.rs"}
+
+
+def test_files_with_unanchorable_deletions_skips_replacement_edits() -> None:
+    """A replacement edit adds lines, so a finding about it can be anchored.
+
+    Treating every patch that removes a line as unanchorable disabled the
+    anti-generalization filter for most modified files.
+    """
+    mod = load_module()
+    diff = "\n".join(
+        [
+            "diff --git a/a.rs b/a.rs",
+            "--- a/a.rs",
+            "+++ b/a.rs",
+            "@@ -1,1 +1,1 @@",
+            "-let a = 1;",
+            "+let a = 2;",
+            "diff --git a/b.rs b/b.rs",
+            "--- a/b.rs",
+            "+++ b/b.rs",
+            "@@ -1,2 +1,1 @@",
+            " keep",
+            "-// SAFETY: checked above",
+        ]
+    )
+    assert mod.files_with_unanchorable_deletions(diff) == {"b.rs"}
+
+
+def test_sensitive_diff_ignores_an_expression_continuation() -> None:
+    """A credential-LOADING expression is not a credential value.
+
+    The bare continuation alternative matched the whole expression, so
+    `let api_key =` followed by `std::env::var("API_KEY")?;` blocked the
+    required gate even though no credential appears in the diff.
+    """
+    mod = load_module()
+    for continuation in (
+        '+    std::env::var("API_KEY")?;',
+        "+    env::var(name).unwrap();",
+        "+    settings.api_key();",
+    ):
+        diff = "\n".join(
+            [
+                "diff --git a/src/x.rs b/src/x.rs",
+                "--- a/src/x.rs",
+                "+++ b/src/x.rs",
+                "@@ -1,2 +1,2 @@",
+                f" {KEYNAME} =",
+                continuation,
+            ]
+        )
+        assert mod.sensitive_diff_finding(diff) is None, continuation
 
 
 def test_sensitive_diff_blocks_a_bare_continuation_value() -> None:
@@ -1374,7 +1447,10 @@ def main() -> int:
         test_call_deepseek_does_not_retry_past_the_deadline,
         test_budget_exhausted_finding_warns_without_blocking,
         test_filter_findings_keeps_file_level_block_for_deletions,
-        test_files_with_deleted_lines_reads_the_new_side_path,
+        test_files_with_unanchorable_deletions_reads_the_new_side_path,
+        test_files_with_unanchorable_deletions_keeps_a_fully_deleted_file,
+        test_files_with_unanchorable_deletions_skips_replacement_edits,
+        test_sensitive_diff_ignores_an_expression_continuation,
         test_sensitive_diff_blocks_a_bare_continuation_value,
         test_sensitive_diff_ignores_an_ordinary_bare_continuation,
         test_sensitive_diff_blocks_a_value_on_a_continuation_line,

--- a/scripts/test-repository-rules-review.py
+++ b/scripts/test-repository-rules-review.py
@@ -1361,6 +1361,52 @@ def test_sensitive_diff_ignores_an_expression_continuation() -> None:
         assert mod.sensitive_diff_finding(diff) is None, continuation
 
 
+def test_files_with_unanchorable_deletions_keeps_a_mixed_hunk_deletion() -> None:
+    """An unrelated addition elsewhere in the file is not a valid anchor.
+
+    Aggregating additions and deletions per FILE removed a deletion-only hunk
+    from the set as soon as any other hunk added a line, so `filter_findings`
+    dropped a real block about removed validation or a `// SAFETY:` comment.
+    """
+    mod = load_module()
+    diff = "\n".join(
+        [
+            "diff --git a/a.rs b/a.rs",
+            "--- a/a.rs",
+            "+++ b/a.rs",
+            "@@ -1,2 +1,1 @@",
+            " keep",
+            "-// SAFETY: checked above",
+            "@@ -20,1 +19,2 @@",
+            " ctx",
+            "+let extra = 1;",
+        ]
+    )
+    assert mod.files_with_unanchorable_deletions(diff) == {"a.rs"}
+
+
+def test_sensitive_diff_ignores_a_field_access_continuation() -> None:
+    """A dotted member expression is not a credential value.
+
+    `.` in the bare class let `let api_key =` continued by `settings.api_key;`
+    read as a leaked secret, so credential-LOADING code still could not pass
+    the required gate.
+    """
+    mod = load_module()
+    for continuation in ("+    settings.api_key;", "+    self.token;"):
+        diff = "\n".join(
+            [
+                "diff --git a/src/x.rs b/src/x.rs",
+                "--- a/src/x.rs",
+                "+++ b/src/x.rs",
+                "@@ -1,2 +1,2 @@",
+                f" {KEYNAME} =",
+                continuation,
+            ]
+        )
+        assert mod.sensitive_diff_finding(diff) is None, continuation
+
+
 def test_sensitive_diff_blocks_a_bare_continuation_value() -> None:
     """The continuation value need not be quoted."""
     mod = load_module()
@@ -1451,6 +1497,8 @@ def main() -> int:
         test_files_with_unanchorable_deletions_keeps_a_fully_deleted_file,
         test_files_with_unanchorable_deletions_skips_replacement_edits,
         test_sensitive_diff_ignores_an_expression_continuation,
+        test_sensitive_diff_ignores_a_field_access_continuation,
+        test_files_with_unanchorable_deletions_keeps_a_mixed_hunk_deletion,
         test_sensitive_diff_blocks_a_bare_continuation_value,
         test_sensitive_diff_ignores_an_ordinary_bare_continuation,
         test_sensitive_diff_blocks_a_value_on_a_continuation_line,

--- a/scripts/test-repository-rules-review.py
+++ b/scripts/test-repository-rules-review.py
@@ -1258,6 +1258,68 @@ def test_redactor_does_not_consume_a_deletion_marker_as_the_value() -> None:
     assert mod.redact_sensitive_text(text).splitlines()[1] == '-    "old";'
 
 
+def test_filter_findings_keeps_file_level_block_for_deletions() -> None:
+    """A deletion-only violation has no new-file line the model can anchor to."""
+    mod = load_module()
+    block = mod.Finding("x", "block", "S", "a.rs", None, "removed validation", "d")
+    assert mod.filter_findings([block], ["a.rs"], {}) == []
+    kept = mod.filter_findings([block], ["a.rs"], {}, files_with_deletions={"a.rs"})
+    assert kept == [block]
+
+
+def test_files_with_deleted_lines_reads_the_new_side_path() -> None:
+    mod = load_module()
+    diff = "\n".join(
+        [
+            "diff --git a/a.rs b/a.rs",
+            "--- a/a.rs",
+            "+++ b/a.rs",
+            "@@ -1,2 +1,1 @@",
+            " keep",
+            "-gone",
+            "diff --git a/b.rs b/b.rs",
+            "--- a/b.rs",
+            "+++ b/b.rs",
+            "@@ -1,1 +1,2 @@",
+            " keep",
+            "+added",
+        ]
+    )
+    assert mod.files_with_deleted_lines(diff) == {"a.rs"}
+
+
+def test_sensitive_diff_blocks_a_bare_continuation_value() -> None:
+    """The continuation value need not be quoted."""
+    mod = load_module()
+    diff = "\n".join(
+        [
+            "diff --git a/src/x.rs b/src/x.rs",
+            "--- a/src/x.rs",
+            "+++ b/src/x.rs",
+            "@@ -1,2 +1,2 @@",
+            f" {KEYNAME} =",
+            "-old",
+            "+abcdefghijklmnopqrstuvwx",
+        ]
+    )
+    assert mod.sensitive_diff_finding(diff) is not None
+
+
+def test_sensitive_diff_ignores_an_ordinary_bare_continuation() -> None:
+    mod = load_module()
+    diff = "\n".join(
+        [
+            "diff --git a/src/x.rs b/src/x.rs",
+            "--- a/src/x.rs",
+            "+++ b/src/x.rs",
+            "@@ -1,2 +1,2 @@",
+            " let total =",
+            "+    compute_sum(values)",
+        ]
+    )
+    assert mod.sensitive_diff_finding(diff) is None
+
+
 def main() -> int:
     for test in [
         test_added_lines_by_file,
@@ -1311,6 +1373,10 @@ def main() -> int:
         test_budget_is_smaller_than_the_workflow_timeout,
         test_call_deepseek_does_not_retry_past_the_deadline,
         test_budget_exhausted_finding_warns_without_blocking,
+        test_filter_findings_keeps_file_level_block_for_deletions,
+        test_files_with_deleted_lines_reads_the_new_side_path,
+        test_sensitive_diff_blocks_a_bare_continuation_value,
+        test_sensitive_diff_ignores_an_ordinary_bare_continuation,
         test_sensitive_diff_blocks_a_value_on_a_continuation_line,
         test_sensitive_diff_ignores_an_ordinary_continuation_value,
         test_sensitive_diff_ignores_an_unchanged_continuation_value,

--- a/scripts/test-repository-rules-review.py
+++ b/scripts/test-repository-rules-review.py
@@ -2421,6 +2421,74 @@ def test_sensitive_diff_ignores_a_field_access_continuation() -> None:
         assert mod.sensitive_diff_finding(diff) is None, continuation
 
 
+def test_sensitive_diff_ignores_an_identifier_continuation() -> None:
+    """A plain identifier is spelled from the same alphabet as a credential.
+
+    Length and word shape carry the discrimination: `configured_token` (16)
+    and `ENV_API_KEY` (11) are below the 20-character floor the file already
+    uses for bare credentials, and snake_case / SCREAMING_SNAKE_CASE is an
+    identifier convention that base64/hex credentials do not follow.
+    """
+    mod = load_module()
+    for continuation in (
+        "+    configured_token;",
+        "+    ENV_API_KEY;",
+        "+    configured_authentication_token;",
+    ):
+        diff = "\n".join(
+            [
+                "diff --git a/src/x.rs b/src/x.rs",
+                "--- a/src/x.rs",
+                "+++ b/src/x.rs",
+                "@@ -1,2 +1,2 @@",
+                f" {KEYNAME} =",
+                continuation,
+            ]
+        )
+        assert mod.sensitive_diff_finding(diff) is None, continuation
+
+
+def test_is_standalone_secret_value_keeps_credential_shapes() -> None:
+    """The positive cases the guard exists for must survive the narrowing."""
+    mod = load_module()
+    assert mod.is_standalone_secret_value("    abcdefghijklmnopqrstuvwx")
+    assert mod.is_standalone_secret_value("    A1b2C3d4E5f6G7h8J9k0;")
+    assert mod.is_standalone_secret_value('    "quoted-secret-value"')
+    assert not mod.is_standalone_secret_value("    short_id;")
+
+
+def test_files_with_unanchorable_deletions_reads_headers_outside_hunks() -> None:
+    """`--- validation` inside a hunk is a deleted body line, not a header.
+
+    Treating it as an old-file header reset the hunk flags, so the file was
+    lost from the set and a real unanchored block was still discarded.
+    """
+    mod = load_module()
+    diff = "\n".join(
+        [
+            "diff --git a/a.rs b/a.rs",
+            "--- a/a.rs",
+            "+++ b/a.rs",
+            "@@ -1,2 +1,1 @@",
+            " keep",
+            "--- validation",
+        ]
+    )
+    assert mod.files_with_unanchorable_deletions(diff) == {"a.rs"}
+    # The `+++` twin: deleting nothing, adding a line that reads `++ added`.
+    added = "\n".join(
+        [
+            "diff --git a/b.rs b/b.rs",
+            "--- a/b.rs",
+            "+++ b/b.rs",
+            "@@ -1,2 +1,3 @@",
+            " keep",
+            "+++ added",
+        ]
+    )
+    assert mod.files_with_unanchorable_deletions(added) == set()
+
+
 def test_sensitive_diff_blocks_a_bare_continuation_value() -> None:
     """The continuation value need not be quoted."""
     mod = load_module()
@@ -2560,6 +2628,9 @@ def main() -> int:
         test_files_with_unanchorable_deletions_skips_replacement_edits,
         test_sensitive_diff_ignores_an_expression_continuation,
         test_sensitive_diff_ignores_a_field_access_continuation,
+        test_sensitive_diff_ignores_an_identifier_continuation,
+        test_is_standalone_secret_value_keeps_credential_shapes,
+        test_files_with_unanchorable_deletions_reads_headers_outside_hunks,
         test_files_with_unanchorable_deletions_keeps_a_mixed_hunk_deletion,
         test_sensitive_diff_blocks_a_bare_continuation_value,
         test_sensitive_diff_ignores_an_ordinary_bare_continuation,


### PR DESCRIPTION
#1603 merged at `16affa23`, one commit short of the branch. This carries that commit — the final Codex round on #1603 and the parallel round on tensor4all/tensor4all-rs#568 landed after the merge point, so these three fixes are not in `main`.

## Deletion-only violations were silently dropped

`filter_findings` discarded every unanchored `block`. But a violation introduced by *deleting* required validation, coverage, or a `// SAFETY:` comment has no new-file line to point at, so the model is obliged to return `line: null` — and the finding was thrown away. A deletion-only diff passed the gate even when the LLM correctly identified a blocking violation.

The unanchored-block rule still earns its keep against the model generalising about a whole file, so rather than removing it the exception is scoped: file-level blocks survive for files this diff deletes lines from. `files_with_deleted_lines` keys on the new-side path so it lines up with how findings are addressed.

## Continuation values need not be quoted

The continuation guard added in #1603 only accepted quoted literals, so this went through untouched:

```diff
 API_KEY =
-old
+abcdefghijklmnopqrstuvwx
```

Bare tokens are accepted now. `awaiting_value` is only set when the opener's name passed `is_credential_name`, so an ordinary `let total =` / `compute_sum(values)` continuation cannot trigger it — asserted by a negative test.

## A deadline timeout was reported as a block

This one defeated the budget's own purpose. The budget clamps the final chunk's timeout to the remaining time; when that clamped request timed out, the handler converted it into `llm-review-unusable` — a **block** — instead of the warn-only budget-exhausted finding. So the mechanism added to make an over-long review degrade gracefully was failing the required gate at exactly the moment it engaged.

Deadline-triggered transport failures now emit the warn. The discrimination is `isinstance(exc, TRANSPORT_ERRORS) and time.monotonic() >= llm_deadline`, so a genuine transport failure with budget remaining still blocks, and a `ValueError` from an unparseable response blocks regardless of timing.

## Verification

- `python3 scripts/test-repository-rules-review.py` passes, with new tests for each fix
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD` → `Verdict: pass`
- No Rust changed; `cargo fmt --all --check` clean

Note for sequencing: #1582 also rewrites this file. It has been merged with current `main` and is `MERGEABLE`, but it does not contain these three fixes. Whichever lands second will need the other's changes merged in — the regions differ (`filter_findings`, `sensitive_diff_location`, the chunk loop's exception handler) from #1582's (`select_rule_sections`, new deterministic checks), so a merge should be mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)