### PR TITLE
fix: harden unsafe safety boundaries and GPU cache eviction

### DIFF
--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -23,7 +23,9 @@ use tenferro_runtime::{
 };
 use tenferro_tensor::TypedTensorView;
 use tenferro_tensor::{AllocationGroup, DescriptorSlot, GroupError, Tensor};
-use tenferro_tensor::{DType, DotGeneralConfig, TensorElementwise};
+use tenferro_tensor::{
+    BackendSession, BackendSessionHost, DType, DotGeneralConfig, TensorElementwise,
+};
 use tenferro_tensor::{ErrorKind, ValidationKind};
 use tenferro_tensor::{TensorFusion, TensorRead, TensorStructural, TensorView, TensorWrite};
 
@@ -120,6 +122,29 @@ fn eager_runtime_execution_session_runs_cpu_operation() {
         .unwrap();
 
     assert_eq!(output.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+}
+
+#[test]
+fn eager_backend_session_identity_projects_to_owner() {
+    let mut backend = EagerBackend::cpu(CpuBackend::new());
+    let owner = (&mut backend as *mut EagerBackend).cast::<()>();
+    let identity = backend.session_type_id();
+    let projected = unsafe { backend.session_data_mut() };
+    assert_eq!(identity, backend.session_type_id());
+    assert_eq!(projected, owner);
+
+    let materializations = Arc::new(AtomicUsize::new(0));
+    let mut recording = EagerBackend::recording_cpu(materializations);
+    let recording_identity = recording.with_backend_session(|session| {
+        let identity = session.session_type_id();
+        let projected = unsafe { session.session_data_mut() };
+        assert!(!projected.is_null());
+        identity
+    });
+    assert_eq!(
+        recording_identity,
+        recording.with_backend_session(|session| { session.session_type_id() })
+    );
 }
 
 #[test]

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -135,16 +135,19 @@ fn eager_backend_session_identity_projects_to_owner() {
 
     let materializations = Arc::new(AtomicUsize::new(0));
     let mut recording = EagerBackend::recording_cpu(materializations);
+    let recording_owner = recording.recording_session_owner().unwrap() as usize;
     let recording_identity = recording.with_backend_session(|session| {
         let identity = session.session_type_id();
         let projected = unsafe { session.session_data_mut() };
-        assert!(!projected.is_null());
+        assert_eq!(projected as usize, recording_owner);
         identity
     });
+    assert_ne!(recording_identity, identity);
     assert_eq!(
         recording_identity,
         recording.with_backend_session(|session| { session.session_type_id() })
     );
+    assert!(backend.recording_session_owner().is_none());
 }
 
 #[test]

--- a/crates/tenferro-ad/src/eager_backend.rs
+++ b/crates/tenferro-ad/src/eager_backend.rs
@@ -13,11 +13,10 @@ use tenferro_runtime::{
 use tenferro_tensor::backend::ElementwiseFusionPlan;
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
-    BackendSessionIdentity, CompareDir, DType,
-    DotGeneralConfig, ElementwiseReadOp, GatherConfig, PadConfig, Result as TensorResult,
-    ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
-    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
-    TensorReduction, TensorStructural, TensorValue, TensorWrite,
+    BackendSessionIdentity, CompareDir, DType, DotGeneralConfig, ElementwiseReadOp, GatherConfig,
+    PadConfig, Result as TensorResult, ScatterConfig, SliceConfig, Tensor, TensorAnalytic,
+    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
+    TensorIndexing, TensorRead, TensorReduction, TensorStructural, TensorValue, TensorWrite,
 };
 
 #[doc(hidden)]

--- a/crates/tenferro-ad/src/eager_backend.rs
+++ b/crates/tenferro-ad/src/eager_backend.rs
@@ -1,3 +1,4 @@
+use std::any::TypeId;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(test)]
@@ -12,15 +13,15 @@ use tenferro_runtime::{
 };
 use tenferro_tensor::backend::ElementwiseFusionPlan;
 use tenferro_tensor::{
-    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
-    BackendSessionIdentity, CompareDir, DType, DotGeneralConfig, ElementwiseReadOp, GatherConfig,
-    PadConfig, Result as TensorResult, ScatterConfig, SliceConfig, Tensor, TensorAnalytic,
-    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
-    TensorIndexing, TensorRead, TensorReduction, TensorStructural, TensorValue, TensorWrite,
+    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir, DType,
+    DotGeneralConfig, ElementwiseReadOp, GatherConfig, PadConfig, Result as TensorResult,
+    ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
+    TensorReduction, TensorStructural, TensorValue, TensorWrite,
 };
 
 #[doc(hidden)]
-pub struct EagerBackendSessionMarker;
+struct EagerBackendSessionMarker;
 
 pub(crate) enum EagerBackend {
     Cpu(CpuBackend),
@@ -170,7 +171,7 @@ macro_rules! dispatch {
 
 #[cfg(test)]
 #[doc(hidden)]
-pub struct RecordingBackendSessionMarker;
+struct RecordingBackendSessionMarker;
 
 #[cfg(test)]
 #[derive(Debug)]
@@ -191,8 +192,14 @@ macro_rules! delegate_recording_backend_methods {
 }
 
 #[cfg(test)]
-impl BackendSessionIdentity for RecordingBackend {
-    type Marker = RecordingBackendSessionMarker;
+impl BackendSession for RecordingBackend {
+    fn session_type_id(&self) -> TypeId {
+        TypeId::of::<RecordingBackendSessionMarker>()
+    }
+
+    unsafe fn session_data_mut(&mut self) -> *mut () {
+        self as *mut Self as *mut ()
+    }
 }
 
 #[cfg(test)]
@@ -342,8 +349,14 @@ macro_rules! delegate_tensor_backend_methods {
     };
 }
 
-impl BackendSessionIdentity for EagerBackend {
-    type Marker = EagerBackendSessionMarker;
+impl BackendSession for EagerBackend {
+    fn session_type_id(&self) -> TypeId {
+        TypeId::of::<EagerBackendSessionMarker>()
+    }
+
+    unsafe fn session_data_mut(&mut self) -> *mut () {
+        self as *mut Self as *mut ()
+    }
 }
 
 impl BackendRuntimeCache for EagerBackend {

--- a/crates/tenferro-ad/src/eager_backend.rs
+++ b/crates/tenferro-ad/src/eager_backend.rs
@@ -81,6 +81,14 @@ impl EagerBackend {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn recording_session_owner(&mut self) -> Option<*mut ()> {
+        match self {
+            Self::Recording(backend) => Some((backend as *mut RecordingBackend).cast()),
+            _ => None,
+        }
+    }
+
     #[cfg(feature = "cuda")]
     pub(crate) fn cuda(backend: CudaBackend) -> Self {
         Self::Cuda(backend)

--- a/crates/tenferro-ad/src/eager_backend.rs
+++ b/crates/tenferro-ad/src/eager_backend.rs
@@ -12,12 +12,16 @@ use tenferro_runtime::{
 };
 use tenferro_tensor::backend::ElementwiseFusionPlan;
 use tenferro_tensor::{
-    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir, DType,
+    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
+    BackendSessionIdentity, CompareDir, DType,
     DotGeneralConfig, ElementwiseReadOp, GatherConfig, PadConfig, Result as TensorResult,
     ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
     TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
     TensorReduction, TensorStructural, TensorValue, TensorWrite,
 };
+
+#[doc(hidden)]
+pub struct EagerBackendSessionMarker;
 
 pub(crate) enum EagerBackend {
     Cpu(CpuBackend),
@@ -166,6 +170,10 @@ macro_rules! dispatch {
 }
 
 #[cfg(test)]
+#[doc(hidden)]
+pub struct RecordingBackendSessionMarker;
+
+#[cfg(test)]
 #[derive(Debug)]
 pub struct RecordingBackend {
     materializations: Arc<AtomicUsize>,
@@ -181,6 +189,11 @@ macro_rules! delegate_recording_backend_methods {
             }
         )*
     };
+}
+
+#[cfg(test)]
+impl BackendSessionIdentity for RecordingBackend {
+    type Marker = RecordingBackendSessionMarker;
 }
 
 #[cfg(test)]
@@ -328,6 +341,10 @@ macro_rules! delegate_tensor_backend_methods {
             }
         )*
     };
+}
+
+impl BackendSessionIdentity for EagerBackend {
+    type Marker = EagerBackendSessionMarker;
 }
 
 impl BackendRuntimeCache for EagerBackend {

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -35,7 +35,8 @@ use tenferro_tensor::backend::{ElementwiseFusionPlan, GroupedGemmConfig};
 use tenferro_tensor::SharedTensorAllocationDomain;
 use tenferro_tensor::{
     AllocationDomainId, BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
-    DotGeneralAccumulation, ElementwiseReadOp, TensorAnalytic, TensorBackend, TensorBuffer,
+    BackendSessionIdentity, DotGeneralAccumulation, ElementwiseReadOp, TensorAnalytic, TensorBackend,
+    TensorBuffer,
     TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorReduction, TensorStructural, TensorViewCanonicalization,
 };
@@ -1020,6 +1021,9 @@ fn saturating_add_tensor_cache_stats(total: &mut CacheStats, value: CacheStats) 
 /// let clone = backend.clone();
 /// assert_eq!(backend.kind(), clone.kind());
 /// ```
+#[doc(hidden)]
+pub struct CpuBackendSessionMarker;
+
 #[derive(Clone)]
 pub struct CpuBackend {
     runtime_identity: CpuRuntimeIdentity,
@@ -2710,6 +2714,10 @@ impl CpuBackend {
             }
         }
     }
+}
+
+impl BackendSessionIdentity for CpuBackend {
+    type Marker = CpuBackendSessionMarker;
 }
 
 impl BackendRuntimeCache for CpuBackend {

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -1,3 +1,4 @@
+use std::any::TypeId;
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::env;
@@ -35,9 +36,9 @@ use tenferro_tensor::backend::{ElementwiseFusionPlan, GroupedGemmConfig};
 use tenferro_tensor::SharedTensorAllocationDomain;
 use tenferro_tensor::{
     AllocationDomainId, BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
-    BackendSessionIdentity, DotGeneralAccumulation, ElementwiseReadOp, TensorAnalytic,
-    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
-    TensorIndexing, TensorReduction, TensorStructural, TensorViewCanonicalization,
+    DotGeneralAccumulation, ElementwiseReadOp, TensorAnalytic, TensorBackend, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorReduction, TensorStructural, TensorViewCanonicalization,
 };
 use tenferro_tensor::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
@@ -1021,7 +1022,7 @@ fn saturating_add_tensor_cache_stats(total: &mut CacheStats, value: CacheStats) 
 /// assert_eq!(backend.kind(), clone.kind());
 /// ```
 #[doc(hidden)]
-pub struct CpuBackendSessionMarker;
+struct CpuBackendSessionMarker;
 
 #[derive(Clone)]
 pub struct CpuBackend {
@@ -2715,8 +2716,14 @@ impl CpuBackend {
     }
 }
 
-impl BackendSessionIdentity for CpuBackend {
-    type Marker = CpuBackendSessionMarker;
+impl BackendSession for CpuBackend {
+    fn session_type_id(&self) -> TypeId {
+        TypeId::of::<CpuBackendSessionMarker>()
+    }
+
+    unsafe fn session_data_mut(&mut self) -> *mut () {
+        self as *mut Self as *mut ()
+    }
 }
 
 impl BackendRuntimeCache for CpuBackend {

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -35,10 +35,9 @@ use tenferro_tensor::backend::{ElementwiseFusionPlan, GroupedGemmConfig};
 use tenferro_tensor::SharedTensorAllocationDomain;
 use tenferro_tensor::{
     AllocationDomainId, BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
-    BackendSessionIdentity, DotGeneralAccumulation, ElementwiseReadOp, TensorAnalytic, TensorBackend,
-    TensorBuffer,
-    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
-    TensorReduction, TensorStructural, TensorViewCanonicalization,
+    BackendSessionIdentity, DotGeneralAccumulation, ElementwiseReadOp, TensorAnalytic,
+    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
+    TensorIndexing, TensorReduction, TensorStructural, TensorViewCanonicalization,
 };
 use tenferro_tensor::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -1,7 +1,9 @@
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::{Tensor, TensorRead, TensorValue, TensorWrite};
 use std::sync::Arc;
-use tenferro_tensor::backend::{ElementwiseFusionPlan, GroupedGemmConfig};
+use tenferro_tensor::backend::{
+    BackendSessionIdentity, ElementwiseFusionPlan, GroupedGemmConfig,
+};
 use tenferro_tensor::{
     CompareDir, ContractionScalar, DType, DotGeneralConfig, ElementwiseReadOp, GatherConfig,
     PadConfig, ScatterConfig, SharedTensorAllocationDomain, SliceConfig, TypedTensor,
@@ -21,6 +23,10 @@ use super::{
     analytic, copy_tensor_read_into, elementwise, gemm, indexing, materialize_tensor_read,
     reduction, structural,
 };
+
+/// Marker for the concrete erased CPU execution-session target.
+#[doc(hidden)]
+pub struct CpuExecSessionMarker;
 
 /// Borrowed CPU execution session used by scheduler-owned extension regions.
 #[doc(hidden)]
@@ -800,6 +806,10 @@ impl TensorFusion for CpuExecSession<'_> {
             )
         })
     }
+}
+
+impl BackendSessionIdentity for CpuExecSession<'_> {
+    type Marker = CpuExecSessionMarker;
 }
 
 #[cfg(test)]

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -1,9 +1,7 @@
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::{Tensor, TensorRead, TensorValue, TensorWrite};
 use std::sync::Arc;
-use tenferro_tensor::backend::{
-    BackendSessionIdentity, ElementwiseFusionPlan, GroupedGemmConfig,
-};
+use tenferro_tensor::backend::{BackendSessionIdentity, ElementwiseFusionPlan, GroupedGemmConfig};
 use tenferro_tensor::{
     CompareDir, ContractionScalar, DType, DotGeneralConfig, ElementwiseReadOp, GatherConfig,
     PadConfig, ScatterConfig, SharedTensorAllocationDomain, SliceConfig, TypedTensor,

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -1,7 +1,8 @@
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::{Tensor, TensorRead, TensorValue, TensorWrite};
+use std::any::TypeId;
 use std::sync::Arc;
-use tenferro_tensor::backend::{BackendSessionIdentity, ElementwiseFusionPlan, GroupedGemmConfig};
+use tenferro_tensor::backend::{BackendSession, ElementwiseFusionPlan, GroupedGemmConfig};
 use tenferro_tensor::{
     CompareDir, ContractionScalar, DType, DotGeneralConfig, ElementwiseReadOp, GatherConfig,
     PadConfig, ScatterConfig, SharedTensorAllocationDomain, SliceConfig, TypedTensor,
@@ -24,7 +25,7 @@ use super::{
 
 /// Marker for the concrete erased CPU execution-session target.
 #[doc(hidden)]
-pub struct CpuExecSessionMarker;
+pub(super) struct CpuExecSessionMarker;
 
 /// Borrowed CPU execution session used by scheduler-owned extension regions.
 #[doc(hidden)]
@@ -806,8 +807,14 @@ impl TensorFusion for CpuExecSession<'_> {
     }
 }
 
-impl BackendSessionIdentity for CpuExecSession<'_> {
-    type Marker = CpuExecSessionMarker;
+impl BackendSession for CpuExecSession<'_> {
+    fn session_type_id(&self) -> TypeId {
+        TypeId::of::<CpuExecSessionMarker>()
+    }
+
+    unsafe fn session_data_mut(&mut self) -> *mut () {
+        self as *mut Self as *mut ()
+    }
 }
 
 #[cfg(test)]

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -189,7 +189,7 @@ where
         return None;
     }
     let data = unsafe { session.session_data_mut() };
-    // SAFETY: the exact marker is supplied by the same blanket
+    // SAFETY: the exact marker is supplied by CpuExecSession's explicit
     // `BackendSession` implementation that produced `session_data_mut`, and
     // the equality above proves that the erased value is `CpuExecSession`.
     // The callback is higher-ranked and returns no session borrow, so the

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -173,10 +173,10 @@ pub use topology::{
 
 /// Visit a CPU execution session carried by a type-erased backend session.
 ///
-/// This is a backend-leaf capability bridge. The type-name check is performed
-/// before the erased pointer is reconstructed, and the callback cannot return
-/// a borrow of the session, so the borrowed resource lease remains scoped to
-/// the caller's session closure.
+/// This is a backend-leaf capability bridge. The exact session marker is checked
+/// before the erased pointer is reconstructed, and the callback cannot return a
+/// borrow of the session, so the borrowed resource lease remains scoped to the
+/// caller's session closure.
 #[doc(hidden)]
 pub fn with_cpu_exec_session<B, R>(
     session: &mut B,
@@ -185,11 +185,11 @@ pub fn with_cpu_exec_session<B, R>(
 where
     B: tenferro_tensor::BackendSession + ?Sized,
 {
-    if session.session_type_name() != std::any::type_name::<CpuExecSession<'static>>() {
+    if session.session_type_id() != std::any::TypeId::of::<exec_session::CpuExecSessionMarker>() {
         return None;
     }
     let data = unsafe { session.session_data_mut() };
-    // SAFETY: `session_type_name` is supplied by the same blanket
+    // SAFETY: the exact marker is supplied by the same blanket
     // `BackendSession` implementation that produced `session_data_mut`, and
     // the equality above proves that the erased value is `CpuExecSession`.
     // The callback is higher-ranked and returns no session borrow, so the

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -13,13 +13,14 @@ use crate::{
     abs, add, broadcast_in_dim, clamp, compare, conj, div, dynamic_slice, dynamic_update_slice,
     embed_diagonal, extract_diagonal, gather, maximum, minimum, mul, neg, pad, pow, reduce_max,
     reduce_min, reduce_prod, reduce_sum, reduce_sum_squares, rem, reshape, scatter, select, sign,
-    transpose, tril, triu, CpuBackend, CpuContext, Error,
+    transpose, tril, triu, with_cpu_exec_session, CpuBackend, CpuContext, CpuExecSession, Error,
 };
 use tenferro_tensor::backend::{GroupedGemmConfig, GroupedGemmJob};
 #[cfg(feature = "cpu-blas")]
 use tenferro_tensor::StridedSliceSpec;
 use tenferro_tensor::{
-    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, ContractionScalar,
+    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendSessionIdentity,
+    ContractionScalar,
     DotGeneralAccumulation, SessionCachedDot, TensorAnalytic, TensorBackend, TensorBuffer,
     TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorReduction, TensorStructural,
@@ -31,6 +32,27 @@ use tenferro_tensor::{
     DType, Tensor, TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensor,
     TypedTensorViewMut,
 };
+
+#[test]
+fn with_cpu_exec_session_checks_exact_marker_and_scopes_borrow() {
+    let mut backend = CpuBackend::new();
+    let mut called = false;
+    assert!(with_cpu_exec_session(&mut backend, |_| {
+        called = true;
+    })
+    .is_none());
+    assert!(!called);
+
+    let value = backend
+        .with_backend_session(|session| {
+            with_cpu_exec_session(session, |session: &mut CpuExecSession<'_>| {
+                let _: &mut CpuExecSession<'_> = session;
+                17usize
+            })
+        })
+        .expect("CpuBackend must expose its scoped CpuExecSession");
+    assert_eq!(value, 17);
+}
 
 fn get_f64(t: &Tensor, idx: &[usize]) -> f64 {
     match t {

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -19,9 +19,9 @@ use tenferro_tensor::backend::{GroupedGemmConfig, GroupedGemmJob};
 #[cfg(feature = "cpu-blas")]
 use tenferro_tensor::StridedSliceSpec;
 use tenferro_tensor::{
-    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendSessionIdentity,
-    ContractionScalar, DotGeneralAccumulation, SessionCachedDot, TensorAnalytic, TensorBackend,
-    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, ContractionScalar,
+    DotGeneralAccumulation, SessionCachedDot, TensorAnalytic, TensorBackend, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorReduction, TensorStructural,
 };
 use tenferro_tensor::{
@@ -35,6 +35,10 @@ use tenferro_tensor::{
 #[test]
 fn with_cpu_exec_session_checks_exact_marker_and_scopes_borrow() {
     let mut backend = CpuBackend::new();
+    assert_ne!(
+        backend.session_type_id(),
+        std::any::TypeId::of::<crate::exec_session::CpuExecSessionMarker>()
+    );
     let mut called = false;
     assert!(with_cpu_exec_session(&mut backend, |_| {
         called = true;

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -20,9 +20,8 @@ use tenferro_tensor::backend::{GroupedGemmConfig, GroupedGemmJob};
 use tenferro_tensor::StridedSliceSpec;
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendSessionIdentity,
-    ContractionScalar,
-    DotGeneralAccumulation, SessionCachedDot, TensorAnalytic, TensorBackend, TensorBuffer,
-    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    ContractionScalar, DotGeneralAccumulation, SessionCachedDot, TensorAnalytic, TensorBackend,
+    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorReduction, TensorStructural,
 };
 use tenferro_tensor::{

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -1398,6 +1398,7 @@ fn test_exec_session_read_reductions_and_reclaim_cover_typed_paths() {
 
 #[test]
 fn test_default_backend_session_methods_cover_cache_fallbacks() {
+    #[doc(hidden)]
     struct DefaultOnlyBackendSessionMarker;
     struct DefaultOnlyBackend;
 
@@ -1512,8 +1513,14 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
 
     impl BackendCachedDot for DefaultOnlyBackend {}
 
-    impl BackendSessionIdentity for DefaultOnlyBackend {
-        type Marker = DefaultOnlyBackendSessionMarker;
+    impl BackendSession for DefaultOnlyBackend {
+        fn session_type_id(&self) -> std::any::TypeId {
+            std::any::TypeId::of::<DefaultOnlyBackendSessionMarker>()
+        }
+
+        unsafe fn session_data_mut(&mut self) -> *mut () {
+            self as *mut Self as *mut ()
+        }
     }
 
     impl BackendSessionHost for DefaultOnlyBackend {}

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -1398,6 +1398,7 @@ fn test_exec_session_read_reductions_and_reclaim_cover_typed_paths() {
 
 #[test]
 fn test_default_backend_session_methods_cover_cache_fallbacks() {
+    struct DefaultOnlyBackendSessionMarker;
     struct DefaultOnlyBackend;
 
     macro_rules! panic_backend_methods {
@@ -1510,6 +1511,10 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
     }
 
     impl BackendCachedDot for DefaultOnlyBackend {}
+
+    impl BackendSessionIdentity for DefaultOnlyBackend {
+        type Marker = DefaultOnlyBackendSessionMarker;
+    }
 
     impl BackendSessionHost for DefaultOnlyBackend {}
 

--- a/crates/tenferro-cpu/tests/integration/backend_capability_contracts.rs
+++ b/crates/tenferro-cpu/tests/integration/backend_capability_contracts.rs
@@ -704,11 +704,31 @@ fn cpu_provider_dispatch_has_no_runtime_registry_lookup_or_legacy_staging() {
     let sources = [
         ("dot_runtime", include_str!("../../src/dot_runtime.rs")),
         ("provider", include_str!("../../src/provider.rs")),
-        ("exec_session", include_str!("../../src/exec_session.rs")),
         ("gemm_analysis", include_str!("../../src/gemm/mod.rs")),
     ];
     for (module, source) in sources {
         assert_direct_dispatch(module, source);
+    }
+
+    // exec_session.rs also owns the concrete BackendSession type identity;
+    // scan only its contraction entry points so that this unrelated TypeId is
+    // not mistaken for a dispatch registry.
+    let exec_session = include_str!("../../src/exec_session.rs");
+    for function in [
+        "with_linalg_pool",
+        "dot_general",
+        "dot_general_read",
+        "dot_general_read_into",
+        "dot_general_read_into_accum",
+        "dot_general_with_conj",
+        "dot_general_cached",
+        "dot_general_with_conj_cached",
+        "dot_general_read_into_accum_cached",
+        "grouped_gemm_cached",
+    ] {
+        let body = rust_function_body(exec_session, function)
+            .unwrap_or_else(|| panic!("exec-session dispatch function `{function}` must exist"));
+        assert_direct_dispatch(&format!("exec_session::{function}"), body);
     }
 
     // backend.rs also owns opt-in profiling state, so scanning the entire file

--- a/crates/tenferro-einsum/src/eager/tests.rs
+++ b/crates/tenferro-einsum/src/eager/tests.rs
@@ -1,10 +1,9 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{
     BackendSessionHost, BackendSessionIdentity, CompareDir, DotGeneralConfig, Error, GatherConfig,
-    PadConfig, Result,
-    ScatterConfig, SessionCachedDot, SliceConfig, Tensor, TensorAnalytic, TensorBuffer,
-    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
-    TensorReduction, TensorStructural, TensorView,
+    PadConfig, Result, ScatterConfig, SessionCachedDot, SliceConfig, Tensor, TensorAnalytic,
+    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorRead, TensorReduction, TensorStructural, TensorView,
 };
 
 use super::{

--- a/crates/tenferro-einsum/src/eager/tests.rs
+++ b/crates/tenferro-einsum/src/eager/tests.rs
@@ -1,6 +1,6 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{
-    BackendSessionHost, BackendSessionIdentity, CompareDir, DotGeneralConfig, Error, GatherConfig,
+    BackendSession, BackendSessionHost, CompareDir, DotGeneralConfig, Error, GatherConfig,
     PadConfig, Result, ScatterConfig, SessionCachedDot, SliceConfig, Tensor, TensorAnalytic,
     TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorRead, TensorReduction, TensorStructural, TensorView,
@@ -160,6 +160,7 @@ fn generic_binary_contract_reduces_then_builds_dot_config() {
     assert_eq!(tensor.as_slice::<f64>().unwrap(), &[24.0; 10]);
 }
 
+#[doc(hidden)]
 struct NoBroadcastMaterializationBackendSessionMarker;
 
 struct NoBroadcastMaterializationBackend {
@@ -168,8 +169,14 @@ struct NoBroadcastMaterializationBackend {
     rhs_strides: &'static [isize],
 }
 
-impl BackendSessionIdentity for NoBroadcastMaterializationBackend {
-    type Marker = NoBroadcastMaterializationBackendSessionMarker;
+impl BackendSession for NoBroadcastMaterializationBackend {
+    fn session_type_id(&self) -> std::any::TypeId {
+        std::any::TypeId::of::<NoBroadcastMaterializationBackendSessionMarker>()
+    }
+
+    unsafe fn session_data_mut(&mut self) -> *mut () {
+        self as *mut Self as *mut ()
+    }
 }
 
 fn unexpected(op: &'static str) -> Error {

--- a/crates/tenferro-einsum/src/eager/tests.rs
+++ b/crates/tenferro-einsum/src/eager/tests.rs
@@ -1,6 +1,7 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{
-    BackendSessionHost, CompareDir, DotGeneralConfig, Error, GatherConfig, PadConfig, Result,
+    BackendSessionHost, BackendSessionIdentity, CompareDir, DotGeneralConfig, Error, GatherConfig,
+    PadConfig, Result,
     ScatterConfig, SessionCachedDot, SliceConfig, Tensor, TensorAnalytic, TensorBuffer,
     TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
     TensorReduction, TensorStructural, TensorView,
@@ -160,10 +161,16 @@ fn generic_binary_contract_reduces_then_builds_dot_config() {
     assert_eq!(tensor.as_slice::<f64>().unwrap(), &[24.0; 10]);
 }
 
+struct NoBroadcastMaterializationBackendSessionMarker;
+
 struct NoBroadcastMaterializationBackend {
     shape: &'static [usize],
     lhs_strides: &'static [isize],
     rhs_strides: &'static [isize],
+}
+
+impl BackendSessionIdentity for NoBroadcastMaterializationBackend {
+    type Marker = NoBroadcastMaterializationBackendSessionMarker;
 }
 
 fn unexpected(op: &'static str) -> Error {

--- a/crates/tenferro-einsum/src/typed_eager_tests.rs
+++ b/crates/tenferro-einsum/src/typed_eager_tests.rs
@@ -1,6 +1,7 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{
-    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, CompareDir, DType, DotGeneralConfig,
+    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendSessionIdentity, CompareDir,
+    DType, DotGeneralConfig,
     GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend,
     TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorRead, TensorReduction, TensorStructural, TensorView, TensorWrite, TypedTensor,
@@ -138,6 +139,10 @@ impl TensorDot for WrongDTypeBackend {
 }
 
 impl BackendCachedDot for WrongDTypeBackend {}
+
+impl BackendSessionIdentity for WrongDTypeBackend {
+    type Marker = WrongDTypeBackend;
+}
 
 impl BackendSessionHost for WrongDTypeBackend {}
 

--- a/crates/tenferro-einsum/src/typed_eager_tests.rs
+++ b/crates/tenferro-einsum/src/typed_eager_tests.rs
@@ -1,10 +1,10 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{
-    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendSessionIdentity, CompareDir,
-    DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor,
-    TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot,
-    TensorElementwise, TensorFusion, TensorIndexing, TensorRead, TensorReduction, TensorStructural,
-    TensorView, TensorWrite, TypedTensor,
+    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir, DType,
+    DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor, TensorAnalytic,
+    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
+    TensorIndexing, TensorRead, TensorReduction, TensorStructural, TensorView, TensorWrite,
+    TypedTensor,
 };
 
 use crate::eager::{
@@ -26,6 +26,8 @@ fn typed_eager_einsum_does_not_erase_through_host_copies() {
 
 #[derive(Default)]
 struct WrongDTypeBackend;
+#[doc(hidden)]
+struct WrongDTypeBackendSessionMarker;
 
 macro_rules! panic_backend_methods {
     ($($name:ident($($arg:ident : $argty:ty),*) -> $ret:ty;)+) => {
@@ -140,8 +142,14 @@ impl TensorDot for WrongDTypeBackend {
 
 impl BackendCachedDot for WrongDTypeBackend {}
 
-impl BackendSessionIdentity for WrongDTypeBackend {
-    type Marker = WrongDTypeBackend;
+impl BackendSession for WrongDTypeBackend {
+    fn session_type_id(&self) -> std::any::TypeId {
+        std::any::TypeId::of::<WrongDTypeBackendSessionMarker>()
+    }
+
+    unsafe fn session_data_mut(&mut self) -> *mut () {
+        self as *mut Self as *mut ()
+    }
 }
 
 impl BackendSessionHost for WrongDTypeBackend {}

--- a/crates/tenferro-einsum/src/typed_eager_tests.rs
+++ b/crates/tenferro-einsum/src/typed_eager_tests.rs
@@ -1,10 +1,10 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendSessionIdentity, CompareDir,
-    DType, DotGeneralConfig,
-    GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend,
-    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
-    TensorRead, TensorReduction, TensorStructural, TensorView, TensorWrite, TypedTensor,
+    DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor,
+    TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot,
+    TensorElementwise, TensorFusion, TensorIndexing, TensorRead, TensorReduction, TensorStructural,
+    TensorView, TensorWrite, TypedTensor,
 };
 
 use crate::eager::{

--- a/crates/tenferro-fft/tests/backend_capability.rs
+++ b/crates/tenferro-fft/tests/backend_capability.rs
@@ -14,12 +14,11 @@ use tenferro_fft::{
 use tenferro_runtime::{ExtensionCacheKey, Runtime};
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendSessionIdentity,
-    BackendStorageHandle, CompareDir,
-    DType, DeviceId, DeviceKind, DotGeneralConfig, ErrorKind, GatherConfig, GpuBackendKind,
-    MemoryKind, PadConfig, Placement, ScatterConfig, SliceConfig, StorageBuffer, Tensor,
-    TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot,
-    TensorElementwise, TensorFusion, TensorIndexing, TensorRead, TensorReduction, TensorStructural,
-    TypedTensor,
+    BackendStorageHandle, CompareDir, DType, DeviceId, DeviceKind, DotGeneralConfig, ErrorKind,
+    GatherConfig, GpuBackendKind, MemoryKind, PadConfig, Placement, ScatterConfig, SliceConfig,
+    StorageBuffer, Tensor, TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer,
+    TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead, TensorReduction,
+    TensorStructural, TypedTensor,
 };
 
 macro_rules! unreachable_backend_methods {

--- a/crates/tenferro-fft/tests/backend_capability.rs
+++ b/crates/tenferro-fft/tests/backend_capability.rs
@@ -13,7 +13,8 @@ use tenferro_fft::{
 };
 use tenferro_runtime::{ExtensionCacheKey, Runtime};
 use tenferro_tensor::{
-    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendStorageHandle, CompareDir,
+    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendSessionIdentity,
+    BackendStorageHandle, CompareDir,
     DType, DeviceId, DeviceKind, DotGeneralConfig, ErrorKind, GatherConfig, GpuBackendKind,
     MemoryKind, PadConfig, Placement, ScatterConfig, SliceConfig, StorageBuffer, Tensor,
     TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot,
@@ -132,6 +133,9 @@ macro_rules! impl_minimal_tensor_backend {
             }
         }
         impl BackendCachedDot for $ty {}
+        impl BackendSessionIdentity for $ty {
+            type Marker = $ty;
+        }
         impl BackendSessionHost for $ty {}
         impl TensorBackend for $ty {}
     };

--- a/crates/tenferro-fft/tests/backend_capability.rs
+++ b/crates/tenferro-fft/tests/backend_capability.rs
@@ -13,7 +13,7 @@ use tenferro_fft::{
 };
 use tenferro_runtime::{ExtensionCacheKey, Runtime};
 use tenferro_tensor::{
-    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendSessionIdentity,
+    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
     BackendStorageHandle, CompareDir, DType, DeviceId, DeviceKind, DotGeneralConfig, ErrorKind,
     GatherConfig, GpuBackendKind, MemoryKind, PadConfig, Placement, ScatterConfig, SliceConfig,
     StorageBuffer, Tensor, TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer,
@@ -33,7 +33,7 @@ macro_rules! unreachable_backend_methods {
 }
 
 macro_rules! impl_minimal_tensor_backend {
-    ($ty:ty) => {
+    ($ty:ty, $marker:ty) => {
         impl BackendRuntimeCache for $ty {
             type RuntimeCache = ();
         }
@@ -132,8 +132,14 @@ macro_rules! impl_minimal_tensor_backend {
             }
         }
         impl BackendCachedDot for $ty {}
-        impl BackendSessionIdentity for $ty {
-            type Marker = $ty;
+        impl BackendSession for $ty {
+            fn session_type_id(&self) -> std::any::TypeId {
+                std::any::TypeId::of::<$marker>()
+            }
+
+            unsafe fn session_data_mut(&mut self) -> *mut () {
+                self as *mut Self as *mut ()
+            }
         }
         impl BackendSessionHost for $ty {}
         impl TensorBackend for $ty {}
@@ -147,7 +153,9 @@ impl TensorOnlyBackend {
     fn record_transfer(&self) {}
 }
 
-impl_minimal_tensor_backend!(TensorOnlyBackend);
+#[doc(hidden)]
+struct TensorOnlyBackendSessionMarker;
+impl_minimal_tensor_backend!(TensorOnlyBackend, TensorOnlyBackendSessionMarker);
 
 #[derive(Debug, Default)]
 struct MockNonCpuSession {
@@ -159,7 +167,9 @@ impl MockNonCpuSession {
     fn record_transfer(&self) {}
 }
 
-impl_minimal_tensor_backend!(MockNonCpuSession);
+#[doc(hidden)]
+struct MockNonCpuSessionMarker;
+impl_minimal_tensor_backend!(MockNonCpuSession, MockNonCpuSessionMarker);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct MockNonCpuPlanKey {
@@ -248,7 +258,9 @@ impl RecordingFftSession {
     }
 }
 
-impl_minimal_tensor_backend!(RecordingFftSession);
+#[doc(hidden)]
+struct RecordingFftSessionMarker;
+impl_minimal_tensor_backend!(RecordingFftSession, RecordingFftSessionMarker);
 
 impl FftBackend for RecordingFftSession {
     fn execute_fft(

--- a/crates/tenferro-gpu/src/cubecl/exec_session.rs
+++ b/crates/tenferro-gpu/src/cubecl/exec_session.rs
@@ -1,9 +1,8 @@
 use cubecl::prelude::{CubeElement, CubePrimitive};
 use tenferro_tensor::backend::{
     BackendSession, BackendSessionHost, BackendSessionIdentity, ElementwiseFusionPlan,
-    GroupedGemmConfig, SessionCachedDot,
-    TensorAnalytic, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
-    TensorIndexing, TensorReduction, TensorStructural,
+    GroupedGemmConfig, SessionCachedDot, TensorAnalytic, TensorBuffer, TensorDeviceTransfer,
+    TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
 };
 use tenferro_tensor::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,

--- a/crates/tenferro-gpu/src/cubecl/exec_session.rs
+++ b/crates/tenferro-gpu/src/cubecl/exec_session.rs
@@ -1,8 +1,9 @@
 use cubecl::prelude::{CubeElement, CubePrimitive};
+use std::any::TypeId;
 use tenferro_tensor::backend::{
-    BackendSession, BackendSessionHost, BackendSessionIdentity, ElementwiseFusionPlan,
-    GroupedGemmConfig, SessionCachedDot, TensorAnalytic, TensorBuffer, TensorDeviceTransfer,
-    TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
+    BackendSession, BackendSessionHost, ElementwiseFusionPlan, GroupedGemmConfig, SessionCachedDot,
+    TensorAnalytic, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
+    TensorIndexing, TensorReduction, TensorStructural,
 };
 use tenferro_tensor::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
@@ -16,7 +17,7 @@ use super::{CudaBackend, CudaExtensionCache, CudaRuntime, CudaRuntimeIdentity};
 
 /// Marker for the concrete erased CUDA execution-session target.
 #[doc(hidden)]
-pub struct CudaExecSessionMarker;
+pub(super) struct CudaExecSessionMarker;
 
 /// Borrowed CUDA execution capability.
 #[doc(hidden)]
@@ -308,8 +309,14 @@ delegate_cached! {
     ) -> crate::Result<()>;
 }
 
-impl BackendSessionIdentity for CudaExecSession<'_> {
-    type Marker = CudaExecSessionMarker;
+impl BackendSession for CudaExecSession<'_> {
+    fn session_type_id(&self) -> TypeId {
+        TypeId::of::<CudaExecSessionMarker>()
+    }
+
+    unsafe fn session_data_mut(&mut self) -> *mut () {
+        self as *mut Self as *mut ()
+    }
 }
 
 impl BackendSessionHost for CudaBackend {

--- a/crates/tenferro-gpu/src/cubecl/exec_session.rs
+++ b/crates/tenferro-gpu/src/cubecl/exec_session.rs
@@ -1,6 +1,7 @@
 use cubecl::prelude::{CubeElement, CubePrimitive};
 use tenferro_tensor::backend::{
-    BackendSession, BackendSessionHost, ElementwiseFusionPlan, GroupedGemmConfig, SessionCachedDot,
+    BackendSession, BackendSessionHost, BackendSessionIdentity, ElementwiseFusionPlan,
+    GroupedGemmConfig, SessionCachedDot,
     TensorAnalytic, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
     TensorIndexing, TensorReduction, TensorStructural,
 };
@@ -13,6 +14,10 @@ use tenferro_tensor::{
 use tenferro_tensor::{TensorRank, TensorScalar, TensorViewCanonicalization, TypedTensorView};
 
 use super::{CudaBackend, CudaExtensionCache, CudaRuntime, CudaRuntimeIdentity};
+
+/// Marker for the concrete erased CUDA execution-session target.
+#[doc(hidden)]
+pub struct CudaExecSessionMarker;
 
 /// Borrowed CUDA execution capability.
 #[doc(hidden)]
@@ -94,11 +99,11 @@ pub fn with_cuda_exec_session<B, R>(
 where
     B: BackendSession + ?Sized,
 {
-    if session.session_type_name() != std::any::type_name::<CudaExecSession<'static>>() {
+    if session.session_type_id() != std::any::TypeId::of::<CudaExecSessionMarker>() {
         return None;
     }
     let data = unsafe { session.session_data_mut() };
-    // SAFETY: the type-name check and the BackendSession erased-pointer
+    // SAFETY: the exact marker check and the BackendSession erased-pointer
     // contract identify the value as CudaExecSession for this scoped visit.
     Some(unsafe { f(&mut *(data.cast::<CudaExecSession<'static>>())) })
 }
@@ -302,6 +307,10 @@ delegate_cached! {
         config: &GroupedGemmConfig<'_>,
         out: TensorWrite<'_>,
     ) -> crate::Result<()>;
+}
+
+impl BackendSessionIdentity for CudaExecSession<'_> {
+    type Marker = CudaExecSessionMarker;
 }
 
 impl BackendSessionHost for CudaBackend {

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -257,6 +257,11 @@ struct DotGeneralLayout {
 }
 
 struct Workspace {
+    // SAFETY: in pinned CubeCL rev 1c88bb6, CUDA storage records handle
+    // deallocation and matches async allocations with `cuMemFreeAsync` on the
+    // allocation stream (or sync allocations with `cuMemFree`). Dropping an
+    // evicted handle therefore follows CubeCL's stream-owned release contract;
+    // this cache does not free the device pointer directly.
     _handle: Option<cubecl_runtime::server::Handle>,
     ptr: *mut c_void,
     size: u64,
@@ -500,6 +505,8 @@ impl CutensorContractionPlanCache {
     }
 
     fn touch(&mut self, key: &CutensorContractionKey) {
+        // INVARIANT: the LRU order is bounded by configured `max_entries`, so
+        // this retain scan has a constant configured ceiling.
         self.order.retain(|existing| existing != key);
         self.order.push_back(key.clone());
     }
@@ -533,6 +540,8 @@ impl CutensorContractionPlanCache {
     }
 
     fn retained_bytes(&self) -> usize {
+        // INVARIANT: retained entries are bounded by configured `max_entries`,
+        // so this retained-byte fold has a constant configured ceiling.
         let entries_bytes =
             self.entries
                 .iter()

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -257,7 +257,7 @@ struct DotGeneralLayout {
 }
 
 struct Workspace {
-    // SAFETY: in pinned CubeCL rev 1c88bb6, CUDA storage records handle
+    // INVARIANT: in pinned CubeCL rev 1c88bb6, CUDA storage records handle
     // deallocation and matches async allocations with `cuMemFreeAsync` on the
     // allocation stream (or sync allocations with `cuMemFree`). Dropping an
     // evicted handle therefore follows CubeCL's stream-owned release contract;
@@ -1124,6 +1124,20 @@ pub(super) fn cutensor_plan_cache_stats(backend: &CudaBackend) -> crate::Result<
     };
     let plan_cache = lock_cutensor_plan_cache(&plan_cache)?;
     Ok(plan_cache.stats())
+}
+
+#[cfg(test)]
+pub(super) fn cutensor_plan_cache_workspace_bytes(backend: &CudaBackend) -> crate::Result<u64> {
+    let Some(plan_cache) = backend
+        .cuda_extension_cache()
+        .get_cloned::<CutensorPlanCacheState>()?
+    else {
+        return Ok(0);
+    };
+    let plan_cache = lock_cutensor_plan_cache(&plan_cache)?;
+    Ok(plan_cache.entries.values().fold(0, |total, cached| {
+        total.saturating_add(cached.workspace.size)
+    }))
 }
 
 pub(super) fn cutensor_plan_cache_max_entries(

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -82,7 +82,8 @@ use tenferro_tensor::CacheStats;
 use tenferro_tensor::{DotGeneralAccumulation, TensorRead, TensorWrite};
 
 use crate::backend::{
-    BackendCachedDot, BackendRuntimeCache, TensorAnalytic, TensorBackend, TensorBuffer,
+    BackendCachedDot, BackendRuntimeCache, BackendSessionIdentity, TensorAnalytic, TensorBackend,
+    TensorBuffer,
     TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorReduction, TensorStructural,
 };
@@ -301,6 +302,9 @@ fn scatter_update_len(meta: &ScatterLaunchMeta) -> crate::Result<usize> {
 ///
 /// let _ctor: fn(CudaDeviceId) -> Result<CudaBackend, CudaDeviceError> = CudaBackend::new;
 /// ```
+#[doc(hidden)]
+pub struct CudaBackendSessionMarker;
+
 #[derive(Clone)]
 pub struct CudaBackend {
     inner: Arc<CudaBackendState>,
@@ -5697,6 +5701,10 @@ impl TensorFusion for CudaBackend {
             _ => Err(dtype_mismatch("broadcast_multiply", lhs, rhs)),
         }
     }
+}
+
+impl BackendSessionIdentity for CudaBackend {
+    type Marker = CudaBackendSessionMarker;
 }
 
 impl BackendCachedDot for CudaBackend {}

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -83,8 +83,7 @@ use tenferro_tensor::{DotGeneralAccumulation, TensorRead, TensorWrite};
 
 use crate::backend::{
     BackendCachedDot, BackendRuntimeCache, BackendSessionIdentity, TensorAnalytic, TensorBackend,
-    TensorBuffer,
-    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorReduction, TensorStructural,
 };
 use crate::config::{

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -82,7 +82,7 @@ use tenferro_tensor::CacheStats;
 use tenferro_tensor::{DotGeneralAccumulation, TensorRead, TensorWrite};
 
 use crate::backend::{
-    BackendCachedDot, BackendRuntimeCache, BackendSessionIdentity, TensorAnalytic, TensorBackend,
+    BackendCachedDot, BackendRuntimeCache, BackendSession, TensorAnalytic, TensorBackend,
     TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorReduction, TensorStructural,
 };
@@ -302,7 +302,7 @@ fn scatter_update_len(meta: &ScatterLaunchMeta) -> crate::Result<usize> {
 /// let _ctor: fn(CudaDeviceId) -> Result<CudaBackend, CudaDeviceError> = CudaBackend::new;
 /// ```
 #[doc(hidden)]
-pub struct CudaBackendSessionMarker;
+struct CudaBackendSessionMarker;
 
 #[derive(Clone)]
 pub struct CudaBackend {
@@ -5702,8 +5702,14 @@ impl TensorFusion for CudaBackend {
     }
 }
 
-impl BackendSessionIdentity for CudaBackend {
-    type Marker = CudaBackendSessionMarker;
+impl BackendSession for CudaBackend {
+    fn session_type_id(&self) -> TypeId {
+        TypeId::of::<CudaBackendSessionMarker>()
+    }
+
+    unsafe fn session_data_mut(&mut self) -> *mut () {
+        self as *mut Self as *mut ()
+    }
 }
 
 impl BackendCachedDot for CudaBackend {}

--- a/crates/tenferro-gpu/src/cubecl/permutation.rs
+++ b/crates/tenferro-gpu/src/cubecl/permutation.rs
@@ -262,6 +262,8 @@ impl CutensorPermutationPlanCache {
     }
 
     fn touch(&mut self, key: &CutensorPermutationKey) {
+        // INVARIANT: the LRU order is bounded by configured `max_entries`, so
+        // this retain scan has a constant configured ceiling.
         self.order.retain(|existing| existing != key);
         self.order.push_back(key.clone());
     }
@@ -295,6 +297,8 @@ impl CutensorPermutationPlanCache {
     }
 
     fn retained_bytes(&self) -> usize {
+        // INVARIANT: retained entries are bounded by configured `max_entries`,
+        // so this retained-byte fold has a constant configured ceiling.
         let entries_bytes =
             self.entries
                 .iter()

--- a/crates/tenferro-gpu/src/cubecl/tests/gemm_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/gemm_tests.rs
@@ -6,6 +6,7 @@ use crate::DotGeneralConfig;
 use crate::Tensor;
 use tenferro_tensor::TensorDot;
 
+use super::super::gemm::cutensor_plan_cache_workspace_bytes;
 use super::{
     assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c32, tensor_c64, tensor_f32,
     tensor_f64, upload,
@@ -33,10 +34,10 @@ fn cuda_cutensor_cache_eviction_keeps_inflight_workspace_valid() {
     gpu.set_cutensor_plan_cache_max_entries(NonZeroUsize::new(1).unwrap())
         .unwrap();
 
-    let lhs_a = tensor_f32(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0]);
-    let rhs_a = tensor_f32(vec![2, 2], vec![5.0, 7.0, 6.0, 8.0]);
-    let lhs_b = tensor_f32(vec![3, 2], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
-    let rhs_b = tensor_f32(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let lhs_a = tensor_f32(vec![64, 64], vec![1.0; 64 * 64]);
+    let rhs_a = tensor_f32(vec![64, 64], vec![1.0; 64 * 64]);
+    let lhs_b = tensor_f32(vec![65, 64], vec![1.0; 65 * 64]);
+    let rhs_b = tensor_f32(vec![64, 65], vec![1.0; 64 * 65]);
     let expected_a = cpu.dot_general(&lhs_a, &rhs_a, &matmul_config()).unwrap();
     let expected_b = cpu.dot_general(&lhs_b, &rhs_b, &matmul_config()).unwrap();
 
@@ -47,9 +48,20 @@ fn cuda_cutensor_cache_eviction_keeps_inflight_workspace_valid() {
     let actual_a = gpu
         .dot_general(&gpu_lhs_a, &gpu_rhs_a, &matmul_config())
         .unwrap();
+    assert!(
+        cutensor_plan_cache_workspace_bytes(&gpu).unwrap() > 0,
+        "first contraction must retain a nonzero cuTENSOR workspace"
+    );
+
     let actual_b = gpu
         .dot_general(&gpu_lhs_b, &gpu_rhs_b, &matmul_config())
         .unwrap();
+    let cache_stats = gpu.cutensor_plan_cache_stats().unwrap();
+    assert_eq!(cache_stats.entries, 1);
+    assert!(
+        cache_stats.evictions > 0,
+        "second contraction must evict the first plan"
+    );
 
     // Eviction drops the first plan while its launch may still be queued. The
     // pinned CubeCL CUDA allocator retires async frees on the owning stream.

--- a/crates/tenferro-gpu/src/cubecl/tests/gemm_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/gemm_tests.rs
@@ -1,5 +1,6 @@
 // Run with: cargo test --features cuda -- --ignored
 use num_complex::{Complex32, Complex64};
+use std::num::NonZeroUsize;
 
 use crate::DotGeneralConfig;
 use crate::Tensor;
@@ -22,6 +23,39 @@ fn run_dot_general_case(lhs: Tensor, rhs: Tensor, config: DotGeneralConfig, tol:
 
     assert_eq!(actual.shape(), expected.shape());
     assert_tensor_close(&actual, &expected, tol);
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_cutensor_cache_eviction_keeps_inflight_workspace_valid() {
+    let mut cpu = cpu_backend();
+    let mut gpu = gpu_backend();
+    gpu.set_cutensor_plan_cache_max_entries(NonZeroUsize::new(1).unwrap())
+        .unwrap();
+
+    let lhs_a = tensor_f32(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0]);
+    let rhs_a = tensor_f32(vec![2, 2], vec![5.0, 7.0, 6.0, 8.0]);
+    let lhs_b = tensor_f32(vec![3, 2], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let rhs_b = tensor_f32(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let expected_a = cpu.dot_general(&lhs_a, &rhs_a, &matmul_config()).unwrap();
+    let expected_b = cpu.dot_general(&lhs_b, &rhs_b, &matmul_config()).unwrap();
+
+    let gpu_lhs_a = upload(&gpu, &lhs_a);
+    let gpu_rhs_a = upload(&gpu, &rhs_a);
+    let gpu_lhs_b = upload(&gpu, &lhs_b);
+    let gpu_rhs_b = upload(&gpu, &rhs_b);
+    let actual_a = gpu
+        .dot_general(&gpu_lhs_a, &gpu_rhs_a, &matmul_config())
+        .unwrap();
+    let actual_b = gpu
+        .dot_general(&gpu_lhs_b, &gpu_rhs_b, &matmul_config())
+        .unwrap();
+
+    // Eviction drops the first plan while its launch may still be queued. The
+    // pinned CubeCL CUDA allocator retires async frees on the owning stream.
+    gpu.runtime().synchronize().unwrap();
+    assert_tensor_close(&download(&gpu, &actual_a), &expected_a, 1e-4);
+    assert_tensor_close(&download(&gpu, &actual_b), &expected_b, 1e-4);
 }
 
 fn matmul_config() -> DotGeneralConfig {

--- a/crates/tenferro-gpu/src/webgpu/exec_session.rs
+++ b/crates/tenferro-gpu/src/webgpu/exec_session.rs
@@ -1,8 +1,7 @@
 use tenferro_tensor::backend::{
     BackendSession, BackendSessionHost, BackendSessionIdentity, ElementwiseFusionPlan,
-    GroupedGemmConfig, SessionCachedDot,
-    TensorAnalytic, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
-    TensorIndexing, TensorReduction, TensorStructural,
+    GroupedGemmConfig, SessionCachedDot, TensorAnalytic, TensorBuffer, TensorDeviceTransfer,
+    TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
 };
 use tenferro_tensor::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,

--- a/crates/tenferro-gpu/src/webgpu/exec_session.rs
+++ b/crates/tenferro-gpu/src/webgpu/exec_session.rs
@@ -1,5 +1,6 @@
 use tenferro_tensor::backend::{
-    BackendSession, BackendSessionHost, ElementwiseFusionPlan, GroupedGemmConfig, SessionCachedDot,
+    BackendSession, BackendSessionHost, BackendSessionIdentity, ElementwiseFusionPlan,
+    GroupedGemmConfig, SessionCachedDot,
     TensorAnalytic, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
     TensorIndexing, TensorReduction, TensorStructural,
 };
@@ -9,6 +10,10 @@ use tenferro_tensor::config::{
 use tenferro_tensor::{DotGeneralAccumulation, Tensor, TensorRead, TensorValue, TensorWrite};
 
 use super::{WebGpuBackend, WebGpuRuntime, WebGpuRuntimeIdentity};
+
+/// Marker for the concrete erased WebGPU execution-session target.
+#[doc(hidden)]
+pub struct WebGpuExecSessionMarker;
 
 /// Borrowed WebGPU execution capability.
 #[doc(hidden)]
@@ -43,11 +48,11 @@ pub fn with_webgpu_exec_session<B, R>(
 where
     B: BackendSession + ?Sized,
 {
-    if session.session_type_name() != std::any::type_name::<WebGpuExecSession<'static>>() {
+    if session.session_type_id() != std::any::TypeId::of::<WebGpuExecSessionMarker>() {
         return None;
     }
     let data = unsafe { session.session_data_mut() };
-    // SAFETY: the type-name check and BackendSession erased-pointer contract
+    // SAFETY: the exact marker check and BackendSession erased-pointer contract
     // identify the value as WebGpuExecSession for this scoped visit.
     Some(unsafe { f(&mut *(data.cast::<WebGpuExecSession<'static>>())) })
 }
@@ -242,6 +247,10 @@ delegate_cached! {
         config: &GroupedGemmConfig<'_>,
         out: TensorWrite<'_>,
     ) -> crate::Result<()>;
+}
+
+impl BackendSessionIdentity for WebGpuExecSession<'_> {
+    type Marker = WebGpuExecSessionMarker;
 }
 
 impl BackendSessionHost for WebGpuBackend {

--- a/crates/tenferro-gpu/src/webgpu/exec_session.rs
+++ b/crates/tenferro-gpu/src/webgpu/exec_session.rs
@@ -1,7 +1,8 @@
+use std::any::TypeId;
 use tenferro_tensor::backend::{
-    BackendSession, BackendSessionHost, BackendSessionIdentity, ElementwiseFusionPlan,
-    GroupedGemmConfig, SessionCachedDot, TensorAnalytic, TensorBuffer, TensorDeviceTransfer,
-    TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
+    BackendSession, BackendSessionHost, ElementwiseFusionPlan, GroupedGemmConfig, SessionCachedDot,
+    TensorAnalytic, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
+    TensorIndexing, TensorReduction, TensorStructural,
 };
 use tenferro_tensor::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
@@ -12,7 +13,7 @@ use super::{WebGpuBackend, WebGpuRuntime, WebGpuRuntimeIdentity};
 
 /// Marker for the concrete erased WebGPU execution-session target.
 #[doc(hidden)]
-pub struct WebGpuExecSessionMarker;
+pub(super) struct WebGpuExecSessionMarker;
 
 /// Borrowed WebGPU execution capability.
 #[doc(hidden)]
@@ -248,8 +249,14 @@ delegate_cached! {
     ) -> crate::Result<()>;
 }
 
-impl BackendSessionIdentity for WebGpuExecSession<'_> {
-    type Marker = WebGpuExecSessionMarker;
+impl BackendSession for WebGpuExecSession<'_> {
+    fn session_type_id(&self) -> TypeId {
+        TypeId::of::<WebGpuExecSessionMarker>()
+    }
+
+    unsafe fn session_data_mut(&mut self) -> *mut () {
+        self as *mut Self as *mut ()
+    }
 }
 
 impl BackendSessionHost for WebGpuBackend {

--- a/crates/tenferro-gpu/src/webgpu/mod.rs
+++ b/crates/tenferro-gpu/src/webgpu/mod.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 
 use crate::{
     AccessError, AllocationDomainId, AllocationId, AllocationKey, BackendAllocation,
-    BackendCachedDot, BackendId, BackendRuntimeCache, CompareDir, DType, DeviceAccessError,
+    BackendCachedDot, BackendId, BackendRuntimeCache, BackendSessionIdentity, CompareDir, DType,
+    DeviceAccessError,
     DeviceAccessRequest, DeviceId, DeviceKind, DotGeneralConfig, Error, GatherConfig,
     GpuBackendKind, HostAccessError, MemoryKind, PadConfig, Placement, PreparedDeviceAccess,
     ProviderCapabilities, ProviderReadMapping, ProviderWriteMapping, RootBoundSpan,
@@ -614,6 +615,9 @@ fn webgpu_placement(rt: &WebGpuRuntime) -> Placement {
 ///
 /// let _ctor: fn(usize) -> tenferro_tensor::Result<WebGpuBackend> = WebGpuBackend::new;
 /// ```
+#[doc(hidden)]
+pub struct WebGpuBackendSessionMarker;
+
 #[derive(Clone)]
 pub struct WebGpuBackend {
     runtime: WebGpuRuntime,
@@ -1050,6 +1054,10 @@ impl TensorDeviceTransfer for WebGpuBackend {
 
 impl BackendRuntimeCache for WebGpuBackend {
     type RuntimeCache = ();
+}
+
+impl BackendSessionIdentity for WebGpuBackend {
+    type Marker = WebGpuBackendSessionMarker;
 }
 
 impl BackendCachedDot for WebGpuBackend {}

--- a/crates/tenferro-gpu/src/webgpu/mod.rs
+++ b/crates/tenferro-gpu/src/webgpu/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::{
     AccessError, AllocationDomainId, AllocationId, AllocationKey, BackendAllocation,
-    BackendCachedDot, BackendId, BackendRuntimeCache, BackendSessionIdentity, CompareDir, DType,
+    BackendCachedDot, BackendId, BackendRuntimeCache, BackendSession, CompareDir, DType,
     DeviceAccessError, DeviceAccessRequest, DeviceId, DeviceKind, DotGeneralConfig, Error,
     GatherConfig, GpuBackendKind, HostAccessError, MemoryKind, PadConfig, Placement,
     PreparedDeviceAccess, ProviderCapabilities, ProviderReadMapping, ProviderWriteMapping,
@@ -615,7 +615,7 @@ fn webgpu_placement(rt: &WebGpuRuntime) -> Placement {
 /// let _ctor: fn(usize) -> tenferro_tensor::Result<WebGpuBackend> = WebGpuBackend::new;
 /// ```
 #[doc(hidden)]
-pub struct WebGpuBackendSessionMarker;
+struct WebGpuBackendSessionMarker;
 
 #[derive(Clone)]
 pub struct WebGpuBackend {
@@ -1055,8 +1055,14 @@ impl BackendRuntimeCache for WebGpuBackend {
     type RuntimeCache = ();
 }
 
-impl BackendSessionIdentity for WebGpuBackend {
-    type Marker = WebGpuBackendSessionMarker;
+impl BackendSession for WebGpuBackend {
+    fn session_type_id(&self) -> std::any::TypeId {
+        std::any::TypeId::of::<WebGpuBackendSessionMarker>()
+    }
+
+    unsafe fn session_data_mut(&mut self) -> *mut () {
+        self as *mut Self as *mut ()
+    }
 }
 
 impl BackendCachedDot for WebGpuBackend {}

--- a/crates/tenferro-gpu/src/webgpu/mod.rs
+++ b/crates/tenferro-gpu/src/webgpu/mod.rs
@@ -8,13 +8,12 @@ use std::sync::Arc;
 use crate::{
     AccessError, AllocationDomainId, AllocationId, AllocationKey, BackendAllocation,
     BackendCachedDot, BackendId, BackendRuntimeCache, BackendSessionIdentity, CompareDir, DType,
-    DeviceAccessError,
-    DeviceAccessRequest, DeviceId, DeviceKind, DotGeneralConfig, Error, GatherConfig,
-    GpuBackendKind, HostAccessError, MemoryKind, PadConfig, Placement, PreparedDeviceAccess,
-    ProviderCapabilities, ProviderReadMapping, ProviderWriteMapping, RootBoundSpan,
-    RootResourceExtent, ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend,
-    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
-    TensorRank, TensorRead, TensorReduction, TensorScalar, TensorStructural,
+    DeviceAccessError, DeviceAccessRequest, DeviceId, DeviceKind, DotGeneralConfig, Error,
+    GatherConfig, GpuBackendKind, HostAccessError, MemoryKind, PadConfig, Placement,
+    PreparedDeviceAccess, ProviderCapabilities, ProviderReadMapping, ProviderWriteMapping,
+    RootBoundSpan, RootResourceExtent, ScatterConfig, SliceConfig, Tensor, TensorAnalytic,
+    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
+    TensorIndexing, TensorRank, TensorRead, TensorReduction, TensorScalar, TensorStructural,
     TensorViewCanonicalization, TensorWrite, TypedTensor, TypedTensorView, TypedTensorViewMut,
 };
 

--- a/crates/tenferro-internal-cpu-kernels/src/buffer_pool/tests.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/buffer_pool/tests.rs
@@ -444,13 +444,13 @@ fn internal_full_overwrite_sources_use_the_guard_boundary() {
 
     assert!(
         !elementwise.contains(
-            "// SAFETY: the successful zip/map replay writes every logical destination element and retains no destination view.\\n        // SAFETY:"
+            "// SAFETY: the successful zip/map replay writes every logical destination element and retains no destination view.\n        // SAFETY:"
         ),
         "generic zip/map overwrite proof must not be duplicated"
     );
     assert!(
         !elementwise.contains(
-            "// SAFETY: the successful scalar map replay writes every logical destination element and retains no destination view.\\n        // SAFETY:"
+            "// SAFETY: the successful scalar map replay writes every logical destination element and retains no destination view.\n        // SAFETY:"
         ),
         "generic scalar-map overwrite proof must not be duplicated"
     );

--- a/crates/tenferro-internal-cpu-kernels/src/buffer_pool/tests.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/buffer_pool/tests.rs
@@ -441,6 +441,57 @@ fn internal_full_overwrite_sources_use_the_guard_boundary() {
             "{helper} must retain the pinned same-shape kernel"
         );
     }
+
+    assert!(
+        !elementwise.contains(
+            "// SAFETY: the successful zip/map replay writes every logical destination element and retains no destination view.\\n        // SAFETY:"
+        ),
+        "generic zip/map overwrite proof must not be duplicated"
+    );
+    assert!(
+        !elementwise.contains(
+            "// SAFETY: the successful scalar map replay writes every logical destination element and retains no destination view.\\n        // SAFETY:"
+        ),
+        "generic scalar-map overwrite proof must not be duplicated"
+    );
+
+    let generic_binary = elementwise
+        .split_once("fn typed_binary_view_with_pool")
+        .and_then(|(_, suffix)| suffix.split_once("fn typed_unary_view_with_pool"))
+        .map(|(body, _)| body)
+        .expect("generic binary helper must remain present");
+    assert!(generic_binary.contains(
+        "// SAFETY: the successful runtime-selected zip/map replay writes every logical destination element and retains no destination view."
+    ));
+    assert!(generic_binary.contains(
+        "// SAFETY: the successful runtime-selected scalar-map replay writes every logical destination element and retains no destination view."
+    ));
+
+    let add = elementwise
+        .split_once("pub fn typed_add_view_with_pool")
+        .and_then(|(_, suffix)| suffix.split_once("pub fn typed_sub_with_pool"))
+        .map(|(body, _)| body)
+        .expect("add view helper must remain present");
+    assert!(add.contains(
+        "// SAFETY: the successful add zip/map replay writes every logical destination element and retains no destination view."
+    ));
+    assert!(add.contains(
+        "// SAFETY: the successful add scalar-map replay writes every logical destination element and retains no destination view."
+    ));
+    assert!(
+        !add.contains("successful multiplication kernel"),
+        "add overwrite proofs must not claim multiplication"
+    );
+
+    let multiplication = elementwise
+        .split_once("pub fn typed_mul_view_with_pool")
+        .and_then(|(_, suffix)| suffix.split_once("fn typed_div_with_pool"))
+        .map(|(body, _)| body)
+        .expect("multiplication helpers must remain present");
+    assert!(
+        multiplication.contains("successful multiplication kernel"),
+        "same-shape multiplication must retain its operation-specific proof"
+    );
 }
 
 #[test]

--- a/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
@@ -1486,8 +1486,7 @@ where
             |a, b| MaybeUninit::new(f(a, b)),
         )
         .map_err(|err| crate::Error::backend_source(op, err))?;
-        // SAFETY: the successful zip/map replay writes every logical destination element and retains no destination view.
-        // SAFETY: the successful add zip/map replay writes every logical destination element and retains no destination view.
+        // SAFETY: the successful runtime-selected zip/map replay writes every logical destination element and retains no destination view.
         Ok(unsafe { out.assume_init()? })
     } else if lhs.shape().is_empty() {
         let scalar = typed_view_from_view(op, lhs)?.get(&[]);
@@ -1498,8 +1497,7 @@ where
             |x| MaybeUninit::new(f(scalar, x)),
         )
         .map_err(|err| crate::Error::backend_source(op, err))?;
-        // SAFETY: the successful scalar map replay writes every logical destination element and retains no destination view.
-        // SAFETY: the successful multiplication kernel writes every logical destination element and retains no destination view.
+        // SAFETY: the successful runtime-selected scalar-map replay writes every logical destination element and retains no destination view.
         Ok(unsafe { out.assume_init()? })
     } else if rhs.shape().is_empty() {
         let scalar = typed_view_from_view(op, rhs)?.get(&[]);
@@ -3579,7 +3577,7 @@ where
             |x, y| MaybeUninit::new(x + y),
         )
         .map_err(|err| crate::Error::backend_source("add", err))?;
-        // SAFETY: the successful multiplication kernel writes every logical destination element and retains no destination view.
+        // SAFETY: the successful add zip/map replay writes every logical destination element and retains no destination view.
         Ok(unsafe { out.assume_init()? })
     } else if lhs.shape().is_empty() {
         let scalar = typed_view_from_view("add", lhs)?.get(&[]);
@@ -3590,7 +3588,7 @@ where
             |x| MaybeUninit::new(scalar + x),
         )
         .map_err(|err| crate::Error::backend_source("add", err))?;
-        // SAFETY: the successful multiplication kernel writes every logical destination element and retains no destination view.
+        // SAFETY: the successful add scalar-map replay writes every logical destination element and retains no destination view.
         Ok(unsafe { out.assume_init()? })
     } else if rhs.shape().is_empty() {
         let scalar = typed_view_from_view("add", rhs)?.get(&[]);

--- a/crates/tenferro-linalg/tests/integration/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/integration/backend_errors.rs
@@ -5,7 +5,8 @@ use num_complex::{Complex32, Complex64};
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::{LinalgBackend, TensorLinalgExt};
 use tenferro_tensor::{
-    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendStorageHandle, CompareDir,
+    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendSessionIdentity,
+    BackendStorageHandle, CompareDir,
     DType, DotGeneralConfig, Error, ErrorKind, GatherConfig, MemoryKind, PadConfig, Placement,
     ScatterConfig, SliceConfig, StorageBuffer, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
     TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
@@ -231,6 +232,9 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         }
     }
     impl BackendCachedDot for DefaultOnlyLinalgBackend {}
+    impl BackendSessionIdentity for DefaultOnlyLinalgBackend {
+        type Marker = DefaultOnlyLinalgBackend;
+    }
     impl BackendSessionHost for DefaultOnlyLinalgBackend {}
     impl TensorBackend for DefaultOnlyLinalgBackend {}
 

--- a/crates/tenferro-linalg/tests/integration/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/integration/backend_errors.rs
@@ -6,12 +6,11 @@ use tenferro_cpu::CpuBackend;
 use tenferro_linalg::{LinalgBackend, TensorLinalgExt};
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendSessionIdentity,
-    BackendStorageHandle, CompareDir,
-    DType, DotGeneralConfig, Error, ErrorKind, GatherConfig, MemoryKind, PadConfig, Placement,
-    ScatterConfig, SliceConfig, StorageBuffer, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
-    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
-    TensorReduction, TensorStructural, TensorView, TensorWrite, TypedTensor, TypedTensorView,
-    ValidationError,
+    BackendStorageHandle, CompareDir, DType, DotGeneralConfig, Error, ErrorKind, GatherConfig,
+    MemoryKind, PadConfig, Placement, ScatterConfig, SliceConfig, StorageBuffer, Tensor,
+    TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot,
+    TensorElementwise, TensorFusion, TensorIndexing, TensorRead, TensorReduction, TensorStructural,
+    TensorView, TensorWrite, TypedTensor, TypedTensorView, ValidationError,
 };
 
 use super::support;

--- a/crates/tenferro-linalg/tests/integration/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/integration/backend_errors.rs
@@ -5,7 +5,7 @@ use num_complex::{Complex32, Complex64};
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::{LinalgBackend, TensorLinalgExt};
 use tenferro_tensor::{
-    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, BackendSessionIdentity,
+    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
     BackendStorageHandle, CompareDir, DType, DotGeneralConfig, Error, ErrorKind, GatherConfig,
     MemoryKind, PadConfig, Placement, ScatterConfig, SliceConfig, StorageBuffer, Tensor,
     TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot,
@@ -231,8 +231,17 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         }
     }
     impl BackendCachedDot for DefaultOnlyLinalgBackend {}
-    impl BackendSessionIdentity for DefaultOnlyLinalgBackend {
-        type Marker = DefaultOnlyLinalgBackend;
+    #[doc(hidden)]
+    struct DefaultOnlyLinalgBackendSessionMarker;
+
+    impl BackendSession for DefaultOnlyLinalgBackend {
+        fn session_type_id(&self) -> std::any::TypeId {
+            std::any::TypeId::of::<DefaultOnlyLinalgBackendSessionMarker>()
+        }
+
+        unsafe fn session_data_mut(&mut self) -> *mut () {
+            self as *mut Self as *mut ()
+        }
     }
     impl BackendSessionHost for DefaultOnlyLinalgBackend {}
     impl TensorBackend for DefaultOnlyLinalgBackend {}

--- a/crates/tenferro-runtime/src/exec.rs
+++ b/crates/tenferro-runtime/src/exec.rs
@@ -8,8 +8,9 @@ use tenferro_ops::{dim_expr::DimExpr, ShapeExtent};
 use tenferro_tensor::backend::ElementwiseFusionOp;
 use tenferro_tensor::Error as TensorError;
 use tenferro_tensor::{
-    BackendSession, CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,
-    SliceConfig, Tensor, TensorBackend, TensorRead, TensorValue, TypedTensor, ValidationError,
+    BackendCachedDot, BackendSession, CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig,
+    ScatterConfig, SliceConfig, Tensor, TensorBackend, TensorRead, TensorValue, TypedTensor,
+    ValidationError,
 };
 
 use crate::extension_cache::ExtensionCacheStore;
@@ -840,7 +841,8 @@ pub(crate) fn execute_ffi_instruction_cached<'input, B: TensorBackend + 'static>
 ) -> Result<()> {
     match &inst.op {
         ExecOp::DotGeneral(config) => {
-            let result = backend.dot_general_read_cached(
+            let result = BackendCachedDot::dot_general_read_cached(
+                backend,
                 backend_cache,
                 cache_slot,
                 get_read(slots, &inst.input_slots, 0)?,
@@ -855,7 +857,8 @@ pub(crate) fn execute_ffi_instruction_cached<'input, B: TensorBackend + 'static>
             lhs_conj,
             rhs_conj,
         } => {
-            let result = backend.dot_general_with_conj_read_cached(
+            let result = BackendCachedDot::dot_general_with_conj_read_cached(
+                backend,
                 backend_cache,
                 cache_slot,
                 get_read(slots, &inst.input_slots, 0)?,

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -4128,11 +4128,7 @@ pub trait BackendSession: TensorBackendOps + SessionCachedDot + TensorDeviceTran
 
 impl<T> BackendSession for T
 where
-    T: TensorBackendOps
-        + SessionCachedDot
-        + TensorDeviceTransfer
-        + BackendSessionIdentity
-        + Sized,
+    T: TensorBackendOps + SessionCachedDot + TensorDeviceTransfer + BackendSessionIdentity + Sized,
 {
     fn session_type_id(&self) -> TypeId {
         TypeId::of::<T::Marker>()

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use num_complex::{Complex32, Complex64};
 use smallvec::SmallVec;
+use std::any::TypeId;
 use std::ptr::NonNull;
 use strided_kernel::{
     erased_map_into, erased_zip_into, ErasedMapOp, ErasedRawStridedMut, ErasedRawStridedPtr,
@@ -4030,7 +4031,7 @@ pub trait BackendSessionHost: BackendRuntimeCache {
         f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
     ) -> R
     where
-        Self: TensorBackend + Sized,
+        Self: TensorBackend + BackendSessionIdentity + Sized,
     {
         default_backend_session(self, f)
     }
@@ -4042,7 +4043,7 @@ pub trait BackendSessionHost: BackendRuntimeCache {
         f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
     ) -> R
     where
-        Self: TensorBackend + Sized,
+        Self: TensorBackend + BackendSessionIdentity + Sized,
     {
         self.with_backend_session(f)
     }
@@ -4097,10 +4098,19 @@ impl<T> TensorBackendOps for T where
 ///     backend.with_backend_session(|exec| exec.add(a, b))
 /// }
 /// ```
+/// Identity contract for a concrete erased backend-session target.
+///
+/// Implementors must use a distinct zero-sized `'static` marker for each
+/// concrete target that a backend leaf may reconstruct from an erased session.
+#[doc(hidden)]
+pub trait BackendSessionIdentity {
+    type Marker: 'static;
+}
+
 pub trait BackendSession: TensorBackendOps + SessionCachedDot + TensorDeviceTransfer {
-    /// Build-local type identity for backend-extension session capability dispatch.
+    /// Build-local identity for backend-extension session capability dispatch.
     #[doc(hidden)]
-    fn session_type_name(&self) -> &'static str;
+    fn session_type_id(&self) -> TypeId;
 
     /// Erased pointer used only by backend leaf crates for a checked session
     /// capability bridge. The pointer is borrowed for the lifetime of `self`.
@@ -4111,17 +4121,21 @@ pub trait BackendSession: TensorBackendOps + SessionCachedDot + TensorDeviceTran
     /// by `self`, and that pointer must remain valid and uniquely borrowed for
     /// the duration of the `&mut self` borrow. Backend leaf crates may use this
     /// contract to recover a concrete session capability after checking
-    /// [`Self::session_type_name`].
+    /// [`Self::session_type_id`].
     #[doc(hidden)]
     unsafe fn session_data_mut(&mut self) -> *mut ();
 }
 
 impl<T> BackendSession for T
 where
-    T: TensorBackendOps + SessionCachedDot + TensorDeviceTransfer + Sized,
+    T: TensorBackendOps
+        + SessionCachedDot
+        + TensorDeviceTransfer
+        + BackendSessionIdentity
+        + Sized,
 {
-    fn session_type_name(&self) -> &'static str {
-        std::any::type_name::<T>()
+    fn session_type_id(&self) -> TypeId {
+        TypeId::of::<T::Marker>()
     }
 
     unsafe fn session_data_mut(&mut self) -> *mut () {
@@ -4140,6 +4154,7 @@ where
 /// ```
 pub trait TensorBackend:
     BackendRuntimeCache
+    + BackendSessionIdentity
     + TensorBackendOps
     + BackendCachedDot
     + TensorDeviceTransfer
@@ -4163,7 +4178,7 @@ impl<T> SessionCachedDot for T where T: TensorBackend + ?Sized {}
 ///     default_backend_session(backend, |_exec| 1usize)
 /// }
 /// ```
-pub fn default_backend_session<B: TensorBackend, R: Send>(
+pub fn default_backend_session<B: TensorBackend + BackendSessionIdentity, R: Send>(
     backend: &mut B,
     f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
 ) -> R {

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -4031,7 +4031,7 @@ pub trait BackendSessionHost: BackendRuntimeCache {
         f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
     ) -> R
     where
-        Self: TensorBackend + BackendSessionIdentity + Sized,
+        Self: TensorBackend + Sized,
     {
         default_backend_session(self, f)
     }
@@ -4043,7 +4043,7 @@ pub trait BackendSessionHost: BackendRuntimeCache {
         f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
     ) -> R
     where
-        Self: TensorBackend + BackendSessionIdentity + Sized,
+        Self: TensorBackend + Sized,
     {
         self.with_backend_session(f)
     }
@@ -4098,15 +4098,6 @@ impl<T> TensorBackendOps for T where
 ///     backend.with_backend_session(|exec| exec.add(a, b))
 /// }
 /// ```
-/// Identity contract for a concrete erased backend-session target.
-///
-/// Implementors must use a distinct zero-sized `'static` marker for each
-/// concrete target that a backend leaf may reconstruct from an erased session.
-#[doc(hidden)]
-pub trait BackendSessionIdentity {
-    type Marker: 'static;
-}
-
 pub trait BackendSession: TensorBackendOps + SessionCachedDot + TensorDeviceTransfer {
     /// Build-local identity for backend-extension session capability dispatch.
     #[doc(hidden)]
@@ -4126,19 +4117,6 @@ pub trait BackendSession: TensorBackendOps + SessionCachedDot + TensorDeviceTran
     unsafe fn session_data_mut(&mut self) -> *mut ();
 }
 
-impl<T> BackendSession for T
-where
-    T: TensorBackendOps + SessionCachedDot + TensorDeviceTransfer + BackendSessionIdentity + Sized,
-{
-    fn session_type_id(&self) -> TypeId {
-        TypeId::of::<T::Marker>()
-    }
-
-    unsafe fn session_data_mut(&mut self) -> *mut () {
-        self as *mut T as *mut ()
-    }
-}
-
 /// Standard runtime backend over dynamic [`Tensor`] values.
 ///
 /// # Examples
@@ -4150,7 +4128,7 @@ where
 /// ```
 pub trait TensorBackend:
     BackendRuntimeCache
-    + BackendSessionIdentity
+    + BackendSession
     + TensorBackendOps
     + BackendCachedDot
     + TensorDeviceTransfer
@@ -4174,7 +4152,7 @@ impl<T> SessionCachedDot for T where T: TensorBackend + ?Sized {}
 ///     default_backend_session(backend, |_exec| 1usize)
 /// }
 /// ```
-pub fn default_backend_session<B: TensorBackend + BackendSessionIdentity, R: Send>(
+pub fn default_backend_session<B: TensorBackend, R: Send>(
     backend: &mut B,
     f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
 ) -> R {

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -64,9 +64,8 @@ pub mod validate;
 pub use backend::{
     default_backend_session, BackendCachedDot, BackendRuntimeCache, BackendSession,
     BackendSessionHost, BackendSessionIdentity, ContractionScalar, DotGeneralAccumulation,
-    ElementwiseReadOp,
-    SessionCachedDot, TensorAnalytic, TensorBackend, TensorBackendOps, TensorBuffer,
-    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    ElementwiseReadOp, SessionCachedDot, TensorAnalytic, TensorBackend, TensorBackendOps,
+    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorReduction, TensorStructural, TensorViewCanonicalization,
 };
 pub use cache::{CacheStats, RuntimeCacheControl};

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -63,9 +63,9 @@ pub mod validate;
 
 pub use backend::{
     default_backend_session, BackendCachedDot, BackendRuntimeCache, BackendSession,
-    BackendSessionHost, BackendSessionIdentity, ContractionScalar, DotGeneralAccumulation,
-    ElementwiseReadOp, SessionCachedDot, TensorAnalytic, TensorBackend, TensorBackendOps,
-    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    BackendSessionHost, ContractionScalar, DotGeneralAccumulation, ElementwiseReadOp,
+    SessionCachedDot, TensorAnalytic, TensorBackend, TensorBackendOps, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorReduction, TensorStructural, TensorViewCanonicalization,
 };
 pub use cache::{CacheStats, RuntimeCacheControl};

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -63,7 +63,8 @@ pub mod validate;
 
 pub use backend::{
     default_backend_session, BackendCachedDot, BackendRuntimeCache, BackendSession,
-    BackendSessionHost, ContractionScalar, DotGeneralAccumulation, ElementwiseReadOp,
+    BackendSessionHost, BackendSessionIdentity, ContractionScalar, DotGeneralAccumulation,
+    ElementwiseReadOp,
     SessionCachedDot, TensorAnalytic, TensorBackend, TensorBackendOps, TensorBuffer,
     TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorReduction, TensorStructural, TensorViewCanonicalization,

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -3,12 +3,11 @@ use crate::{
         validate_dot_general_read_into, validate_grouped_gemm, GroupedGemmConfig, GroupedGemmJob,
     },
     BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
-    BackendSessionIdentity, CompareDir,
-    ContractionScalar, DType, DotGeneralAccumulation, DotGeneralConfig, GatherConfig, PadConfig,
-    ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
-    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
-    TensorReduction, TensorScalar, TensorStructural, TensorView, TensorViewMut, TensorWrite,
-    TypedTensor, TypedTensorView, TypedTensorViewMut,
+    BackendSessionIdentity, CompareDir, ContractionScalar, DType, DotGeneralAccumulation,
+    DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor, TensorAnalytic,
+    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
+    TensorIndexing, TensorRead, TensorReduction, TensorScalar, TensorStructural, TensorView,
+    TensorViewMut, TensorWrite, TypedTensor, TypedTensorView, TypedTensorViewMut,
 };
 use num_complex::{Complex32, Complex64};
 

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -2,15 +2,16 @@ use crate::{
     backend::{
         validate_dot_general_read_into, validate_grouped_gemm, GroupedGemmConfig, GroupedGemmJob,
     },
-    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
-    BackendSessionIdentity, CompareDir, ContractionScalar, DType, DotGeneralAccumulation,
-    DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor, TensorAnalytic,
-    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
-    TensorIndexing, TensorRead, TensorReduction, TensorScalar, TensorStructural, TensorView,
-    TensorViewMut, TensorWrite, TypedTensor, TypedTensorView, TypedTensorViewMut,
+    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir,
+    ContractionScalar, DType, DotGeneralAccumulation, DotGeneralConfig, GatherConfig, PadConfig,
+    ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
+    TensorReduction, TensorScalar, TensorStructural, TensorView, TensorViewMut, TensorWrite,
+    TypedTensor, TypedTensorView, TypedTensorViewMut,
 };
 use num_complex::{Complex32, Complex64};
 
+#[doc(hidden)]
 struct DefaultReadBackendSessionMarker;
 
 struct DefaultReadBackend {
@@ -520,8 +521,14 @@ impl BackendRuntimeCache for DefaultReadBackend {
 
 impl BackendCachedDot for DefaultReadBackend {}
 
-impl BackendSessionIdentity for DefaultReadBackend {
-    type Marker = DefaultReadBackendSessionMarker;
+impl BackendSession for DefaultReadBackend {
+    fn session_type_id(&self) -> std::any::TypeId {
+        std::any::TypeId::of::<DefaultReadBackendSessionMarker>()
+    }
+
+    unsafe fn session_data_mut(&mut self) -> *mut () {
+        self as *mut Self as *mut ()
+    }
 }
 
 impl BackendSessionHost for DefaultReadBackend {}

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -2,7 +2,8 @@ use crate::{
     backend::{
         validate_dot_general_read_into, validate_grouped_gemm, GroupedGemmConfig, GroupedGemmJob,
     },
-    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir,
+    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
+    BackendSessionIdentity, CompareDir,
     ContractionScalar, DType, DotGeneralAccumulation, DotGeneralConfig, GatherConfig, PadConfig,
     ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
     TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
@@ -10,6 +11,8 @@ use crate::{
     TypedTensor, TypedTensorView, TypedTensorViewMut,
 };
 use num_complex::{Complex32, Complex64};
+
+struct DefaultReadBackendSessionMarker;
 
 struct DefaultReadBackend {
     calls: Vec<&'static str>,
@@ -517,6 +520,10 @@ impl BackendRuntimeCache for DefaultReadBackend {
 }
 
 impl BackendCachedDot for DefaultReadBackend {}
+
+impl BackendSessionIdentity for DefaultReadBackend {
+    type Marker = DefaultReadBackendSessionMarker;
+}
 
 impl BackendSessionHost for DefaultReadBackend {}
 

--- a/docs/worklogs/2026-08-06-issue-1576-safety-audit.md
+++ b/docs/worklogs/2026-08-06-issue-1576-safety-audit.md
@@ -40,6 +40,11 @@ Passed:
 - `cargo check -p tenferro-gpu --features webgpu --lib`
 - `cargo test -p tenferro-gpu --features cuda --lib cuda_cutensor_cache_eviction_keeps_inflight_workspace_valid -- --ignored`
 - `cargo fmt --all`
+- After rebasing onto `origin/main`, the backend capability contract was
+  narrowed to scan only CPU contraction entry-point bodies in
+  `exec_session.rs`; `cargo test -p tenferro-cpu --test integration
+  backend_capability_contracts::cpu_provider_dispatch_has_no_runtime_registry_lookup_or_legacy_staging
+  -- --exact` passed.
 
 The CUDA eviction test passed on the available CUDA GPU/toolkit environment.
 No new dependency, synchronization, registry, downcast framework, or shim was

--- a/docs/worklogs/2026-08-06-issue-1576-safety-audit.md
+++ b/docs/worklogs/2026-08-06-issue-1576-safety-audit.md
@@ -8,21 +8,21 @@ add, and multiplication operations; the source-contract test checks those
 phrases and rejects duplicate adjacent proofs. TBLIS thread-control FFI now
 states the process-global ABI/serialized guard/Drop-restoration contract.
 
-The erased session bridge now uses a doc-hidden `BackendSessionIdentity` with
-per-concrete-target `'static` marker `TypeId`s instead of `type_name`; CPU,
-CUDA, WebGPU, eager, and test backends/sessions were updated. CPU tests cover
-foreign-marker rejection without callback invocation and a scoped concrete
-borrow.
+The erased session bridge now uses explicit `BackendSession` implementations
+for each concrete backend/session and private `'static` marker structs whose
+`TypeId`s identify the concrete target; it no longer uses a shared
+`BackendSessionIdentity` or `type_name`. CPU tests cover foreign-marker
+rejection without callback invocation and a scoped concrete borrow.
 
 CUDA cache scans have canonical bounded `// INVARIANT:` markers. The pinned
 CubeCL source was inspected at revision `1c88bb6f1a47ffb11755e05048b7828a743f53e1`:
 `cubecl-cuda/src/compute/storage/gpu.rs` records deallocations and matches
 `malloc_async` with `free_async` on the owning stream, while sync allocations
 use `free_sync`; `cubecl-runtime` flushes storage through the CUDA server.
-The cache SAFETY marker records this handle-owned release contract. A real
-CUDA eviction test runs two asynchronous cuTENSOR matmuls with
-`max_entries = 1`, synchronizes at the test boundary, and validates both
-outputs.
+The cache INVARIANT marker records this handle-owned release contract. A real
+CUDA eviction test retains nonzero workspace, asserts that allocation and an
+actual eviction occur with `max_entries = 1`, synchronizes at the test
+boundary, and validates both outputs.
 
 ## Verification
 
@@ -43,5 +43,5 @@ Passed:
 
 The CUDA eviction test passed on the available CUDA GPU/toolkit environment.
 No new dependency, synchronization, registry, downcast framework, or shim was
-added. Generated build directories and subagent artifacts are cleanup items
-before handoff.
+added. Generated build directories, Cargo.lock files, and subagent artifacts
+were removed before handoff.

--- a/docs/worklogs/2026-08-06-issue-1576-safety-audit.md
+++ b/docs/worklogs/2026-08-06-issue-1576-safety-audit.md
@@ -12,7 +12,9 @@ The erased session bridge now uses explicit `BackendSession` implementations
 for each concrete backend/session and private `'static` marker structs whose
 `TypeId`s identify the concrete target; it no longer uses a shared
 `BackendSessionIdentity` or `type_name`. CPU tests cover foreign-marker
-rejection without callback invocation and a scoped concrete borrow.
+rejection without callback invocation and a scoped concrete borrow. The
+EagerBackend owner projection is also covered by a direct CPU test and a
+recording-session pointer/marker test.
 
 CUDA cache scans have canonical bounded `// INVARIANT:` markers. The pinned
 CubeCL source was inspected at revision `1c88bb6f1a47ffb11755e05048b7828a743f53e1`:
@@ -40,6 +42,14 @@ Passed:
 - `cargo check -p tenferro-gpu --features webgpu --lib`
 - `cargo test -p tenferro-gpu --features cuda --lib cuda_cutensor_cache_eviction_keeps_inflight_workspace_valid -- --ignored`
 - `cargo fmt --all`
+- `cargo test -p tenferro-ad --lib eager_backend_session_identity_projects_to_owner`
+- `cargo llvm-cov -p tenferro-ad --lib --release --json --output-path
+  /tmp/tenferro-ad-coverage-1576-v2.json` → `eager_backend.rs` reached 88.8%.
+- Exact hosted-profile coverage:
+  `cargo llvm-cov --workspace --exclude tenferro-tutorial-code --profile ci
+  --json --output-path /tmp/coverage-1576-ci.json` followed by
+  `python3 scripts/check-coverage.py /tmp/coverage-1576-ci.json` → 191/191
+  files passed.
 - After rebasing onto `origin/main`, the backend capability contract was
   narrowed to scan only CPU contraction entry-point bodies in
   `exec_session.rs`; `cargo test -p tenferro-cpu --test integration

--- a/docs/worklogs/2026-08-06-issue-1576-safety-audit.md
+++ b/docs/worklogs/2026-08-06-issue-1576-safety-audit.md
@@ -1,0 +1,47 @@
+# Issue #1576 safety-audit remediation
+
+## Summary
+
+Implemented the accepted five-item remediation from #1576 on `origin/main`
+(a992a44c). Overwrite proofs now name the runtime-selected zip/map, scalar-map,
+add, and multiplication operations; the source-contract test checks those
+phrases and rejects duplicate adjacent proofs. TBLIS thread-control FFI now
+states the process-global ABI/serialized guard/Drop-restoration contract.
+
+The erased session bridge now uses a doc-hidden `BackendSessionIdentity` with
+per-concrete-target `'static` marker `TypeId`s instead of `type_name`; CPU,
+CUDA, WebGPU, eager, and test backends/sessions were updated. CPU tests cover
+foreign-marker rejection without callback invocation and a scoped concrete
+borrow.
+
+CUDA cache scans have canonical bounded `// INVARIANT:` markers. The pinned
+CubeCL source was inspected at revision `1c88bb6f1a47ffb11755e05048b7828a743f53e1`:
+`cubecl-cuda/src/compute/storage/gpu.rs` records deallocations and matches
+`malloc_async` with `free_async` on the owning stream, while sync allocations
+use `free_sync`; `cubecl-runtime` flushes storage through the CUDA server.
+The cache SAFETY marker records this handle-owned release contract. A real
+CUDA eviction test runs two asynchronous cuTENSOR matmuls with
+`max_entries = 1`, synchronizes at the test boundary, and validates both
+outputs.
+
+## Verification
+
+Passed:
+
+- `cargo test -p tenferro-internal-cpu-kernels --lib internal_full_overwrite_sources_use_the_guard_boundary`
+- `cargo test --manifest-path ext/tenferro-cpu-tblis/Cargo.toml`
+- `cargo test -p tenferro-tensor --lib backend_default_read`
+- `cargo test -p tenferro-cpu --lib with_cpu_exec_session`
+- `cargo test -p tenferro-ad --test integration runtime_snapshot`
+- `cargo test -p tenferro-einsum --lib typed_eager`
+- `cargo test -p tenferro-fft --test backend_capability`
+- `cargo test -p tenferro-linalg --test integration backend_errors`
+- `cargo check -p tenferro-gpu --features cuda --lib`
+- `cargo check -p tenferro-gpu --features webgpu --lib`
+- `cargo test -p tenferro-gpu --features cuda --lib cuda_cutensor_cache_eviction_keeps_inflight_workspace_valid -- --ignored`
+- `cargo fmt --all`
+
+The CUDA eviction test passed on the available CUDA GPU/toolkit environment.
+No new dependency, synchronization, registry, downcast framework, or shim was
+added. Generated build directories and subagent artifacts are cleanup items
+before handoff.

--- a/ext/tenferro-cpu-tblis/src/lib.rs
+++ b/ext/tenferro-cpu-tblis/src/lib.rs
@@ -517,9 +517,9 @@ where
     };
 
     // SAFETY: the CPU runtime validated dtype, shapes, axes, and reachable
-    // ranges before provider entry. This adapter additionally accepts only
-    // positive strides and host-backed operands, clamps TBLIS to one thread for
-    // the duration of the call, and keeps all descriptor buffers live.
+    // ranges before provider entry. `checked_output_base_offset` proves that
+    // `out_offset` reaches only the host allocation, and this adapter additionally
+    // accepts only positive strides and keeps all descriptor buffers live.
     unsafe {
         tblis_tensor_mult(
             std::ptr::null(),
@@ -546,7 +546,11 @@ impl TblisRuntimeCall<'_> {
         let lock = tblis_runtime_lock().lock().map_err(|_| {
             Error::runtime_state(OP, "TBLIS runtime thread-control lock was poisoned")
         })?;
+        // SAFETY: TBLIS exposes process-global thread control; this read is
+        // serialized by the existing runtime-call guard held in `_lock`.
         let previous_threads = unsafe { tblis_get_num_threads() };
+        // SAFETY: the same serialized guard protects the process-global ABI
+        // mutation, and `Drop` restores `previous_threads` before releasing it.
         unsafe {
             tblis_set_num_threads(1);
         }
@@ -559,6 +563,8 @@ impl TblisRuntimeCall<'_> {
 
 impl Drop for TblisRuntimeCall<'_> {
     fn drop(&mut self) {
+        // SAFETY: the process-global TBLIS ABI remains serialized by `_lock`
+        // until this Drop completes, and this restores the value saved in enter.
         unsafe {
             tblis_set_num_threads(self.previous_threads);
         }


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1576

## Summary

Remediates the five safety-review false negatives without adding runtime defenses:

- operation-specific elementwise overwrite proofs and a hardened source-contract test;
- concrete TBLIS FFI safety comments for serialized process-global thread control and Drop restoration;
- explicit per-concrete-type `BackendSession` implementations using private static `TypeId` markers instead of `type_name` or a blanket erased-session implementation;
- the pinned CubeCL stream-safe handle deallocation invariant, bounded-cache markers, and a CUDA eviction regression that proves nonzero workspace allocation, eviction, and post-synchronization results;
- canonical `INVARIANT` markers for bounded cache scans.

No new dependency, public API facade, runtime synchronization-on-eviction, registry, generic downcast framework, or compatibility shim was added.

## Work log

- [docs/worklogs/2026-08-06-issue-1576-safety-audit.md](https://github.com/tensor4all/tenferro-rs/blob/codex/issue-1576-safety-audit/docs/worklogs/2026-08-06-issue-1576-safety-audit.md)

## Verification

- `cargo test -p tenferro-internal-cpu-kernels --lib internal_full_overwrite_sources_use_the_guard_boundary`
- `cargo test --manifest-path ext/tenferro-cpu-tblis/Cargo.toml`
- `cargo test -p tenferro-tensor --lib backend_default_read`
- `cargo test -p tenferro-cpu --lib with_cpu_exec_session`
- `cargo test -p tenferro-ad --test integration runtime_snapshot`
- `cargo test -p tenferro-einsum --lib typed_eager`
- `cargo test -p tenferro-fft --test backend_capability`
- `cargo test -p tenferro-linalg --test integration backend_errors`
- `cargo check -p tenferro-gpu --features cuda --lib`
- `cargo check -p tenferro-gpu --features webgpu --lib`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda cargo test -p tenferro-gpu --features cuda --lib cuda_cutensor_cache_eviction_keeps_inflight_workspace_valid -- --ignored`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-internal-cpu-kernels --lib internal_full_overwrite_sources_use_the_guard_boundary'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1576-final.json`
- `git diff --check origin/main...HEAD`

The ignored CUDA regression passed on the available A100 environment. Generated build directories, Cargo.lock files, and subagent artifacts were removed after verification. The final independent reviews found no actionable issues; pre-existing stale CUDA trybuild stderr fixtures are unchanged by this PR.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
