### PR TITLE
ci: run hosted jobs on the same uv-pinned interpreter as local scripts

### DIFF
--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -1,0 +1,17 @@
+name: Set up the uv-pinned Python
+description: >-
+  Install uv and put the interpreter pinned by .python-version on PATH for the
+  rest of the job, so workflow steps run the same Python as local scripts
+  (issue #1606).
+
+runs:
+  using: composite
+  steps:
+    - uses: astral-sh/setup-uv@v5
+      with:
+        # The interpreter itself is pinned by .python-version; this pins the
+        # tool that fetches it.
+        version: "0.11.18"
+    - name: Put the pinned interpreter on PATH
+      shell: bash
+      run: bash scripts/ci/setup-python-shim.sh

--- a/.github/workflows/ci-pr-workspace-tests.yml
+++ b/.github/workflows/ci-pr-workspace-tests.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/setup-uv-python
       - name: Classify change
         id: policy
         env:
@@ -64,6 +65,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         if: needs.changes.outputs.run_workspace == 'true'
+      - uses: ./.github/actions/setup-uv-python
+        if: needs.changes.outputs.run_workspace == 'true'
       - uses: dtolnay/rust-toolchain@stable
         if: needs.changes.outputs.run_workspace == 'true'
       - uses: Swatinem/rust-cache@v2
@@ -93,6 +96,8 @@ jobs:
       RUSTFLAGS: ${{ matrix.cfg.rustflags }}
     steps:
       - uses: actions/checkout@v6
+        if: matrix.cfg.profile != ''
+      - uses: ./.github/actions/setup-uv-python
         if: matrix.cfg.profile != ''
       - uses: dtolnay/rust-toolchain@stable
         if: matrix.cfg.profile != ''
@@ -130,6 +135,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
+        if: needs.changes.outputs.run_extensions == 'true'
+      - uses: ./.github/actions/setup-uv-python
         if: needs.changes.outputs.run_extensions == 'true'
       - uses: dtolnay/rust-toolchain@stable
         if: needs.changes.outputs.run_extensions == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/setup-uv-python
       - name: Classify change
         id: policy
         env:
@@ -49,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+      - uses: ./.github/actions/setup-uv-python
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
       - uses: dtolnay/rust-toolchain@stable
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
@@ -77,6 +80,8 @@ jobs:
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/setup-uv-python
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
       - uses: dtolnay/rust-toolchain@stable
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
         with:
@@ -130,6 +135,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         if: needs.policy.result == 'success' && needs.policy.outputs.run_blas == 'true'
+      - uses: ./.github/actions/setup-uv-python
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_blas == 'true'
       - uses: dtolnay/rust-toolchain@stable
         if: needs.policy.result == 'success' && needs.policy.outputs.run_blas == 'true'
       - uses: Swatinem/rust-cache@v2
@@ -176,6 +183,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+      - uses: ./.github/actions/setup-uv-python
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
       - uses: dtolnay/rust-toolchain@stable
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
         with:
@@ -210,6 +219,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_docs == 'true'
+      - uses: ./.github/actions/setup-uv-python
         if: needs.policy.result == 'success' && needs.policy.outputs.run_docs == 'true'
       - uses: dtolnay/rust-toolchain@stable
         if: needs.policy.result == 'success' && needs.policy.outputs.run_docs == 'true'
@@ -248,6 +259,8 @@ jobs:
         if: needs.policy.result == 'success' && needs.policy.outputs.run_ci_config == 'true'
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/setup-uv-python
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_ci_config == 'true'
       - uses: actions/setup-go@v5
         if: needs.policy.result == 'success' && needs.policy.outputs.run_ci_config == 'true'
         with:

--- a/.github/workflows/review_bot.yml
+++ b/.github/workflows/review_bot.yml
@@ -43,6 +43,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - uses: ./.github/actions/setup-uv-python
       - name: Fetch PR head for diff only
         id: refs
         run: |
@@ -222,6 +223,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
           persist-credentials: false
+      - uses: ./.github/actions/setup-uv-python
       - name: Fetch PR head for diff only
         id: refs
         run: |
@@ -389,6 +391,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
           persist-credentials: false
+      - uses: ./.github/actions/setup-uv-python
       - name: Fetch PR head for diff only
         id: refs
         run: |

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -131,6 +131,7 @@ jobs:
       - name: Checkout trusted CI policy
         uses: actions/checkout@v5
 
+      - uses: ./.github/actions/setup-uv-python
       - name: Check actor and PR source are allowed
         id: resolve_ref
         env:
@@ -310,6 +311,7 @@ jobs:
     steps:
       - name: Checkout trusted RunPod helpers
         uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-uv-python
       - name: Validate GPU IDs and CUDA versions against live OpenAPI
         env:
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}

--- a/docs/worklogs/2026-08-04-python-interpreter-resolution.md
+++ b/docs/worklogs/2026-08-04-python-interpreter-resolution.md
@@ -77,3 +77,35 @@ interpreter. Wiring it (plus `astral-sh/setup-uv`) into the ~23 checkout points
 across six workflow files is a separate change: workflow edits cannot be
 validated locally, and it should land where a red CI run is expected and
 reviewable rather than riding along with this one.
+
+## CI adoption (follow-up PR)
+
+`.github/actions/setup-uv-python` installs uv (pinned to 0.11.18) and runs
+`scripts/ci/setup-python-shim.sh`, which appends the shim directory to
+`$GITHUB_PATH` so every later step in the job uses the interpreter pinned by
+`.python-version`. One step is added after the checkout of each job that runs
+the repository's Python tooling, carrying that checkout's own `if:` condition so
+a skipped job stays skipped:
+
+- `ci.yml` — policy, fmt, clippy, test-inject-blas, coverage, docs-site,
+  ci-config
+- `ci-pr-workspace-tests.yml` — changes, ci-fork, ci-maintainer, ext-samples
+- `review_bot.yml` — review-bot, review-bot-no-llm, review-bot-waived
+- `runpod-gpu-test.yml` — authorize, runpod-contract
+
+**Not** added to the GPU pod-side steps in `CI_gpu.yml` and the rest of
+`runpod-gpu-test.yml`. Those `python3` calls are not this repository's tooling —
+they parse CUDA manifests, run the pod smoke test, and `pip download` inside a
+container — and pinning them to a uv-managed interpreter would change unrelated
+behaviour on the pod for no benefit.
+
+Security note: the two `pull_request_target` / `workflow_run` workflows check
+out the TRUSTED base or default-branch revision (both say so in a comment and
+treat PR contents as data only), so `uses: ./.github/actions/setup-uv-python`
+resolves to trusted content rather than PR-controlled code. That is the reason
+the composite action is safe to reference by path in those jobs.
+
+Verified with `actionlint` (clean), plus `run_profile.py ci-config` — which runs
+`test_workflow_contracts.py`, the tests that pin workflow text — and
+`run_profile.py docs`. Workflow behaviour itself can only be confirmed by the
+hosted run on this PR.


### PR DESCRIPTION
Follow-up to #1607. **Based on `ci/resolve-python-311`** — it will retarget to `main`
automatically once #1607 merges, and its diff then reduces to the six files listed below.

## Why

#1607 makes local shell entry points run on the interpreter pinned by `.python-version`.
Hosted jobs invoke `python3 …` directly in workflow steps rather than through those entry
points, so sourcing `scripts/lib/python.sh` in one step would be lost by the next: CI kept
using the runner's own interpreter, and the local/CI parity that motivated the pin was only
half real.

## Change

`.github/actions/setup-uv-python` installs uv and runs `scripts/ci/setup-python-shim.sh`
(added in #1607), which appends the shim directory to `$GITHUB_PATH` so every later step in
the job uses the pinned interpreter.

One step is added after the checkout of each job that runs **this repository's** Python
tooling, carrying that checkout's own `if:` condition so a skipped job stays skipped:

| workflow | jobs |
|---|---|
| `ci.yml` | policy, fmt, clippy, test-inject-blas, coverage, docs-site, ci-config |
| `ci-pr-workspace-tests.yml` | changes, ci-fork, ci-maintainer, ext-samples |
| `review_bot.yml` | review-bot, review-bot-no-llm, review-bot-waived |
| `runpod-gpu-test.yml` | authorize, runpod-contract |

### Deliberately excluded

The GPU pod-side steps in `CI_gpu.yml` and the rest of `runpod-gpu-test.yml`. Those
`python3` calls are not this repository's tooling — they parse CUDA manifests, run the pod
smoke test, and `pip download` inside a container — so pinning them would change unrelated
behaviour on the pod for no benefit.

### Security

`review_bot.yml` (`pull_request_target`) and `runpod-gpu-test.yml` (`workflow_run`) check
out the **trusted** base / default-branch revision and treat PR contents as data only —
both say so in a comment at the checkout. So `uses: ./.github/actions/setup-uv-python`
resolves to trusted content, not PR-controlled code. That is what makes referencing the
composite action by path safe in those jobs; it would not be if they checked out the PR
head.

## Verification

- `actionlint` — clean.
- `python3 scripts/ci/run_profile.py ci-config` — runs `test_workflow_contracts.py`, the
  tests that pin workflow text, plus the rest of the CI-config suite. Passes.
- `python3 scripts/ci/run_profile.py docs` — passes.
- Workflow *behaviour* can only be confirmed by the hosted run on this PR; that is why this
  is a separate PR from #1607 rather than riding along with it.

Worklog: `docs/worklogs/2026-08-04-python-interpreter-resolution.md` (§CI adoption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)