### PR TITLE
fix(ad): reject malformed broadcast VJP metadata

### DIFF
--- a/crates/tenferro-ad/src/semantic_transform.rs
+++ b/crates/tenferro-ad/src/semantic_transform.rs
@@ -1256,7 +1256,34 @@ fn transpose_broadcast(
         SemanticTransformRole::Vjp,
         "broadcast cotangent",
     )?;
-    let mut reduce_axes: Vec<_> = (0..output_shape.shape.len())
+    let input_rank = input_shape.shape.len();
+    let output_rank = output_shape.shape.len();
+    let metadata_error = |message| SemanticAdTransformError::UnsupportedMetadata {
+        role: SemanticTransformRole::Vjp,
+        message,
+    };
+    if dims.len() != input_rank {
+        return Err(metadata_error(format!(
+            "broadcast dims length {} does not match input rank {input_rank}",
+            dims.len()
+        )));
+    }
+    let mut seen = HashSet::with_capacity(dims.len());
+    for (input_axis, &output_axis) in dims.iter().enumerate() {
+        if output_axis >= output_rank {
+            return Err(metadata_error(format!(
+                "broadcast dims[{input_axis}] = {output_axis} is out of bounds for output rank {output_rank}"
+            )));
+        }
+        if !seen.insert(output_axis) {
+            return Err(metadata_error(format!(
+                "broadcast dims[{input_axis}] = {output_axis} duplicates an earlier output axis"
+            )));
+        }
+    }
+    // INVARIANT: these repeated membership and position scans are bounded by tensor rank;
+    // replace them with axis maps only if unusually high-rank tensors make this measurable.
+    let mut reduce_axes: Vec<_> = (0..output_rank)
         .filter(|axis| !dims.contains(axis))
         .collect();
     reduce_axes.extend(
@@ -1282,7 +1309,7 @@ fn transpose_broadcast(
         )?[0];
     }
 
-    let remaining_output_axes: Vec<_> = (0..output_shape.shape.len())
+    let remaining_output_axes: Vec<_> = (0..output_rank)
         .filter(|axis| !reduce_axes.contains(axis))
         .collect();
     let perm: Vec<_> = dims
@@ -1293,9 +1320,13 @@ fn transpose_broadcast(
             remaining_output_axes
                 .iter()
                 .position(|candidate| *candidate == axis)
-                .expect("broadcast dims survive unless reduced")
+                .ok_or_else(|| {
+                    metadata_error(format!(
+                        "broadcast output axis {axis} did not survive cotangent reduction"
+                    ))
+                })
         })
-        .collect();
+        .collect::<Result<_, _>>()?;
     if perm.iter().copied().ne(0..perm.len()) {
         value = builder.add_op(CoreSemanticOp::Transpose { perm }, &[value])?[0];
     }

--- a/crates/tenferro-ad/tests/integration/semantic_transform.rs
+++ b/crates/tenferro-ad/tests/integration/semantic_transform.rs
@@ -12,7 +12,7 @@ use tenferro_ad::semantic_transform::SemanticAdTransformError;
 use tenferro_ad::AdContext;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::ext_op::{ExtensionAliasDeclaration, ExtensionEffectDeclaration, ExtensionOp};
-use tenferro_ops::{ExtensionShapeContext, SymDim};
+use tenferro_ops::{ExtensionShapeContext, ShapeExtent, SymDim};
 use tenferro_runtime::program::{CoreSemanticOp, ProgramInputSpec, SemanticProgramBuilder};
 use tenferro_runtime::GraphCompiler;
 use tenferro_tensor::{
@@ -489,6 +489,110 @@ fn semantic_core_reduce_sum_squares_jvp_and_vjp_apply_twice_the_input() {
     assert!(matches!(
         vjp_suffix[2].op(),
         tenferro_runtime::program::SemanticOpRef::Core(CoreSemanticOp::Add)
+    ));
+}
+
+#[test]
+fn broadcast_vjp_rejects_out_of_bounds_dims() {
+    let source = unary_core_program(
+        [DimExpr::Const(1)],
+        CoreSemanticOp::BroadcastInDim {
+            shape: vec![DimExpr::Const(1)],
+            dims: vec![2],
+        },
+    );
+
+    let error = ad_context()
+        .vjp_program(&source, &[true], &[true])
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        SemanticAdTransformError::UnsupportedMetadata {
+            role: tenferro_ad::semantic_transform::SemanticTransformRole::Vjp,
+            message,
+        } if message.contains("dims[0] = 2") && message.contains("output rank 1")
+    ));
+}
+
+#[test]
+fn broadcast_vjp_rejects_invalid_dim_count_and_duplicates() {
+    let cases = [
+        (
+            vec![DimExpr::Const(1)],
+            vec![DimExpr::Const(1), DimExpr::Const(1)],
+            vec![0, 1],
+            ["dims length 2", "input rank 1"],
+        ),
+        (
+            vec![DimExpr::Const(1), DimExpr::Const(1)],
+            vec![DimExpr::Const(1), DimExpr::Const(1)],
+            vec![0, 0],
+            ["dims[1] = 0", "duplicates an earlier output axis"],
+        ),
+    ];
+
+    for (input_shape, output_shape, dims, expected) in cases {
+        let source = unary_core_program(
+            input_shape,
+            CoreSemanticOp::BroadcastInDim {
+                shape: output_shape,
+                dims,
+            },
+        );
+        let error = ad_context()
+            .vjp_program(&source, &[true], &[true])
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            SemanticAdTransformError::UnsupportedMetadata {
+                role: tenferro_ad::semantic_transform::SemanticTransformRole::Vjp,
+                message,
+            } if expected.iter().all(|fragment| message.contains(fragment))
+        ));
+    }
+}
+
+#[test]
+fn broadcast_vjp_accepts_identity_dims() {
+    let source = unary_core_program(
+        [DimExpr::Const(2), DimExpr::Const(3)],
+        CoreSemanticOp::BroadcastInDim {
+            shape: vec![DimExpr::Const(2), DimExpr::Const(3)],
+            dims: vec![0, 1],
+        },
+    );
+
+    let transformed = ad_context().vjp_program(&source, &[true], &[true]).unwrap();
+    let output = transformed.frozen().program.outputs()[0];
+    assert_eq!(
+        transformed
+            .frozen()
+            .program
+            .value_metadata(output)
+            .unwrap()
+            .shape(),
+        [
+            ShapeExtent::Exact(DimExpr::Const(2)),
+            ShapeExtent::Exact(DimExpr::Const(3))
+        ]
+    );
+}
+
+#[test]
+fn broadcast_vjp_accepts_permuted_dims() {
+    let source = unary_core_program(
+        [DimExpr::Const(2), DimExpr::Const(3)],
+        CoreSemanticOp::BroadcastInDim {
+            shape: vec![DimExpr::Const(3), DimExpr::Const(2)],
+            dims: vec![1, 0],
+        },
+    );
+
+    let transformed = ad_context().vjp_program(&source, &[true], &[true]).unwrap();
+    assert!(matches!(
+        transformed.frozen().program.operations().last().unwrap().op(),
+        tenferro_runtime::program::SemanticOpRef::Core(CoreSemanticOp::Transpose { perm })
+            if perm.as_slice() == [1, 0]
     ));
 }
 

--- a/docs/worklogs/2026-08-07-issue-1588-broadcast-vjp.md
+++ b/docs/worklogs/2026-08-07-issue-1588-broadcast-vjp.md
@@ -1,0 +1,88 @@
+# Issue #1588 broadcast VJP metadata validation
+
+## Session summary
+
+Fixed a public semantic VJP panic caused by malformed `BroadcastInDim`
+dimension metadata. The transform now returns typed `UnsupportedMetadata`
+diagnostics without changing valid identity, permuted, inserted-axis, or
+singleton-axis behavior.
+
+## Context reviewed
+
+- Issue #1588's accepted plan and acceptance criteria;
+- `AGENTS.md`, `REPOSITORY_RULES.md`, and the shared common, Rust, numerical,
+  documentation, and test rules;
+- `crates/tenferro-ad/src/semantic_transform.rs` and its semantic-transform
+  integration tests;
+- semantic program metadata inference in `tenferro-runtime`;
+- broadcast validation and the adjacent primitive AD transpose implementation
+  in `tenferro-internal-ops`.
+
+## Root cause and decision
+
+Semantic program metadata inference takes a `BroadcastInDim` output shape from
+the operation payload, so malformed `dims` can remain in a frozen program.
+`transpose_broadcast` then indexed input and output shape vectors through that
+unchecked mapping and used an infallible permutation lookup. An out-of-range or
+overlong mapping could therefore panic through the public semantic VJP API.
+
+After obtaining the input and cotangent shape plans, `transpose_broadcast` now
+validates mapping arity, output-axis bounds, and uniqueness before indexing.
+Every rejection uses `SemanticAdTransformError::UnsupportedMetadata` with role
+`Vjp` and concrete offending values. The later permutation lookup remains
+fallible and returns the same typed error category if its invariant is broken.
+
+## Rejected alternatives
+
+- `catch_unwind` would hide rather than remove unchecked public-boundary logic.
+- A global validator registry would add state and indirection for one local
+  metadata contract.
+- A duplicate shape engine would create competing inference semantics.
+- A compatibility fallback would silently reinterpret malformed metadata.
+- Broader semantic-builder validation would change construction semantics
+  outside the accepted VJP repair.
+
+## RED to GREEN evidence
+
+The first exact public regression used output rank 1 with `dims = [2]`. Before
+production edits it failed with exit 101 at `output_shape.shape[2]`: `index out
+of bounds: the len is 1 but the index is 2`. After validation was added, the
+same exact test passed and asserted `UnsupportedMetadata`, role `Vjp`, and a
+diagnostic identifying `dims[0] = 2` and output rank 1.
+
+Table-driven follow-up cases also pass for an overlong mapping (`dims` length 2
+versus input rank 1) and duplicate output axis (`dims[1] = 0`). Positive
+identity and permuted mappings remain accepted.
+
+## Verification
+
+- Exact out-of-bounds regression: 1 passed, 0 failed.
+- Exact arity/duplicate table regression: 1 passed, 0 failed.
+- `cargo test -p tenferro-ad --test integration semantic_transform`: 36 passed,
+  0 failed.
+- `cargo test -p tenferro-ad --test integration shape_inference`: 14 passed,
+  0 failed.
+- `cargo test -p tenferro-ad --lib`: 66 passed, 0 failed.
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p
+  tenferro-ad --test integration semantic_transform'`: passed, including
+  formatting, doc snippets, workspace and extension clippy, and the focused
+  integration group.
+- `cargo fmt --all --check` and `git diff --check`: passed.
+
+## Neighborhood scan
+
+The semantic JVP path re-emits the unary operation without indexing `dims`.
+The adjacent primitive AD transpose path bounds-checks axes before indexing and
+uses `Option` for permutation lookup, so it does not share the panic. Eager
+broadcast construction already uses the existing broadcast validation helper.
+No neighboring subsystem required a change.
+
+## Residual risks
+
+- Raw malformed broadcast metadata remains constructible until an active VJP
+  traverses it, matching the accepted repair boundary.
+- An inactive cotangent path skips validation, but it also returns before shape
+  indexing and therefore cannot trigger this panic.
+- Rank-list membership and position scans remain quadratic in tensor rank. They
+  are rank-bounded, carry the required `INVARIANT` marker, and can become axis
+  maps if unusually high-rank workloads make the cost measurable.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [x] Implementation of accepted issue

## Related issue

Fixes #1588
Refs #1619

## Summary

`BroadcastInDim` semantic VJP previously indexed malformed `dims` metadata before validating it and later used `.position(...).expect(...)`, so public `AdContext::vjp_program` calls could abort the process.

This PR:

- validates dimension count, output-axis bounds, and uniqueness before shape indexing;
- returns the existing typed `SemanticAdTransformError::UnsupportedMetadata` with role `Vjp` and concrete diagnostics;
- keeps the post-reduction permutation lookup fallible;
- adds public-path regressions for out-of-bounds, overlong, duplicate, identity, and permuted mappings;
- documents the deliberate rank-bounded scans with the repository `INVARIANT` marker.

The bug-fix scope gate was applied. No public API, error variant, dependency, compatibility shim, catch-unwind path, registry, duplicate shape engine, hidden transfer, or valid semantic behavior was added or changed.

Neighborhood scans covered semantic JVP, primitive AD broadcast transpose, eager broadcast construction, and raw semantic shape inference. No same-root-cause sibling remained in the accepted subsystem.

## Work log

- [`docs/worklogs/2026-08-07-issue-1588-broadcast-vjp.md`](docs/worklogs/2026-08-07-issue-1588-broadcast-vjp.md)

## Verification

- RED before production edits: exact malformed-dims regression reproduced an index-out-of-bounds panic (exit 101)
- Exact malformed-dims GREEN regression: passed
- Exact arity/duplicate regression: passed
- `cargo test -p tenferro-ad --test integration semantic_transform` — 36 passed
- `cargo test -p tenferro-ad --test integration shape_inference` — 14 passed
- `cargo test -p tenferro-ad --lib` — 66 passed
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-ad --test integration semantic_transform'` — passed
- `cargo fmt --all --check` — passed
- `cargo test --workspace --release` — passed
- `cargo llvm-cov --workspace --release --json --output-path coverage.json` — passed
- `python3 scripts/check-coverage.py coverage.json` — 210/210 files passed
- `cargo doc --workspace --no-deps` — passed
- `python3 scripts/check-docs-site.py --root-dir .` — passed
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1588.json` — pass, 0 findings
- independent specification review — PASS
- independent quality review and two scoped re-reviews — CLEAN
- final whole-branch review — CLEAN
- `git diff --check origin/main...HEAD` — passed

No hardware-specific path is affected or required for this metadata-only AD transform fix.

## Residual scope

Raw malformed semantic broadcast metadata remains constructible and is rejected when an active VJP traverses it, matching the accepted repair boundary. Inactive cotangent paths return before indexing and cannot trigger the former panic.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
