### PR TITLE
fix(fft): dispatch domain-bound CPU input by storage

### DIFF
--- a/crates/tenferro-fft/src/cpu.rs
+++ b/crates/tenferro-fft/src/cpu.rs
@@ -34,13 +34,13 @@ impl FftBackend for CpuExecSession<'_> {
         validate_spec_input(input, spec)?;
         let mut plans = ExtensionFftPlanCache::new(cache.store_mut());
         let allocation_domain = self.shared_allocation_domain();
-        match allocation_domain.as_deref() {
-            Some(domain) => execute_managed_fft_with_plans(input, spec, domain, &mut plans),
-            None => {
-                validate_host_fft_input(fft_op_name(spec.operation()), input)?;
-                execute_fft_with_plans(input, spec, &mut plans)
+        if input.is_backend_buffer() {
+            if let Some(domain) = allocation_domain.as_deref() {
+                return execute_managed_fft_with_plans(input, spec, domain, &mut plans);
             }
         }
+        validate_host_fft_input(fft_op_name(spec.operation()), input)?;
+        execute_fft_with_plans(input, spec, &mut plans)
     }
 }
 

--- a/crates/tenferro-fft/src/cpu/managed_tests.rs
+++ b/crates/tenferro-fft/src/cpu/managed_tests.rs
@@ -8,10 +8,10 @@ use tenferro_cpu::{with_cpu_exec_session, CpuBackend, CpuExecSession};
 use tenferro_tensor::{
     AllocationDomainId, AllocationId, BackendSessionHost, BackendStorage, DType, HostAccessError,
     HostReadGuard, HostWriteGuard, MemoryKind, Placement, SharedTensorAllocationDomain,
-    StorageBuffer, Tensor, TensorScalar, TypedTensor,
+    StorageBuffer, Tensor, TensorRead, TensorScalar, TypedTensor,
 };
 
-use crate::{FftNorm, TensorFftExt};
+use crate::{FftNorm, TensorFftExt, TensorReadFftExt};
 
 #[derive(Debug, Default)]
 struct AccessCounts {
@@ -188,6 +188,86 @@ fn assert_managed_output(output: &Tensor, domain: &FakeDomain, input_id: Option<
     assert_eq!(output_domain, Some(domain.id));
     assert_ne!(output_id, input_id);
     assert_eq!(output.placement().memory_kind, MemoryKind::Managed);
+}
+
+#[test]
+fn domain_bound_backend_accepts_host_owned_fft() {
+    let domain = FakeDomain::new();
+    let host = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let mut backend = backend(&domain);
+
+    let output = with_cpu_session(&mut backend, |backend| {
+        host.rfft(None, 0, FftNorm::Backward, backend)
+    })
+    .unwrap();
+    let Tensor::C64(output) = output else {
+        panic!("expected C64 host FFT output")
+    };
+
+    assert_eq!(
+        output.as_slice().unwrap(),
+        &[
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+        ]
+    );
+    assert!(matches!(output.buffer(), StorageBuffer::Host(_)));
+    assert_eq!(output.allocation_domain(), None);
+    assert_eq!(output.placement().memory_kind, MemoryKind::UnpinnedHost);
+    assert_eq!(domain.counts.reads.load(Ordering::Relaxed), 0);
+    assert_eq!(domain.counts.writes.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn domain_bound_backend_accepts_host_read_fft() {
+    let domain = FakeDomain::new();
+    let host = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let input = TensorRead::from_tensor(&host);
+    let mut backend = backend(&domain);
+
+    let output = with_cpu_session(&mut backend, |backend| {
+        input.rfft_read(None, 0, FftNorm::Backward, backend)
+    })
+    .unwrap();
+    let Tensor::C64(output) = output else {
+        panic!("expected C64 host FFT output")
+    };
+
+    assert_eq!(
+        output.as_slice().unwrap(),
+        &[
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+        ]
+    );
+    assert!(matches!(output.buffer(), StorageBuffer::Host(_)));
+    assert_eq!(output.allocation_domain(), None);
+    assert_eq!(output.placement().memory_kind, MemoryKind::UnpinnedHost);
+    assert_eq!(domain.counts.reads.load(Ordering::Relaxed), 0);
+    assert_eq!(domain.counts.writes.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn domain_bound_backend_rejects_foreign_fft_input() {
+    let domain = FakeDomain::new();
+    let foreign = FakeDomain::new();
+    let input = Tensor::F64(foreign.tensor(&[4], vec![1.0_f64, 2.0, 3.0, 4.0]));
+    let mut backend = backend(&domain);
+
+    let error = with_cpu_session(&mut backend, |backend| {
+        input.rfft(None, 0, FftNorm::Backward, backend)
+    })
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        tenferro_tensor::Error::HostAccess {
+            source: HostAccessError::ForeignDomain { .. },
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/docs/worklogs/2026-08-07-issue-1579-fft-domain.md
+++ b/docs/worklogs/2026-08-07-issue-1579-fft-domain.md
@@ -1,0 +1,42 @@
+# 2026-08-07 FFT input-storage dispatch (#1579)
+
+## Scope
+
+Fix `CpuExecSession::execute_fft` so a domain-bound CPU session selects the
+execution path from the input's actual storage. Host-owned inputs use the
+existing host RustFFT path and produce host-owned outputs; backend inputs use
+the managed path only when a shared allocation domain is bound. No transfer,
+public API, dependency, or fallback behavior was added.
+
+## Context reviewed
+
+- Accepted implementation plan and comments for #1579, plus umbrella #1619.
+- `AGENTS.md`, `REPOSITORY_RULES.md`, and the shared common/Rust,
+  performance, numerical, and docs/tests rules.
+- `docs/design/fft-backend-execution.md`.
+- Existing FFT managed tests and the matching Cholesky dispatch/tests from
+  #1428.
+
+## Decision
+
+Keep the existing managed executor and `with_managed_read` validation intact.
+At the `execute_fft` boundary, check `input.is_backend_buffer()` before using a
+session allocation domain. A host input therefore stays on the host path even
+when the backend is domain-bound. A foreign or unsupported backend buffer still
+enters `with_managed_read`, preserving its typed domain/backend error.
+
+## Verification
+
+- Added RED coverage for host-owned direct FFT and host read FFT on a
+  domain-bound backend; both failed with `HostAccessError::Unsupported {
+  backend: "host" }` before the dispatch fix.
+- Added foreign-domain rejection coverage and retained matching-domain managed
+  coverage.
+- Targeted host tests and the full `cpu::managed_tests` suite pass after the
+  fix; `cargo fmt --all -- --check` passes.
+
+## Residual risks
+
+The Apple/Metal integration tests remain hardware-gated and were not run on
+this host. The change is limited to CPU FFT dispatch; no implicit transfer is
+introduced.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1579

## Summary

`CpuExecSession::execute_fft` now selects host versus managed execution from the input's actual storage instead of the backend's configured allocation domain. Domain-bound CPU sessions therefore accept ordinary host tensors and preserve host-owned FFT outputs, while matching-domain managed inputs and foreign-domain errors retain their existing behavior. No implicit transfer was added.

## Work log

- [docs/worklogs/2026-08-07-issue-1579-fft-domain.md](https://github.com/tensor4all/tenferro-rs/blob/codex/issue-1579-fft-domain/docs/worklogs/2026-08-07-issue-1579-fft-domain.md)

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p tenferro-fft`
- `cargo test -p tenferro-fft --features webgpu --lib cpu::managed_tests`
- `cargo test -p tenferro-fft --features webgpu --test webgpu_metal_fft --no-run`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-fft --features webgpu --lib cpu::managed_tests'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1579.json`
- `git diff --check origin/main...HEAD`

Apple/Metal hardware-gated execution was unavailable locally; the WebGPU/Metal test target compiled successfully.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
