### PR TITLE
ci: audit examples on public trait methods

### DIFF
--- a/docs/worklogs/2026-08-01-rules-review-structural-checks.md
+++ b/docs/worklogs/2026-08-01-rules-review-structural-checks.md
@@ -91,9 +91,10 @@ judgment.
 - The diagram-sync check only runs when a `crates/*/Cargo.toml` or the
   architecture doc changes, so pre-existing drift (issue #1578) surfaces on
   the next touching PR rather than immediately.
-- `missing-doc-examples` treats a trait-level example as satisfying the
-  mandate for the trait item; per-method gaps inside traits remain LLM-only
-  (issue #1575 tracks the current backlog).
+- Issue #1605 is resolved: `missing-doc-examples` now checks diff-added
+  methods inside reachable public traits. The check remains diff-scoped, so
+  unchanged methods and non-public traits remain outside the deterministic
+  audit.
 
 ## Review Follow-ups (Codex on PR #1582)
 

--- a/scripts/repository-rules-review.py
+++ b/scripts/repository-rules-review.py
@@ -1476,8 +1476,8 @@ def strip_code_comments(line: str, in_block_comment: bool) -> tuple[str, bool]:
 
 
 def strip_code_comments_and_literals(
-    line: str, state: tuple[bool, bool, int | None]
-) -> tuple[str, tuple[bool, bool, int | None]]:
+    line: str, state: tuple[int, bool, int | None]
+) -> tuple[str, tuple[int, bool, int | None]]:
     """Drop comments AND string/char literal contents, for brace counting.
 
     A brace inside a literal is not structural: `let expected = "}";` inside an
@@ -1487,27 +1487,38 @@ def strip_code_comments_and_literals(
     `strip_code_comments`, because a forbidden symbol appearing inside a string
     is still worth reporting there.
 
-    `state` is `(in_block_comment, in_string, raw_hashes)`; `raw_hashes` is the
-    `#` count of an open raw string (`r#"..."#`), or `None` when not in one.
-    Rust normal strings and raw strings may span lines, hence the carried state.
+    `state` is `(block_comment_depth, in_string, raw_hashes)`;
+    `raw_hashes` is the `#` count of an open raw string (`r#"..."#`), or `None`
+    when not in one. Rust normal strings and raw strings may span lines, hence
+    the carried state. Rust block comments may nest, so the depth is carried
+    rather than reduced to a boolean.
     """
-    in_block_comment, in_string, raw_hashes = state
+    block_comment_depth, in_string, raw_hashes = state
     result: list[str] = []
     index = 0
     length = len(line)
     while index < length:
-        if in_block_comment:
-            end = line.find("*/", index)
-            if end == -1:
-                return "".join(result), (True, False, None)
-            index = end + 2
-            in_block_comment = False
+        if block_comment_depth:
+            opening = line.find("/*", index)
+            closing = line.find("*/", index)
+            if closing == -1:
+                if opening == -1:
+                    return "".join(result), (block_comment_depth, False, None)
+                block_comment_depth += 1
+                index = opening + 2
+                continue
+            if opening != -1 and opening < closing:
+                block_comment_depth += 1
+                index = opening + 2
+                continue
+            block_comment_depth -= 1
+            index = closing + 2
             continue
         if raw_hashes is not None:
             closer = '"' + "#" * raw_hashes
             end = line.find(closer, index)
             if end == -1:
-                return "".join(result), (False, False, raw_hashes)
+                return "".join(result), (0, False, raw_hashes)
             index = end + len(closer)
             raw_hashes = None
             continue
@@ -1515,17 +1526,19 @@ def strip_code_comments_and_literals(
             index, in_string = _scan_string_body(line, index)
             continue
         if line.startswith("/*", index):
-            in_block_comment = True
+            block_comment_depth = 1
             index += 2
             continue
         if line.startswith("//", index):
             break
         raw = RAW_STRING_OPEN.match(line, index)
         if raw:
+            result.append('""')
             raw_hashes = len(raw.group(1))
             index = raw.end()
             continue
         if line[index] == '"':
+            result.append('""')
             index, in_string = _scan_string_body(line, index + 1)
             continue
         if line[index] == "'":
@@ -1539,7 +1552,18 @@ def strip_code_comments_and_literals(
             continue
         result.append(line[index])
         index += 1
-    return "".join(result), (in_block_comment, in_string, raw_hashes)
+    return "".join(result), (block_comment_depth, in_string, raw_hashes)
+
+
+def rust_code_lines(text: str) -> tuple[list[str], list[str]]:
+    """Return source lines and their comment/string-stripped counterparts."""
+    lines = text.splitlines()
+    code_lines: list[str] = []
+    scan_state: tuple[int, bool, int | None] = (0, False, None)
+    for line in lines:
+        code, scan_state = strip_code_comments_and_literals(line, scan_state)
+        code_lines.append(code)
+    return lines, code_lines
 
 
 def _scan_string_body(line: str, index: int) -> tuple[int, bool]:
@@ -1614,6 +1638,13 @@ INLINE_TEST_MOD = re.compile(r"^(?:pub(?:\([^)]*\))?\s+)?mod\s+\w+\s*\{")
 PUB_ITEM = re.compile(
     r"^\s*pub\s+(?:async\s+|unsafe\s+|const\s+|extern\s+\"[^\"]*\"\s+)*"
     r"(fn|struct|enum|union|trait|type)\s+([A-Za-z_]\w*)"
+)
+PUB_TRAIT = re.compile(
+    r"^\s*pub\s+(?:(?:unsafe|auto)\s+)*trait\s+([A-Za-z_]\w*)\b"
+)
+TRAIT_METHOD = re.compile(
+    r"^\s*(?:(?:async|unsafe|const)\s+|extern\s+\"[^\"]*\"\s+)*"
+    r"fn\s+([A-Za-z_]\w*)\b"
 )
 AI_REPORT_PATH = re.compile(r"(^|/)\.superpowers/|-report\.md$")
 RUST_MOD_OPEN = re.compile(r"^(?:pub(\([^)]*\))?\s+)?mod\s+\w+\s*\{")
@@ -1930,6 +1961,30 @@ def rust_private_mod_spans(text: str) -> list[tuple[int, int]]:
     return spans
 
 
+def rust_public_trait_spans(text: str) -> list[tuple[int, int, str]]:
+    """Return 1-based (start, end, name) spans for public trait bodies."""
+    _, code_lines = rust_code_lines(text)
+    total = len(code_lines)
+    spans: list[tuple[int, int, str]] = []
+    for index, code_line in enumerate(code_lines):
+        match = PUB_TRAIT.match(code_line)
+        if not match:
+            continue
+        depth = 0
+        opened = False
+        end = total - 1
+        for cursor in range(index, total):
+            code = code_lines[cursor]
+            depth += code.count("{") - code.count("}")
+            opened = opened or "{" in code
+            if opened and depth <= 0:
+                end = cursor
+                break
+        if opened:
+            spans.append((index + 1, end + 1, match.group(1)))
+    return spans
+
+
 def doc_block_above(lines: list[str], item_index: int) -> tuple[bool, bool]:
     """Return (has_examples, is_doc_hidden) for the doc/attr block above an item."""
     has_examples = False
@@ -2099,14 +2154,14 @@ def missing_doc_example_findings(
         )
         if not reachable:
             continue
-        lines = text.splitlines()
+        lines, code_lines = rust_code_lines(text)
         skip_spans = rust_inline_test_blocks(text) + rust_private_mod_spans(text)
         missing: list[str] = []
         first_line: int | None = None
         for line_no in sorted(touched):
             if line_no > len(lines):
                 continue
-            match = PUB_ITEM.match(lines[line_no - 1])
+            match = PUB_ITEM.match(code_lines[line_no - 1])
             if not match:
                 continue
             if any(start <= line_no <= end for start, end in skip_spans):
@@ -2121,6 +2176,35 @@ def missing_doc_example_findings(
             missing.append(f"{match.group(1)} {match.group(2)} (line {line_no})")
             if first_line is None:
                 first_line = line_no
+
+        for trait_start, trait_end, trait_name in rust_public_trait_spans(text):
+            if item_filter is not None and trait_name not in item_filter:
+                # A selective module re-export exposes the trait name, not its
+                # individual associated methods.
+                continue
+            depth = 0
+            for line_no in range(trait_start, trait_end + 1):
+                code_line = code_lines[line_no - 1]
+                if (
+                    depth == 1
+                    and line_no in touched
+                    and not any(
+                        start <= line_no <= end for start, end in skip_spans
+                    )
+                ):
+                    method = TRAIT_METHOD.match(code_line)
+                    if method:
+                        has_examples, hidden = doc_block_above(
+                            lines, line_no - 1
+                        )
+                        if not has_examples and not hidden:
+                            missing.append(
+                                f"{trait_name}::{method.group(1)} "
+                                f"(line {line_no})"
+                            )
+                            if first_line is None:
+                                first_line = line_no
+                depth += code_line.count("{") - code_line.count("}")
         if missing:
             shown = ", ".join(missing[:10])
             extra = f", +{len(missing) - 10} more" if len(missing) > 10 else ""

--- a/scripts/test-repository-rules-review.py
+++ b/scripts/test-repository-rules-review.py
@@ -1257,6 +1257,346 @@ def test_missing_doc_example_findings_ignores_unchanged_items() -> None:
     assert findings == []
 
 
+def test_missing_doc_example_findings_flags_added_public_trait_method() -> None:
+    mod = load_module()
+    source = "\n".join(
+        [
+            "pub trait PublicApi {",
+            "    fn old(&self);",
+            "    fn method(&self);",
+            "}",
+        ]
+    )
+    _with_fake_text(mod, {"crates/x/src/lib.rs": source})
+    diff = "\n".join(
+        [
+            "diff --git a/crates/x/src/lib.rs b/crates/x/src/lib.rs",
+            "--- a/crates/x/src/lib.rs",
+            "+++ b/crates/x/src/lib.rs",
+            "@@ -1,3 +1,4 @@",
+            " pub trait PublicApi {",
+            "     fn old(&self);",
+            "+    fn method(&self);",
+            " }",
+        ]
+    )
+    findings = mod.missing_doc_example_findings(
+        ["crates/x/src/lib.rs"],
+        ref="HEAD",
+        worktree=False,
+        added_lines=mod.added_lines_by_file(diff),
+    )
+    assert len(findings) == 1
+    assert findings[0].id == "missing-doc-examples"
+    assert findings[0].severity == "warn"
+    assert "PublicApi::method" in findings[0].detail
+
+
+def test_missing_doc_example_findings_accepts_trait_method_examples() -> None:
+    mod = load_module()
+    source = "\n".join(
+        [
+            "/// Public API.",
+            "///",
+            "/// # Examples",
+            "///",
+            "/// ```",
+            "/// let _ = 1;",
+            "/// ```",
+            "pub trait PublicApi {",
+            "    /// Calls the API.",
+            "    ///",
+            "    /// # Examples",
+            "    ///",
+            "    /// ```",
+            "    /// let _ = 1;",
+            "    /// ```",
+            "    fn method(&self);",
+            "}",
+        ]
+    )
+    _with_fake_text(mod, {"crates/x/src/lib.rs": source})
+    findings = mod.missing_doc_example_findings(
+        ["crates/x/src/lib.rs"],
+        ref="HEAD",
+        worktree=False,
+        added_lines={"crates/x/src/lib.rs": {16}},
+    )
+    assert findings == []
+
+
+def test_missing_doc_example_findings_skips_hidden_trait_methods() -> None:
+    mod = load_module()
+    source = "\n".join(
+        [
+            "/// Public API.",
+            "///",
+            "/// # Examples",
+            "///",
+            "/// ```",
+            "/// let _ = 1;",
+            "/// ```",
+            "pub trait PublicApi {",
+            "    #[doc(hidden)]",
+            "    fn hidden_method(&self);",
+            "}",
+        ]
+    )
+    _with_fake_text(mod, {"crates/x/src/lib.rs": source})
+    findings = mod.missing_doc_example_findings(
+        ["crates/x/src/lib.rs"],
+        ref="HEAD",
+        worktree=False,
+        added_lines={"crates/x/src/lib.rs": {10}},
+    )
+    assert findings == []
+
+
+def test_missing_doc_example_findings_skips_private_traits() -> None:
+    mod = load_module()
+    source = "\n".join(
+        [
+            "trait PrivateApi {",
+            "    fn method(&self);",
+            "}",
+        ]
+    )
+    _with_fake_text(mod, {"crates/x/src/lib.rs": source})
+    findings = mod.missing_doc_example_findings(
+        ["crates/x/src/lib.rs"],
+        ref="HEAD",
+        worktree=False,
+        added_lines={"crates/x/src/lib.rs": {1, 2, 3}},
+    )
+    assert findings == []
+
+
+def test_missing_doc_example_findings_recognizes_trait_method_forms() -> None:
+    mod = load_module()
+    source = "\n".join(
+        [
+            "/// Public API.",
+            "///",
+            "/// # Examples",
+            "///",
+            "/// ```",
+            "/// let _ = 1;",
+            "/// ```",
+            "pub trait PublicApi {",
+            "    fn required(&self);",
+            "    fn provided(&self) {",
+            "        // } in a comment",
+            '        let _string = "}";',
+            "        /* { in a block comment */",
+            "        let _value = 1;",
+            "    }",
+            "    fn default_method(&self) {",
+            '        let _raw = r#"} {"#;',
+            "    }",
+            "    async fn async_method(&self);",
+            "    unsafe fn unsafe_method(&self);",
+            "    const fn const_method(&self);",
+            '    extern "C" fn extern_method(&self);',
+            "}",
+        ]
+    )
+    _with_fake_text(mod, {"crates/x/src/lib.rs": source})
+    findings = mod.missing_doc_example_findings(
+        ["crates/x/src/lib.rs"],
+        ref="HEAD",
+        worktree=False,
+        added_lines={"crates/x/src/lib.rs": set(range(1, len(source.splitlines()) + 1))},
+    )
+    assert len(findings) == 1
+    detail = findings[0].detail
+    for method in (
+        "required",
+        "provided",
+        "default_method",
+        "async_method",
+        "unsafe_method",
+        "const_method",
+        "extern_method",
+    ):
+        assert f"PublicApi::{method}" in detail
+
+
+def test_missing_doc_example_findings_ignores_unchanged_trait_methods() -> None:
+    mod = load_module()
+    source = "\n".join(
+        [
+            "pub trait PublicApi {",
+            "    fn old(&self);",
+            "    // unrelated changed line",
+            "}",
+        ]
+    )
+    _with_fake_text(mod, {"crates/x/src/lib.rs": source})
+    diff = "\n".join(
+        [
+            "diff --git a/crates/x/src/lib.rs b/crates/x/src/lib.rs",
+            "--- a/crates/x/src/lib.rs",
+            "+++ b/crates/x/src/lib.rs",
+            "@@ -1,3 +1,4 @@",
+            " pub trait PublicApi {",
+            "     fn old(&self);",
+            "+    // unrelated changed line",
+            " }",
+        ]
+    )
+    findings = mod.missing_doc_example_findings(
+        ["crates/x/src/lib.rs"],
+        ref="HEAD",
+        worktree=False,
+        added_lines=mod.added_lines_by_file(diff),
+    )
+    assert findings == []
+
+
+def test_missing_doc_example_findings_uses_trait_name_for_selective_reexports() -> None:
+    mod = load_module()
+    source = "\n".join(
+        [
+            "/// Public API.",
+            "///",
+            "/// # Examples",
+            "///",
+            "/// ```",
+            "/// let _ = 1;",
+            "/// ```",
+            "pub trait PublicApi {",
+            "    fn method(&self);",
+            "}",
+            "",
+            "/// Private API.",
+            "///",
+            "/// # Examples",
+            "///",
+            "/// ```",
+            "/// let _ = 1;",
+            "/// ```",
+            "pub trait PrivateApi {",
+            "    fn hidden_method(&self);",
+            "}",
+        ]
+    )
+    _with_fake_text(
+        mod,
+        {
+            "crates/x/src/concrete.rs": source,
+            "crates/x/src/lib.rs": "mod concrete;\npub use concrete::PublicApi;",
+        },
+    )
+    findings = mod.missing_doc_example_findings(
+        ["crates/x/src/concrete.rs"],
+        ref="HEAD",
+        worktree=False,
+        added_lines={
+            "crates/x/src/concrete.rs": set(range(1, len(source.splitlines()) + 1))
+        },
+    )
+    assert len(findings) == 1
+    assert "PublicApi::method" in findings[0].detail
+    assert "PrivateApi::hidden_method" not in findings[0].detail
+
+
+def test_missing_doc_example_findings_ignores_nested_trait_helpers() -> None:
+    mod = load_module()
+    source = "\n".join(
+        [
+            "pub trait PublicApi {",
+            "    fn provided(&self) {",
+            "        fn helper() {}",
+            "    }",
+            "}",
+        ]
+    )
+    _with_fake_text(mod, {"crates/x/src/lib.rs": source})
+    findings = mod.missing_doc_example_findings(
+        ["crates/x/src/lib.rs"],
+        ref="HEAD",
+        worktree=False,
+        added_lines={"crates/x/src/lib.rs": {3}},
+    )
+    assert findings == []
+
+
+def test_missing_doc_example_findings_ignores_trait_comments_and_literals() -> None:
+    mod = load_module()
+    source = "\n".join(
+        [
+            "pub trait PublicApi {",
+            "    /*",
+            "        fn block_fake(&self);",
+            "    */",
+            "    const NORMAL: &str = \"\\",
+            "fn normal_fake(&self);\\",
+            "\";",
+            "    const RAW: &str = r#\"",
+            "fn raw_fake(&self);",
+            "\"#;",
+            "    // fn line_fake(&self);",
+            "}",
+        ]
+    )
+    _with_fake_text(mod, {"crates/x/src/lib.rs": source})
+    findings = mod.missing_doc_example_findings(
+        ["crates/x/src/lib.rs"],
+        ref="HEAD",
+        worktree=False,
+        added_lines={"crates/x/src/lib.rs": {3, 6, 9, 11}},
+    )
+    assert findings == []
+
+
+def test_missing_doc_example_findings_ignores_traits_in_outer_comments() -> None:
+    mod = load_module()
+    source = "\n".join(
+        [
+            "/*",
+            "pub trait Fake {",
+            "    fn fake(&self);",
+            "}",
+            "*/",
+        ]
+    )
+    _with_fake_text(mod, {"crates/x/src/lib.rs": source})
+    findings = mod.missing_doc_example_findings(
+        ["crates/x/src/lib.rs"],
+        ref="HEAD",
+        worktree=False,
+        added_lines={"crates/x/src/lib.rs": set(range(1, 6))},
+    )
+    assert findings == []
+
+
+def test_missing_doc_example_findings_tracks_nested_block_comments() -> None:
+    mod = load_module()
+    source = "\n".join(
+        [
+            "pub trait PublicApi {",
+            "    /*",
+            "        /*",
+            "        */",
+            "        }",
+            "        fn fake(&self);",
+            "    */",
+            "    fn real(&self);",
+            "}",
+        ]
+    )
+    _with_fake_text(mod, {"crates/x/src/lib.rs": source})
+    findings = mod.missing_doc_example_findings(
+        ["crates/x/src/lib.rs"],
+        ref="HEAD",
+        worktree=False,
+        added_lines={"crates/x/src/lib.rs": {6, 8}},
+    )
+    assert len(findings) == 1
+    assert "PublicApi::real" in findings[0].detail
+    assert "PublicApi::fake" not in findings[0].detail
+
+
 def test_vacuous_doc_example_findings_flags_path_only_example() -> None:
     mod = load_module()
     vacuous = "\n".join(
@@ -2581,6 +2921,17 @@ def main() -> int:
         test_inline_test_module_findings_skips_untouched_block,
         test_missing_doc_example_findings_flags_only_real_gaps,
         test_missing_doc_example_findings_ignores_unchanged_items,
+        test_missing_doc_example_findings_flags_added_public_trait_method,
+        test_missing_doc_example_findings_accepts_trait_method_examples,
+        test_missing_doc_example_findings_skips_hidden_trait_methods,
+        test_missing_doc_example_findings_skips_private_traits,
+        test_missing_doc_example_findings_recognizes_trait_method_forms,
+        test_missing_doc_example_findings_ignores_unchanged_trait_methods,
+        test_missing_doc_example_findings_uses_trait_name_for_selective_reexports,
+        test_missing_doc_example_findings_ignores_nested_trait_helpers,
+        test_missing_doc_example_findings_ignores_trait_comments_and_literals,
+        test_missing_doc_example_findings_ignores_traits_in_outer_comments,
+        test_missing_doc_example_findings_tracks_nested_block_comments,
         test_vacuous_doc_example_findings_flags_path_only_example,
         test_vacuous_doc_example_findings_ignores_comment_lines,
         test_vacuous_doc_example_findings_accepts_comment_only_example,


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] Documentation
- [x] CI / repository tooling
- [x] Implementation of accepted issue

## Related issue

Fixes #1605

## Summary

Extends the existing deterministic `missing-doc-examples` check to inspect diff-added methods inside reachable public traits.

- discovers public-trait body spans with the existing comment/string-aware Rust scanner;
- checks only added associated-method declarations at immediate trait-body depth;
- recognizes required/provided/default, `async`, `unsafe`, `const`, and explicit-ABI `extern` forms;
- reuses existing `# Examples` and `#[doc(hidden)]` handling;
- reports `Trait::method` and filters selective re-exports by the enclosing trait name;
- remains warn-severity, diff-scoped, dependency-free, and one finding per file.

No Rust parser, macro expansion, inherited-item resolution, baseline allowlist, generic lint framework, or repository-wide backlog scan was added.

## RED / GREEN

Before production changes, the new public-trait fixture failed because an undocumented added method produced zero findings:

```text
test_missing_doc_example_findings_flags_added_public_trait_method
assert len(findings) == 1
AssertionError
```

After implementation, all accepted fixtures passed: undocumented/documented/hidden/private methods, method forms, unchanged methods, selective re-exports, and braces in comments, literals, and default bodies.

Independent review then found declaration-looking text could be misclassified inside nested method bodies and lexical content. Four additional RED fixtures reproduced those cases. The final scanner carries lexical state from file start, tracks nested block-comment depth, classifies sanitized code, and matches methods only at immediate trait depth. Both scoped re-reviews found no Critical, Important, or Minor findings.

## Work log

Updates the existing structural-review record and closes its #1605 residual-risk disposition:

- [`docs/worklogs/2026-08-01-rules-review-structural-checks.md`](docs/worklogs/2026-08-01-rules-review-structural-checks.md)

## Verification

- `python3 scripts/test-repository-rules-review.py`
- `python3 -m py_compile scripts/repository-rules-review.py scripts/test-repository-rules-review.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --dry-run --output-json /tmp/rules-review-1605-final.json` — pass, zero findings
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'python3 scripts/test-repository-rules-review.py'`
- `python3 scripts/ci/run_profile.py fmt`
- CI-parity workspace and extension clippy via `python3 scripts/ci/run_profile.py clippy`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json` — 209/209 files passed
- `cargo doc --workspace --no-deps`
- `python3 scripts/ci/run_profile.py docs`
- `python3 scripts/check-public-error-docs.py`
- `bash scripts/check-tensor-core-deps.sh`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1605-final.json` — pass, zero findings

## Residual risks

The detector intentionally remains a lightweight, line-oriented diff audit. It does not reconstruct rustfmt-noncanonical multiline declarations, expand macros, resolve inherited trait items, or scan unchanged backlog. Those behaviors are outside the accepted #1605 scope.

## Checklist

- [x] I read the shared and repository-specific rules.
- [x] I followed the accepted implementation plan and recorded RED→GREEN evidence.
- [x] I added focused deterministic regressions.
- [x] I linked and updated the existing durable work log.
- [x] The final diff is one commit across exactly the three accepted files.
