### PR TITLE
refactor: deduplicate validation and strided views

### DIFF
--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -496,22 +496,34 @@ fn typed_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     .map_err(|err| crate::Error::backend_source("slice", err))?;
 
     let mut out = PooledUninitOutput::new(buffers, out_shape.clone())?;
-    let input_ref = crate::erased_raw_strided_ref(
-        dtype,
-        typed_bytes(typed_host_data("slice", input)?),
-        input_shape,
-        &input_strides,
-        0,
-    )
+    let input_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            dtype,
+            typed_bytes(typed_host_data("slice", input)?),
+            input_shape,
+            &input_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("slice", err))?;
     let input_ptr = ErasedRawStridedPtr::from_ref(&input_ref);
-    let mut out_ref = crate::erased_raw_strided_uninit_mut(
-        dtype,
-        out.as_uninit_bytes_mut(),
-        &out_shape,
-        &out_strides,
-        0,
-    )
+    let mut out_ref = unsafe {
+        // SAFETY: the output guard exclusively owns aligned storage whose
+        // byte layout agrees with dtype; validated dimensions, strides, and
+        // offset keep every destination in bounds, and the following kernel
+        // overwrites every reachable element before typed exposure.
+        crate::erased_raw_strided_uninit_mut(
+            dtype,
+            out.as_uninit_bytes_mut(),
+            &out_shape,
+            &out_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("slice", err))?;
     plan.execute_uninit(exec_context, &mut out_ref, &input_ptr)
         .map_err(|err| crate::Error::backend_source("slice", err))?;
@@ -638,13 +650,19 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar + TensorScalar>(
         .iter()
         .zip(input_strides.iter())
         .map(|(input, strides)| {
-            crate::erased_raw_strided_ref(
-                dtype,
-                typed_bytes(typed_host_data("concatenate", input)?),
-                input.shape(),
-                strides,
-                0,
-            )
+            unsafe {
+                // SAFETY: this operation supplies initialized typed bytes with
+                // alignment and dtype matching the descriptor; validated dimensions,
+                // strides, and offset keep every reachable source element in bounds
+                // for the retained borrow.
+                crate::erased_raw_strided_ref(
+                    dtype,
+                    typed_bytes(typed_host_data("concatenate", input)?),
+                    input.shape(),
+                    strides,
+                    0,
+                )
+            }
             .map_err(|err| crate::Error::backend_source("concatenate", err))
         })
         .collect::<crate::Result<_>>()?;
@@ -652,13 +670,19 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar + TensorScalar>(
         .iter()
         .map(ErasedRawStridedPtr::from_ref)
         .collect();
-    let mut out_ref = crate::erased_raw_strided_uninit_mut(
-        dtype,
-        out.as_uninit_bytes_mut(),
-        &out_shape,
-        &out_strides,
-        0,
-    )
+    let mut out_ref = unsafe {
+        // SAFETY: the output guard exclusively owns aligned storage whose
+        // byte layout agrees with dtype; validated dimensions, strides, and
+        // offset keep every destination in bounds, and the following kernel
+        // overwrites every reachable element before typed exposure.
+        crate::erased_raw_strided_uninit_mut(
+            dtype,
+            out.as_uninit_bytes_mut(),
+            &out_shape,
+            &out_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("concatenate", err))?;
     plan.execute_uninit(exec_context, &mut out_ref, &input_ptrs)
         .map_err(|err| crate::Error::backend_source("concatenate", err))?;
@@ -690,22 +714,34 @@ fn typed_reverse<T: Copy + Clone + PoolScalar + TensorScalar>(
         .map_err(|err| crate::Error::backend_source("reverse", err))?;
 
     let mut out = PooledUninitOutput::new(buffers, input_shape.to_vec())?;
-    let input_ref = crate::erased_raw_strided_ref(
-        dtype,
-        typed_bytes(typed_host_data("reverse", input)?),
-        input_shape,
-        &input_strides,
-        0,
-    )
+    let input_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            dtype,
+            typed_bytes(typed_host_data("reverse", input)?),
+            input_shape,
+            &input_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("reverse", err))?;
     let input_ptr = ErasedRawStridedPtr::from_ref(&input_ref);
-    let mut out_ref = crate::erased_raw_strided_uninit_mut(
-        dtype,
-        out.as_uninit_bytes_mut(),
-        input_shape,
-        &out_strides,
-        0,
-    )
+    let mut out_ref = unsafe {
+        // SAFETY: the output guard exclusively owns aligned storage whose
+        // byte layout agrees with dtype; validated dimensions, strides, and
+        // offset keep every destination in bounds, and the following kernel
+        // overwrites every reachable element before typed exposure.
+        crate::erased_raw_strided_uninit_mut(
+            dtype,
+            out.as_uninit_bytes_mut(),
+            input_shape,
+            &out_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("reverse", err))?;
     plan.execute_uninit(exec_context, &mut out_ref, &input_ptr)
         .map_err(|err| crate::Error::backend_source("reverse", err))?;
@@ -1049,29 +1085,47 @@ fn typed_gather<T: Copy + Clone + PoolScalar + TensorScalar>(
         })
         .map_err(|err| crate::Error::backend_source("gather", err))?;
 
-    let operand_ref = crate::erased_raw_strided_ref(
-        dtype,
-        typed_bytes(typed_host_data("gather", operand)?),
-        operand_shape,
-        &operand_strides,
-        0,
-    )
+    let operand_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            dtype,
+            typed_bytes(typed_host_data("gather", operand)?),
+            operand_shape,
+            &operand_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("gather", err))?;
-    let index_ref = crate::erased_raw_strided_ref(
-        index_dtype,
-        typed_bytes(&start_indices.values),
-        &start_indices.shape,
-        &index_strides,
-        0,
-    )
+    let index_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            index_dtype,
+            typed_bytes(&start_indices.values),
+            &start_indices.shape,
+            &index_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("gather", err))?;
-    let mut out_ref = crate::erased_raw_strided_uninit_mut(
-        dtype,
-        out.as_uninit_bytes_mut(),
-        &out_shape,
-        &out_strides,
-        0,
-    )
+    let mut out_ref = unsafe {
+        // SAFETY: the output guard exclusively owns aligned storage whose
+        // byte layout agrees with dtype; validated dimensions, strides, and
+        // offset keep every destination in bounds, and the following kernel
+        // overwrites every reachable element before typed exposure.
+        crate::erased_raw_strided_uninit_mut(
+            dtype,
+            out.as_uninit_bytes_mut(),
+            &out_shape,
+            &out_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("gather", err))?;
     let operand_ptr = ErasedRawStridedPtr::from_ref(&operand_ref);
     let index_ptr = ErasedRawStridedPtr::from_ref(&index_ref);
@@ -1303,37 +1357,61 @@ where
     // INVARIANT: ErasedScatterPlan first copies the full operand into `out`,
     // then applies every additive update.
     let mut out = PooledUninitOutput::<T>::new(buffers, operand_shape.to_vec())?;
-    let operand_ref = crate::erased_raw_strided_ref(
-        dtype,
-        typed_bytes(typed_host_data("scatter", operand)?),
-        operand_shape,
-        &operand_strides,
-        0,
-    )
+    let operand_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            dtype,
+            typed_bytes(typed_host_data("scatter", operand)?),
+            operand_shape,
+            &operand_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("scatter", err))?;
-    let index_ref = crate::erased_raw_strided_ref(
-        index_dtype,
-        typed_bytes(&scatter_indices.values),
-        &scatter_indices.shape,
-        &index_strides,
-        0,
-    )
+    let index_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            index_dtype,
+            typed_bytes(&scatter_indices.values),
+            &scatter_indices.shape,
+            &index_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("scatter", err))?;
-    let update_ref = crate::erased_raw_strided_ref(
-        dtype,
-        typed_bytes(typed_host_data("scatter", updates)?),
-        updates_shape,
-        &update_strides,
-        0,
-    )
+    let update_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            dtype,
+            typed_bytes(typed_host_data("scatter", updates)?),
+            updates_shape,
+            &update_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("scatter", err))?;
-    let mut out_ref = crate::erased_raw_strided_uninit_mut(
-        dtype,
-        out.as_uninit_bytes_mut(),
-        operand_shape,
-        &out_strides,
-        0,
-    )
+    let mut out_ref = unsafe {
+        // SAFETY: the output guard exclusively owns aligned storage whose
+        // byte layout agrees with dtype; validated dimensions, strides, and
+        // offset keep every destination in bounds, and the following kernel
+        // overwrites every reachable element before typed exposure.
+        crate::erased_raw_strided_uninit_mut(
+            dtype,
+            out.as_uninit_bytes_mut(),
+            operand_shape,
+            &out_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("scatter", err))?;
     let operand_ptr = ErasedRawStridedPtr::from_ref(&operand_ref);
     let index_ptr = ErasedRawStridedPtr::from_ref(&index_ref);
@@ -1427,29 +1505,47 @@ fn typed_dynamic_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
         .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
     // INVARIANT: ErasedDynamicSlicePlan writes every output coordinate exactly once.
     let mut out = PooledUninitOutput::<T>::new(buffers, out_shape.clone())?;
-    let input_ref = crate::erased_raw_strided_ref(
-        dtype,
-        typed_bytes(typed_host_data("dynamic_slice", input)?),
-        input_shape,
-        &input_strides,
-        0,
-    )
+    let input_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            dtype,
+            typed_bytes(typed_host_data("dynamic_slice", input)?),
+            input_shape,
+            &input_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
-    let start_ref = crate::erased_raw_strided_ref(
-        index_dtype,
-        typed_bytes(&starts.values),
-        &starts.shape,
-        &start_strides,
-        0,
-    )
+    let start_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            index_dtype,
+            typed_bytes(&starts.values),
+            &starts.shape,
+            &start_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
-    let mut out_ref = crate::erased_raw_strided_uninit_mut(
-        dtype,
-        out.as_uninit_bytes_mut(),
-        &out_shape,
-        &out_strides,
-        0,
-    )
+    let mut out_ref = unsafe {
+        // SAFETY: the output guard exclusively owns aligned storage whose
+        // byte layout agrees with dtype; validated dimensions, strides, and
+        // offset keep every destination in bounds, and the following kernel
+        // overwrites every reachable element before typed exposure.
+        crate::erased_raw_strided_uninit_mut(
+            dtype,
+            out.as_uninit_bytes_mut(),
+            &out_shape,
+            &out_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
     let input_ptr = ErasedRawStridedPtr::from_ref(&input_ref);
     let start_ptr = ErasedRawStridedPtr::from_ref(&start_ref);
@@ -1543,37 +1639,61 @@ fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     // INVARIANT: ErasedDynamicUpdateSlicePlan copies the full operand into
     // `out` before overwriting the update window.
     let mut out = PooledUninitOutput::<T>::new(buffers, operand_shape.to_vec())?;
-    let operand_ref = crate::erased_raw_strided_ref(
-        dtype,
-        typed_bytes(typed_host_data("dynamic_update_slice", operand)?),
-        operand_shape,
-        &operand_strides,
-        0,
-    )
+    let operand_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            dtype,
+            typed_bytes(typed_host_data("dynamic_update_slice", operand)?),
+            operand_shape,
+            &operand_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
-    let update_ref = crate::erased_raw_strided_ref(
-        dtype,
-        typed_bytes(typed_host_data("dynamic_update_slice", update)?),
-        update_shape,
-        &update_strides,
-        0,
-    )
+    let update_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            dtype,
+            typed_bytes(typed_host_data("dynamic_update_slice", update)?),
+            update_shape,
+            &update_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
-    let start_ref = crate::erased_raw_strided_ref(
-        index_dtype,
-        typed_bytes(&starts.values),
-        &starts.shape,
-        &start_strides,
-        0,
-    )
+    let start_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            index_dtype,
+            typed_bytes(&starts.values),
+            &starts.shape,
+            &start_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
-    let mut out_ref = crate::erased_raw_strided_uninit_mut(
-        dtype,
-        out.as_uninit_bytes_mut(),
-        operand_shape,
-        &out_strides,
-        0,
-    )
+    let mut out_ref = unsafe {
+        // SAFETY: the output guard exclusively owns aligned storage whose
+        // byte layout agrees with dtype; validated dimensions, strides, and
+        // offset keep every destination in bounds, and the following kernel
+        // overwrites every reachable element before typed exposure.
+        crate::erased_raw_strided_uninit_mut(
+            dtype,
+            out.as_uninit_bytes_mut(),
+            operand_shape,
+            &out_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
     let operand_ptr = ErasedRawStridedPtr::from_ref(&operand_ref);
     let update_ptr = ErasedRawStridedPtr::from_ref(&update_ref);
@@ -1697,22 +1817,34 @@ fn typed_pad<T: Copy + Clone + PoolScalar + TensorScalar>(
     .map_err(|err| crate::Error::backend_source("pad", err))?;
     let fill = T::pool_zero();
     let mut out = PooledUninitOutput::new(buffers, out_shape.clone())?;
-    let input_ref = crate::erased_raw_strided_ref(
-        dtype,
-        typed_bytes(typed_host_data("pad", input)?),
-        input_shape,
-        &input_strides,
-        0,
-    )
+    let input_ref = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            dtype,
+            typed_bytes(typed_host_data("pad", input)?),
+            input_shape,
+            &input_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("pad", err))?;
     let input_ptr = ErasedRawStridedPtr::from_ref(&input_ref);
-    let mut out_ref = crate::erased_raw_strided_uninit_mut(
-        dtype,
-        out.as_uninit_bytes_mut(),
-        &out_shape,
-        &out_strides,
-        0,
-    )
+    let mut out_ref = unsafe {
+        // SAFETY: the output guard exclusively owns aligned storage whose
+        // byte layout agrees with dtype; validated dimensions, strides, and
+        // offset keep every destination in bounds, and the following kernel
+        // overwrites every reachable element before typed exposure.
+        crate::erased_raw_strided_uninit_mut(
+            dtype,
+            out.as_uninit_bytes_mut(),
+            &out_shape,
+            &out_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source("pad", err))?;
     plan.execute_uninit(
         exec_context,

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -65,6 +65,9 @@ mod domain_executor;
 #[allow(dead_code)]
 mod dot_runtime;
 pub(crate) use tenferro_internal_cpu_kernels::elementwise;
+pub(crate) use tenferro_internal_cpu_kernels::elementwise::{
+    erased_raw_strided_ref, erased_raw_strided_uninit_mut,
+};
 pub(crate) use tenferro_internal_cpu_kernels::PooledUninitOutput;
 mod engine;
 mod exec_session;
@@ -82,7 +85,6 @@ mod runtime_adapter;
 mod structural;
 mod topology;
 
-use std::mem::MaybeUninit;
 use std::ptr::NonNull;
 #[cfg(test)]
 use strided_kernel::StridedArray;
@@ -90,28 +92,6 @@ use strided_kernel::{col_major_strides as kernel_col_major_strides, StridedView}
 
 use crate::buffer_pool::BufferPool;
 pub(crate) use tenferro_tensor::*;
-
-pub(crate) fn erased_raw_strided_ref<'a>(
-    dtype: strided_kernel::KernelDType,
-    data: &'a [u8],
-    dims: &'a [usize],
-    strides: &'a [isize],
-    offset: isize,
-) -> strided_kernel::Result<strided_kernel::ErasedRawStridedRef<'a>> {
-    let data_ptr = NonNull::new(data.as_ptr().cast_mut()).unwrap_or_else(NonNull::dangling);
-    // SAFETY: callers derive `data` from initialized typed host storage and
-    // keep that storage alive for the returned descriptor lifetime.
-    unsafe {
-        strided_kernel::ErasedRawStridedRef::from_raw_parts(
-            dtype,
-            data_ptr,
-            data.len(),
-            dims,
-            strides,
-            offset,
-        )
-    }
-}
 
 pub(crate) fn erased_raw_strided_mut<'a>(
     dtype: strided_kernel::KernelDType,
@@ -125,28 +105,6 @@ pub(crate) fn erased_raw_strided_mut<'a>(
     // destination and retain that borrow for the returned descriptor lifetime.
     unsafe {
         strided_kernel::ErasedRawStridedMut::from_raw_parts(
-            dtype,
-            data_ptr,
-            data.len(),
-            dims,
-            strides,
-            offset,
-        )
-    }
-}
-
-pub(crate) fn erased_raw_strided_uninit_mut<'a>(
-    dtype: strided_kernel::KernelDType,
-    data: &'a mut [MaybeUninit<u8>],
-    dims: &'a [usize],
-    strides: &'a [isize],
-    offset: isize,
-) -> strided_kernel::Result<strided_kernel::ErasedRawStridedUninitMut<'a>> {
-    let data_ptr = NonNull::new(data.as_mut_ptr().cast::<u8>()).unwrap_or_else(NonNull::dangling);
-    // SAFETY: the guard owns the allocation, and the caller proves that every
-    // reachable destination element is overwritten before typed exposure.
-    unsafe {
-        strided_kernel::ErasedRawStridedUninitMut::from_raw_parts(
             dtype,
             data_ptr,
             data.len(),

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -731,13 +731,19 @@ where
         axes,
     )
     .map_err(|err| crate::Error::backend_source(label, err))?;
-    let source = crate::erased_raw_strided_ref(
-        dtype,
-        typed_bytes(input_view.data()),
-        input_view.dims(),
-        input_view.strides(),
-        input_view.offset(),
-    )
+    let source = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            dtype,
+            typed_bytes(input_view.data()),
+            input_view.dims(),
+            input_view.strides(),
+            input_view.offset(),
+        )
+    }
     .map_err(|err| crate::Error::backend_source(label, err))?;
     // SAFETY: ErasedReducePlan writes every destination element.
     let mut output = unsafe { uninit_full_overwrite_vec(output_len) };
@@ -848,22 +854,34 @@ where
         axes,
     )
     .map_err(|err| crate::Error::backend_source(label, err))?;
-    let source = crate::erased_raw_strided_ref(
-        dtype,
-        typed_bytes(input_view.data()),
-        input_view.dims(),
-        input_view.strides(),
-        input_view.offset(),
-    )
+    let source = unsafe {
+        // SAFETY: this operation supplies initialized typed bytes with
+        // alignment and dtype matching the descriptor; validated dimensions,
+        // strides, and offset keep every reachable source element in bounds
+        // for the retained borrow.
+        crate::erased_raw_strided_ref(
+            dtype,
+            typed_bytes(input_view.data()),
+            input_view.dims(),
+            input_view.strides(),
+            input_view.offset(),
+        )
+    }
     .map_err(|err| crate::Error::backend_source(label, err))?;
     let mut output = PooledUninitOutput::<T>::new(buffers, output_shape.clone())?;
-    let mut dest = crate::erased_raw_strided_uninit_mut(
-        dtype,
-        output.as_uninit_bytes_mut(),
-        &output_shape,
-        &output_strides,
-        0,
-    )
+    let mut dest = unsafe {
+        // SAFETY: the output guard exclusively owns aligned storage whose
+        // byte layout agrees with dtype; validated dimensions, strides, and
+        // offset keep every destination in bounds, and the following kernel
+        // overwrites every reachable element before typed exposure.
+        crate::erased_raw_strided_uninit_mut(
+            dtype,
+            output.as_uninit_bytes_mut(),
+            &output_shape,
+            &output_strides,
+            0,
+        )
+    }
     .map_err(|err| crate::Error::backend_source(label, err))?;
     let source_ptr = strided_kernel::ErasedRawStridedPtr::from_ref(&source);
     plan.execute_uninit(exec_context, &mut dest, &source_ptr)

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -205,29 +205,6 @@ fn view_offset_i64(offset: isize, op: &'static str) -> crate::Result<i64> {
     })
 }
 
-fn compact_strides_isize(op: &'static str, shape: &[usize]) -> crate::Result<Vec<isize>> {
-    let mut strides = Vec::with_capacity(shape.len());
-    let mut stride = 1isize;
-    for &dim in shape {
-        strides.push(stride);
-        let dim = isize::try_from(dim).map_err(|_| {
-            crate::Error::invalid_argument(
-                op,
-                "shape",
-                format!("dimension {dim} cannot be represented as isize"),
-            )
-        })?;
-        stride = stride.checked_mul(dim).ok_or_else(|| {
-            crate::Error::invalid_argument(
-                op,
-                "shape",
-                format!("column-major stride overflow for shape {shape:?}"),
-            )
-        })?;
-    }
-    Ok(strides)
-}
-
 fn launch_native_materialization<E: CubePrimitive>(
     backend: &CudaBackend,
     output: ArrayArg<CubeclCudaRuntime>,
@@ -974,7 +951,8 @@ impl CudaBackend {
         validate_permutation("transpose", perm, input.shape().len())?;
         let output_shape: Vec<usize> = perm.iter().map(|&axis| input.shape()[axis]).collect();
         ensure_resident_on_runtime(self.runtime(), input, "transpose")?;
-        let input_strides = compact_strides_isize("transpose", input.shape())?;
+        let input_strides =
+            crate::native_permutation::compact_col_major_strides("transpose", input.shape())?;
         let plan = NativePermutationPlan::for_transpose(
             "transpose",
             input.shape(),
@@ -1000,7 +978,8 @@ impl CudaBackend {
         validate_permutation("transpose", perm, input.shape().len())?;
         let output_shape: Vec<usize> = perm.iter().map(|&axis| input.shape()[axis]).collect();
         ensure_resident_on_runtime(self.runtime(), input, "transpose")?;
-        let input_strides = compact_strides_isize("transpose", input.shape())?;
+        let input_strides =
+            crate::native_permutation::compact_col_major_strides("transpose", input.shape())?;
         let plan = NativePermutationPlan::for_transpose(
             "transpose",
             input.shape(),

--- a/crates/tenferro-gpu/src/native_permutation.rs
+++ b/crates/tenferro-gpu/src/native_permutation.rs
@@ -2,6 +2,35 @@ use strided_perm::plan_bilateral_fusion;
 use tenferro_tensor::validate::{checked_shape_product, validate_permutation_axes};
 use tenferro_tensor::{DynRank, TensorLayout};
 
+#[cfg(test)]
+mod compact_stride_tests;
+
+pub(crate) fn compact_col_major_strides(
+    op: &'static str,
+    shape: &[usize],
+) -> crate::Result<Vec<isize>> {
+    let mut strides = Vec::with_capacity(shape.len());
+    let mut stride = 1isize;
+    for &dim in shape {
+        strides.push(stride);
+        let dim = isize::try_from(dim).map_err(|_| {
+            crate::Error::invalid_argument(
+                op,
+                "shape",
+                format!("dimension {dim} cannot be represented as isize"),
+            )
+        })?;
+        stride = stride.checked_mul(dim).ok_or_else(|| {
+            crate::Error::invalid_argument(
+                op,
+                "shape",
+                format!("column-major stride overflow for shape {shape:?}"),
+            )
+        })?;
+    }
+    Ok(strides)
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum NativePermutationKind {
     LinearCopy,
@@ -232,29 +261,6 @@ impl NativePermutationPlan {
     }
 }
 
-fn compact_col_major_strides(op: &'static str, dims: &[usize]) -> crate::Result<Vec<isize>> {
-    let mut strides = Vec::with_capacity(dims.len());
-    let mut stride = 1isize;
-    for &dim in dims {
-        strides.push(stride);
-        let dim = isize::try_from(dim).map_err(|_| {
-            crate::Error::invalid_argument(
-                op,
-                "shape",
-                format!("dimension {dim} cannot be represented as isize"),
-            )
-        })?;
-        stride = stride.checked_mul(dim).ok_or_else(|| {
-            crate::Error::invalid_argument(
-                op,
-                "shape",
-                format!("column-major stride overflow for shape {dims:?}"),
-            )
-        })?;
-    }
-    Ok(strides)
-}
-
 fn classify(
     dims: &[usize],
     src_strides: &[isize],
@@ -306,208 +312,4 @@ fn tiled_transpose_eligible(dims: &[usize], src_strides: &[isize], dst_strides: 
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    const OP: &str = "native_permutation_test";
-
-    fn plan(dims: &[usize], src_strides: &[isize], dst_strides: &[isize]) -> NativePermutationPlan {
-        let len: usize = dims.iter().product();
-        let src_len = 1 + dims
-            .iter()
-            .zip(src_strides)
-            .map(|(&dim, &stride)| dim.saturating_sub(1) * stride.unsigned_abs())
-            .sum::<usize>();
-        let dst_len = 1 + dims
-            .iter()
-            .zip(dst_strides)
-            .map(|(&dim, &stride)| dim.saturating_sub(1) * stride.unsigned_abs())
-            .sum::<usize>();
-        NativePermutationPlan::new(
-            OP,
-            dims,
-            src_strides,
-            dst_strides,
-            0,
-            src_len.max(len).max(1),
-            dst_len.max(len).max(1),
-            false,
-        )
-        .unwrap()
-    }
-
-    #[test]
-    fn identity_collapses_to_linear_copy() {
-        let plan = plan(&[2, 3, 4], &[1, 2, 6], &[1, 2, 6]);
-        assert_eq!(plan.kind, NativePermutationKind::LinearCopy);
-        assert_eq!(plan.dims, [24]);
-        assert_eq!(plan.src_strides, [1]);
-        assert_eq!(plan.dst_strides, [1]);
-    }
-
-    #[test]
-    fn compact_two_dimensional_transpose_is_tiled_eligible() {
-        let plan =
-            NativePermutationPlan::for_transpose(OP, &[2, 3], &[1, 2], &[1, 0], 0, 6, 6, false)
-                .unwrap();
-        assert_eq!(plan.kind, NativePermutationKind::TiledTranspose);
-        assert_eq!(plan.dims, [3, 2]);
-        assert_eq!(plan.src_strides, [2, 1]);
-        assert_eq!(plan.dst_strides, [1, 3]);
-    }
-
-    #[test]
-    fn batched_compact_transpose_is_tiled_eligible() {
-        let plan = NativePermutationPlan::for_transpose(
-            OP,
-            &[256, 256, 240],
-            &[1, 256, 65_536],
-            &[1, 0, 2],
-            0,
-            15_728_640,
-            15_728_640,
-            false,
-        )
-        .unwrap();
-        assert_eq!(plan.kind, NativePermutationKind::TiledTranspose);
-
-        let tile = NativeTransposeTile::new(16, 8, 1, 1);
-        assert_eq!(
-            tile.dispatch_grid(OP, &plan.dims, 65_535).unwrap(),
-            Some((16, 16, 240))
-        );
-        assert_eq!(tile.dispatch_grid(OP, &plan.dims, 128).unwrap(), None);
-    }
-
-    #[test]
-    fn batched_noncompact_transpose_remains_generic() {
-        let plan = plan(&[3, 2, 4], &[2, 1, 7], &[1, 3, 6]);
-        assert_eq!(plan.kind, NativePermutationKind::GenericStrided);
-    }
-
-    #[test]
-    fn transpose_and_equivalent_view_share_one_plan() {
-        let transpose =
-            NativePermutationPlan::for_transpose(OP, &[2, 3], &[1, 2], &[1, 0], 0, 6, 6, false)
-                .unwrap();
-        let view =
-            NativePermutationPlan::for_contiguous_output(OP, &[3, 2], &[2, 1], 0, 6, 6, false)
-                .unwrap();
-        assert_eq!(transpose, view);
-    }
-
-    #[test]
-    fn three_dimensional_swap_preserves_output_axis_order() {
-        let plan = NativePermutationPlan::for_transpose(
-            OP,
-            &[256, 256, 240],
-            &[1, 256, 65_536],
-            &[1, 0, 2],
-            0,
-            15_728_640,
-            15_728_640,
-            false,
-        )
-        .unwrap();
-        assert_eq!(plan.dims, [256, 256, 240]);
-        assert_eq!(plan.src_strides, [256, 1, 65_536]);
-        assert_eq!(plan.dst_strides, [1, 256, 65_536]);
-    }
-
-    #[test]
-    fn tile_selection_is_bounded_and_can_force_generic_fallback() {
-        assert_eq!(
-            NativeTransposeTile::parse(OP, "32x8-p1-v4").unwrap(),
-            Some(NativeTransposeTile::new(32, 8, 1, 4))
-        );
-        assert_eq!(NativeTransposeTile::parse(OP, "generic").unwrap(), None);
-        assert!(NativeTransposeTile::parse(OP, "64x1-p0-v8").is_err());
-    }
-
-    #[test]
-    fn tile_grid_falls_back_when_a_dispatch_dimension_exceeds_the_runtime_limit() {
-        let tile = NativeTransposeTile::new(16, 8, 1, 1);
-        assert_eq!(
-            tile.dispatch_grid(OP, &[1024, 2048], 65_535).unwrap(),
-            Some((128, 64, 1))
-        );
-        assert_eq!(
-            tile.dispatch_grid(OP, &[4_782_976, 16], 65_535).unwrap(),
-            None
-        );
-    }
-
-    #[test]
-    fn partial_fusion_preserves_affine_metadata() {
-        let plan = plan(&[2, 3, 4], &[1, 2, 100], &[1, 2, 6]);
-        assert_eq!(plan.kind, NativePermutationKind::GenericStrided);
-        assert_eq!(plan.dims, [6, 4]);
-        assert_eq!(plan.src_strides, [1, 100]);
-        assert_eq!(plan.dst_strides, [1, 6]);
-    }
-
-    #[test]
-    fn rank_24_identity_collapses_to_linear_copy() {
-        let mut dims = vec![64];
-        dims.extend([2; 23]);
-        let dst = compact_col_major_strides(OP, &dims).unwrap();
-        let plan = plan(&dims, &dst, &dst);
-        assert_eq!(plan.kind, NativePermutationKind::LinearCopy);
-        assert_eq!(plan.dims.len(), 1);
-    }
-
-    #[test]
-    fn negative_stride_remains_generic_and_preserves_offset() {
-        let plan = NativePermutationPlan::new(OP, &[4], &[-1], &[1], 3, 4, 4, false).unwrap();
-        assert_eq!(plan.kind, NativePermutationKind::GenericStrided);
-        assert_eq!(plan.src_offset, 3);
-    }
-
-    #[test]
-    fn zero_sized_plan_is_linear_without_allocations() {
-        let plan =
-            NativePermutationPlan::new(OP, &[0, 3], &[1, 0], &[1, 0], 0, 0, 0, true).unwrap();
-        assert_eq!(plan.kind, NativePermutationKind::LinearCopy);
-        assert_eq!(plan.len, 0);
-    }
-
-    #[test]
-    fn invalid_permutation_and_metadata_lengths_are_rejected() {
-        let error =
-            NativePermutationPlan::for_transpose(OP, &[2, 3], &[1, 2], &[0, 0], 0, 6, 6, false)
-                .unwrap_err();
-        assert!(matches!(error, crate::Error::Validation { .. }));
-
-        let error =
-            NativePermutationPlan::new(OP, &[2, 3], &[1], &[1, 2], 0, 6, 6, false).unwrap_err();
-        assert!(matches!(error, crate::Error::Validation { .. }));
-    }
-
-    #[test]
-    fn product_overflow_and_source_range_violation_are_rejected() {
-        let error = NativePermutationPlan::new(
-            OP,
-            &[usize::MAX, 2],
-            &[1, 1],
-            &[1, 1],
-            0,
-            usize::MAX,
-            usize::MAX,
-            false,
-        )
-        .unwrap_err();
-        assert!(matches!(error, crate::Error::Validation { .. }));
-
-        let error = NativePermutationPlan::new(OP, &[4], &[2], &[1], 0, 4, 4, false).unwrap_err();
-        assert!(matches!(error, crate::Error::Validation { .. }));
-    }
-
-    #[test]
-    fn destination_and_allocation_overlap_are_rejected() {
-        let error =
-            NativePermutationPlan::new(OP, &[2, 2], &[1, 2], &[1, 1], 0, 4, 4, false).unwrap_err();
-        assert!(matches!(error, crate::Error::Validation { .. }));
-
-        let error = NativePermutationPlan::new(OP, &[4], &[1], &[1], 0, 4, 4, true).unwrap_err();
-        assert!(matches!(error, crate::Error::Validation { .. }));
-    }
-}
+mod tests;

--- a/crates/tenferro-gpu/src/native_permutation/compact_stride_tests.rs
+++ b/crates/tenferro-gpu/src/native_permutation/compact_stride_tests.rs
@@ -1,0 +1,47 @@
+use super::compact_col_major_strides;
+use tenferro_tensor::{ErrorKind, ValidationKind};
+
+const OP: &str = "native_permutation_test";
+
+#[test]
+fn compact_col_major_strides_validate_shape_metadata_once() {
+    assert_eq!(
+        compact_col_major_strides(OP, &[]).unwrap(),
+        Vec::<isize>::new()
+    );
+    assert_eq!(compact_col_major_strides(OP, &[2, 3]).unwrap(), vec![1, 2]);
+
+    let dimension = usize::MAX;
+    let error = compact_col_major_strides("compact_stride_test", &[dimension]).unwrap_err();
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
+    );
+    assert!(matches!(
+        error,
+        crate::Error::Validation {
+            op: "compact_stride_test",
+            source: tenferro_tensor::ValidationError::InvalidArgument {
+                argument: "shape",
+                message,
+            },
+        } if message == format!("dimension {dimension} cannot be represented as isize")
+    ));
+
+    let shape = [isize::MAX as usize, 2];
+    let error = compact_col_major_strides("compact_stride_test", &shape).unwrap_err();
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
+    );
+    assert!(matches!(
+        error,
+        crate::Error::Validation {
+            op: "compact_stride_test",
+            source: tenferro_tensor::ValidationError::InvalidArgument {
+                argument: "shape",
+                message,
+            },
+        } if message == format!("column-major stride overflow for shape {shape:?}")
+    ));
+}

--- a/crates/tenferro-gpu/src/native_permutation/tests.rs
+++ b/crates/tenferro-gpu/src/native_permutation/tests.rs
@@ -1,0 +1,199 @@
+use super::*;
+
+const OP: &str = "native_permutation_test";
+
+fn plan(dims: &[usize], src_strides: &[isize], dst_strides: &[isize]) -> NativePermutationPlan {
+    let len: usize = dims.iter().product();
+    let src_len = 1 + dims
+        .iter()
+        .zip(src_strides)
+        .map(|(&dim, &stride)| dim.saturating_sub(1) * stride.unsigned_abs())
+        .sum::<usize>();
+    let dst_len = 1 + dims
+        .iter()
+        .zip(dst_strides)
+        .map(|(&dim, &stride)| dim.saturating_sub(1) * stride.unsigned_abs())
+        .sum::<usize>();
+    NativePermutationPlan::new(
+        OP,
+        dims,
+        src_strides,
+        dst_strides,
+        0,
+        src_len.max(len).max(1),
+        dst_len.max(len).max(1),
+        false,
+    )
+    .unwrap()
+}
+
+#[test]
+fn identity_collapses_to_linear_copy() {
+    let plan = plan(&[2, 3, 4], &[1, 2, 6], &[1, 2, 6]);
+    assert_eq!(plan.kind, NativePermutationKind::LinearCopy);
+    assert_eq!(plan.dims, [24]);
+    assert_eq!(plan.src_strides, [1]);
+    assert_eq!(plan.dst_strides, [1]);
+}
+
+#[test]
+fn compact_two_dimensional_transpose_is_tiled_eligible() {
+    let plan = NativePermutationPlan::for_transpose(OP, &[2, 3], &[1, 2], &[1, 0], 0, 6, 6, false)
+        .unwrap();
+    assert_eq!(plan.kind, NativePermutationKind::TiledTranspose);
+    assert_eq!(plan.dims, [3, 2]);
+    assert_eq!(plan.src_strides, [2, 1]);
+    assert_eq!(plan.dst_strides, [1, 3]);
+}
+
+#[test]
+fn batched_compact_transpose_is_tiled_eligible() {
+    let plan = NativePermutationPlan::for_transpose(
+        OP,
+        &[256, 256, 240],
+        &[1, 256, 65_536],
+        &[1, 0, 2],
+        0,
+        15_728_640,
+        15_728_640,
+        false,
+    )
+    .unwrap();
+    assert_eq!(plan.kind, NativePermutationKind::TiledTranspose);
+
+    let tile = NativeTransposeTile::new(16, 8, 1, 1);
+    assert_eq!(
+        tile.dispatch_grid(OP, &plan.dims, 65_535).unwrap(),
+        Some((16, 16, 240))
+    );
+    assert_eq!(tile.dispatch_grid(OP, &plan.dims, 128).unwrap(), None);
+}
+
+#[test]
+fn batched_noncompact_transpose_remains_generic() {
+    let plan = plan(&[3, 2, 4], &[2, 1, 7], &[1, 3, 6]);
+    assert_eq!(plan.kind, NativePermutationKind::GenericStrided);
+}
+
+#[test]
+fn transpose_and_equivalent_view_share_one_plan() {
+    let transpose =
+        NativePermutationPlan::for_transpose(OP, &[2, 3], &[1, 2], &[1, 0], 0, 6, 6, false)
+            .unwrap();
+    let view =
+        NativePermutationPlan::for_contiguous_output(OP, &[3, 2], &[2, 1], 0, 6, 6, false).unwrap();
+    assert_eq!(transpose, view);
+}
+
+#[test]
+fn three_dimensional_swap_preserves_output_axis_order() {
+    let plan = NativePermutationPlan::for_transpose(
+        OP,
+        &[256, 256, 240],
+        &[1, 256, 65_536],
+        &[1, 0, 2],
+        0,
+        15_728_640,
+        15_728_640,
+        false,
+    )
+    .unwrap();
+    assert_eq!(plan.dims, [256, 256, 240]);
+    assert_eq!(plan.src_strides, [256, 1, 65_536]);
+    assert_eq!(plan.dst_strides, [1, 256, 65_536]);
+}
+
+#[test]
+fn tile_selection_is_bounded_and_can_force_generic_fallback() {
+    assert_eq!(
+        NativeTransposeTile::parse(OP, "32x8-p1-v4").unwrap(),
+        Some(NativeTransposeTile::new(32, 8, 1, 4))
+    );
+    assert_eq!(NativeTransposeTile::parse(OP, "generic").unwrap(), None);
+    assert!(NativeTransposeTile::parse(OP, "64x1-p0-v8").is_err());
+}
+
+#[test]
+fn tile_grid_falls_back_when_a_dispatch_dimension_exceeds_the_runtime_limit() {
+    let tile = NativeTransposeTile::new(16, 8, 1, 1);
+    assert_eq!(
+        tile.dispatch_grid(OP, &[1024, 2048], 65_535).unwrap(),
+        Some((128, 64, 1))
+    );
+    assert_eq!(
+        tile.dispatch_grid(OP, &[4_782_976, 16], 65_535).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn partial_fusion_preserves_affine_metadata() {
+    let plan = plan(&[2, 3, 4], &[1, 2, 100], &[1, 2, 6]);
+    assert_eq!(plan.kind, NativePermutationKind::GenericStrided);
+    assert_eq!(plan.dims, [6, 4]);
+    assert_eq!(plan.src_strides, [1, 100]);
+    assert_eq!(plan.dst_strides, [1, 6]);
+}
+
+#[test]
+fn rank_24_identity_collapses_to_linear_copy() {
+    let mut dims = vec![64];
+    dims.extend([2; 23]);
+    let dst = compact_col_major_strides(OP, &dims).unwrap();
+    let plan = plan(&dims, &dst, &dst);
+    assert_eq!(plan.kind, NativePermutationKind::LinearCopy);
+    assert_eq!(plan.dims.len(), 1);
+}
+
+#[test]
+fn negative_stride_remains_generic_and_preserves_offset() {
+    let plan = NativePermutationPlan::new(OP, &[4], &[-1], &[1], 3, 4, 4, false).unwrap();
+    assert_eq!(plan.kind, NativePermutationKind::GenericStrided);
+    assert_eq!(plan.src_offset, 3);
+}
+
+#[test]
+fn zero_sized_plan_is_linear_without_allocations() {
+    let plan = NativePermutationPlan::new(OP, &[0, 3], &[1, 0], &[1, 0], 0, 0, 0, true).unwrap();
+    assert_eq!(plan.kind, NativePermutationKind::LinearCopy);
+    assert_eq!(plan.len, 0);
+}
+
+#[test]
+fn invalid_permutation_and_metadata_lengths_are_rejected() {
+    let error = NativePermutationPlan::for_transpose(OP, &[2, 3], &[1, 2], &[0, 0], 0, 6, 6, false)
+        .unwrap_err();
+    assert!(matches!(error, crate::Error::Validation { .. }));
+
+    let error = NativePermutationPlan::new(OP, &[2, 3], &[1], &[1, 2], 0, 6, 6, false).unwrap_err();
+    assert!(matches!(error, crate::Error::Validation { .. }));
+}
+
+#[test]
+fn product_overflow_and_source_range_violation_are_rejected() {
+    let error = NativePermutationPlan::new(
+        OP,
+        &[usize::MAX, 2],
+        &[1, 1],
+        &[1, 1],
+        0,
+        usize::MAX,
+        usize::MAX,
+        false,
+    )
+    .unwrap_err();
+    assert!(matches!(error, crate::Error::Validation { .. }));
+
+    let error = NativePermutationPlan::new(OP, &[4], &[2], &[1], 0, 4, 4, false).unwrap_err();
+    assert!(matches!(error, crate::Error::Validation { .. }));
+}
+
+#[test]
+fn destination_and_allocation_overlap_are_rejected() {
+    let error =
+        NativePermutationPlan::new(OP, &[2, 2], &[1, 2], &[1, 1], 0, 4, 4, false).unwrap_err();
+    assert!(matches!(error, crate::Error::Validation { .. }));
+
+    let error = NativePermutationPlan::new(OP, &[4], &[1], &[1], 0, 4, 4, true).unwrap_err();
+    assert!(matches!(error, crate::Error::Validation { .. }));
+}

--- a/crates/tenferro-gpu/src/webgpu/structural.rs
+++ b/crates/tenferro-gpu/src/webgpu/structural.rs
@@ -11,32 +11,10 @@ use super::{
     alloc_output, comptime_sequence, cube_count_for_len, cube_dim_1d,
     ensure_placement_resident_on_runtime, prepared_webgpu_view, unsupported_dtype, WebGpuBackend,
 };
+use crate::native_permutation::compact_col_major_strides;
 
 const TRANSPOSE_OP: &str = "webgpu_transpose";
 const MATERIALIZE_OP: &str = "WebGpuBackend::to_contiguous_read";
-
-fn dense_strides(shape: &[usize], op: &'static str) -> crate::Result<Vec<isize>> {
-    let mut strides = Vec::with_capacity(shape.len());
-    let mut stride = 1isize;
-    for &dim in shape {
-        strides.push(stride);
-        let dim = isize::try_from(dim).map_err(|_| {
-            crate::Error::invalid_argument(
-                op,
-                "shape",
-                format!("dimension {dim} cannot be represented as isize"),
-            )
-        })?;
-        stride = stride.checked_mul(dim).ok_or_else(|| {
-            crate::Error::invalid_argument(
-                op,
-                "shape",
-                format!("column-major stride overflow for shape {shape:?}"),
-            )
-        })?;
-    }
-    Ok(strides)
-}
 
 fn view_allocation_len<T, R>(
     view: &TypedTensorView<'_, T, R>,
@@ -235,7 +213,7 @@ where
 {
     validate_permutation_axes(TRANSPOSE_OP, input.shape().len(), perm)?;
     let output_shape: Vec<usize> = perm.iter().map(|&axis| input.shape()[axis]).collect();
-    let input_strides = dense_strides(input.shape(), TRANSPOSE_OP)?;
+    let input_strides = compact_col_major_strides(TRANSPOSE_OP, input.shape())?;
     let plan = NativePermutationPlan::for_transpose(
         TRANSPOSE_OP,
         input.shape(),

--- a/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
@@ -24,7 +24,22 @@ use tenferro_tensor::{
 
 use super::{typed_host_data, typed_view, typed_view_from_view};
 
-fn erased_raw_strided_ref<'a>(
+// This hidden public boundary is required by the separate tenferro-cpu crate;
+// that crate re-exports it only at crate visibility and no user-facing safe
+// wrapper exposes the raw constructor.
+/// Construct an erased read-only strided view over initialized typed storage.
+///
+/// # Safety
+///
+/// The caller must ensure that `data` retains the alignment and byte layout
+/// required by `dtype`, and that `dtype` agrees with the elements in the
+/// backing storage. Every element reachable through `dims`, `strides`, and
+/// `offset` must be within `data`; the metadata must remain alive for `'a`, and
+/// the borrow must not be invalidated or mutated incompatibly while the view
+/// exists. All reachable elements must be initialized and readable for the
+/// lifetime of the returned view.
+#[doc(hidden)]
+pub unsafe fn erased_raw_strided_ref<'a>(
     dtype: KernelDType,
     data: &'a [u8],
     dims: &'a [usize],
@@ -32,14 +47,30 @@ fn erased_raw_strided_ref<'a>(
     offset: isize,
 ) -> strided_kernel::Result<ErasedRawStridedRef<'a>> {
     let data_ptr = NonNull::new(data.as_ptr().cast_mut()).unwrap_or_else(NonNull::dangling);
-    // SAFETY: elementwise fusion receives initialized typed host storage and
-    // retains the backing borrows for the descriptor lifetime.
+    // SAFETY: all documented preconditions are met: `dtype` matches the
+    // aligned, initialized storage; the metadata keeps every reachable element
+    // in bounds; and the storage and metadata remain valid for the returned view.
     unsafe {
         ErasedRawStridedRef::from_raw_parts(dtype, data_ptr, data.len(), dims, strides, offset)
     }
 }
 
-fn erased_raw_strided_uninit_mut<'a>(
+// The same narrow cross-crate boundary is used for the uninitialized output
+// constructor; it is not a user-facing API and has no safe compatibility shim.
+/// Construct an erased writable strided view over exclusively owned storage.
+///
+/// # Safety
+///
+/// The caller must ensure that `data` retains the alignment and byte layout
+/// required by `dtype`, and that `dtype` agrees with the eventual typed output.
+/// Every element reachable through `dims`, `strides`, and `offset` must be
+/// within the allocation, with all metadata and the exclusive borrow valid for
+/// `'a`. No other reference may access the allocation while the view exists.
+/// The caller must keep the storage uninitialized only as `MaybeUninit` until
+/// every reachable element has been fully written, and must not expose it as
+/// typed storage before that full initialization is proven.
+#[doc(hidden)]
+pub unsafe fn erased_raw_strided_uninit_mut<'a>(
     dtype: KernelDType,
     data: &'a mut [MaybeUninit<u8>],
     dims: &'a [usize],
@@ -47,8 +78,10 @@ fn erased_raw_strided_uninit_mut<'a>(
     offset: isize,
 ) -> strided_kernel::Result<ErasedRawStridedUninitMut<'a>> {
     let data_ptr = NonNull::new(data.as_mut_ptr().cast::<u8>()).unwrap_or_else(NonNull::dangling);
-    // SAFETY: the pooled output guard owns this storage and the fused replay
-    // proves that every reachable element is overwritten before exposure.
+    // SAFETY: all documented preconditions are met: `dtype` matches the
+    // aligned storage; the metadata keeps every reachable element in bounds;
+    // and the exclusive borrow remains valid while the storage is kept as
+    // `MaybeUninit` until every reachable element is written before exposure.
     unsafe {
         ErasedRawStridedUninitMut::from_raw_parts(
             dtype,
@@ -1232,7 +1265,10 @@ pub fn elementwise_fusion_with_pool(
     let input_refs = input_layouts
         .iter()
         .map(|input| {
-            erased_raw_strided_ref(dtype, input.data, &input.dims, &input.strides, 0)
+            // SAFETY: fusion inputs are initialized typed storage with matching
+            // dtype and alignment; validated layouts bound every reachable read
+            // for the retained input borrow.
+            unsafe { erased_raw_strided_ref(dtype, input.data, &input.dims, &input.strides, 0) }
                 .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))
         })
         .collect::<crate::Result<Vec<_>>>()?;
@@ -1415,9 +1451,13 @@ where
         .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
     let mut out = PooledUninitOutput::<T>::new(buffers, shape.to_vec())?;
     let output_strides = col_major_strides(shape)?;
-    let mut dest =
+    // SAFETY: `out` exclusively owns the output allocation with matching
+    // dtype/alignment and the fused plan overwrites every reachable element
+    // before `assume_init` exposes typed storage.
+    let mut dest = unsafe {
         erased_raw_strided_uninit_mut(dtype, out.as_uninit_bytes_mut(), shape, &output_strides, 0)
-            .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
+    }
+    .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
     erased_plan
         .execute_uninit(exec_context, &mut dest, input_ptrs)
         .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;

--- a/crates/tenferro-linalg/src/eager_composites.rs
+++ b/crates/tenferro-linalg/src/eager_composites.rs
@@ -3,6 +3,7 @@ use tenferro_ad::{CompareDir, DType, DotGeneralConfig, EagerTensor, Error, Resul
 use tenferro_runtime::ErrorPhase;
 
 use crate::eager_ext::{eig, eigh, lu, qr, solve, svd, triangular_solve};
+use crate::validation::validate_lstsq;
 
 pub(crate) fn slogdet(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
     let (_p, _l, u, parity) = lu(a)?;
@@ -25,21 +26,14 @@ pub(crate) fn inv(a: &EagerTensor) -> Result<EagerTensor> {
 }
 
 pub(crate) fn lstsq(a: &EagerTensor, b: &EagerTensor) -> Result<EagerTensor> {
-    ensure_float_or_complex("lstsq", a.dtype())?;
-    ensure_min_rank("lstsq", a.shape().len(), 2)?;
-    ensure_min_rank("lstsq", b.shape().len(), 2)?;
-    let (m, n) = (a.shape()[0], a.shape()[1]);
-    if m < n {
-        return Err(Error::invalid_argument(
-            "lstsq",
-            ErrorPhase::GraphBuild,
-            "shape",
-            format!(
-                "lstsq requires a tall or square matrix (rows {m} >= cols {n}); \
-                 underdetermined (wide) systems are not supported"
-            ),
-        ));
-    }
+    validate_lstsq(
+        "lstsq",
+        a.dtype(),
+        a.shape().len(),
+        b.shape().len(),
+        || Ok((a.shape()[0], a.shape()[1])),
+        |message| Error::invalid_argument("lstsq", ErrorPhase::GraphBuild, "shape", message),
+    )?;
     // Least squares via thin QR: A = Q R (full column rank), so
     // argmin_x |A x - b| solves R x = Qᴴ b.
     let (q, r) = qr(a)?;

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -52,6 +52,7 @@ mod extension;
 mod gpu;
 mod tensor_ext;
 mod traced;
+mod validation;
 
 #[cfg(feature = "autodiff")]
 pub use ad::semantic_ad_rules;

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -9,6 +9,7 @@ use tenferro_runtime::{
 use crate::extension::{
     validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, QrOptions, SvdOptions,
 };
+use crate::validation::validate_lstsq;
 
 /// Linear algebra extension methods for [`TracedTensor`].
 pub trait TracedTensorLinalgExt {
@@ -957,23 +958,21 @@ pub fn solve(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
 /// Backend QR and triangular-solve failures and concrete shape mismatches are
 /// reported during compile or execution.
 pub fn lstsq(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
-    ensure_float_or_complex("lstsq", a.dtype)?;
-    ensure_min_rank("lstsq", a.rank, 2)?;
-    ensure_min_rank("lstsq", b.rank, 2)?;
-    let a_shape = require_concrete_shape("lstsq", a)?;
-    let (m, n) = (a_shape[0], a_shape[1]);
-    if m < n {
-        return Err(Error::TensorRuntime(
-            tenferro_tensor::Error::invalid_argument(
-                "lstsq",
-                "shape",
-                format!(
-                    "lstsq requires a tall or square matrix (rows {m} >= cols {n}); \
-                     underdetermined (wide) systems are not supported"
-                ),
-            ),
-        ));
-    }
+    validate_lstsq(
+        "lstsq",
+        a.dtype,
+        a.rank,
+        b.rank,
+        || {
+            let shape = require_concrete_shape("lstsq", a)?;
+            Ok((shape[0], shape[1]))
+        },
+        |message| {
+            Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
+                "lstsq", "shape", message,
+            ))
+        },
+    )?;
     let (q, r) = qr(a)?;
     let qh = q.conj()?.transpose(&matrix_transpose_perm(q.rank))?;
     let qh_b = matmul_preserve_trailing_batch(&qh, b)?;

--- a/crates/tenferro-linalg/src/validation.rs
+++ b/crates/tenferro-linalg/src/validation.rs
@@ -1,0 +1,40 @@
+use tenferro_runtime::{DType, Error, Result};
+
+pub(crate) fn validate_lstsq(
+    op: &'static str,
+    dtype: DType,
+    a_rank: usize,
+    b_rank: usize,
+    shape: impl FnOnce() -> Result<(usize, usize)>,
+    wide_error: impl FnOnce(String) -> Error,
+) -> Result<()> {
+    ensure_float_or_complex(op, dtype)?;
+    ensure_min_rank(op, a_rank, 2)?;
+    ensure_min_rank(op, b_rank, 2)?;
+    let (m, n) = shape()?;
+    if m < n {
+        return Err(wide_error(format!(
+            "lstsq requires a tall or square matrix (rows {m} >= cols {n}); \
+             underdetermined (wide) systems are not supported"
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_float_or_complex(op: &'static str, dtype: DType) -> Result<()> {
+    match dtype {
+        DType::F32 | DType::F64 | DType::C32 | DType::C64 => Ok(()),
+        DType::I32 | DType::I64 | DType::Bool => Err(Error::TensorRuntime(
+            crate::error::unsupported_dtype(op, dtype),
+        )),
+    }
+}
+
+fn ensure_min_rank(op: &'static str, actual: usize, expected: usize) -> Result<()> {
+    if actual < expected {
+        return Err(Error::TensorRuntime(tenferro_tensor::Error::rank_mismatch(
+            op, expected, actual,
+        )));
+    }
+    Ok(())
+}

--- a/crates/tenferro-linalg/tests/integration/eager_surface_parity.rs
+++ b/crates/tenferro-linalg/tests/integration/eager_surface_parity.rs
@@ -3,7 +3,8 @@
 use num_complex::Complex64;
 use tenferro_ad::{AdContext, EagerRuntime, EagerTensor, Tensor};
 use tenferro_cpu::CpuBackend;
-use tenferro_linalg::EagerTensorLinalgExt;
+use tenferro_linalg::{EagerTensorLinalgExt, TracedTensorLinalgExt};
+use tenferro_runtime::{DType, Error, ErrorPhase, TracedTensor, TypedTensor};
 
 fn eager(data: Vec<f64>, shape: Vec<usize>) -> EagerTensor {
     EagerTensor::from_tensor_in(
@@ -19,6 +20,69 @@ fn eager_complex(data: Vec<Complex64>, shape: Vec<usize>) -> EagerTensor {
         EagerRuntime::with_cpu_backend(CpuBackend::new()).unwrap(),
     )
     .unwrap()
+}
+
+fn eager_i32(data: Vec<i32>, shape: Vec<usize>) -> EagerTensor {
+    EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(shape, data).unwrap(),
+        EagerRuntime::with_cpu_backend(CpuBackend::new()).unwrap(),
+    )
+    .unwrap()
+}
+
+fn traced_i32(data: Vec<i32>, shape: Vec<usize>) -> TracedTensor {
+    TracedTensor::from_tensor_concrete_shape(Tensor::I32(
+        TypedTensor::from_vec_col_major(shape, data).unwrap(),
+    ))
+    .unwrap()
+}
+
+fn assert_lstsq_validation_reason(
+    label: &str,
+    eager_result: tenferro_ad::Result<EagerTensor>,
+    traced_result: tenferro_runtime::Result<TracedTensor>,
+    expected_reason: &str,
+) {
+    let eager_error = eager_result.expect_err(label);
+    let traced_error = traced_result.expect_err(label);
+    assert!(
+        eager_error.to_string().contains(expected_reason),
+        "{label}: eager expected {expected_reason:?}, got {eager_error}"
+    );
+    assert!(
+        traced_error.to_string().contains(expected_reason),
+        "{label}: traced expected {expected_reason:?}, got {traced_error}"
+    );
+}
+
+fn assert_lstsq_wide_error_contract(
+    eager_error: &Error,
+    traced_error: &Error,
+    expected_reason: &str,
+) {
+    assert!(matches!(
+        eager_error,
+        Error::Validation {
+            phase: ErrorPhase::GraphBuild,
+            ..
+        }
+    ));
+    assert_eq!(eager_error.phase(), Some(ErrorPhase::GraphBuild));
+    assert_eq!(
+        eager_error.to_string(),
+        Error::invalid_argument("lstsq", ErrorPhase::GraphBuild, "shape", expected_reason)
+            .to_string()
+    );
+
+    assert!(matches!(
+        traced_error,
+        Error::TensorRuntime(tenferro_tensor::Error::Validation { .. })
+    ));
+    assert_eq!(traced_error.phase(), Some(ErrorPhase::Execution));
+    assert_eq!(
+        traced_error.to_string(),
+        tenferro_tensor::Error::invalid_argument("lstsq", "shape", expected_reason).to_string()
+    );
 }
 
 fn f64_values(tensor: &EagerTensor) -> Vec<f64> {
@@ -151,6 +215,88 @@ fn eager_composite_records_existing_primitives_for_backward() {
     for (&actual, expected) in actual.iter().zip([4.0, 0.0, 0.0, 2.0]) {
         assert!((actual - expected).abs() < 1.0e-12);
     }
+}
+
+#[test]
+fn lstsq_validation_is_paired_across_eager_and_traced_surfaces() {
+    let eager_a = eager_i32(vec![1, 0, 0, 1], vec![2, 2]);
+    let eager_b = eager_i32(vec![1, 2], vec![2, 1]);
+    let traced_a = traced_i32(vec![1, 0, 0, 1], vec![2, 2]);
+    let traced_b = traced_i32(vec![1, 2], vec![2, 1]);
+    assert_lstsq_validation_reason(
+        "integer dtype",
+        eager_a.lstsq(&eager_b),
+        traced_a.lstsq(&traced_b),
+        "does not support dtype I32",
+    );
+
+    let eager_a = eager(vec![1.0, 2.0], vec![2]);
+    let eager_b = eager(vec![1.0, 2.0], vec![2, 1]);
+    let traced_a = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let traced_b = TracedTensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0]).unwrap();
+    assert_lstsq_validation_reason(
+        "rank-one A",
+        eager_a.lstsq(&eager_b),
+        traced_a.lstsq(&traced_b),
+        "rank mismatch",
+    );
+
+    let eager_a = eager(vec![1.0, 0.0, 0.0, 1.0], vec![2, 2]);
+    let eager_b = eager(vec![1.0, 2.0], vec![2]);
+    let traced_a =
+        TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap();
+    let traced_b = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    assert_lstsq_validation_reason(
+        "rank-one B",
+        eager_a.lstsq(&eager_b),
+        traced_a.lstsq(&traced_b),
+        "rank mismatch",
+    );
+
+    let eager_a = eager(vec![1.0, 0.0, 0.0, 1.0, 1.0, 1.0], vec![2, 3]);
+    let eager_b = eager(vec![1.0, 2.0], vec![2, 1]);
+    let traced_a =
+        TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 0.0, 0.0, 1.0, 1.0, 1.0])
+            .unwrap();
+    let traced_b = TracedTensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0]).unwrap();
+    let eager_error = eager_a.lstsq(&eager_b).unwrap_err();
+    let traced_error = traced_a.lstsq(&traced_b).unwrap_err();
+    const WIDE_REASON: &str = "lstsq requires a tall or square matrix (rows 2 >= cols 3); \
+        underdetermined (wide) systems are not supported";
+    assert!(eager_error.to_string().contains("tall or square"));
+    assert!(traced_error.to_string().contains("tall or square"));
+    assert_lstsq_wide_error_contract(&eager_error, &traced_error, WIDE_REASON);
+}
+
+#[test]
+fn traced_lstsq_symbolic_shape_keeps_dtype_and_rank_precedence() {
+    let b = TracedTensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0]).unwrap();
+
+    let symbolic_i32 = TracedTensor::input_symbolic_shape(DType::I32, 2).unwrap();
+    let error = symbolic_i32.lstsq(&b).unwrap_err();
+    assert!(error.to_string().contains("does not support dtype I32"));
+    assert!(!error.to_string().contains("symbolic shape"));
+
+    let symbolic_rank_one = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
+    let error = symbolic_rank_one.lstsq(&b).unwrap_err();
+    assert!(error.to_string().contains("rank mismatch"));
+    assert!(!error.to_string().contains("symbolic shape"));
+
+    let a = TracedTensor::input_symbolic_shape(DType::F64, 2).unwrap();
+    let rank_one_b = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let error = a.lstsq(&rank_one_b).unwrap_err();
+    assert!(error.to_string().contains("rank mismatch"));
+    assert!(!error.to_string().contains("symbolic shape"));
+
+    let error = a.lstsq(&b).unwrap_err();
+    let expected = Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
+        "lstsq",
+        "shape",
+        "symbolic shape is not supported by this traced linalg helper",
+    ));
+    assert!(matches!(error, Error::TensorRuntime(_)));
+    assert_eq!(error.phase(), Some(ErrorPhase::Execution));
+    assert_eq!(error.to_string(), expected.to_string());
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/integration/linalg_internal_path_contract.rs
+++ b/crates/tenferro-linalg/tests/integration/linalg_internal_path_contract.rs
@@ -471,3 +471,35 @@ fn faer_batched_paths_reuse_pooled_scratch_inputs() {
         "Faer batched paths should not allocate a new Vec for every batch slice"
     );
 }
+
+#[test]
+fn traced_lstsq_validates_once_without_symbolic_shape_probe_allocation() {
+    let source = crate_source("src/traced.rs");
+    let lstsq_source = source_section(
+        &source,
+        "pub fn lstsq",
+        "/// Build a traced full-pivot LU solve op",
+    );
+
+    assert!(
+        lstsq_source.contains("validate_lstsq"),
+        "traced lstsq should use the shared validator"
+    );
+    assert_eq!(
+        lstsq_source.matches("require_concrete_shape").count(),
+        1,
+        "traced lstsq should extract a concrete shape exactly once"
+    );
+    assert!(
+        !lstsq_source.contains("try_concrete_shape") && !lstsq_source.contains("vec![0; a.rank]"),
+        "symbolic lstsq validation must not probe or allocate a dummy shape"
+    );
+
+    let validation = crate_source("src/validation.rs");
+    assert!(
+        validation.contains("shape: impl FnOnce() -> Result<(usize, usize)>")
+            && validation.contains("ensure_float_or_complex(op, dtype)?")
+            && validation.contains("ensure_min_rank(op, a_rank, 2)?"),
+        "shared lstsq validation must keep dtype/rank checks ahead of lazy shape extraction"
+    );
+}

--- a/docs/worklogs/2026-08-01-rules-review-structural-checks.md
+++ b/docs/worklogs/2026-08-01-rules-review-structural-checks.md
@@ -262,3 +262,36 @@ failures, so hosted/hardware evidence remains conditional; they do not prove
 constructor availability. Non-Apple hosts exercise and assert the typed
 unavailable branch, while the successful Apple transfer branch requires a
 supported host-visible Metal adapter.
+
+## Issue #1577 follow-up
+
+The remaining structural duplicates were limited to three ownership seams:
+`lstsq` validation in eager/traced linalg, checked compact strides in the CUDA
+and WebGPU providers, and erased initialized/uninitialized view constructors in
+the CPU crate and internal kernels. The private linalg validator now owns the
+shared dtype, rank, and tall-or-square checks while callers provide lazy shape
+extraction and their pre-existing wide-error wrapper. This preserves eager's
+`GraphBuild` validation display and traced's transparent
+`TensorRuntime`/`Execution` display, including dtype/rank/wide precedence. The
+traced path extracts a concrete shape once and performs no dummy symbolic-rank
+allocation or second probe. The provider-neutral GPU helper now lives in
+`native_permutation` and is called by both CUDA and WebGPU. The
+`elementwise` module owns both erased constructors, with the CPU crate using a
+direct narrow re-export; both constructors are explicitly unsafe with contracts
+covering alignment, dtype/storage agreement, bounds, borrows, initialization,
+and typed exposure.
+
+RED coverage added paired eager/traced `lstsq` cases for unsupported integer
+dtypes, rank-one `A` and `b`, wide `2x3` inputs, and symbolic-shape precedence;
+source assertions guard the single concrete-shape extraction and absence of the
+old dummy vector/probe. The prior candidate was intentionally checked against
+these source/base-contract snapshots first: it still contained the
+`try_concrete_shape` probe and dummy rank vector, and it routed the traced wide
+error through the eager `GraphBuild` wrapper, so the checks were RED. The wide
+case now retains per-surface wrapper, phase, and display snapshots. GPU RED
+tests covered empty, normal, unrepresentable-dimension, and
+stride-product-overflow shapes with caller-supplied operation names. GREEN
+passed after the three ownership extractions. Verification covered the focused
+suites, provider helper tests and clippy, formatting, source ownership searches,
+and the final PR gate; residual risk is limited to hardware-gated GPU
+execution.


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [ ] Documentation
- [x] Refactor / cleanup
- [x] Implementation of accepted issue

## Related issue

Fixes #1577
Refs #1619

## Summary

Deduplicate the three validation/construction seams that still exist on current `main`:

- share `lstsq` dtype/rank/tall-matrix validation between eager and traced paths while preserving each surface's exact typed error wrapper, phase, display, and symbolic-shape precedence;
- share checked compact column-major `isize` stride construction across CUDA, WebGPU, and native permutation planning;
- keep erased raw strided-view construction in `tenferro-internal-cpu-kernels` and reuse it from `tenferro-cpu` through the narrowest cross-crate Rust boundary.

The obsolete LU duplication named by the original audit no longer exists and was intentionally not recreated or refactored. The three accepted commit subjects and order are preserved.

The two cross-crate erased constructors are necessarily `pub unsafe` because Rust restricted visibility cannot cross crate boundaries. They are `#[doc(hidden)]`, fully Safety-documented, and imported by `tenferro-cpu` only with `pub(crate) use`; an independent adjudication confirmed this is the narrowest implementation satisfying the accepted plan without adding a wrapper, trait, macro, crate, or dependency.

A newly touched oversized inline GPU test module was mechanically extracted to module-local test files to satisfy repository rules; test names, assertions, and behavior are unchanged.

### TDD evidence

RED before extraction:

- paired eager/traced `lstsq` coverage exposed the pre-existing wide-matrix phase drift (`GraphBuild` vs `Execution`);
- provider-neutral compact-stride tests failed to compile because the shared helper did not yet exist;
- source-contract coverage caught repeated/dummy symbolic-shape probing before the one-shot lazy shape extraction was implemented.

GREEN now covers integer dtype, rank-1 A/B, wide matrices, symbolic dtype/rank precedence, one-shot shape validation, empty/compact/overflowing stride metadata, and all existing CPU/GPU callers.

## Work log

- [`docs/worklogs/2026-08-01-rules-review-structural-checks.md`](docs/worklogs/2026-08-01-rules-review-structural-checks.md)

## Verification

- `ACTIONLINT_VERSION=1.7.7 python3 scripts/ci/run_profile.py full` (all Rust/docs/coverage stages passed; final `ci-config` was rerun with pinned actionlint on `PATH`)
- coverage: 210/210 files passed
- `PATH=/tmp/actionlint-v1.7.7:$PATH python3 scripts/ci/run_profile.py ci-config` — 188 tests + actionlint passed
- `cargo test -p tenferro-gpu --features webgpu --lib` — 26 passed, 1 ignored
- `CUBECL_DEBUG_LOG=0 CUDARC_CUDA_VERSION=12080 cargo test -p tenferro-gpu --features cuda --lib` — 87 passed, 116 ignored
- `cargo test -p tenferro-internal-cpu-kernels` — passed
- `cargo test -p tenferro-cpu` — passed
- focused linalg autodiff integration suite — 198 passed
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-linalg --features autodiff --test integration eager_surface_parity'` — passed
- docs site build — passed
- repository-rules review — pass, 0 findings
- final independent review — no unresolved Critical/Important/Minor findings
- `cargo fmt --all -- --check`, `git diff --check origin/main...HEAD` — passed

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
