### PR TITLE
chore(release): add crates.io and docs.rs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.2.0"
+rust-version = "1.96"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = [

--- a/crates/tenferro-ad/Cargo.toml
+++ b/crates/tenferro-ad/Cargo.toml
@@ -10,6 +10,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Eager runtime, eager tensors, and traced AD extension traits for tenferro."
+rust-version.workspace = true
+keywords = ["tensor", "autodiff", "numerical", "graph"]
+categories = ["science", "mathematics", "algorithms"]
+documentation = "https://docs.rs/tenferro-ad"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+features = ["cpu-faer", "cuda", "webgpu"]
 
 [lib]
 name = "tenferro_ad"

--- a/crates/tenferro-core-ops/Cargo.toml
+++ b/crates/tenferro-core-ops/Cargo.toml
@@ -9,6 +9,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Internal core primitive operation catalog used by graph, runtime, and backend dispatch."
+rust-version.workspace = true
+keywords = ["tensor", "operations", "graph"]
+categories = ["science", "mathematics", "algorithms"]
+documentation = "https://docs.rs/tenferro-core-ops"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
 
 [lib]
 name = "tenferro_core_ops"

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -10,6 +10,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "CPU backend, kernels, provider selection, and CPU resource pools for tenferro."
+rust-version.workspace = true
+keywords = ["tensor", "cpu", "linear-algebra", "numerical"]
+categories = ["science", "mathematics", "hardware-support"]
+documentation = "https://docs.rs/tenferro-cpu"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+features = ["cpu-faer"]
 
 [lib]
 name = "tenferro_cpu"

--- a/crates/tenferro-einsum/Cargo.toml
+++ b/crates/tenferro-einsum/Cargo.toml
@@ -10,6 +10,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Subscripts, contraction planning, concrete/traced/eager einsum APIs, extension runtime, and AD rule for tenferro."
+rust-version.workspace = true
+keywords = ["tensor", "einsum", "contraction", "numerical"]
+categories = ["science", "mathematics", "algorithms"]
+documentation = "https://docs.rs/tenferro-einsum"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+features = ["autodiff", "cpu-faer", "cuda", "webgpu"]
 
 [features]
 default = ["cpu-faer"]

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -9,6 +9,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "FFT extension runtime and public concrete/traced FFT APIs for tenferro."
+rust-version.workspace = true
+keywords = ["tensor", "fft", "signal-processing", "numerical"]
+categories = ["science", "mathematics"]
+documentation = "https://docs.rs/tenferro-fft"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+features = ["autodiff", "cpu-faer", "cuda", "webgpu"]
 
 [features]
 default = ["cpu-faer"]

--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -10,6 +10,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "CubeCL-backed CUDA and WebGPU provider backends for tenferro tensors."
+rust-version.workspace = true
+keywords = ["tensor", "gpu", "cuda", "webgpu"]
+categories = ["science", "hardware-support", "mathematics"]
+documentation = "https://docs.rs/tenferro-gpu"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+features = ["cpu-faer", "cuda", "webgpu"]
 
 [lib]
 name = "tenferro_gpu"

--- a/crates/tenferro-internal-cpu-kernels/Cargo.toml
+++ b/crates/tenferro-internal-cpu-kernels/Cargo.toml
@@ -9,6 +9,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Internal CPU kernel implementations and buffer pools for tenferro-cpu."
+rust-version.workspace = true
+keywords = ["tensor", "kernels", "cpu", "numerical"]
+categories = ["science", "mathematics", "hardware-support"]
+documentation = "https://docs.rs/tenferro-internal-cpu-kernels"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
 
 [lib]
 name = "tenferro_internal_cpu_kernels"

--- a/crates/tenferro-internal-extension-macros/Cargo.toml
+++ b/crates/tenferro-internal-extension-macros/Cargo.toml
@@ -9,6 +9,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Procedural macros for tenferro extension-op registration."
+rust-version.workspace = true
+keywords = ["tensor", "macros", "code-generation"]
+categories = ["development-tools", "development-tools::procedural-macro-helpers"]
+documentation = "https://docs.rs/tenferro-internal-extension-macros"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
 
 [lib]
 name = "tenferro_extension_macros"

--- a/crates/tenferro-internal-ops/Cargo.toml
+++ b/crates/tenferro-internal-ops/Cargo.toml
@@ -9,6 +9,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Graph op vocabulary and AD rule implementations for the tenferro workspace."
+rust-version.workspace = true
+keywords = ["tensor", "operations", "autodiff", "graph"]
+categories = ["science", "mathematics", "algorithms"]
+documentation = "https://docs.rs/tenferro-internal-ops"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
 
 [lib]
 name = "tenferro_ops"

--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -10,6 +10,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Linear algebra traced APIs, eager helpers, extension runtime, and optional AD rules for tenferro."
+rust-version.workspace = true
+keywords = ["linear-algebra", "tensor", "mathematics", "numerical"]
+categories = ["science", "mathematics", "algorithms"]
+documentation = "https://docs.rs/tenferro-linalg"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+features = ["autodiff", "cpu-faer", "cuda", "webgpu"]
 
 [features]
 default = ["cpu-faer"]

--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -10,6 +10,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Concrete tensor helpers, traced tensors, graph execution, and extension runtime support for tenferro."
+rust-version.workspace = true
+keywords = ["tensor", "runtime", "graph", "numerical"]
+categories = ["science", "mathematics", "data-structures"]
+documentation = "https://docs.rs/tenferro-runtime"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+features = ["cpu-faer"]
 
 [lib]
 name = "tenferro_runtime"

--- a/crates/tenferro-tensor-core/Cargo.toml
+++ b/crates/tenferro-tensor-core/Cargo.toml
@@ -9,6 +9,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Host-only tensor data model, dtype tags, scalar trait, and metadata-only views for tenferro."
+rust-version.workspace = true
+keywords = ["tensor", "data-structures", "numerical"]
+categories = ["science", "mathematics", "data-structures"]
+documentation = "https://docs.rs/tenferro-tensor-core"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
 
 [lib]
 name = "tenferro_tensor_core"

--- a/crates/tenferro-tensor/Cargo.toml
+++ b/crates/tenferro-tensor/Cargo.toml
@@ -9,6 +9,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Dense runtime tensors, views, backend traits, and backend-independent contracts for tenferro."
+rust-version.workspace = true
+keywords = ["tensor", "numerical", "array"]
+categories = ["science", "mathematics", "data-structures"]
+documentation = "https://docs.rs/tenferro-tensor"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
 
 [lib]
 name = "tenferro_tensor"

--- a/crates/tenferro-xla/Cargo.toml
+++ b/crates/tenferro-xla/Cargo.toml
@@ -10,6 +10,14 @@ readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Experimental StableHLO lowering and runtime PJRT plugin loading for tenferro static graph programs."
+rust-version.workspace = true
+keywords = ["tensor", "xla", "stablehlo", "compiler"]
+categories = ["science", "mathematics", "development-tools"]
+documentation = "https://docs.rs/tenferro-xla"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
 
 [lib]
 name = "tenferro_xla"

--- a/docs/worklogs/2026-07-04-release-publish-workflow.md
+++ b/docs/worklogs/2026-07-04-release-publish-workflow.md
@@ -38,3 +38,46 @@ cleanup, the branch was pushed, `v0.2.0` was tagged on the publish commit
   verified live during Phase 3.
 - Test suite not rerun locally for this docs-only branch (code tree
   identical to `origin/main`); PR CI gates the merge.
+
+## #1608 follow-up: published crate metadata
+
+Added the accepted 14-crate metadata contract: workspace MSRV `1.96`, inherited
+`rust-version`, crates.io keywords/categories, exact docs.rs URLs, and docs.rs
+`rustdoc-args`. The checker and focused importlib tests reject missing metadata,
+invalid counts or keyword syntax, invalid URLs, invalid docs.rs feature modes,
+and undefined explicit docs.rs features. Published discovery uses Cargo
+metadata's `package.publish` semantics, with the 14-crate order above as the
+allowlisted publishable set.
+
+| Crate | Keywords | Categories | docs.rs mode |
+| --- | --- | --- | --- |
+| tenferro-tensor | tensor, numerical, array | science, mathematics, data-structures | all features |
+| tenferro-cpu | tensor, cpu, linear-algebra, numerical | science, mathematics, hardware-support | `cpu-faer` |
+| tenferro-gpu | tensor, gpu, cuda, webgpu | science, hardware-support, mathematics | `cpu-faer`, `cuda`, `webgpu` |
+| tenferro-runtime | tensor, runtime, graph, numerical | science, mathematics, data-structures | `cpu-faer` |
+| tenferro-ad | tensor, autodiff, numerical, graph | science, mathematics, algorithms | `cpu-faer`, `cuda`, `webgpu` |
+| tenferro-xla | tensor, xla, stablehlo, compiler | science, mathematics, development-tools | all features |
+| tenferro-linalg | linear-algebra, tensor, mathematics, numerical | science, mathematics, algorithms | `autodiff`, `cpu-faer`, `cuda`, `webgpu` |
+| tenferro-einsum | tensor, einsum, contraction, numerical | science, mathematics, algorithms | `autodiff`, `cpu-faer`, `cuda`, `webgpu` |
+| tenferro-fft | tensor, fft, signal-processing, numerical | science, mathematics | `autodiff`, `cpu-faer`, `cuda`, `webgpu` |
+| tenferro-tensor-core | tensor, data-structures, numerical | science, mathematics, data-structures | all features |
+| tenferro-core-ops | tensor, operations, graph | science, mathematics, algorithms | all features |
+| tenferro-internal-cpu-kernels | tensor, kernels, cpu, numerical | science, mathematics, hardware-support | all features |
+| tenferro-internal-ops | tensor, operations, autodiff, graph | science, mathematics, algorithms | all features |
+| tenferro-internal-extension-macros | tensor, macros, code-generation | development-tools, development-tools::procedural-macro-helpers | all features |
+
+The explicit docs.rs lists avoid mutually exclusive CPU/BLAS providers and
+rocm/provider-inject features. The CUDA/WebGPU combinations for GPU, AD, and
+all three public extensions compile in hardware-free nightly documentation
+builds, so those extension APIs remain discoverable. Faer is the only CPU
+provider selected for docs. The exact `cargo +1.96.0 check --workspace`,
+metadata discovery (14 manifests), focused checker tests/check, and nightly
+GPU/AD/extension docs builds passed. `cargo package` produced and inspected the
+tensor, runtime, linalg, tensor-core, and internal-ops package manifests;
+metadata survived and packaged manifests had no git-only dependency entries.
+Verification of tensor/runtime/linalg and internal-ops tarballs is blocked by
+registry drift: their existing published 0.2.0 dependency artifacts lack
+current workspace symbols; tensor-core verification passed. No dependency,
+README, service, facade, feature-default, or MSRV-matrix change was made.
+Residual: publish deep crates only after matching dependencies are available on
+crates.io; package verification should then be rerun.

--- a/scripts/check-publish-layout.py
+++ b/scripts/check-publish-layout.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 
@@ -37,17 +38,20 @@ IMPLEMENTATION_CRATE_ORDER = [
 TENFERRO_CRATES = (
     USER_CRATE_ORDER + EXTENSION_CRATE_ORDER + IMPLEMENTATION_CRATE_ORDER
 )
-PUBLISHED_CRATES = set(
-    USER_CRATE_ORDER
-    + EXTENSION_CRATE_ORDER
-    + [
-        "tenferro-tensor-core",
-        "tenferro-core-ops",
-        "tenferro-internal-cpu-kernels",
-        "tenferro-internal-ops",
-        "tenferro-internal-extension-macros",
-    ]
-)
+VALID_CATEGORIES = {
+    "algorithms",
+    "api-bindings",
+    "data-structures",
+    "development-tools",
+    "development-tools::procedural-macro-helpers",
+    "external-ffi-bindings",
+    "hardware-support",
+    "mathematics",
+    "no-std",
+    "rust-patterns",
+    "science",
+    "simulation",
+}
 
 
 def rel(path: Path) -> str:
@@ -90,11 +94,30 @@ def markdown_section(text: str, heading: str) -> str:
     return rest
 
 
+def publishable_crates(metadata: dict) -> set[str]:
+    return {
+        package["name"]
+        for package in metadata["packages"]
+        if Path(package["manifest_path"]).parent.parent == ROOT / "crates"
+        and package["name"].startswith("tenferro-")
+        and package.get("publish") != []
+    }
+
+
 def check_workspace_members(metadata: dict, root_text: str, errors: list[str]) -> None:
     packages = {package["name"]: package for package in metadata["packages"]}
 
     if "tenferro" in packages:
         errors.append("workspace must not include a root tenferro facade crate")
+
+    workspace_crates = publishable_crates(metadata)
+    expected_crates = set(TENFERRO_CRATES)
+    missing_crates = sorted(expected_crates - workspace_crates)
+    unexpected_crates = sorted(workspace_crates - expected_crates)
+    if missing_crates:
+        errors.append(f"workspace missing published crates: {missing_crates}")
+    if unexpected_crates:
+        errors.append(f"workspace has unexpected published crates: {unexpected_crates}")
 
     for crate in TENFERRO_CRATES:
         package = packages.get(crate)
@@ -122,6 +145,7 @@ def check_workspace_members(metadata: dict, root_text: str, errors: list[str]) -
 def check_workspace_metadata(root_text: str, errors: list[str]) -> None:
     package_section = section(root_text, "workspace.package")
     required_lines = [
+        'rust-version = "1.96"',
         'publish = true',
         'readme = "README.md"',
         'repository = "https://github.com/tensor4all/tenferro-rs"',
@@ -153,6 +177,97 @@ def workspace_version(root_text: str) -> str:
     raise ValueError("workspace.package missing version")
 
 
+def check_crate_metadata(
+    crate: str, manifest_text: str, errors: list[str], manifest_name: str
+) -> None:
+    try:
+        manifest = tomllib.loads(manifest_text)
+    except tomllib.TOMLDecodeError as error:
+        errors.append(f"{manifest_name} has invalid TOML: {error}")
+        return
+
+    package = manifest.get("package", {})
+    if package.get("rust-version") != {"workspace": True}:
+        errors.append(
+            f"{manifest_name} package.rust-version must inherit workspace metadata"
+        )
+
+    for key in ("keywords", "categories"):
+        values = package.get(key)
+        if not isinstance(values, list) or not 1 <= len(values) <= 5:
+            errors.append(f"{manifest_name} package.{key} must contain 1-5 entries")
+        elif any(not isinstance(value, str) or not value for value in values):
+            errors.append(f"{manifest_name} package.{key} entries must be non-empty strings")
+        elif key == "keywords":
+            if len(set(values)) != len(values):
+                errors.append(f"{manifest_name} package.keywords must be unique")
+            invalid_keywords = [
+                value
+                for value in values
+                if len(value) > 20
+                or not value[0].isascii()
+                or not value[0].isalnum()
+                or any(
+                    not character.isascii()
+                    or not (character.isalnum() or character in "_+-")
+                    for character in value[1:]
+                )
+            ]
+            if invalid_keywords:
+                errors.append(
+                    f"{manifest_name} package.keywords contain invalid crates.io syntax: "
+                    f"{invalid_keywords}"
+                )
+
+    categories = package.get("categories")
+    if isinstance(categories, list):
+        invalid = sorted(set(categories) - VALID_CATEGORIES)
+        if invalid:
+            errors.append(
+                f"{manifest_name} package.categories has invalid crates.io slugs: {invalid}"
+            )
+
+    expected_documentation = f"https://docs.rs/{crate}"
+    if package.get("documentation") != expected_documentation:
+        errors.append(
+            f"{manifest_name} package.documentation must be {expected_documentation!r}"
+        )
+
+    docs_rs = package.get("metadata", {}).get("docs", {}).get("rs")
+    if not isinstance(docs_rs, dict):
+        errors.append(f"{manifest_name} missing [package.metadata.docs.rs]")
+        return
+    if docs_rs.get("rustdoc-args") != ["--cfg", "docsrs"]:
+        errors.append(
+            f"{manifest_name} docs.rs rustdoc-args must be ['--cfg', 'docsrs']"
+        )
+
+    has_all_features = "all-features" in docs_rs
+    has_explicit_features = "features" in docs_rs
+    if has_all_features == has_explicit_features:
+        errors.append(
+            f"{manifest_name} docs.rs must set exactly one of all-features or features"
+        )
+    elif has_all_features:
+        if docs_rs["all-features"] is not True:
+            errors.append(f"{manifest_name} docs.rs all-features must be true")
+    else:
+        features = docs_rs["features"]
+        if not isinstance(features, list) or not features:
+            errors.append(f"{manifest_name} docs.rs features must be a non-empty list")
+        elif any(not isinstance(feature, str) or not feature for feature in features):
+            errors.append(f"{manifest_name} docs.rs features must be non-empty strings")
+        else:
+            defined_features = manifest.get("features", {})
+            if not isinstance(defined_features, dict):
+                defined_features = {}
+            missing_features = sorted(set(features) - set(defined_features))
+            if missing_features:
+                errors.append(
+                    f"{manifest_name} docs.rs features are not defined: {missing_features}"
+                )
+
+
 def check_package_metadata(root_text: str, errors: list[str]) -> None:
     expected_version = workspace_version(root_text)
     for crate in TENFERRO_CRATES:
@@ -163,19 +278,17 @@ def check_package_metadata(root_text: str, errors: list[str]) -> None:
 
         manifest_text = manifest_path.read_text(encoding="utf-8")
         package_section = section(manifest_text, "package")
-        if crate in PUBLISHED_CRATES:
-            if "publish.workspace = true" not in package_section:
-                errors.append(
-                    f"{rel(manifest_path)} package.publish must inherit workspace metadata"
-                )
-        else:
-            errors.append(f"no publish-layout classification for crate {crate!r}")
+        if "publish.workspace = true" not in package_section:
+            errors.append(
+                f"{rel(manifest_path)} package.publish must inherit workspace metadata"
+            )
 
         for key in ("readme", "repository", "homepage"):
             if f"{key}.workspace = true" not in package_section:
                 errors.append(
                     f"{rel(manifest_path)} package.{key} must inherit workspace metadata"
                 )
+        check_crate_metadata(crate, manifest_text, errors, rel(manifest_path))
         for line_no, line in enumerate(manifest_text.splitlines(), start=1):
             version_fragment = f'version = "{expected_version}"'
             if 'path = "../tenferro-' in line and version_fragment not in line:

--- a/scripts/test-check-publish-layout.py
+++ b/scripts/test-check-publish-layout.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Focused tests for the crates.io publish-layout checker."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("check-publish-layout.py")
+SPEC = importlib.util.spec_from_file_location("check_publish_layout", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot import {SCRIPT}")
+CHECKER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECKER)
+
+
+VALID_ALL_FEATURES = """\
+[package]
+name = "tenferro-fixture"
+rust-version.workspace = true
+keywords = ["tensor"]
+categories = ["science"]
+documentation = "https://docs.rs/tenferro-fixture"
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
+
+[features]
+cpu-faer = []
+autodiff = []
+"""
+VALID_EXPLICIT_FEATURES = VALID_ALL_FEATURES.replace(
+    "all-features = true", 'features = ["cpu-faer", "autodiff"]'
+)
+
+
+class PublishMetadataTests(unittest.TestCase):
+    def check(self, manifest: str) -> list[str]:
+        errors: list[str] = []
+        CHECKER.check_crate_metadata(
+            "tenferro-fixture", manifest, errors, "fixture/Cargo.toml"
+        )
+        return errors
+
+    def test_accepts_all_features_mode(self) -> None:
+        self.assertEqual(self.check(VALID_ALL_FEATURES), [])
+
+    def test_accepts_explicit_features_mode(self) -> None:
+        self.assertEqual(self.check(VALID_EXPLICIT_FEATURES), [])
+
+    def test_accepts_crates_io_keyword_syntax(self) -> None:
+        manifest = VALID_ALL_FEATURES.replace(
+            'keywords = ["tensor"]', 'keywords = ["123", "a_b", "a-b", "a+b"]'
+        )
+        self.assertEqual(self.check(manifest), [])
+
+    def test_rejects_missing_rust_version_keywords_categories_and_docs_metadata(self) -> None:
+        manifest = VALID_ALL_FEATURES.replace("rust-version.workspace = true\n", "")
+        manifest = manifest.replace('keywords = ["tensor"]', "keywords = []")
+        manifest = manifest.replace('categories = ["science"]', "categories = []")
+        manifest = manifest.replace("[package.metadata.docs.rs]", "[package.metadata.missing]")
+        errors = self.check(manifest)
+        self.assertTrue(any("rust-version" in error for error in errors))
+        self.assertTrue(any("keywords" in error for error in errors))
+        self.assertTrue(any("categories" in error for error in errors))
+        self.assertTrue(any("docs.rs" in error for error in errors))
+
+    def test_rejects_invalid_keyword_and_category_counts(self) -> None:
+        manifest = VALID_ALL_FEATURES.replace(
+            'keywords = ["tensor"]',
+            'keywords = ["a", "b", "c", "d", "e", "f"]',
+        ).replace(
+            'categories = ["science"]',
+            'categories = ["science", "mathematics", "algorithms", "simulation", "data-structures", "no-std"]',
+        )
+        errors = self.check(manifest)
+        self.assertTrue(any("keywords must contain 1-5" in error for error in errors))
+        self.assertTrue(any("categories must contain 1-5" in error for error in errors))
+
+    def test_rejects_invalid_keyword_syntax(self) -> None:
+        cases = (
+            '["tensor words"]',
+            '["tensor!"]',
+            '["_tensor"]',
+            '["ténsor"]',
+            '["abcdefghijklmnopqrstu"]',
+        )
+        for keywords in cases:
+            with self.subTest(keywords=keywords):
+                errors = self.check(VALID_ALL_FEATURES.replace('keywords = ["tensor"]', f"keywords = {keywords}"))
+                self.assertTrue(any("keywords" in error and "syntax" in error for error in errors))
+
+        errors = self.check(
+            VALID_ALL_FEATURES.replace(
+                'keywords = ["tensor"]', 'keywords = ["tensor", "tensor"]'
+            )
+        )
+        self.assertTrue(any("keywords must be unique" in error for error in errors))
+
+    def test_rejects_invalid_documentation_url(self) -> None:
+        errors = self.check(
+            VALID_ALL_FEATURES.replace(
+                'documentation = "https://docs.rs/tenferro-fixture"',
+                'documentation = "https://example.invalid/tenferro-fixture"',
+            )
+        )
+        self.assertTrue(any("documentation" in error for error in errors))
+
+    def test_rejects_invalid_docs_rs_modes(self) -> None:
+        cases = (
+            VALID_ALL_FEATURES.replace("all-features = true", ""),
+            VALID_ALL_FEATURES.replace("all-features = true", "all-features = false"),
+            VALID_ALL_FEATURES.replace("all-features = true", 'features = []'),
+            VALID_ALL_FEATURES.replace("all-features = true", 'features = "cpu-faer"'),
+            VALID_EXPLICIT_FEATURES.replace(
+                'features = ["cpu-faer", "autodiff"]',
+                'all-features = true\nfeatures = ["cpu-faer"]',
+            ),
+            VALID_EXPLICIT_FEATURES.replace(
+                'features = ["cpu-faer", "autodiff"]',
+                'all-features = false\nfeatures = ["cpu-faer"]',
+            ),
+            VALID_EXPLICIT_FEATURES.replace(
+                'features = ["cpu-faer", "autodiff"]',
+                'features = ["missing-feature"]',
+            ),
+        )
+        for manifest in cases:
+            with self.subTest(manifest=manifest):
+                self.assertTrue(
+                    any("docs.rs" in error for error in self.check(manifest))
+                )
+
+    def test_discovers_only_publishable_nested_crates(self) -> None:
+        root = CHECKER.ROOT
+        metadata = {
+            "packages": [
+                {
+                    "name": "tenferro-fixture",
+                    "manifest_path": str(root / "crates/tenferro-fixture/Cargo.toml"),
+                    "publish": None,
+                },
+                {
+                    "name": "tenferro-hidden",
+                    "manifest_path": str(root / "crates/tenferro-hidden/Cargo.toml"),
+                    "publish": [],
+                },
+                {
+                    "name": "tenferro-nested",
+                    "manifest_path": str(root / "crates/tenferro-nested/deep/Cargo.toml"),
+                    "publish": None,
+                },
+            ]
+        }
+        self.assertEqual(CHECKER.publishable_crates(metadata), {"tenferro-fixture"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] Documentation
- [ ] Refactor / cleanup
- [x] Implementation of accepted issue

## Related issue

Fixes #1608

## Summary

Adds the accepted crates.io/docs.rs/MSRV metadata contract to all 14 published `tenferro-*` crates.

- declares workspace Rust `1.96` and inherits it from every published crate;
- adds crate-specific keywords, valid crates.io categories, and exact docs.rs URLs;
- configures docs.rs with `--cfg docsrs`, using `all-features` only where compatible and explicit Faer/CUDA/WebGPU/autodiff combinations where provider features conflict;
- discovers publishable crates from Cargo metadata and validates the authoritative 14-crate set;
- enforces crates.io keyword/category and docs.rs mode/declared-feature constraints in `check-publish-layout.py`.

The checker-first commit was RED only for the missing workspace/per-crate metadata. Review then exposed invalid category and docs-mode blind spots plus hidden GPU/AD docs surfaces; the final checker/tests and manifest modes address all of them. Independent final review found no Critical, Important, or Minor findings.

## Work log

- [`docs/worklogs/2026-07-04-release-publish-workflow.md`](docs/worklogs/2026-07-04-release-publish-workflow.md#cratesiodocsrs-metadata-follow-up-1608)

It records the full 14-crate metadata/mode matrix, decisions, package sampling, and the pre-existing registry-drift residual.

## RED / GREEN

- Corrected checker-first commit: missing workspace MSRV plus missing per-crate rust-version/keywords/categories/documentation/docs.rs blocks; no false “all crates missing” discovery failure.
- Final: 9 focused checker tests pass, including malformed docs.rs modes, undefined features, invalid keyword/category metadata, and `publish = false` discovery.
- Hardware-free nightly docs pass for all seven explicit modes, including GPU/AD and linalg/einsum/FFT with CUDA + WebGPU surfaces.

## Verification

- `python3 -m unittest scripts/test-check-publish-layout.py` — 9 passed
- `python3 scripts/check-publish-layout.py`
- `cargo metadata --no-deps --format-version 1` — 14 publishable crates, Rust 1.96 metadata
- `cargo +1.96.0 check --workspace`
- nightly docs for all 7 explicit feature modes and all-features docs for the other 7 crates
- `bash scripts/check-pr-fast.sh --no-fetch --coverage-reviewed --test 'python3 -m unittest scripts/test-check-publish-layout.py'`
- `python3 scripts/ci/run_profile.py full` components:
  - fmt and CI-parity clippy
  - Faer and BLAS workspace release tests
  - BLAS provider injection and extension tests
  - workspace docs
  - coverage: 209/209 files passed
  - CI config: storage contracts, 188 Python tests, pinned actionlint v1.7.7
- `bash scripts/build_docs_site.sh` — 14 workspace library crates verified
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1608-final.json` — pass, 0 findings
- package normalization samples: tensor, runtime, linalg, tensor-core, internal-ops retained the new metadata and no git-only dependency entries

## Residual risks

Deep verification of tensor/runtime/linalg/internal-ops package tarballs remains blocked by pre-existing crates.io `0.2.0` dependency artifacts that lack current workspace symbols. `tenferro-tensor-core` verification passes. No dependency specifications, source, defaults, README, lockfile, facade, service, or MSRV matrix changed; deep package verification must be rerun in publish order when matching internal artifacts are available.

## Checklist

- [x] I read `CONTRIBUTING.md`, shared rules, and `REPOSITORY_RULES.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved all findings.
- [x] The linked issue has an accepted implementation plan.
- [x] I updated and linked the owning durable work log.
- [x] The final history contains exactly the two accepted commits.
