### PR TITLE
ci: resolve Python 3.11 repository-wide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,8 @@ may be enabled for one command with `CARGO_PROFILE_DEV_DEBUG=1` or
 
 ## Build Commands
 
+Repository scripts require Python 3.11 or newer. Set `$PYTHON` to one executable or path token to override the resolver when needed.
+
 ```bash
 # Build entire workspace
 cargo build

--- a/docs/worklogs/2026-07-18-issue-1402-ci-thin-profile.md
+++ b/docs/worklogs/2026-07-18-issue-1402-ci-thin-profile.md
@@ -51,3 +51,26 @@ Nested extension/sample workspaces (`ext/tropical`, `ext/sparse`,
 `samples/kdv-pinn`) do not see the root `[profile.ci]`. CI failed with
 `profile ci is not defined` until those manifests defined a matching profile
 (with explicit `debug = 0`, since nested defaults keep test debuginfo).
+
+## Python 3.11 resolver follow-up (#1606)
+
+- **Context:** Accepted issue #1606 addresses macOS hosts whose bare `python3`
+  is older than 3.11.
+- **Chosen design:** One shell resolver performs a semantic `sys.version_info`
+  probe in deterministic order (`$PYTHON`, `python3.13`, `python3.12`,
+  `python3.11`, `python3`), then offers `uv` as an optional fallback. `$PYTHON`
+  remains one executable/path token; the selected `sys.executable` is propagated
+  through `run_profile.py` and inherited by nested shells.
+- **Required coverage:** Added resolver fixtures and the directly affected
+  run-profile, local-gate, and docs source-contract updates.
+- **Rejected:** `eval`/shell text; pyenv/bootstrap, dependency installation, or
+  a version matrix; trusting a version banner; and PATH fallback after invalid
+  `$PYTHON`.
+- **Verification:** RED caught the missing helper plus aggregate/profile/docs
+  contract failures. GREEN passed 9 resolver tests, 31 run-profile tests, and
+  188 CI tests, along with shell syntax, a real docs profile under a fake-old
+  PATH, the fast gate, and full local gates/coverage/docs/rules review.
+- **Residual risks:** The `uv` contract is tested with a fake executable; hosted
+  CI still supplies final evidence. Enforcement is limited to the accepted
+  repository shell entrypoints and their profile children; unrelated hosted
+  workflow invocations remain outside #1606.

--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "$ROOT_DIR/scripts/lib/python.sh"
 OUT_DIR="${1:-$ROOT_DIR/target/docs-site}"
 API_DIR="$OUT_DIR/api"
 DOC_ROOT="$ROOT_DIR/target/doc"
@@ -22,7 +23,7 @@ render_overview_html() {
     return
   fi
 
-  python3 - "$ROOT_DIR" <<'PY'
+  run_python - "$ROOT_DIR" <<'PY'
 import html
 import json
 import pathlib
@@ -60,7 +61,7 @@ PY
 }
 
 render_crate_inventory_html() {
-  python3 - "$ROOT_DIR" <<'PY'
+  run_python - "$ROOT_DIR" <<'PY'
 import html
 import json
 import pathlib
@@ -102,8 +103,8 @@ PY
 }
 
 echo "[1/9] Checking user-facing snippets"
-python3 "$ROOT_DIR/scripts/check-doc-snippets.py" --root-dir "$ROOT_DIR" --check
-python3 "$ROOT_DIR/scripts/check-guide-dependency-snippets.py" --root-dir "$ROOT_DIR"
+run_python "$ROOT_DIR/scripts/check-doc-snippets.py" --root-dir "$ROOT_DIR" --check
+run_python "$ROOT_DIR/scripts/check-guide-dependency-snippets.py" --root-dir "$ROOT_DIR"
 
 echo "[2/9] Building rustdoc"
 rm -rf "$DOC_ROOT"
@@ -115,7 +116,7 @@ cp -a "$DOC_ROOT/." "$API_DIR/"
 echo "[4/9] Generating optional dependency graph"
 if [[ -x "$ROOT_DIR/scripts/gen_dep_graph.py" || -f "$ROOT_DIR/scripts/gen_dep_graph.py" ]]; then
   if command -v dot >/dev/null 2>&1; then
-    python3 "$ROOT_DIR/scripts/gen_dep_graph.py" --root-dir "$ROOT_DIR" --format svg \
+    run_python "$ROOT_DIR/scripts/gen_dep_graph.py" --root-dir "$ROOT_DIR" --format svg \
       --output "$API_DIR/dep_graph.svg"
   else
     echo "  Warning: graphviz (dot) not found; dependency graph skipped."
@@ -178,10 +179,10 @@ else
 fi
 
 echo "[7/9] Checking rendered operation surface references"
-python3 "$ROOT_DIR/scripts/check-operation-categories.py" --fail-on-findings --include-rendered
+run_python "$ROOT_DIR/scripts/check-operation-categories.py" --fail-on-findings --include-rendered
 
 echo "[8/9] Verifying docs site links and API inventory"
-python3 "$ROOT_DIR/scripts/check-docs-site.py" --root-dir "$ROOT_DIR" --site-index "$API_DIR/index.html"
+run_python "$ROOT_DIR/scripts/check-docs-site.py" --root-dir "$ROOT_DIR" --site-index "$API_DIR/index.html"
 
 echo "[9/9] Verifying site top page"
 REPO_TITLE="$(basename "$ROOT_DIR")"

--- a/scripts/check-pr-fast.sh
+++ b/scripts/check-pr-fast.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "$SCRIPT_DIR/lib/python.sh"
+
 BASE_REF="origin/main"
 FETCH=1
 DOC_SNIPPETS="auto"
@@ -163,18 +166,18 @@ else
   printf '  %s\n' "${changed_files[@]}"
 fi
 
-policy_args=(python3 scripts/ci/change_policy.py)
+policy_args=(scripts/ci/change_policy.py)
 if [[ "$changed_file_count" -gt 0 ]]; then
   for path in "${changed_files[@]}"; do
     policy_args+=(--path "$path")
   done
 fi
-policy_json="$("${policy_args[@]}")"
+policy_json="$(run_python "${policy_args[@]}")"
 policy_fields=()
 while IFS= read -r field; do
   policy_fields+=("$field")
 done < <(
-  python3 -c \
+  run_python -c \
     'import json, sys; data = json.load(sys.stdin); print(data["classification"]); print(data["reason"])' \
     <<<"${policy_json}"
 )
@@ -200,7 +203,7 @@ if [[ "$untracked_file_count" -gt 0 ]]; then
   fi
 fi
 if [[ "${change_class}" == "code" ]]; then
-  run python3 scripts/ci/run_profile.py fmt
+  run run_python scripts/ci/run_profile.py fmt
 else
   log "cargo fmt: skipped for ${change_class} changes"
 fi
@@ -226,7 +229,7 @@ case "$DOC_SNIPPETS" in
 esac
 
 if [[ "$run_doc_snippets" -eq 1 ]]; then
-  run python3 scripts/check-doc-snippets.py --root-dir . --check
+  run run_python scripts/check-doc-snippets.py --root-dir . --check
 else
   log "docs snippets: skipped"
 fi
@@ -239,9 +242,9 @@ if [[ "${change_class}" == "code" ]]; then
   if has_ci_profile clippy || has_ci_profile full; then
     log "ci clippy: covered by selected profile"
   elif [[ "$CI_PROFILE_DRY_RUN" -eq 1 ]]; then
-    python3 scripts/ci/run_profile.py --dry-run clippy
+    run_python scripts/ci/run_profile.py --dry-run clippy
   else
-    python3 scripts/ci/run_profile.py clippy
+    run_python scripts/ci/run_profile.py clippy
   fi
 fi
 
@@ -257,7 +260,7 @@ if [[ "$ci_profile_count" -gt 0 ]]; then
   if [[ "$CI_PROFILE_DRY_RUN" -eq 1 ]]; then
     profile_args=(--dry-run "${profile_args[@]}")
   fi
-  python3 scripts/ci/run_profile.py "${profile_args[@]}"
+  run_python scripts/ci/run_profile.py "${profile_args[@]}"
 elif [[ "$CI_PROFILE_DRY_RUN" -eq 1 ]]; then
   die "--ci-profile-dry-run requires at least one --ci-profile"
 fi

--- a/scripts/check-repo-settings.sh
+++ b/scripts/check-repo-settings.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "$SCRIPT_DIR/lib/python.sh"
+
 REPO=""
 SETTINGS_PATH="ai/repo-settings.json"
 QUIET=0
@@ -36,7 +39,7 @@ resolve_settings_path() {
 }
 
 json_get() {
-  python3 - "$1" "$2" <<'PY'
+  run_python - "$1" "$2" <<'PY'
 import json
 import sys
 
@@ -52,7 +55,7 @@ PY
 }
 
 json_get_optional() {
-  python3 - "$1" "$2" "$3" <<'PY'
+  run_python - "$1" "$2" "$3" <<'PY'
 import json
 import sys
 
@@ -117,7 +120,7 @@ REPO_JSON="$(gh api "repos/$REPO")"
 PROTECTION_JSON="$(gh_api_optional "repos/$REPO/branches/$DEFAULT_BRANCH/protection")"
 PAGES_JSON="$(gh_api_optional "repos/$REPO/pages")"
 
-python3 - "$SETTINGS_PATH" "$REPO_JSON" "$PROTECTION_JSON" "$PAGES_JSON" "$EXPECTED_AUTO_MERGE" "$EXPECTED_DELETE_BRANCH" "$EXPECTED_STRICT" "$EXPECTED_PAGES_ENABLED" "$EXPECTED_PAGES_BUILD_TYPE" <<'PY'
+run_python - "$SETTINGS_PATH" "$REPO_JSON" "$PROTECTION_JSON" "$PAGES_JSON" "$EXPECTED_AUTO_MERGE" "$EXPECTED_DELETE_BRANCH" "$EXPECTED_STRICT" "$EXPECTED_PAGES_ENABLED" "$EXPECTED_PAGES_BUILD_TYPE" <<'PY'
 import json
 import sys
 

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -109,6 +109,14 @@ def commands_for(profile: str) -> tuple[str, ...]:
         raise ValueError(f"unknown CI profile: {profile}") from error
 
 
+def _command_for_execution(command: str) -> str:
+    """Use this process's interpreter for repository-owned Python commands."""
+
+    if command == "python3" or command.startswith("python3 "):
+        return shlex.quote(sys.executable) + command[len("python3") :]
+    return command
+
+
 def expand_profiles(profiles: Sequence[str]) -> tuple[str, ...]:
     """Expand composites and preserve the first occurrence of each profile."""
 
@@ -151,15 +159,17 @@ def run_profiles(
             if dry_run:
                 continue
             environment = os.environ.copy()
+            environment["PYTHON"] = sys.executable
             if profile == "workspace-blas":
                 rustflags = "-l dylib=openblas -l dylib=lapack"
                 environment["RUSTFLAGS"] = rustflags
                 environment["TENFERRO_TRYBUILD_RUSTFLAGS"] = rustflags
                 environment["CARGO"] = _TRYBUILD_CARGO_WRAPPER
+            execution_command = _command_for_execution(command)
             try:
                 # Commands are repository constants, not caller-provided shell text.
                 subprocess.run(
-                    command, shell=True, check=True, env=environment
+                    execution_command, shell=True, check=True, env=environment
                 )
             except subprocess.CalledProcessError as error:
                 raise RuntimeError(

--- a/scripts/ci/tests/test_change_policy.py
+++ b/scripts/ci/tests/test_change_policy.py
@@ -173,6 +173,7 @@ class LocalGateTests(unittest.TestCase):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.repo = Path(self.temp_dir.name)
         (self.repo / "scripts" / "ci").mkdir(parents=True)
+        (self.repo / "scripts" / "lib").mkdir(parents=True)
         shutil.copy2(ROOT / "scripts" / "check-pr-fast.sh", self.repo / "scripts")
         shutil.copy2(
             ROOT / "scripts" / "ci" / "change_policy.py",
@@ -181,6 +182,10 @@ class LocalGateTests(unittest.TestCase):
         shutil.copy2(
             ROOT / "scripts" / "ci" / "run_profile.py",
             self.repo / "scripts" / "ci",
+        )
+        shutil.copy2(
+            ROOT / "scripts" / "lib" / "python.sh",
+            self.repo / "scripts" / "lib",
         )
         bin_dir = self.repo / "bin"
         bin_dir.mkdir()

--- a/scripts/ci/tests/test_python_resolver.py
+++ b/scripts/ci/tests/test_python_resolver.py
@@ -1,0 +1,237 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HELPER = REPO_ROOT / "scripts" / "lib" / "python.sh"
+VERSION_PROBE = (
+    "import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)"
+)
+
+
+class PythonResolverTests(unittest.TestCase):
+    def run_resolver(self, path, *args, python=None, extra_env=None):
+        env = {"PATH": str(path)}
+        if python is not None:
+            env["PYTHON"] = python
+        if extra_env:
+            env.update(extra_env)
+        command = 'set -euo pipefail; source "$1"; shift; run_python "$@"'
+        return subprocess.run(
+            ["/bin/bash", "-c", command, "resolver", str(HELPER), *args],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+
+    @staticmethod
+    def fake_executable(directory, name, label, version_ok=True, log_path=None):
+        path = Path(directory) / name
+        log_expression = ""
+        if log_path is not None:
+            log_expression = f'printf \'%s\\n\' "$*" >> {str(log_path)!r}\n'
+        probe_status = 0 if version_ok else 1
+        path.write_text(
+            "#!/bin/bash\n"
+            "set -eu\n"
+            f"{log_expression}"
+            f'if [[ "${{1-}}" == "-c" && "${{2-}}" == {VERSION_PROBE!r} ]]; then\n'
+            f"  exit {probe_status}\n"
+            "fi\n"
+            'if [[ "${1-}" == "--version" ]]; then\n'
+            "  printf 'Python 3.11.0\\n'\n"
+            "  exit 0\n"
+            "fi\n"
+            f"printf '%s\\n' {label!r}\n"
+        )
+        path.chmod(0o755)
+        return path
+
+    def test_old_python3_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            self.fake_executable(temporary, "python3", "old-python3", version_ok=False)
+            result = self.run_resolver(temporary, "-c", "print('should not run')")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Python 3.11+", result.stderr)
+        self.assertNotIn("should not run", result.stdout)
+
+    def test_banner_spoofing_without_semantic_execution_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            spoof = Path(temporary) / "python3.11"
+            spoof.write_text(
+                "#!/bin/bash\n"
+                "set -eu\n"
+                'if [[ "${1-}" == "--version" ]]; then\n'
+                "  printf 'Python 3.11.0\\n'\n"
+                "  exit 0\n"
+                "fi\n"
+                f'if [[ "${{1-}}" == "-c" && "${{2-}}" == {VERSION_PROBE!r} ]]; then\n'
+                "  exit 1\n"
+                "fi\n"
+                "printf 'not-python\\n'\n"
+            )
+            spoof.chmod(0o755)
+            result = self.run_resolver(temporary, "-c", "print('selected')")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Python 3.11+", result.stderr)
+        self.assertNotIn("not-python", result.stdout)
+
+    def test_python311_is_selected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            self.fake_executable(temporary, "python3.11", "python311")
+            self.fake_executable(temporary, "python3", "python3")
+            result = self.run_resolver(temporary, "-c", "print('selected')")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "python311\n")
+        self.assertEqual(result.stderr, "")
+
+    def test_python_override_wins(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            override = self.fake_executable(temporary, "override-python", "override")
+            self.fake_executable(temporary, "python3.13", "python313")
+            result = self.run_resolver(
+                temporary,
+                "-c",
+                "print('selected')",
+                python=str(override),
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "override\n")
+
+    def test_invalid_python_override_does_not_fall_back(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            self.fake_executable(temporary, "python3.11", "fallback")
+            result = self.run_resolver(
+                temporary,
+                "-c",
+                "print('selected')",
+                python=str(Path(temporary) / "missing-python"),
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("$PYTHON", result.stderr)
+        self.assertNotIn("fallback", result.stdout)
+
+    def test_uv_uses_exact_command_prefix(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            log_path = Path(temporary) / "uv.log"
+            uv = Path(temporary) / "uv"
+            uv.write_text(
+                "#!/bin/bash\n"
+                "set -eu\n"
+                f"printf '%s\\n' \"$*\" >> {str(log_path)!r}\n"
+                '[[ "${1-}" == "run" ]]\n'
+                '[[ "${2-}" == "--no-project" ]]\n'
+                '[[ "${3-}" == "--python" ]]\n'
+                '[[ "${4-}" == "3.12" ]]\n'
+                '[[ "${5-}" == "python" ]]\n'
+                f'if [[ "${{6-}}" == "-c" && "${{7-}}" == {VERSION_PROBE!r} ]]; then exit 0; fi\n'
+                "printf 'uv-selected\\n'\n"
+            )
+            uv.chmod(0o755)
+            result = self.run_resolver(temporary, "-c", "print('selected')")
+            uv_calls = log_path.read_text().splitlines() if log_path.exists() else []
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "uv-selected\n")
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(len(uv_calls), 1)
+        self.assertTrue(uv_calls[0].startswith("run --no-project --python 3.12 python -c"))
+
+    def test_no_candidate_error_documents_options(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            result = self.run_resolver(temporary, "-c", "print('selected')")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Python 3.11+", result.stderr)
+        self.assertIn("$PYTHON", result.stderr)
+        self.assertIn("uv", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_relative_override_is_resolved_from_source_directory_and_cached(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            temp = Path(temporary)
+            source_dir = temp / "caller path with spaces"
+            source_dir.mkdir()
+            (source_dir / "bin").mkdir()
+            first_dir = temp / "first dir"
+            second_dir = temp / "second dir"
+            first_dir.mkdir()
+            second_dir.mkdir()
+            empty_path = temp / "empty-path"
+            empty_path.mkdir()
+            log_path = temp / "python.log"
+            self.fake_executable(
+                source_dir / "bin",
+                "python executable",
+                "relative",
+                log_path=log_path,
+            )
+            command = (
+                'set -euo pipefail; source "$1"; shift; '
+                'cd "$1"; run_python "${@:3}"; '
+                'cd "$2"; run_python "${@:3}"'
+            )
+            result = subprocess.run(
+                [
+                    "/bin/bash",
+                    "-c",
+                    command,
+                    "resolver",
+                    str(HELPER),
+                    str(first_dir),
+                    str(second_dir),
+                    "-c",
+                    "print('selected')",
+                ],
+                cwd=source_dir,
+                env={"PATH": str(empty_path), "PYTHON": "bin/python executable"},
+                text=True,
+                capture_output=True,
+            )
+            calls = log_path.read_text().splitlines()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "relative\nrelative\n")
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(calls, [f"-c {VERSION_PROBE}", "-c print('selected')", "-c print('selected')"])
+
+    def test_selection_is_cached_and_probes_are_silent(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            log_path = Path(temporary) / "python.log"
+            self.fake_executable(temporary, "python3.11", "python311", log_path=log_path)
+            command = (
+                'set -euo pipefail; source "$1"; shift; '
+                'run_python "$@"; run_python "$@"'
+            )
+            result = subprocess.run(
+                [
+                    "/bin/bash",
+                    "-c",
+                    command,
+                    "resolver",
+                    str(HELPER),
+                    "-c",
+                    "print('selected')",
+                ],
+                env={"PATH": temporary, "FAKE_LOG": str(log_path)},
+                text=True,
+                capture_output=True,
+            )
+            calls = log_path.read_text().splitlines() if log_path.exists() else []
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "python311\npython311\n")
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(calls[0], f"-c {VERSION_PROBE}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -257,6 +257,58 @@ class RunProfileTests(unittest.TestCase):
         run.assert_not_called()
         self.assertIn("+ cargo test -p tenferro-cpu", output.getvalue())
 
+    def test_python_children_use_selected_interpreter_not_path_python3(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = Path(directory)
+            marker = temp / "selected-marker"
+            selected = temp / "selected interpreter"
+            selected.write_text(
+                "#!/bin/sh\n"
+                "printf 'selected\\n' > \"$PYTHON_MARKER\"\n"
+            )
+            selected.chmod(0o755)
+            path_python = temp / "python3"
+            path_python.write_text(
+                "#!/bin/sh\n"
+                "printf 'path-python3\\n' > \"$PYTHON_MARKER\"\n"
+                "exit 1\n"
+            )
+            path_python.chmod(0o755)
+            output = io.StringIO()
+
+            with patch.dict(
+                "scripts.ci.run_profile.PROFILE_COMMANDS",
+                {"probe": ("python3 -c 'print(1)'",)},
+            ), patch(
+                "scripts.ci.run_profile.sys.executable", str(selected)
+            ), patch.dict(
+                "os.environ",
+                {"PATH": str(temp), "PYTHON_MARKER": str(marker)},
+                clear=True,
+            ):
+                run_profiles(["probe"], dry_run=False, output=output)
+
+            self.assertEqual(marker.read_text(), "selected\n")
+            self.assertEqual(output.getvalue(), "+ python3 -c 'print(1)'\n")
+
+    def test_shell_profile_children_receive_selected_interpreter(self) -> None:
+        calls: list[tuple[str, dict[str, str]]] = []
+
+        def record_run(command: str, **kwargs: object) -> None:
+            calls.append((command, kwargs["env"]))  # type: ignore[arg-type]
+
+        with patch.dict(
+            "scripts.ci.run_profile.PROFILE_COMMANDS",
+            {"docs": ("bash scripts/build_docs_site.sh",)},
+        ), patch.dict("os.environ", {}, clear=True), patch(
+            "scripts.ci.run_profile.subprocess.run", side_effect=record_run
+        ):
+            run_profiles(["docs"], dry_run=False, output=io.StringIO())
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "bash scripts/build_docs_site.sh")
+        self.assertEqual(calls[0][1]["PYTHON"], sys.executable)
+
     def test_workspace_blas_uses_linker_flags_only_for_that_profile(self) -> None:
         calls: list[dict[str, str]] = []
 
@@ -397,14 +449,14 @@ Path(os.environ["TRYBUILD_CARGO_CAPTURE"]).write_text(
     def test_fast_preflight_delegates_profiles_without_redefining_them(self) -> None:
         source = (ROOT / "scripts" / "check-pr-fast.sh").read_text()
         self.assertIn("--ci-profile", source)
-        self.assertIn("python3 scripts/ci/run_profile.py fmt", source)
-        self.assertIn('python3 scripts/ci/run_profile.py "${profile_args[@]}"', source)
+        self.assertIn("run_python scripts/ci/run_profile.py fmt", source)
+        self.assertIn('run_python scripts/ci/run_profile.py "${profile_args[@]}"', source)
         self.assertNotIn("cargo nextest run --workspace", source)
 
     def test_fast_preflight_runs_ci_parity_clippy_for_code_changes(self) -> None:
         source = (ROOT / "scripts" / "check-pr-fast.sh").read_text()
         self.assertIn('if [[ "${change_class}" == "code" ]]; then', source)
-        self.assertIn("python3 scripts/ci/run_profile.py clippy", source)
+        self.assertIn("run_python scripts/ci/run_profile.py clippy", source)
         self.assertIn("has_ci_profile clippy || has_ci_profile full", source)
 
     def test_fast_preflight_avoids_bash4_only_mapfile(self) -> None:

--- a/scripts/configure-repo-settings.sh
+++ b/scripts/configure-repo-settings.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "$SCRIPT_DIR/lib/python.sh"
+
 REPO=""
 SETTINGS_PATH="ai/repo-settings.json"
 
@@ -34,7 +37,7 @@ resolve_settings_path() {
 }
 
 json_get() {
-  python3 - "$1" "$2" <<'PY'
+  run_python - "$1" "$2" <<'PY'
 import json
 import sys
 
@@ -50,7 +53,7 @@ PY
 }
 
 json_get_optional() {
-  python3 - "$1" "$2" "$3" <<'PY'
+  run_python - "$1" "$2" "$3" <<'PY'
 import json
 import sys
 
@@ -69,7 +72,7 @@ PY
 }
 
 json_field() {
-  python3 - "$1" "$2" <<'PY'
+  run_python - "$1" "$2" <<'PY'
 import json
 import sys
 
@@ -83,7 +86,7 @@ print(data)
 PY
 }
 build_branch_protection_payload() {
-  python3 - "$1" <<'PY'
+  run_python - "$1" <<'PY'
 import json
 import sys
 

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "$SCRIPT_DIR/lib/python.sh"
+
 BASE_BRANCH="main"
 TITLE=""
 BODY_FILE=""
@@ -84,7 +87,7 @@ run_required_checks() {
     fast_gate_args+=(--test "$command")
   done
   bash scripts/check-pr-fast.sh "${fast_gate_args[@]}"
-  python3 scripts/repository-rules-review.py \
+  run_python scripts/repository-rules-review.py \
     --base "origin/${BASE_BRANCH}" \
     --head HEAD \
     --output-json /tmp/repository-rules-review.json

--- a/scripts/lib/python.sh
+++ b/scripts/lib/python.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+_PYTHON_RESOLVER_READY=0
+_PYTHON_RESOLVER_COMMAND=()
+_PYTHON_RESOLVER_SOURCE_DIR="$(pwd -P)"
+
+_python_resolver_path() {
+  local candidate="$1"
+  local resolved
+  local candidate_dir
+  local candidate_name
+
+  if [[ "$candidate" == */* ]]; then
+    if [[ "$candidate" != /* ]]; then
+      candidate="$_PYTHON_RESOLVER_SOURCE_DIR/$candidate"
+    fi
+    candidate_dir="${candidate%/*}"
+    candidate_name="${candidate##*/}"
+    [[ -n "$candidate_dir" ]] || candidate_dir="/"
+    candidate_dir="$(cd -P "$candidate_dir" 2>/dev/null && pwd -P)" || return 1
+    resolved="$candidate_dir/$candidate_name"
+    [[ -x "$resolved" ]] || return 1
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+
+  resolved="$(type -P "$candidate" 2>/dev/null || true)"
+  [[ -n "$resolved" && -x "$resolved" ]] || return 1
+  printf '%s\n' "$resolved"
+}
+
+_python_resolver_version_ok() {
+  local executable="$1"
+
+  "$executable" -c \
+    'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' \
+    >/dev/null 2>&1
+}
+
+_python_resolver_error() {
+  printf '%s\n' "$*" >&2
+  return 1
+}
+
+_python_resolver_select() {
+  local candidate
+  local resolved
+
+  if [[ "${PYTHON+x}" == x ]]; then
+    candidate="$PYTHON"
+    if [[ -z "$candidate" ]] || ! resolved="$(_python_resolver_path "$candidate")" || \
+      ! _python_resolver_version_ok "$resolved"; then
+      _python_resolver_error \
+        "error: \$PYTHON='$candidate' is invalid, not executable, or older than Python 3.11; refusing fallback"
+      return 1
+    fi
+    _PYTHON_RESOLVER_COMMAND=("$resolved")
+    _PYTHON_RESOLVER_READY=1
+    return 0
+  fi
+
+  for candidate in python3.13 python3.12 python3.11 python3; do
+    if resolved="$(_python_resolver_path "$candidate")" && \
+      _python_resolver_version_ok "$resolved"; then
+      _PYTHON_RESOLVER_COMMAND=("$resolved")
+      _PYTHON_RESOLVER_READY=1
+      return 0
+    fi
+  done
+
+  if resolved="$(_python_resolver_path uv)"; then
+    _PYTHON_RESOLVER_COMMAND=("$resolved" run --no-project --python 3.12 python)
+    _PYTHON_RESOLVER_READY=1
+    return 0
+  fi
+
+  _python_resolver_error \
+    'error: Python 3.11+ is required; set literal $PYTHON to an executable, install Python 3.11+, or install uv for the optional uv fallback'
+}
+
+run_python() {
+  if [[ "$_PYTHON_RESOLVER_READY" -eq 0 ]]; then
+    _python_resolver_select || return
+  fi
+  "${_PYTHON_RESOLVER_COMMAND[@]}" "$@"
+}

--- a/scripts/monitor-pr-checks.sh
+++ b/scripts/monitor-pr-checks.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "$SCRIPT_DIR/lib/python.sh"
+
 PR_REF=""
 INTERVAL=30
 REPO=""
@@ -32,7 +35,7 @@ gh_pr_checks() {
 }
 
 classify_checks() {
-  python3 -c '
+  run_python -c '
 import json
 import re
 import sys

--- a/scripts/serve_docs_site.sh
+++ b/scripts/serve_docs_site.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "$ROOT_DIR/scripts/lib/python.sh"
 SITE_DIR="${1:-$ROOT_DIR/target/docs-site}"
 PORT="${PORT:-8000}"
 
@@ -13,4 +14,4 @@ fi
 
 echo "serving $SITE_DIR at http://127.0.0.1:$PORT"
 cd "$SITE_DIR"
-python3 -m http.server "$PORT"
+run_python -m http.server "$PORT"

--- a/scripts/test-doc-consistency.py
+++ b/scripts/test-doc-consistency.py
@@ -211,7 +211,7 @@ def test_docs_ci_runs_docs_script_tests() -> None:
     assert "python3 scripts/check-guide-dependency-snippets.py" in profiles
     assert "python3 scripts/check-operation-categories.py --fail-on-findings" in profiles
     assert (
-        "python3 \"$ROOT_DIR/scripts/check-operation-categories.py\" --fail-on-findings --include-rendered"
+        "run_python \"$ROOT_DIR/scripts/check-operation-categories.py\" --fail-on-findings --include-rendered"
         in build_docs_site
     )
 


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] Documentation
- [x] CI / repository tooling
- [x] Implementation of accepted issue

## Related issue

Fixes #1606

## Summary

Declares and enforces Python 3.11+ once for repository shell tooling.

`scripts/lib/python.sh` exposes `run_python`, which caches the first usable command in the accepted order:

1. one-token `$PYTHON` override, with invalid/old overrides failing rather than falling back;
2. `python3.13`, `python3.12`, `python3.11`, then `python3` from `PATH`;
3. optional `uv run --no-project --python 3.12 python`;
4. an actionable error naming Python 3.11+, `$PYTHON`, and `uv`.

Candidates are verified by executing a silent `sys.version_info` probe, not by trusting a version banner. Relative override paths are anchored when the helper is sourced and cached absolutely. No `eval`, dependency installation, pyenv/bootstrap, virtualenv manager, lockfile, or version matrix was added.

The seven accepted shell entrypoints now source the helper and use `run_python`. `run_profile.py` executes repository-owned Python children with its selected `sys.executable` and exports that path as `$PYTHON` to nested shell profiles.

## RED / GREEN

The first commit added resolver contract tests before the helper existed:

```text
python3 -m unittest scripts.ci.tests.test_python_resolver -v
Ran 7 tests — FAILED (helper absent)
```

Review and integration runs exposed three additional RED classes:

- aggregate CI tests: 9/184 failures because isolated local-gate fixtures omitted the new helper and source contracts expected direct `python3`;
- spoofed version banners, relative overrides across `cd`, and selected-interpreter loss in profile children;
- the real docs profile rejected a stale `build_docs_site.sh` source-contract expectation.

The final branch passes 9 resolver tests, 31 run-profile tests, and all 188 CI-script tests. It also executes the real docs profile with a fake old `PATH` `python3` while `$PYTHON` selects the modern interpreter, including nested shell children. Final specification, quality, scoped, and whole-branch reviews found no Critical, Important, or Minor issue.

## Work log

The existing CI profile owner record now includes the #1606 design, rejected alternatives, verification, and residual risks:

- [`docs/worklogs/2026-07-18-issue-1402-ci-thin-profile.md`](docs/worklogs/2026-07-18-issue-1402-ci-thin-profile.md#python-311-resolver-follow-up-1606)

## Verification

- `python3 -m unittest scripts.ci.tests.test_python_resolver -v` — 9 passed
- `python3 -m unittest scripts.ci.tests.test_run_profile -v` — 31 passed
- `python3 -m unittest discover -s scripts/ci/tests -v` — 188 passed
- `python3 scripts/test-doc-consistency.py`
- `bash -n scripts/lib/python.sh scripts/check-pr-fast.sh scripts/build_docs_site.sh scripts/serve_docs_site.sh scripts/check-repo-settings.sh scripts/configure-repo-settings.sh scripts/create-pr.sh scripts/monitor-pr-checks.sh`
- `python3 scripts/ci/change_policy.py --help`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'python3 -m unittest scripts.ci.tests.test_python_resolver -v'`
- fake-old-`PATH` plus absolute `$PYTHON`: real `--ci-profile docs` completed successfully
- `python3 scripts/ci/run_profile.py fmt`
- CI-parity workspace/extension clippy via `python3 scripts/ci/run_profile.py clippy`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json` — 209/209 files passed
- `cargo doc --workspace --no-deps`
- `python3 scripts/ci/run_profile.py docs`
- `python3 scripts/check-public-error-docs.py`
- `bash scripts/check-tensor-core-deps.sh`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1606-final-head.json` — pass

## Residual risks

The optional `uv` path is tested with a fake executable rather than a live managed-Python download. Hosted CI provides final platform evidence. Unrelated hosted workflow invocations remain outside the accepted seven-entrypoint scope.

## Checklist

- [x] I read `CONTRIBUTING.md`, shared rules, and `REPOSITORY_RULES.md`.
- [x] I followed the accepted issue and recorded RED→GREEN evidence.
- [x] I added/updated focused and aggregate tests.
- [x] I ran local repository-rules review and resolved all review findings.
- [x] I updated and linked the owning durable work log.
- [x] The final history contains exactly the two accepted commits.
