### PR TITLE
docs: add per-method public API examples

### DIFF
--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -417,6 +417,20 @@ impl EagerTensor {
     /// [`tenferro_tensor::ValidationError::InvalidArgument`] when an integer or
     /// boolean factor is non-finite or outside the input dtype's range. Backend
     /// and runtime execution failures retain their typed source variants.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let x = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let scaled = x.scale_real(2.0)?;
+    /// assert_eq!(scaled.value()?.as_slice::<f64>()?, &[2.0, 4.0]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     pub fn scale_real(&self, factor: f64) -> Result<Self> {
         let scalar = match self.dtype() {
             DType::F64 => Tensor::from_vec_col_major(vec![], vec![factor])?,
@@ -441,6 +455,28 @@ impl EagerTensor {
     /// [`tenferro_tensor::ValidationError::InvalidArgument`] for a non-complex
     /// input dtype. Backend and runtime execution failures retain their typed
     /// source variants.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use num_complex::Complex64;
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let x = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(
+    /// #         vec![2],
+    /// #         vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
+    /// #     )
+    /// #     .unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let scaled = x.scale_complex(Complex64::new(0.0, 1.0))?;
+    /// assert_eq!(
+    ///     scaled.value()?.as_slice::<Complex64>()?,
+    ///     &[Complex64::new(-2.0, 1.0), Complex64::new(-4.0, 3.0)],
+    /// );
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     pub fn scale_complex(&self, factor: Complex64) -> Result<Self> {
         let scalar = match self.dtype() {
             DType::C64 => Tensor::from_vec_col_major(vec![], vec![factor])?,

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -19,6 +19,21 @@ pub trait EagerTensorLinalgExt {
     /// `Error::Extension` with an unsupported-operation or unsupported-dtype
     /// source when the selected backend cannot execute the decomposition, and
     /// `Error::RuntimeState` when the eager runtime or backend is unavailable.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let (_u, s, _vt) = a.svd()?;
+    /// assert_eq!(s.shape(), &[2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn svd(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor)>;
     /// # Errors
     ///
@@ -26,6 +41,21 @@ pub trait EagerTensorLinalgExt {
     /// non-positive, `Error::Extension` for unsupported dtypes or numerical
     /// non-convergence, and `Error::Internal` if the extension violates its
     /// output-count contract.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{EagerTensorLinalgExt, SvdOptions};
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let (_u, s, _vt) = a.svd_with_options(SvdOptions::default())?;
+    /// assert_eq!(s.shape(), &[2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn svd_with_options(
         &self,
         options: SvdOptions,
@@ -42,18 +72,92 @@ pub trait EagerTensorLinalgExt {
     /// slice). Automatic differentiation through the full variant is
     /// unsupported and surfaces a typed error rather than a silent thin
     /// fallback.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "cpu-faer")]
+    /// # {
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::{CpuBackend, CpuBackendKind};
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let faer = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer)
+    /// #     .expect("faer CPU backend");
+    /// # let ctx = EagerRuntime::with_cpu_backend(faer)?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let (u, s, vh) = a.svd_full()?;
+    /// assert_eq!(u.shape(), &[1, 1]);
+    /// assert_eq!(s.shape(), &[1]);
+    /// assert_eq!(vh.shape(), &[2, 2]);
+    /// let singular_values = s.value()?.as_slice::<f64>()?;
+    /// assert!((singular_values[0] - 2.0_f64.sqrt()).abs() < 1e-12);
+    /// # }
+    /// # #[cfg(all(feature = "cpu-blas", not(feature = "cpu-faer")))]
+    /// # {
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::{CpuBackend, CpuBackendKind};
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let blas = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Blas)
+    /// #     .expect("BLAS CPU backend");
+    /// # let ctx = EagerRuntime::with_cpu_backend(blas)?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// # let error = match a.svd_full() {
+    /// #     Ok(_) => panic!("expected full-matrices SVD to be unsupported for BLAS"),
+    /// #     Err(error) => error,
+    /// # };
+    /// # assert!(error.to_string().contains("full-matrices SVD"));
+    /// # }
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn svd_full(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor)>;
     /// # Errors
     ///
     /// Returns `Error::Validation` for invalid matrix rank or shape,
     /// `Error::Extension` for unsupported dtypes or numerical failure, and
     /// `Error::RuntimeState` when the eager runtime or backend is unavailable.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let (q, r) = a.qr()?;
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// assert_eq!(r.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn qr(&self) -> Result<(EagerTensor, EagerTensor)>;
     /// # Errors
     ///
     /// Returns `Error::Validation` for invalid matrix rank or shape,
     /// `Error::Extension` for unsupported dtypes or numerical failure, and
     /// `Error::Internal` if the extension violates its output-count contract.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{EagerTensorLinalgExt, QrOptions};
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let (q, r) = a.qr_with_options(QrOptions::default())?;
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// assert_eq!(r.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn qr_with_options(&self, options: QrOptions) -> Result<(EagerTensor, EagerTensor)>;
     /// # Errors
     ///
@@ -61,6 +165,23 @@ pub trait EagerTensorLinalgExt {
     /// `Error::Extension` for an unsupported dtype or singular numerical
     /// result, and `Error::RuntimeState` when execution cannot access its
     /// backend.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let (_p, l, u, parity) = a.lu()?;
+    /// assert_eq!(l.shape(), &[2, 2]);
+    /// assert_eq!(u.shape(), &[2, 2]);
+    /// assert_eq!(parity.shape(), &[]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn lu(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor, EagerTensor)>;
     /// # Errors
     ///
@@ -68,6 +189,23 @@ pub trait EagerTensorLinalgExt {
     /// `Error::Extension` for unsupported dtypes or singular numerical
     /// results, and `Error::Internal` if the extension violates its output
     /// contract.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let (p, _l, _u, q, parity) = a.full_piv_lu()?;
+    /// assert_eq!(p.shape(), &[2, 2]);
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// assert_eq!(parity.shape(), &[]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn full_piv_lu(
         &self,
     ) -> Result<(
@@ -83,12 +221,50 @@ pub trait EagerTensorLinalgExt {
     /// or batch shapes, `Error::Extension` for an unsupported dtype or
     /// singular system, and `Error::RuntimeState` when the backend is
     /// unavailable.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]).unwrap(),
+    /// #     ctx.clone(),
+    /// # )?;
+    /// # let b = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 1], vec![-1.0_f64, 5.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let x = a.full_piv_lu_solve(&b)?;
+    /// assert_eq!(x.shape(), &[2, 1]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn full_piv_lu_solve(&self, b: &EagerTensor) -> Result<EagerTensor>;
     /// # Errors
     ///
     /// Returns `Error::Validation` for incompatible matrix, batch, or dtype
     /// metadata, `Error::Extension` for an unsupported dtype or singular
     /// system, and `Error::RuntimeState` when the backend is unavailable.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap(),
+    /// #     ctx.clone(),
+    /// # )?;
+    /// # let b = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 8.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let x = a.solve(&b)?;
+    /// assert_eq!(x.value()?.as_slice::<f64>()?, &[2.0, 2.0]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn solve(&self, b: &EagerTensor) -> Result<EagerTensor>;
     /// Least-squares solve `argmin_x ||A x - b||_2` for a tall or square,
     /// full-column-rank `A`, via the thin QR factorization.
@@ -101,36 +277,144 @@ pub trait EagerTensorLinalgExt {
     /// QR or triangular-solve failures; and `Error::RuntimeState` when the
     /// backend is unavailable. Rank-deficient `A` is not detected and yields an
     /// ill-defined result.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(
+    /// #         vec![3, 2],
+    /// #         vec![1.0_f64, 0.0, 1.0, 0.0, 1.0, 1.0],
+    /// #     )
+    /// #     .unwrap(),
+    /// #     ctx.clone(),
+    /// # )?;
+    /// # let b = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![3, 1], vec![1.0_f64, 2.0, 3.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let x = a.lstsq(&b)?;
+    /// assert_eq!(x.shape(), &[2, 1]);
+    /// let values = x.value()?.as_slice::<f64>()?;
+    /// assert!((values[0] - 1.0_f64).abs() < 1e-12);
+    /// assert!((values[1] - 2.0_f64).abs() < 1e-12);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn lstsq(&self, b: &EagerTensor) -> Result<EagerTensor>;
     /// # Errors
     ///
     /// Returns `Error::Validation` for a non-square or invalid-rank input,
     /// `Error::Extension` for unsupported dtypes or a non-positive-definite
     /// matrix, and `Error::RuntimeState` when the backend is unavailable.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 2.0, 2.0, 3.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let l = a.cholesky()?;
+    /// assert_eq!(l.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn cholesky(&self) -> Result<EagerTensor>;
     /// # Errors
     ///
     /// Returns `Error::Validation` for a non-square or invalid-rank input,
     /// `Error::Extension` for unsupported dtypes or numerical non-convergence,
     /// and `Error::RuntimeState` when the backend is unavailable.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let (values, vectors) = a.eigh()?;
+    /// assert_eq!(values.value()?.as_slice::<f64>()?, &[1.0, 3.0]);
+    /// assert_eq!(vectors.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn eigh(&self) -> Result<(EagerTensor, EagerTensor)>;
     /// # Errors
     ///
     /// Returns `Error::Validation` for an invalid rank, shape, or
     /// `derivative_eps`, `Error::Extension` for unsupported dtypes or
     /// non-convergence, and `Error::Internal` for an output-count violation.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{EagerTensorLinalgExt, EighOptions};
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let (values, vectors) = a.eigh_with_options(EighOptions::default())?;
+    /// assert_eq!(values.shape(), &[2]);
+    /// assert_eq!(vectors.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn eigh_with_options(&self, options: EighOptions) -> Result<(EagerTensor, EagerTensor)>;
     /// # Errors
     ///
     /// Returns `Error::Validation` for a non-square or invalid-rank input,
     /// `Error::Extension` for unsupported dtypes or numerical non-convergence,
     /// and `Error::RuntimeState` when the backend is unavailable.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let (values, vectors) = a.eig()?;
+    /// assert_eq!(values.shape(), &[2]);
+    /// assert_eq!(vectors.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn eig(&self) -> Result<(EagerTensor, EagerTensor)>;
     /// # Errors
     ///
     /// Returns `Error::Validation` for incompatible matrix, batch, or dtype
     /// metadata, `Error::Extension` for unsupported dtypes or a singular
     /// system, and `Error::RuntimeState` when the backend is unavailable.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 1.0, 3.0]).unwrap(),
+    /// #     ctx.clone(),
+    /// # )?;
+    /// # let b = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 9.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let x = a.triangular_solve(&b, true, false, false, false)?;
+    /// assert_eq!(x.shape(), &[2, 1]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn triangular_solve(
         &self,
         b: &EagerTensor,
@@ -146,6 +430,22 @@ pub trait EagerTensorLinalgExt {
     /// Returns `Error::Validation` for a non-square input, `Error::Extension`
     /// for an unsupported dtype or numerical failure, and `Error::Internal`
     /// if a primitive violates its output contract.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let (sign, logabsdet) = a.slogdet()?;
+    /// assert_eq!(sign.value()?.as_slice::<f64>()?, &[1.0]);
+    /// assert_eq!(logabsdet.shape(), &[]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn slogdet(&self) -> Result<(EagerTensor, EagerTensor)>;
     /// Return the determinant.
     ///
@@ -153,6 +453,21 @@ pub trait EagerTensorLinalgExt {
     ///
     /// Returns `Error::Validation`, `Error::Extension`, `Error::RuntimeState`,
     /// or `Error::Internal` under the conditions documented by [`Self::slogdet`].
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let determinant = a.det()?;
+    /// assert!((determinant.value()?.as_slice::<f64>()?[0] - 8.0).abs() < 1.0e-12);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn det(&self) -> Result<EagerTensor>;
     /// Return the matrix inverse.
     ///
@@ -161,6 +476,21 @@ pub trait EagerTensorLinalgExt {
     /// Returns `Error::Validation` for invalid matrix metadata,
     /// `Error::Extension` for an unsupported dtype or singular solve, and
     /// `Error::RuntimeState` when eager execution cannot access its backend.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let inverse = a.inv()?;
+    /// assert_eq!(inverse.value()?.as_slice::<f64>()?, &[0.5, 0.0, 0.0, 0.25]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn inv(&self) -> Result<EagerTensor>;
     /// Return Hermitian eigenvalues without eigenvectors.
     ///
@@ -168,6 +498,21 @@ pub trait EagerTensorLinalgExt {
     ///
     /// Returns the validation, unsupported-dtype, numerical-convergence,
     /// runtime-state, or output-contract errors reported by [`Self::eigh`].
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let values = a.eigvalsh()?;
+    /// assert_eq!(values.value()?.as_slice::<f64>()?, &[1.0, 3.0]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn eigvalsh(&self) -> Result<EagerTensor>;
     /// Return general eigenvalues without eigenvectors.
     ///
@@ -175,6 +520,21 @@ pub trait EagerTensorLinalgExt {
     ///
     /// Returns the validation, unsupported-dtype, numerical-convergence,
     /// runtime-state, or output-contract errors reported by [`Self::eig`].
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let values = a.eigvals()?;
+    /// assert_eq!(values.shape(), &[2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn eigvals(&self) -> Result<EagerTensor>;
     /// Return the Moore-Penrose pseudoinverse with the default tolerance.
     ///
@@ -183,6 +543,21 @@ pub trait EagerTensorLinalgExt {
     /// Returns `Error::Validation` for invalid matrix metadata,
     /// `Error::Extension` for unsupported SVD execution, and
     /// `Error::Internal` for an unexpected decomposition output contract.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let pseudoinverse = a.pinv()?;
+    /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn pinv(&self) -> Result<EagerTensor>;
     /// Return the Moore-Penrose pseudoinverse with an explicit relative tolerance.
     ///
@@ -190,6 +565,21 @@ pub trait EagerTensorLinalgExt {
     ///
     /// Returns `Error::Validation` when `rtol` is negative or non-finite, plus
     /// the `Error::Extension` and output-contract errors reported by [`Self::pinv`].
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let pseudoinverse = a.pinv_with_rtol(1.0e-12)?;
+    /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn pinv_with_rtol(&self, rtol: f64) -> Result<EagerTensor>;
     /// Return a vector, matrix, or tensor norm.
     ///
@@ -198,6 +588,21 @@ pub trait EagerTensorLinalgExt {
     /// Returns `Error::Validation` for an unsupported order/dimension
     /// combination or invalid axes, `Error::Extension` when a required matrix
     /// decomposition is unsupported, and eager runtime/backend failures.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 4.0]).unwrap(),
+    /// #     ctx,
+    /// # )?;
+    /// let frobenius = a.norm(None, None, false)?;
+    /// assert_eq!(frobenius.shape(), &[]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
     fn norm(&self, ord: Option<f64>, dim: Option<&[usize]>, keepdim: bool) -> Result<EagerTensor>;
 }
 
@@ -436,21 +841,43 @@ pub fn svd_with_options(
 /// # Examples
 ///
 /// ```rust
-/// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
-/// use tenferro_linalg::EagerTensorLinalgExt;
-///
-/// let ctx = EagerRuntime::new()?;
-/// let a = EagerTensor::from_tensor_in(
-///     Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]).unwrap(),
-///     ctx,
-/// ).unwrap();
-/// // Full SVD is provided by the CPU faer backend; other providers (e.g. the
-/// // LAPACK provider) report it as unsupported, so guard on the result.
-/// if let Ok((u, s, vh)) = a.svd_full() {
-///     assert_eq!(u.shape(), &[1, 1]);
-///     assert_eq!(s.shape(), &[1]);
-///     assert_eq!(vh.shape(), &[2, 2]);
-/// }
+/// # #[cfg(feature = "cpu-faer")]
+/// # {
+/// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+/// # use tenferro_cpu::{CpuBackend, CpuBackendKind};
+/// # use tenferro_linalg::EagerTensorLinalgExt;
+/// # let faer = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer)
+/// #     .expect("faer CPU backend");
+/// # let ctx = EagerRuntime::with_cpu_backend(faer)?;
+/// # let a = EagerTensor::from_tensor_in(
+/// #     Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]).unwrap(),
+/// #     ctx,
+/// # )?;
+/// let (u, s, vh) = a.svd_full()?;
+/// assert_eq!(u.shape(), &[1, 1]);
+/// assert_eq!(s.shape(), &[1]);
+/// assert_eq!(vh.shape(), &[2, 2]);
+/// let singular_values = s.value()?.as_slice::<f64>()?;
+/// assert!((singular_values[0] - 2.0_f64.sqrt()).abs() < 1e-12);
+/// # }
+/// # #[cfg(all(feature = "cpu-blas", not(feature = "cpu-faer")))]
+/// # {
+/// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+/// # use tenferro_cpu::{CpuBackend, CpuBackendKind};
+/// # let blas = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Blas)
+/// #     .expect("BLAS CPU backend");
+/// # let ctx = EagerRuntime::with_cpu_backend(blas)?;
+/// # let a = EagerTensor::from_tensor_in(
+/// #     Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]).unwrap(),
+/// #     ctx,
+/// # )?;
+/// # use tenferro_linalg::EagerTensorLinalgExt;
+/// # let error = match a.svd_full() {
+/// #     Ok(_) => panic!("expected full-matrices SVD to be unsupported for BLAS"),
+/// #     Err(error) => error,
+/// # };
+/// # assert!(error.to_string().contains("full-matrices SVD"));
+/// # }
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
 ///

--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -124,6 +124,21 @@ pub trait TensorLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, numerical, or output-contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (_u, s, _vt) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.svd(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(s.shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn svd<B: LinalgBackend>(
         &self,
         backend: &mut B,
@@ -131,6 +146,23 @@ pub trait TensorLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for matrix metadata or options, plus SVD backend errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::{SvdOptions, TensorLinalgExt};
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (_u, s, _vt) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         a.svd_with_options(SvdOptions::default(), backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(s.shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn svd_with_options<B: LinalgBackend>(
         &self,
         options: SvdOptions,
@@ -139,10 +171,44 @@ pub trait TensorLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, numerical, or output-contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (q, r) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.qr(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// assert_eq!(r.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn qr<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for matrix metadata or options, plus QR backend errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::{QrOptions, TensorLinalgExt};
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (q, r) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         a.qr_with_options(QrOptions::default(), backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// assert_eq!(r.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn qr_with_options<B: LinalgBackend>(
         &self,
         options: QrOptions,
@@ -151,6 +217,23 @@ pub trait TensorLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, numerical, or output-contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (_p, l, u, parity) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.lu(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(l.shape(), &[2, 2]);
+    /// assert_eq!(u.shape(), &[2, 2]);
+    /// assert_eq!(parity.shape(), &[]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn lu<B: LinalgBackend>(
         &self,
         backend: &mut B,
@@ -158,6 +241,23 @@ pub trait TensorLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, numerical, or output-contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (p, _l, _u, q, parity) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.full_piv_lu(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(p.shape(), &[2, 2]);
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// assert_eq!(parity.shape(), &[]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn full_piv_lu<B: LinalgBackend>(
         &self,
         backend: &mut B,
@@ -165,6 +265,22 @@ pub trait TensorLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for incompatible inputs or a backend/singular-system error.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0])?;
+    /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![-1.0_f64, 5.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let x = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.full_piv_lu_solve(&b, backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(x.shape(), &[2, 1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn full_piv_lu_solve<B: LinalgBackend>(
         &self,
         b: &Tensor,
@@ -173,6 +289,22 @@ pub trait TensorLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for incompatible inputs or a backend/singular-system error.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 8.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let x = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.solve(&b, backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(x.as_slice::<f64>()?, &[2.0, 2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn solve<B: LinalgBackend>(
         &self,
         b: &Tensor,
@@ -181,14 +313,63 @@ pub trait TensorLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for a non-square input or backend/numerical errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 2.0, 2.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let l = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.cholesky(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(l.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn cholesky<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, convergence, or output-contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (values, vectors) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.eigh(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.as_slice::<f64>()?, &[1.0, 3.0]);
+    /// assert_eq!(vectors.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eigh<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for matrix metadata or options, plus Eigh backend errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::{EighOptions, TensorLinalgExt};
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (values, vectors) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         a.eigh_with_options(EighOptions::default(), backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.shape(), &[2]);
+    /// assert_eq!(vectors.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eigh_with_options<B: LinalgBackend>(
         &self,
         options: EighOptions,
@@ -197,11 +378,45 @@ pub trait TensorLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, convergence, or output-contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (values, vectors) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.eig(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.shape(), &[2]);
+    /// assert_eq!(vectors.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eig<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for incompatible inputs/flags or backend/numerical errors.
     #[allow(clippy::too_many_arguments)]
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 1.0, 3.0])?;
+    /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 9.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let x = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         a.triangular_solve(&b, true, false, false, false, backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(x.shape(), &[2, 1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn triangular_solve<B: LinalgBackend>(
         &self,
         b: &Tensor,
@@ -214,6 +429,22 @@ pub trait TensorLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, numerical, or LU output-contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (sign, logabsdet) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.slogdet(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(sign.as_slice::<f64>()?, &[1.0]);
+    /// assert_eq!(logabsdet.shape(), &[]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn slogdet<B: LinalgBackend>(
         &self,
         backend: &mut B,
@@ -221,26 +452,116 @@ pub trait TensorLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns the validation, backend, numerical, or contract errors from [`Self::slogdet`].
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let determinant = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.det(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert!((determinant.as_slice::<f64>()?[0] - 8.0).abs() < 1.0e-12);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn det<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, or singular-solve numerical errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let inverse = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.inv(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(inverse.as_slice::<f64>()?, &[0.5, 0.0, 0.0, 0.25]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn inv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns the validation, backend, convergence, or contract errors from [`Self::eigh`].
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let values = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.eigvalsh(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.as_slice::<f64>()?, &[1.0, 3.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eigvalsh<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns the validation, backend, convergence, or contract errors from [`Self::eig`].
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let values = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.eigvals(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eigvals<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, numerical, or SVD contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let pseudoinverse = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.pinv(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns a validation error for invalid `rtol`, plus errors from [`Self::pinv`].
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let pseudoinverse = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.pinv_with_rtol(1.0e-12, backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn pinv_with_rtol<B: LinalgBackend>(
         &self,
         rtol: f64,
@@ -249,6 +570,21 @@ pub trait TensorLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for axes/order combinations or required backend operations.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let frobenius = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.norm(None, None, false, backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(frobenius.shape(), &[]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn norm<B: LinalgBackend>(
         &self,
         ord: Option<f64>,
@@ -282,6 +618,23 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, same-placement materialization, backend, numerical, or contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (_u, s, _vt) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).svd_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(s.shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn svd_read<B: LinalgBackend>(
         self,
         backend: &mut B,
@@ -289,6 +642,24 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for metadata/options, plus read/materialization or SVD errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::{SvdOptions, TensorReadLinalgExt};
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (_u, s, _vt) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a)
+    ///             .svd_with_options_read(SvdOptions::default(), backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(s.shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn svd_with_options_read<B: LinalgBackend>(
         self,
         options: SvdOptions,
@@ -297,6 +668,24 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, same-placement materialization, backend, numerical, or contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (q, r) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).qr_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// assert_eq!(r.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn qr_read<B: LinalgBackend>(
         self,
         backend: &mut B,
@@ -304,6 +693,25 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for metadata/options, plus read/materialization or QR errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::{QrOptions, TensorReadLinalgExt};
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (q, r) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a)
+    ///             .qr_with_options_read(QrOptions::default(), backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// assert_eq!(r.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn qr_with_options_read<B: LinalgBackend>(
         self,
         options: QrOptions,
@@ -312,6 +720,24 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, same-placement materialization, backend, numerical, or contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (_p, l, u, _parity) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).lu_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(l.shape(), &[2, 2]);
+    /// assert_eq!(u.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn lu_read<B: LinalgBackend>(
         self,
         backend: &mut B,
@@ -319,6 +745,24 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, same-placement materialization, backend, numerical, or contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (p, _l, _u, q, _parity) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).full_piv_lu_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(p.shape(), &[2, 2]);
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn full_piv_lu_read<B: LinalgBackend>(
         self,
         backend: &mut B,
@@ -326,6 +770,25 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns incompatible-input validation, read/materialization, backend, or singular errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0])?;
+    /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![-1.0_f64, 5.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let x = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a)
+    ///             .full_piv_lu_solve_read(TensorRead::from_tensor(&b), backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(x.shape(), &[2, 1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn full_piv_lu_solve_read<B: LinalgBackend>(
         self,
         b: TensorRead<'_>,
@@ -334,6 +797,24 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns incompatible-input validation, read/materialization, backend, or singular errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 8.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let x = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).solve_read(TensorRead::from_tensor(&b), backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(x.as_slice::<f64>()?, &[2.0, 2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn solve_read<B: LinalgBackend>(
         self,
         b: TensorRead<'_>,
@@ -352,6 +833,29 @@ pub trait TensorReadLinalgExt {
     /// for aliasing or placement violations, `Error::Unsupported` when the
     /// extension implementation or provider is unavailable, and `Error::Singular`
     /// for a singular system.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead, TensorWrite};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 8.0])?;
+    /// # let mut out = Tensor::from_vec_col_major(vec![2, 1], vec![0.0_f64; 2])?;
+    /// # let mut host = CpuBackend::new();
+    /// host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).solve_read_into(
+    ///             TensorRead::from_tensor(&b),
+    ///             TensorWrite::from_tensor(&mut out),
+    ///             backend,
+    ///         )
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(out.as_slice::<f64>()?, &[2.0, 2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn solve_read_into<B: LinalgBackend>(
         self,
         b: TensorRead<'_>,
@@ -370,10 +874,45 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns matrix validation, read/materialization, backend, or positive-definiteness errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 2.0, 2.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let l = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).cholesky_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(l.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn cholesky_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, convergence, or contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (values, vectors) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).eigh_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.as_slice::<f64>()?, &[1.0, 3.0]);
+    /// assert_eq!(vectors.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eigh_read<B: LinalgBackend>(
         self,
         backend: &mut B,
@@ -381,6 +920,25 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for metadata/options, plus read or Eigh backend errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::{EighOptions, TensorReadLinalgExt};
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (values, vectors) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a)
+    ///             .eigh_with_options_read(EighOptions::default(), backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.shape(), &[2]);
+    /// assert_eq!(vectors.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eigh_with_options_read<B: LinalgBackend>(
         self,
         options: EighOptions,
@@ -389,6 +947,24 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, convergence, or contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (values, vectors) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).eig_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.shape(), &[2]);
+    /// assert_eq!(vectors.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eig_read<B: LinalgBackend>(
         self,
         backend: &mut B,
@@ -397,6 +973,31 @@ pub trait TensorReadLinalgExt {
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns incompatible-input/flag validation, read, backend, or singular errors.
     #[allow(clippy::too_many_arguments)]
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 1.0, 3.0])?;
+    /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 9.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let x = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).triangular_solve_read(
+    ///             TensorRead::from_tensor(&b),
+    ///             true,
+    ///             false,
+    ///             false,
+    ///             false,
+    ///             backend,
+    ///         )
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(x.shape(), &[2, 1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn triangular_solve_read<B: LinalgBackend>(
         self,
         b: TensorRead<'_>,
@@ -409,6 +1010,24 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, numerical, or LU contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (sign, logabsdet) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).slogdet_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(sign.as_slice::<f64>()?, &[1.0]);
+    /// assert_eq!(logabsdet.shape(), &[]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn slogdet_read<B: LinalgBackend>(
         self,
         backend: &mut B,
@@ -416,26 +1035,128 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, numerical, or contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let determinant = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).det_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert!((determinant.as_slice::<f64>()?[0] - 8.0).abs() < 1.0e-12);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn det_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, or singular-solve errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let inverse = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).inv_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(inverse.as_slice::<f64>()?, &[0.5, 0.0, 0.0, 0.25]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn inv_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, convergence, or contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let values = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).eigvalsh_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.as_slice::<f64>()?, &[1.0, 3.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eigvalsh_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, convergence, or contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let values = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).eigvals_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eigvals_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, numerical, or SVD contract errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let pseudoinverse = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).pinv_read(backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn pinv_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns a validation error for invalid `rtol`, plus errors from [`Self::pinv_read`].
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let pseudoinverse = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).pinv_with_rtol_read(1.0e-12, backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn pinv_with_rtol_read<B: LinalgBackend>(
         self,
         rtol: f64,
@@ -444,6 +1165,23 @@ pub trait TensorReadLinalgExt {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for axes/order combinations or required read/backend operations.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TensorReadLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let frobenius = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         TensorRead::from_tensor(&a).norm_read(None, None, false, backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(frobenius.shape(), &[]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn norm_read<B: LinalgBackend>(
         self,
         ord: Option<f64>,
@@ -481,10 +1219,42 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (_u, s, _vt) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.svd(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(s.as_slice()?, &[4.0, 2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn svd<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedSvd<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for metadata/options, plus backend or typed-output errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::{SvdOptions, TypedTensorLinalgExt};
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (_u, s, _vt) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         a.svd_with_options(SvdOptions::default(), backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(s.as_slice()?, &[4.0, 2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn svd_with_options<B: LinalgBackend>(
         &self,
         options: SvdOptions,
@@ -493,6 +1263,22 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (q, r) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.qr(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// assert_eq!(r.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn qr<B: LinalgBackend>(
         &self,
         backend: &mut B,
@@ -500,6 +1286,24 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for metadata/options, plus backend or typed-output errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::{QrOptions, TypedTensorLinalgExt};
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (q, r) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         a.qr_with_options(QrOptions::default(), backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// assert_eq!(r.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn qr_with_options<B: LinalgBackend>(
         &self,
         options: QrOptions,
@@ -508,10 +1312,42 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (_p, l, u, _parity) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.lu(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(l.shape(), &[2, 2]);
+    /// assert_eq!(u.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn lu<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedLu<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (p, _l, _u, q, _parity) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.full_piv_lu(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(p.shape(), &[2, 2]);
+    /// assert_eq!(q.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn full_piv_lu<B: LinalgBackend>(
         &self,
         backend: &mut B,
@@ -519,6 +1355,22 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns incompatible-input validation, backend, singular, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![0.0, 2.0, 1.0, 3.0])?;
+    /// # let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 1], vec![-1.0, 5.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let x = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.full_piv_lu_solve(&b, backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(x.shape(), &[2, 1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn full_piv_lu_solve<B: LinalgBackend>(
         &self,
         b: &TypedTensor<T>,
@@ -527,6 +1379,22 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns incompatible-input validation, backend, singular, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
+    /// # let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 1], vec![4.0, 8.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let x = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.solve(&b, backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(x.as_slice()?, &[2.0, 2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn solve<B: LinalgBackend>(
         &self,
         b: &TypedTensor<T>,
@@ -535,6 +1403,21 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns matrix validation, backend, positive-definiteness, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![4.0, 2.0, 2.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let l = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.cholesky(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(l.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn cholesky<B: LinalgBackend>(
         &self,
         backend: &mut B,
@@ -542,6 +1425,22 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, convergence, output-contract, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (values, vectors) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.eigh(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.as_slice()?, &[1.0, 3.0]);
+    /// assert_eq!(vectors.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eigh<B: LinalgBackend>(
         &self,
         backend: &mut B,
@@ -549,6 +1448,24 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for metadata/options, plus backend or typed-output errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::{EighOptions, TypedTensorLinalgExt};
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (values, vectors) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         a.eigh_with_options(EighOptions::default(), backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.shape(), &[2]);
+    /// assert_eq!(vectors.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eigh_with_options<B: LinalgBackend>(
         &self,
         options: EighOptions,
@@ -557,11 +1474,45 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, convergence, output-contract, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (values, vectors) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.eig(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.shape(), &[2]);
+    /// assert_eq!(vectors.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eig<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedEig<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns incompatible-input/flag validation, backend, singular, or typed-output errors.
     #[allow(clippy::too_many_arguments)]
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 1.0, 3.0])?;
+    /// # let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 1], vec![4.0, 9.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let x = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         a.triangular_solve(&b, true, false, false, false, backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(x.shape(), &[2, 1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn triangular_solve<B: LinalgBackend>(
         &self,
         b: &TypedTensor<T>,
@@ -574,6 +1525,22 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let (sign, logabsdet) = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.slogdet(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(sign.as_slice()?, &[1.0]);
+    /// assert_eq!(logabsdet.shape(), &[]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn slogdet<B: LinalgBackend>(
         &self,
         backend: &mut B,
@@ -581,14 +1548,59 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let determinant = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.det(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert!((determinant.as_slice()?[0] - 8.0).abs() < 1.0e-12);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn det<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, singular-solve, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let inverse = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.inv(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(inverse.as_slice()?, &[0.5, 0.0, 0.0, 0.25]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn inv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, convergence, output-contract, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 3.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let values = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.eigvalsh(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.as_slice()?, &[1.0, 3.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eigvalsh<B: LinalgBackend>(
         &self,
         backend: &mut B,
@@ -596,6 +1608,21 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, convergence, output-contract, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let values = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.eigvals(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(values.shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn eigvals<B: LinalgBackend>(
         &self,
         backend: &mut B,
@@ -603,10 +1630,42 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let pseudoinverse = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.pinv(backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns a validation error for invalid `rtol`, plus backend or typed-output errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let pseudoinverse = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         a.pinv_with_rtol(1.0e-12, backend)
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn pinv_with_rtol<B: LinalgBackend>(
         &self,
         rtol: f64,
@@ -615,6 +1674,21 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for axes/order combinations, backend, or typed-output errors.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_linalg::TypedTensorLinalgExt;
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![3.0, 0.0, 0.0, 4.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let frobenius = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| a.norm(None, None, false, backend))
+    ///         .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(frobenius.shape(), &[]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn norm<B: LinalgBackend>(
         &self,
         ord: Option<f64>,

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -1910,6 +1910,18 @@ impl TracedTensor {
     ///
     /// Unsupported dtypes and backend execution failures are reported when the
     /// compiled graph is executed.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_runtime::TracedTensor;
+    /// # let x = TracedTensor::from_vec_col_major(
+    /// #     vec![2, 2],
+    /// #     vec![1.0_f64, 2.0, 3.0, 4.0],
+    /// # )?;
+    /// let squares = x.reduce_sum_squares(&[1])?;
+    /// assert_eq!(squares.rank, 1);
+    /// # Ok::<(), tenferro_runtime::Error>(())
+    /// ```
     pub fn reduce_sum_squares(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_sum_squares")?;

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -5266,6 +5266,16 @@ impl<'a> TensorRead<'a> {
     ///
     /// Owned tensors are borrowed without copying their storage. Existing
     /// views preserve their layout and placement metadata.
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_tensor::{Tensor, TensorRead};
+    /// # let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
+    /// let view = TensorRead::from_tensor(&tensor).tensor_view();
+    /// assert_eq!(view.shape(), &[2]);
+    /// assert_eq!(view.as_slice::<f64>()?, &[1.0, 2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn tensor_view(self) -> TensorView<'a> {
         match self {
             Self::Tensor(tensor) => tensor_view_with_layout(tensor, tensor_layout(tensor)),


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] Documentation
- [ ] Refactor / cleanup
- [x] Implementation of accepted issue

## Related issue

Fixes #1575

## Summary

Adds runnable method-level `# Examples` doctests for the accepted public documentation backlog:

- 64 concrete/read/typed linalg trait methods;
- 23 eager linalg trait methods;
- `TracedTensor::reduce_sum_squares`;
- `EagerTensor::{scale_real, scale_complex}`;
- `TensorRead::tensor_view`.

Every example invokes the exact method it documents using the correct receiver surface and deterministic CPU/faer data. The eager `lstsq` example uses the accepted 3x2 full-rank system and checks shape and values. No API signatures, dependencies, parser/generator, ignored doctests, or out-of-scope files changed.

## RED / GREEN inventory

A one-off scoped inventory inspected the immediately preceding doc block for every accepted method.

- **RED:** 91 methods missing their own nearby `# Examples` block:
  - `TensorLinalgExt`: 21
  - `TensorReadLinalgExt`: 22
  - `TypedTensorLinalgExt`: 21
  - `EagerTensorLinalgExt`: 23
  - named non-linalg methods: 4
- **GREEN:** 0 missing.

The command and complete 91-name baseline are recorded in the implementation report used during review; no parser or inventory script was added to the repository.

## Review and CI corrections

Independent review found a false-green `svd_full` example that conditionally discarded an unsupported-provider error. It now selects `CpuBackendKind::Faer`, propagates `a.svd_full()?`, and asserts all shapes plus the expected singular value.

The first hosted CPU-BLAS run then exposed two backend-sensitive doctest defects: exact floating-point equality in `lstsq`, and unconditional Faer selection in a BLAS-only build. The final examples use tolerance checks for both least-squares values; full-SVD executes and validates the Faer success path, while the BLAS-only path invokes the same method and requires the documented unsupported error. A scoped re-review and final branch review found no remaining Critical, Important, or Minor issue.

## Work log

Existing durable audit record: [`docs/worklogs/2026-08-01-rules-review-structural-checks.md`](docs/worklogs/2026-08-01-rules-review-structural-checks.md), which identifies #1575 as the accepted current backlog. The accepted scope permits only the five documented source files, so no duplicate session report was added.

## Verification

- `cargo fmt --all --check`
- CI-parity workspace and extension clippy via `python3 scripts/ci/run_profile.py clippy`
- `cargo test --workspace --release`
- `cargo test -p tenferro-linalg --doc --features autodiff` — 174 passed
- `cargo test -p tenferro-runtime --doc` — 410 passed
- `cargo test -p tenferro-ad --doc` — 144 passed
- `cargo test -p tenferro-tensor --doc` — 325 passed
- `RUSTFLAGS='-l dylib=openblas -l dylib=lapack' cargo test --doc --workspace --profile ci --no-default-features --features cpu-blas`
- `python3 scripts/ci/run_profile.py coverage` — 209/209 files passed
- `cargo doc --workspace --no-deps`
- `python3 scripts/ci/run_profile.py docs` — docs-site and consistency checks passed
- `python3 scripts/check-public-error-docs.py`
- `python3 scripts/test-repository-rules-review.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1575.json` — pass

The final repository-rules review processed four chunks and returned zero findings.

## Residual risks

No known source-level residual risk remains. Protected CI supplies the final hosted feature/platform evidence after the rewritten branch is pushed.

## Checklist

- [x] I read `CONTRIBUTING.md` and `REPOSITORY_RULES.md`.
- [x] I added runnable method-level examples and executed all affected doctest suites.
- [x] I ran local repository-rules LLM review and resolved its warning with direct doctest evidence.
- [x] The linked issue has an accepted implementation plan.
- [x] The existing durable audit work log is linked above.
