### PR TITLE
docs: resolve architecture and Apple example drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,4 +460,10 @@ tenferro-ad
 
 tenferro-core-ops is internal metadata used by tensor, runtime, GPU, and ops.
 tenferro-internal-extension-macros is used by operation-family crates.
+
+tenferro-gpu              -> tenferro-cpu
+tenferro-fft              -> tenferro-cpu
 ```
+
+See [the complete crate map](docs/architecture/tenferro-crates.md) for the
+complete direct-edge inventory.

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -383,10 +383,10 @@ diff-scoped review bot.
 - Optional capabilities are feature boundaries, not new operation-family
   crates. Put operation-specific AD support behind an `autodiff` feature in the
   owning operation crate instead of adding `*-ad` companion crates.
-- User-facing operation crates expose backend features as `cuda` and `rocm`.
-  Do not document or require a public `gpu` feature on those crates; use
-  internal `cfg(any(feature = "cuda", feature = "rocm"))` checks or internal
-  helper features when needed.
+- User-facing operation crates expose backend features as `cuda`, `rocm`, and
+  `webgpu`. Do not document or require a public `gpu` feature on those crates;
+  use internal `cfg(any(feature = "cuda", feature = "rocm", feature = "webgpu"))`
+  checks or internal helper features when needed.
 - Extension crates depend on the runtime, tensor, AD, or GPU crate they need;
   dependency flow must not require a facade crate to depend back on them.
 - Extension AD rules should be owned by an explicit `tenferro_ad::AdContext`

--- a/crates/tenferro-gpu/src/webgpu/apple.rs
+++ b/crates/tenferro-gpu/src/webgpu/apple.rs
@@ -103,9 +103,22 @@ impl SharedTensorAllocationDomain for AppleAllocationDomain {
 /// # Examples
 ///
 /// ```rust
-/// use tenferro_gpu::apple::AppleContext;
+/// use tenferro_gpu::apple::{AppleContext, AppleTransferStats};
 ///
-/// let _constructor: fn() -> tenferro_tensor::Result<AppleContext> = AppleContext::new;
+/// match AppleContext::new() {
+///     Ok(context) => {
+///         assert_eq!(
+///             context.cpu_backend().allocation_domain(),
+///             Some(context.domain_id())
+///         );
+///         assert_eq!(context.transfer_stats(), AppleTransferStats::default());
+///     }
+///     Err(error) => assert!(matches!(
+///         error,
+///         tenferro_tensor::Error::RuntimeState { .. }
+///             | tenferro_tensor::Error::BackendSource { .. }
+///     )),
+/// }
 /// ```
 #[derive(Clone)]
 pub struct AppleContext {
@@ -130,9 +143,22 @@ impl AppleContext {
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_gpu::apple::AppleContext;
+    /// use tenferro_gpu::apple::{AppleContext, AppleTransferStats};
     ///
-    /// let _constructor: fn() -> tenferro_tensor::Result<AppleContext> = AppleContext::new;
+    /// match AppleContext::new() {
+    ///     Ok(context) => {
+    ///         assert_eq!(
+    ///             context.cpu_backend().allocation_domain(),
+    ///             Some(context.domain_id())
+    ///         );
+    ///         assert_eq!(context.transfer_stats(), AppleTransferStats::default());
+    ///     }
+    ///     Err(error) => assert!(matches!(
+    ///         error,
+    ///         tenferro_tensor::Error::RuntimeState { .. }
+    ///             | tenferro_tensor::Error::BackendSource { .. }
+    ///     )),
+    /// }
     /// ```
     ///
     /// # Errors
@@ -178,8 +204,18 @@ impl AppleContext {
     ///
     /// ```rust
     /// use tenferro_gpu::apple::AppleContext;
-    /// use tenferro_tensor::AllocationDomainId;
-    /// let _method: fn(&AppleContext) -> AllocationDomainId = AppleContext::domain_id;
+    ///
+    /// match AppleContext::new() {
+    ///     Ok(context) => assert_eq!(
+    ///         context.cpu_backend().allocation_domain(),
+    ///         Some(context.domain_id())
+    ///     ),
+    ///     Err(error) => assert!(matches!(
+    ///         error,
+    ///         tenferro_tensor::Error::RuntimeState { .. }
+    ///             | tenferro_tensor::Error::BackendSource { .. }
+    ///     )),
+    /// }
     /// ```
     pub fn domain_id(&self) -> AllocationDomainId {
         self.state.id
@@ -191,7 +227,18 @@ impl AppleContext {
     ///
     /// ```rust
     /// use tenferro_gpu::apple::AppleContext;
-    /// let _method = AppleContext::cpu_backend;
+    ///
+    /// match AppleContext::new() {
+    ///     Ok(context) => assert_eq!(
+    ///         context.cpu_backend().allocation_domain(),
+    ///         Some(context.domain_id())
+    ///     ),
+    ///     Err(error) => assert!(matches!(
+    ///         error,
+    ///         tenferro_tensor::Error::RuntimeState { .. }
+    ///             | tenferro_tensor::Error::BackendSource { .. }
+    ///     )),
+    /// }
     /// ```
     pub fn cpu_backend(&self) -> &CpuBackend {
         &self.cpu
@@ -203,7 +250,21 @@ impl AppleContext {
     ///
     /// ```rust
     /// use tenferro_gpu::apple::AppleContext;
-    /// let _method = AppleContext::metal_backend;
+    ///
+    /// match AppleContext::new() {
+    ///     Ok(context) => {
+    ///         let backend = context.metal_backend();
+    ///         assert_eq!(
+    ///             backend.runtime_identity(),
+    ///             backend.runtime().runtime_identity()
+    ///         );
+    ///     }
+    ///     Err(error) => assert!(matches!(
+    ///         error,
+    ///         tenferro_tensor::Error::RuntimeState { .. }
+    ///             | tenferro_tensor::Error::BackendSource { .. }
+    ///     )),
+    /// }
     /// ```
     pub fn metal_backend(&self) -> &WebGpuBackend {
         &self.metal
@@ -214,8 +275,19 @@ impl AppleContext {
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_gpu::apple::AppleContext;
-    /// let _method = AppleContext::transfer_stats;
+    /// use tenferro_gpu::apple::{AppleContext, AppleTransferStats};
+    ///
+    /// match AppleContext::new() {
+    ///     Ok(context) => assert_eq!(
+    ///         context.transfer_stats(),
+    ///         AppleTransferStats::default()
+    ///     ),
+    ///     Err(error) => assert!(matches!(
+    ///         error,
+    ///         tenferro_tensor::Error::RuntimeState { .. }
+    ///             | tenferro_tensor::Error::BackendSource { .. }
+    ///     )),
+    /// }
     /// ```
     pub fn transfer_stats(&self) -> AppleTransferStats {
         self.state.snapshot()
@@ -226,8 +298,33 @@ impl AppleContext {
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_gpu::apple::AppleContext;
-    /// let _method = AppleContext::upload_tensor;
+    /// use tenferro_gpu::apple::{AppleContext, AppleTransferStats};
+    /// use tenferro_tensor::{Tensor, TypedTensor};
+    ///
+    /// match AppleContext::new() {
+    ///     Ok(context) => {
+    ///         let host = Tensor::from_vec_col_major([2], vec![1.0_f32, 2.0])?;
+    ///         let managed: TypedTensor<f32> = match context.upload_tensor(&host)? {
+    ///             Tensor::F32(typed) => typed,
+    ///             _ => unreachable!("expected f32 tensor"),
+    ///         };
+    ///         assert_eq!(managed.allocation_domain(), Some(context.domain_id()));
+    ///         assert_eq!(managed.with_host_read(|data| data.to_vec())?, [1.0, 2.0]);
+    ///         assert_eq!(
+    ///             context.transfer_stats(),
+    ///             AppleTransferStats {
+    ///                 uploaded_bytes: 8,
+    ///                 downloaded_bytes: 0,
+    ///             }
+    ///         );
+    ///     }
+    ///     Err(error) => assert!(matches!(
+    ///         error,
+    ///         tenferro_tensor::Error::RuntimeState { .. }
+    ///             | tenferro_tensor::Error::BackendSource { .. }
+    ///     )),
+    /// }
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     ///
     /// # Errors
@@ -247,8 +344,30 @@ impl AppleContext {
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_gpu::apple::AppleContext;
-    /// let _method = AppleContext::download_tensor;
+    /// use tenferro_gpu::apple::{AppleContext, AppleTransferStats};
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// match AppleContext::new() {
+    ///     Ok(context) => {
+    ///         let host = Tensor::from_vec_col_major([2], vec![1.0_f32, 2.0])?;
+    ///         let managed = context.upload_tensor(&host)?;
+    ///         let downloaded = context.download_tensor(&managed)?;
+    ///         assert_eq!(downloaded.as_slice::<f32>()?, &[1.0, 2.0]);
+    ///         assert_eq!(
+    ///             context.transfer_stats(),
+    ///             AppleTransferStats {
+    ///                 uploaded_bytes: 8,
+    ///                 downloaded_bytes: 8,
+    ///             }
+    ///         );
+    ///     }
+    ///     Err(error) => assert!(matches!(
+    ///         error,
+    ///         tenferro_tensor::Error::RuntimeState { .. }
+    ///             | tenferro_tensor::Error::BackendSource { .. }
+    ///     )),
+    /// }
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     ///
     /// # Errors

--- a/docs/architecture/tenferro-crates.md
+++ b/docs/architecture/tenferro-crates.md
@@ -123,7 +123,7 @@ runtime-owned execution bridge. It is not a runtime-to-CPU dependency:
 
 ```text
 tenferro-tensor           -> tenferro-tensor-core, tenferro-core-ops
-tenferro-cpu              -> tenferro-tensor
+tenferro-cpu              -> tenferro-tensor, tenferro-core-ops
 tenferro-cpu              -> tenferro-internal-cpu-kernels
 tenferro-cpu              -> tenferro-runtime
 tenferro-gpu              -> tenferro-tensor, tenferro-core-ops,
@@ -140,11 +140,14 @@ tenferro-ad               -> tenferro-runtime, tenferro-internal-ops,
                               tenferro-tensor, tenferro-cpu
 
 tenferro-einsum           -> tenferro-runtime, tenferro-internal-ops,
-                              tenferro-tensor, tenferro-cpu
+                              tenferro-tensor, tenferro-cpu,
+                              tenferro-internal-extension-macros
 tenferro-linalg           -> tenferro-runtime, tenferro-internal-ops,
-                              tenferro-tensor, tenferro-cpu
+                              tenferro-tensor, tenferro-cpu,
+                              tenferro-internal-extension-macros
 tenferro-fft              -> tenferro-runtime, tenferro-internal-ops,
-                              tenferro-tensor, tenferro-cpu
+                              tenferro-tensor, tenferro-cpu,
+                              tenferro-internal-extension-macros
 ```
 
 Additional internal dependencies:

--- a/docs/worklogs/2026-08-01-rules-review-structural-checks.md
+++ b/docs/worklogs/2026-08-01-rules-review-structural-checks.md
@@ -230,3 +230,35 @@ is a repair and is fixed here; one is a scope expansion and is now tracked.
 Coverage: `test_rust_inline_test_blocks_ignores_braces_in_literals` and
 `test_rust_inline_test_blocks_handles_literal_edge_cases` (char literals, raw
 strings, escaped quotes, multi-line strings, and the lifetime negative case).
+
+## Issue #1578 follow-up
+
+The remaining drift was documentation-only: the compressed `AGENTS.md` graph
+omitted the production `tenferro-gpu -> tenferro-cpu` and
+`tenferro-fft -> tenferro-cpu` edges, while the detailed architecture inventory
+also omitted `tenferro-cpu -> tenferro-core-ops` and the three normal operation-
+crate edges to `tenferro-internal-extension-macros`. Eight Apple rustdoc
+examples only named function pointers, and the extension-boundary rule omitted
+`webgpu`. The follow-up uses locked `cargo metadata --no-deps` as the
+production-edge inventory, checks the compressed overview and detailed
+inventory, replaces each Apple example with a runnable success/error case, and
+adds a deterministic durable vacuity fixture for the eight pre-edit findings.
+The inventory now covers published workspace crates' normal non-optional edges;
+optional/dev and docs tutorial-code edges remain excluded. The standard
+extension wording now names `cuda`, `rocm`, and `webgpu` without renaming any
+feature or dependency.
+
+The `docs/guides/tenferro-fft.md` checkout remains pinned to `8ffcc57b`: the
+Apple shared path is explicitly unreleased and the checkout pin is removed when
+a later release task publishes it. Verification covered the documentation and
+repository-rule scripts, all 28 WebGPU doctests (including one-at-a-time
+checks while replacing the eight examples), metadata edge proof, guide pin
+justification, docs profile, and the focused PR gate.
+
+Residuals are limited to the documented hardware boundary: no supported Apple
+host was available in this task. Existing Apple integration tests exercise
+success semantics only when `AppleContext::new()` succeeds and skip constructor
+failures, so hosted/hardware evidence remains conditional; they do not prove
+constructor availability. Non-Apple hosts exercise and assert the typed
+unavailable branch, while the successful Apple transfer branch requires a
+supported host-visible Metal adapter.

--- a/scripts/test-doc-consistency.py
+++ b/scripts/test-doc-consistency.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import pathlib
 import re
 import subprocess
@@ -197,6 +198,62 @@ def test_agents_layer_diagram_lists_cpu_crate() -> None:
     assert "tenferro-cpu" in text
     assert "tenferro-tensor   - Dense runtime tensors, backend traits, CPU backend" not in text
     assert "tenferro-tensor   - Dense runtime tensors, backend traits" in text
+
+
+def test_dependency_overview_matches_metadata_for_published_crates() -> None:
+    metadata = json.loads(
+        subprocess.run(
+            ["cargo", "metadata", "--locked", "--no-deps", "--format-version", "1"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    )
+    workspace_members = set(metadata["workspace_members"])
+    expected_edges = {}
+    for package in metadata["packages"]:
+        manifest_path = pathlib.Path(package["manifest_path"])
+        if (
+            package["id"] not in workspace_members
+            or manifest_path.parent.parent != ROOT / "crates"
+            or not package["name"].startswith("tenferro-")
+            or package.get("publish") == []
+        ):
+            continue
+        dependencies = {
+            dependency["name"]
+            for dependency in package["dependencies"]
+            if dependency["name"].startswith("tenferro-")
+            and dependency["kind"] is None
+            and not dependency["optional"]
+        }
+        if dependencies:
+            expected_edges[package["name"]] = dependencies
+
+    reviewer = load_repository_rules_review()
+    documented_edges = reviewer.parse_dependency_diagram(
+        read("docs/architecture/tenferro-crates.md")
+    )
+    assert documented_edges is not None
+    assert documented_edges == expected_edges
+
+    production_edges = {
+        (source, target)
+        for source, targets in expected_edges.items()
+        for target in targets
+    }
+    expected_gpu_fft_edges = {
+        ("tenferro-gpu", "tenferro-cpu"),
+        ("tenferro-fft", "tenferro-cpu"),
+    }
+    assert expected_gpu_fft_edges <= production_edges
+
+    overview_start = read("AGENTS.md").index("### Dependency Graph")
+    overview = read("AGENTS.md")[overview_start:]
+    for source, target in expected_gpu_fft_edges:
+        assert re.search(rf"{source}\s*->\s*{target}", overview)
+    assert "docs/architecture/tenferro-crates.md" in overview
 
 
 def test_docs_ci_runs_docs_script_tests() -> None:
@@ -595,6 +652,7 @@ def main() -> int:
     for test in [
         test_architecture_svg_lists_cpu_crate_xla_boundary_and_background,
         test_agents_layer_diagram_lists_cpu_crate,
+        test_dependency_overview_matches_metadata_for_published_crates,
         test_docs_ci_runs_docs_script_tests,
         test_design_documentation_requirements_have_named_rendered_homes,
         test_ci_enforces_public_error_docs_and_extension_clippy,

--- a/scripts/test-repository-rules-review.py
+++ b/scripts/test-repository-rules-review.py
@@ -1696,6 +1696,112 @@ def test_vacuous_doc_example_findings_accepts_real_usage() -> None:
     assert findings == []
 
 
+APPLE_PRE_EDIT_FIXTURE = """\
+/// Explicit Apple context.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_gpu::apple::AppleContext;
+///
+/// // Constructor type signature.
+/// let _constructor: fn() -> tenferro_tensor::Result<AppleContext> = AppleContext::new;
+/// ```
+///
+/// Create a context with [`AppleContext::new`].
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_gpu::apple::AppleContext;
+///
+/// // The constructor is fallible.
+/// let _constructor: fn() -> tenferro_tensor::Result<AppleContext> = AppleContext::new;
+/// ```
+///
+/// Return this context's allocation-domain identity.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_gpu::apple::AppleContext;
+/// use tenferro_tensor::AllocationDomainId;
+///
+/// // Inspect the method signature.
+/// let _method: fn(&AppleContext) -> AllocationDomainId = AppleContext::domain_id;
+/// ```
+///
+/// Return the paired CPU backend.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_gpu::apple::AppleContext;
+///
+/// // The endpoint is available from the context.
+/// let _method = AppleContext::cpu_backend;
+/// ```
+///
+/// Return the paired Metal WebGPU backend.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_gpu::apple::AppleContext;
+///
+/// // The endpoint is available from the context.
+/// let _method = AppleContext::metal_backend;
+/// ```
+///
+/// Return transfer statistics.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_gpu::apple::AppleContext;
+///
+/// // Read the current counters.
+/// let _method = AppleContext::transfer_stats;
+/// ```
+///
+/// Upload a host tensor.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_gpu::apple::AppleContext;
+///
+/// // Explicitly create managed storage.
+/// let _method = AppleContext::upload_tensor;
+/// ```
+///
+/// Download a managed tensor.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_gpu::apple::AppleContext;
+///
+/// // Explicitly copy managed storage back to the host.
+/// let _method = AppleContext::download_tensor;
+/// ```
+"""
+
+
+def test_vacuous_doc_example_fixture_audits_pre_edit_apple_examples() -> None:
+    mod = load_module()
+    fixture_path = "crates/tenferro-gpu/src/webgpu/apple.rs"
+    _with_fake_text(mod, {fixture_path: APPLE_PRE_EDIT_FIXTURE})
+    findings = mod.vacuous_doc_example_findings(
+        [fixture_path],
+        ref="HEAD",
+        worktree=False,
+        added_lines={fixture_path: set(range(1, len(APPLE_PRE_EDIT_FIXTURE.splitlines()) + 1))},
+    )
+    assert len(findings) == 8
+    assert all(item.id == "vacuous-doc-example" for item in findings)
+
+
 def test_ai_report_file_findings_flags_reports_outside_worklogs() -> None:
     mod = load_module()
     _with_fake_text(
@@ -2936,6 +3042,7 @@ def main() -> int:
         test_vacuous_doc_example_findings_ignores_comment_lines,
         test_vacuous_doc_example_findings_accepts_comment_only_example,
         test_vacuous_doc_example_findings_accepts_real_usage,
+        test_vacuous_doc_example_fixture_audits_pre_edit_apple_examples,
         test_ai_report_file_findings_flags_reports_outside_worklogs,
         test_parse_cargo_tenferro_dependencies_skips_optional_and_dev,
         test_parse_cargo_tenferro_dependencies_accepts_compact_optional_syntax,


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] Documentation
- [x] Refactor / cleanup
- [x] Implementation of accepted issue

## Related issue

Fixes #1578

## Summary

Closes the remaining documentation and policy drift from the #1424/#1428 audit without changing dependency shape or feature names.

- synchronizes the compressed `AGENTS.md` overview and complete architecture edge inventory with locked Cargo metadata;
- adds deterministic equality coverage for all published crates' normal, non-optional direct edges, plus explicit GPU/FFT→CPU overview checks;
- replaces all eight function-pointer-only `AppleContext` doctests with real calls and supported-host identity/transfer assertions or typed unavailable outcomes;
- preserves and explains the intentional `8ffcc57b` FFT guide pin until the Apple shared path is released;
- records `webgpu` beside `cuda` and `rocm` in the Standard Extension Boundary.

No Cargo manifest, dependency, feature, executable Rust body, guide revision pin, fallback, parser framework, or platform probe changed.

## RED / GREEN

- The new dependency-overview test failed before the AGENTS graph was updated.
- The pre-edit Apple source produced exactly eight vacuous-example findings; the durable synthetic fixture preserves those eight cases without consulting mutable Git refs.
- Each of the eight examples was replaced and the 28-example WebGPU doctest suite rerun incrementally.
- Review found and fixed a merge-unstable `origin/main` fixture, four additional missing architecture edges, weak endpoint assertions, invalid managed `as_slice` access, unlocked metadata, and overstated Apple hardware evidence.
- Final independent specification/quality/whole-branch reviews report no Critical, Important, or Minor findings.

## Work log

- [`docs/worklogs/2026-08-01-rules-review-structural-checks.md`](docs/worklogs/2026-08-01-rules-review-structural-checks.md#issue-1578-follow-up)

## Verification

- `python3 scripts/test-doc-consistency.py`
- `python3 scripts/test-repository-rules-review.py`
- `cargo test --locked -p tenferro-gpu --features webgpu --doc` — 28 passed
- locked metadata vs architecture inventory — exact 39-edge match
- policy and guide-pin searches from the accepted plan
- accepted focused fast gate with the WebGPU doctest
- `python3 scripts/ci/run_profile.py full`:
  - fmt and CI-parity clippy
  - Faer and BLAS workspace release tests
  - BLAS injection and extension tests
  - workspace docs
  - coverage: 209/209 files passed
  - CI config: storage contracts, 188 Python tests, pinned actionlint v1.7.7
- `bash scripts/build_docs_site.sh` — 14 workspace library crates verified
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1578-final.json` — pass, 0 findings

## Residual risks

No supported Apple/Metal host was available locally. Non-Apple doctests execute and assert only the documented typed unavailable constructor outcomes. Existing Apple integration tests exercise the successful identity/managed-transfer semantics only when construction succeeds and skip constructor failures; hosted hardware evidence therefore remains conditional.

## Checklist

- [x] I read `CONTRIBUTING.md`, shared rules, and `REPOSITORY_RULES.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved all findings.
- [x] The linked issue has an accepted revised implementation plan.
- [x] I updated and linked the owning durable work log.
- [x] This remediation PR preserves exactly three coherent accepted commits and will use non-squash merge.
