### PR TITLE
docs: add downstream compute skill and llms index

### DIFF
--- a/.agents/skills/tenferro-compute/SKILL.md
+++ b/.agents/skills/tenferro-compute/SKILL.md
@@ -35,8 +35,9 @@ not when changing tenferro itself.
   fall back to CPU.
 - Traced standard extensions need an explicitly installed extension module and
   a matching registered runtime engine.
-- Keep a scratch crate outside the parent workspace with an empty `[workspace]`
-  table, and enable exactly one BLAS provider when using `cpu-blas`.
+- Keep a scratch crate in its own Cargo workspace (use an empty
+  `[workspace]` table when it lives inside a checkout), and enable exactly one
+  BLAS provider when using `cpu-blas`.
 
 The executable Rust examples in the references are extracted from
 `docs/tutorial-code/src/bin/tenferro_compute_skill.rs` and compiled by the

--- a/.agents/skills/tenferro-compute/SKILL.md
+++ b/.agents/skills/tenferro-compute/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: tenferro-compute
+description: Write Rust programs that use tenferro for tensor computation, autodiff, einsum, linear algebra, and explicit backend execution.
+---
+
+# tenferro-compute
+
+Load this skill when the task is to **use** tenferro from downstream Rust code,
+not when changing tenferro itself.
+
+## Fast path
+
+1. Choose the API tier: direct concrete tensors, eager tensors, or traced
+   graphs. The same operation has different receivers and arities at each tier.
+2. Add the direct crates for that tier. There is no root `tenferro` facade;
+   import operation families such as `tenferro-einsum` and `tenferro-linalg`
+   directly.
+3. Bring the operation's public `*Ext` trait into scope. An E0599 saying that
+   a method does not exist usually means the right extension trait is missing.
+4. Read only the relevant reference below before writing the program.
+
+| Need | Read |
+| --- | --- |
+| Crates, features, CPU providers, scratch crates | [crate selection](references/crate-selection.md) |
+| Tier arities and extension-trait imports | [API cheatsheet](references/api-cheatsheet.md) |
+| Backend/executor reuse and compile-once/run-many | [performance idioms](references/performance-idioms.md) |
+| Column-major data, einsum syntax, registration, and setup traps | [pitfalls](references/pitfalls.md) |
+
+## Non-negotiable defaults
+
+- Dense flat buffers are column-major: the leftmost dimension varies fastest.
+- Bind one backend/runtime/compiler and reuse it across related work.
+- Compile traced programs once outside repeated execution loops.
+- CPU/GPU transfers are explicit; unsupported GPU operations do not silently
+  fall back to CPU.
+- Traced standard extensions need an explicitly installed extension module and
+  a matching registered runtime engine.
+- Keep a scratch crate outside the parent workspace with an empty `[workspace]`
+  table, and enable exactly one BLAS provider when using `cpu-blas`.
+
+The executable Rust examples in the references are extracted from
+`docs/tutorial-code/src/bin/tenferro_compute_skill.rs` and compiled by the
+existing tutorial-binary test.

--- a/.agents/skills/tenferro-compute/agents/openai.yaml
+++ b/.agents/skills/tenferro-compute/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "tenferro Compute"
+  short_description: "Write downstream Rust tensor programs with tenferro."
+  default_prompt: "Use the tenferro-compute skill to write Rust code against tenferro."

--- a/.agents/skills/tenferro-compute/references/api-cheatsheet.md
+++ b/.agents/skills/tenferro-compute/references/api-cheatsheet.md
@@ -1,0 +1,114 @@
+# API cheatsheet
+
+Choose the tier before choosing the method. Direct operations receive an
+explicit mutable backend; eager operations run through an `EagerRuntime`; traced
+operations build a graph and execute it later.
+
+## Direct concrete tensors
+
+Import the backend and the extension trait that owns the method:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#concrete-operation -->
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+
+let mut backend = CpuBackend::new();
+// The leftmost dimension varies fastest: this is a 2 x 3 column-major tensor.
+let x = TypedTensor::<f64>::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
+)?;
+let weights = TypedTensor::<f64>::from_vec_col_major(
+    vec![3, 2],
+    vec![0.5, -1.0, 1.5, 1.0, 2.0, -0.5],
+)?;
+let projected = x.matmul(&weights, &mut backend)?;
+assert_eq!(projected.shape(), &[2, 2]);
+assert_eq!(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
+```
+<!-- end-snippet-source -->
+
+The important shape is `x.matmul(&weights, &mut backend)`. For dynamic dtypes
+use `TensorOpsExt`; for static scalar types use `TypedTensorOpsExt`.
+
+## Eager tensors
+
+`EagerTensor` methods omit the backend argument because the runtime owns it.
+Tracked values support `backward()` and functional eager transforms:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#eager-operation -->
+```rust
+use tenferro_ad::{EagerRuntime, Tensor};
+
+let runtime = EagerRuntime::new()?;
+let x = runtime.variable_from(Tensor::from_vec_col_major(
+    vec![3],
+    vec![1.0_f64, 2.0, 3.0],
+)?)?;
+let prediction = x.mul(&x)?;
+let loss = prediction.reduce_sum(Some(&[0]))?;
+loss.backward()?;
+assert_eq!(
+    x.grad()?.expect("tracked variable should receive a gradient").as_slice::<f64>()?,
+    &[2.0, 4.0, 6.0],
+);
+```
+<!-- end-snippet-source -->
+
+Common import recipes:
+
+- `tenferro_einsum::EagerEinsumExt` for eager einsum.
+- `tenferro_linalg::EagerTensorLinalgExt` for eager linear algebra.
+- `tenferro_ad::{EagerRuntime, Tensor}` for eager values and runtime AD.
+
+## Traced tensors and extensions
+
+Traced core operations compile into a graph. Standard operation families are
+extensions: import their traced trait and install the same family's extension
+module into the runtime that owns the registered backend engine.
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#traced-extension-operation -->
+```rust
+use tenferro_cpu::{runtime_engine_id, runtime_engine_registration, CpuBackend};
+use tenferro_einsum::TraceContextEinsumExt;
+use tenferro_runtime::program::ProgramInputSpec;
+use tenferro_runtime::{GraphCompiler, Runtime, Tensor, TraceContext};
+
+let a = Tensor::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+)?;
+let b = Tensor::from_vec_col_major(
+    vec![3, 2],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+)?;
+let mut trace = TraceContext::new();
+let a_value = trace.input(ProgramInputSpec::new(a.dtype(), [2.into(), 3.into()]))?;
+let b_value = trace.input(ProgramInputSpec::new(b.dtype(), [3.into(), 2.into()]))?;
+let product = trace.einsum(&[a_value, b_value], "ij,jk->ik")?;
+let graph = trace.finish(&[product])?;
+let program = GraphCompiler::new().compile_traced_graph(&graph)?;
+
+let backend = CpuBackend::new();
+let mut builder = Runtime::builder();
+builder.register_engine(runtime_engine_registration(&backend)?)?;
+builder.install_extension_module(tenferro_einsum::extension_module::<CpuBackend>(
+    runtime_engine_id()?,
+)?)?;
+let runtime = builder.build()?;
+let mut outputs = runtime.run_compiled(&program, &[&a, &b])?;
+let result = outputs.remove(0);
+assert_eq!(result.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
+```
+<!-- end-snippet-source -->
+
+Import recipes:
+
+- `tenferro_einsum::TraceContextEinsumExt` or
+  `tenferro_einsum::TracedTensorEinsumExt` for einsum.
+- `tenferro_linalg::TracedTensorLinalgExt` for traced linear algebra.
+- `tenferro_ad::TracedTensorAdExt` for `grad`, `vjp`, and `jvp` transforms.
+
+If a method is present in the guide but Rust reports E0599, check the owning
+crate's root re-exports and bring its `*Ext` trait into the local module.

--- a/.agents/skills/tenferro-compute/references/api-cheatsheet.md
+++ b/.agents/skills/tenferro-compute/references/api-cheatsheet.md
@@ -105,8 +105,9 @@ assert_eq!(result.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
 
 Import recipes:
 
-- `tenferro_einsum::TraceContextEinsumExt` or
-  `tenferro_einsum::TracedTensorEinsumExt` for einsum.
+- `tenferro_einsum::TraceContextEinsumExt` for `TraceContext::einsum` graph
+  construction; use `tenferro_einsum::TracedTensorEinsumExt` when the receiver
+  is an already traced tensor.
 - `tenferro_linalg::TracedTensorLinalgExt` for traced linear algebra.
 - `tenferro_ad::TracedTensorAdExt` for `grad`, `vjp`, and `jvp` transforms.
 

--- a/.agents/skills/tenferro-compute/references/crate-selection.md
+++ b/.agents/skills/tenferro-compute/references/crate-selection.md
@@ -1,0 +1,75 @@
+# Crate selection
+
+There is deliberately no facade crate. Add the direct crates that own the
+value layer, execution backend, and operation family you use.
+
+## Choose by tier
+
+| Program | Minimum direct crates | Add when needed |
+| --- | --- | --- |
+| Concrete `Tensor`/`TypedTensor` | `tenferro-runtime`, `tenferro-cpu` | `tenferro-einsum`, `tenferro-linalg`, or `tenferro-fft` for extensions |
+| Eager forward/AD | `tenferro-ad`, `tenferro-cpu` | `tenferro-einsum`/`tenferro-linalg` with `autodiff` for those families |
+| Traced graph | `tenferro-runtime`, `tenferro-cpu` | `tenferro-ad` for graph transforms and the operation crate for extensions |
+| CUDA | the matching value/operation crates plus `tenferro-gpu` with `cuda` | Add `cuda` to crates whose operation surface needs it |
+| XLA/PJRT | `tenferro-runtime`, `tenferro-xla` with `pjrt` | A PJRT plugin and the operation crates used by the graph |
+
+A minimal release dependency block for a CPU concrete program is:
+
+```toml
+[dependencies]
+tenferro-runtime = "0.2"
+tenferro-cpu = "0.2"
+```
+
+For eager AD and linear algebra, add the owning crates and opt into the
+operation family's AD rules:
+
+```toml
+[dependencies]
+tenferro-ad = "0.2"
+tenferro-runtime = "0.2"
+tenferro-cpu = "0.2"
+tenferro-linalg = { version = "0.2", features = ["autodiff"] }
+```
+
+The exact current publishable package set is discoverable without compiling:
+
+```text
+cargo metadata --no-deps --format-version 1
+```
+
+At this revision it contains 14 publishable `tenferro-*` packages. The
+`tenferro-tutorial-code` package is a private CI helper, not a downstream
+runtime dependency.
+
+## CPU provider features
+
+At least one of `cpu-faer` or `cpu-blas` must be compiled. They are additive;
+`cpu-blas` may be enabled alongside `cpu-faer`, and the default provider is BLAS
+when it is compiled, otherwise faer. For a BLAS build choose one provider
+feature such as `blas-openblas`, `blas-mkl`, or `blas-accelerate`; those provider
+choices are mutually exclusive.
+
+```toml
+[dependencies]
+tenferro-runtime = { version = "0.2", default-features = false, features = ["cpu-blas"] }
+tenferro-cpu = { version = "0.2", default-features = false, features = ["cpu-blas", "blas-openblas"] }
+tenferro-linalg = { version = "0.2", default-features = false, features = ["cpu-blas", "blas-openblas"] }
+```
+
+Do not enable two BLAS provider implementations in one dependency graph.
+
+## Scratch-crate workspace boundary
+
+When experimenting inside a checkout, put an empty workspace table in the
+scratch crate so Cargo does not enroll it in tenferro's parent workspace:
+
+```toml
+[workspace]
+
+[dependencies]
+tenferro-runtime = { path = "../tenferro-rs/crates/tenferro-runtime" }
+```
+
+Use crates.io versions for a real downstream project. Do not copy the workspace
+path layout into a published package.

--- a/.agents/skills/tenferro-compute/references/crate-selection.md
+++ b/.agents/skills/tenferro-compute/references/crate-selection.md
@@ -17,8 +17,8 @@ A minimal release dependency block for a CPU concrete program is:
 
 ```toml
 [dependencies]
-tenferro-runtime = "0.2"
-tenferro-cpu = "0.2"
+tenferro-runtime = { version = "0.2", default-features = false, features = ["cpu-faer"] }
+tenferro-cpu = { version = "0.2", default-features = false, features = ["cpu-faer"] }
 ```
 
 For eager AD and linear algebra, add the owning crates and opt into the
@@ -26,10 +26,10 @@ operation family's AD rules:
 
 ```toml
 [dependencies]
-tenferro-ad = "0.2"
-tenferro-runtime = "0.2"
-tenferro-cpu = "0.2"
-tenferro-linalg = { version = "0.2", features = ["autodiff"] }
+tenferro-ad = { version = "0.2", default-features = false, features = ["cpu-faer"] }
+tenferro-runtime = { version = "0.2", default-features = false, features = ["cpu-faer"] }
+tenferro-cpu = { version = "0.2", default-features = false, features = ["cpu-faer"] }
+tenferro-linalg = { version = "0.2", default-features = false, features = ["autodiff", "cpu-faer"] }
 ```
 
 The exact current publishable package set is discoverable without compiling:
@@ -38,9 +38,10 @@ The exact current publishable package set is discoverable without compiling:
 cargo metadata --no-deps --format-version 1
 ```
 
-At this revision it contains 14 publishable `tenferro-*` packages. The
-`tenferro-tutorial-code` package is a private CI helper, not a downstream
-runtime dependency.
+The `publish` field identifies the packages intended for downstream use; the
+`tenferro-tutorial-code` package is a private CI helper, not a runtime
+dependency. Do not hard-code a package count in tooling or skill text; query
+metadata at the revision you are using.
 
 ## CPU provider features
 
@@ -61,8 +62,18 @@ Do not enable two BLAS provider implementations in one dependency graph.
 
 ## Scratch-crate workspace boundary
 
-When experimenting inside a checkout, put an empty workspace table in the
-scratch crate so Cargo does not enroll it in tenferro's parent workspace:
+When experimenting with a checkout, use a sibling layout so the scratch
+crate is its own workspace:
+
+```text
+work/
+├── tenferro-rs/
+└── scratch/
+    └── Cargo.toml
+```
+
+The scratch `Cargo.toml` then needs an empty workspace table and a path back to
+the checkout:
 
 ```toml
 [workspace]
@@ -71,5 +82,7 @@ scratch crate so Cargo does not enroll it in tenferro's parent workspace:
 tenferro-runtime = { path = "../tenferro-rs/crates/tenferro-runtime" }
 ```
 
-Use crates.io versions for a real downstream project. Do not copy the workspace
-path layout into a published package.
+If the scratch crate is placed inside the checkout instead, keep the empty
+`[workspace]` table so Cargo does not enroll it in the parent workspace. Use
+crates.io versions for a real downstream project; do not copy checkout paths
+into a published package.

--- a/.agents/skills/tenferro-compute/references/performance-idioms.md
+++ b/.agents/skills/tenferro-compute/references/performance-idioms.md
@@ -1,0 +1,62 @@
+# Performance idioms
+
+## Reuse owners
+
+Construct one backend for a related sequence of operations. `CpuBackend` owns
+threading, placement, pools, and runtime caches; repeatedly constructing it
+throws away those resources. For traced work, likewise reuse the compiler and
+runtime across executions when their shape and registration contracts match.
+
+## Compile once, run many
+
+A traced graph is a reusable program. Build its input metadata, compile once,
+register the backend and extensions once, and pass new concrete inputs to the
+same runtime:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#compile-once-run-many -->
+```rust
+use tenferro_cpu::{runtime_engine_id, runtime_engine_registration, CpuBackend};
+use tenferro_einsum::TraceContextEinsumExt;
+use tenferro_runtime::program::ProgramInputSpec;
+use tenferro_runtime::{GraphCompiler, Runtime, Tensor, TraceContext};
+
+let mut trace = TraceContext::new();
+let input = trace.input(ProgramInputSpec::new(tenferro_runtime::DType::F64, [2.into()]))?;
+let output = trace.einsum(&[input], "i->i")?;
+let graph = trace.finish(&[output])?;
+// Compile the shape-specialized program once.
+let program = GraphCompiler::new().compile_traced_graph(&graph)?;
+
+// Reuse one backend, extension registration, and runtime for repeated inputs.
+let backend = CpuBackend::new();
+let mut builder = Runtime::builder();
+builder.register_engine(runtime_engine_registration(&backend)?)?;
+builder.install_extension_module(tenferro_einsum::extension_module::<CpuBackend>(
+    runtime_engine_id()?,
+)?)?;
+let runtime = builder.build()?;
+for (input, expected) in [
+    (vec![1.0_f64, 2.0], vec![1.0, 2.0]),
+    (vec![3.0_f64, 4.0], vec![3.0, 4.0]),
+] {
+    let value = Tensor::from_vec_col_major(vec![2], input)?;
+    let mut outputs = runtime.run_compiled(&program, &[&value])?;
+    assert_eq!(outputs.remove(0).as_slice::<f64>()?, &expected);
+}
+```
+<!-- end-snippet-source -->
+
+The compiled program is shape-specialized. Recompile when the input shape or
+other compile-time metadata changes.
+
+## Threading
+
+Use `CpuBackend::with_threads` or the documented backend configuration rather
+than creating an independent Rayon pool inside an operation. `cpu-faer` follows
+tenferro's CPU context; BLAS/LAPACK provider threads are configured by their
+provider environment variables. Avoid outer parallel loops that oversubscribe
+the provider.
+
+For long-running processes, use the documented runtime/backend cache stats and
+clear operations. Do not defeat cache ownership by constructing a fresh backend
+for every iteration.

--- a/.agents/skills/tenferro-compute/references/performance-idioms.md
+++ b/.agents/skills/tenferro-compute/references/performance-idioms.md
@@ -10,8 +10,8 @@ runtime across executions when their shape and registration contracts match.
 ## Compile once, run many
 
 A traced graph is a reusable program. Build its input metadata, compile once,
-register the backend and extensions once, and pass new concrete inputs to the
-same runtime:
+register the backend and extensions once, and reuse the compiled program,
+backend, and runtime while passing new concrete inputs:
 
 <!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#compile-once-run-many -->
 ```rust
@@ -51,11 +51,12 @@ other compile-time metadata changes.
 
 ## Threading
 
-Use `CpuBackend::with_threads` or the documented backend configuration rather
-than creating an independent Rayon pool inside an operation. `cpu-faer` follows
-tenferro's CPU context; BLAS/LAPACK provider threads are configured by their
-provider environment variables. Avoid outer parallel loops that oversubscribe
-the provider.
+Use `CpuBackend::with_threads(n)` or the documented backend configuration
+rather than creating an independent Rayon pool inside an operation.
+`cpu-faer` follows tenferro's CPU context; BLAS/LAPACK provider threads are
+configured with variables such as `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, or
+`VECLIB_MAXIMUM_THREADS`. Avoid outer parallel loops that oversubscribe the
+provider.
 
 For long-running processes, use the documented runtime/backend cache stats and
 clear operations. Do not defeat cache ownership by constructing a fresh backend

--- a/.agents/skills/tenferro-compute/references/pitfalls.md
+++ b/.agents/skills/tenferro-compute/references/pitfalls.md
@@ -32,6 +32,8 @@ is in the [traced API example](api-cheatsheet.md#traced-tensors-and-extensions).
 
 - A scratch crate inside the checkout needs an empty `[workspace]` table.
 - `cpu-faer` and `cpu-blas` are CPU capability features; at least one is needed.
+- Use `CpuBackend::with_threads(n)` for faer/native CPU work; configure BLAS
+  provider threads with the provider's environment variables.
 - Choose exactly one BLAS provider feature (`blas-openblas`, `blas-mkl`, or
   `blas-accelerate`) when using `cpu-blas`.
 - CUDA is explicit: enable `tenferro-gpu`'s `cuda` feature and upload CPU

--- a/.agents/skills/tenferro-compute/references/pitfalls.md
+++ b/.agents/skills/tenferro-compute/references/pitfalls.md
@@ -1,0 +1,38 @@
+# Pitfalls
+
+## Column-major input
+
+tenferro owns compact dense buffers in column-major order. For shape `[2, 3]`,
+the physical sequence `[a00, a10, a01, a11, a02, a12]` is correct. A row-major
+literal has the wrong values in the right shape; construction does not detect
+that semantic mistake. Reorder external NumPy/PyTorch/JAX buffers explicitly
+before `from_vec_col_major`. The checked column-major example is in the [API
+cheatsheet](api-cheatsheet.md#direct-concrete-tensors).
+
+## Einsum syntax
+
+Use the explicit arrow in every equation: `"ij,jk->ik"`. The tenferro dialect
+is intentionally smaller than NumPy's: `...` ellipsis is not supported, and
+`"i->ii"` is a tenferro extension rather than a general NumPy spelling. Read
+the `tenferro-einsum` guide before porting a large equation.
+
+## Extension registration
+
+A traced extension operation needs both sides of the runtime boundary:
+
+1. register `tenferro_cpu::runtime_engine_registration(&backend)`;
+2. install the matching operation module, for example
+   `tenferro_einsum::extension_module::<CpuBackend>(runtime_engine_id()?)`.
+
+A missing module is a runtime error, not a signal to silently construct another
+backend or fall back to a concrete implementation. The complete checked setup
+is in the [traced API example](api-cheatsheet.md#traced-tensors-and-extensions).
+
+## Cargo setup traps
+
+- A scratch crate inside the checkout needs an empty `[workspace]` table.
+- `cpu-faer` and `cpu-blas` are CPU capability features; at least one is needed.
+- Choose exactly one BLAS provider feature (`blas-openblas`, `blas-mkl`, or
+  `blas-accelerate`) when using `cpu-blas`.
+- CUDA is explicit: enable `tenferro-gpu`'s `cuda` feature and upload CPU
+  tensors before CUDA operations. There is no implicit transfer.

--- a/.claude/skills/tenferro-compute/SKILL.md
+++ b/.claude/skills/tenferro-compute/SKILL.md
@@ -35,8 +35,9 @@ not when changing tenferro itself.
   fall back to CPU.
 - Traced standard extensions need an explicitly installed extension module and
   a matching registered runtime engine.
-- Keep a scratch crate outside the parent workspace with an empty `[workspace]`
-  table, and enable exactly one BLAS provider when using `cpu-blas`.
+- Keep a scratch crate in its own Cargo workspace (use an empty
+  `[workspace]` table when it lives inside a checkout), and enable exactly one
+  BLAS provider when using `cpu-blas`.
 
 The executable Rust examples in the references are extracted from
 `docs/tutorial-code/src/bin/tenferro_compute_skill.rs` and compiled by the

--- a/.claude/skills/tenferro-compute/SKILL.md
+++ b/.claude/skills/tenferro-compute/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: tenferro-compute
+description: Write Rust programs that use tenferro for tensor computation, autodiff, einsum, linear algebra, and explicit backend execution.
+---
+
+# tenferro-compute
+
+Load this skill when the task is to **use** tenferro from downstream Rust code,
+not when changing tenferro itself.
+
+## Fast path
+
+1. Choose the API tier: direct concrete tensors, eager tensors, or traced
+   graphs. The same operation has different receivers and arities at each tier.
+2. Add the direct crates for that tier. There is no root `tenferro` facade;
+   import operation families such as `tenferro-einsum` and `tenferro-linalg`
+   directly.
+3. Bring the operation's public `*Ext` trait into scope. An E0599 saying that
+   a method does not exist usually means the right extension trait is missing.
+4. Read only the relevant reference below before writing the program.
+
+| Need | Read |
+| --- | --- |
+| Crates, features, CPU providers, scratch crates | [crate selection](references/crate-selection.md) |
+| Tier arities and extension-trait imports | [API cheatsheet](references/api-cheatsheet.md) |
+| Backend/executor reuse and compile-once/run-many | [performance idioms](references/performance-idioms.md) |
+| Column-major data, einsum syntax, registration, and setup traps | [pitfalls](references/pitfalls.md) |
+
+## Non-negotiable defaults
+
+- Dense flat buffers are column-major: the leftmost dimension varies fastest.
+- Bind one backend/runtime/compiler and reuse it across related work.
+- Compile traced programs once outside repeated execution loops.
+- CPU/GPU transfers are explicit; unsupported GPU operations do not silently
+  fall back to CPU.
+- Traced standard extensions need an explicitly installed extension module and
+  a matching registered runtime engine.
+- Keep a scratch crate outside the parent workspace with an empty `[workspace]`
+  table, and enable exactly one BLAS provider when using `cpu-blas`.
+
+The executable Rust examples in the references are extracted from
+`docs/tutorial-code/src/bin/tenferro_compute_skill.rs` and compiled by the
+existing tutorial-binary test.

--- a/.claude/skills/tenferro-compute/references/api-cheatsheet.md
+++ b/.claude/skills/tenferro-compute/references/api-cheatsheet.md
@@ -1,0 +1,114 @@
+# API cheatsheet
+
+Choose the tier before choosing the method. Direct operations receive an
+explicit mutable backend; eager operations run through an `EagerRuntime`; traced
+operations build a graph and execute it later.
+
+## Direct concrete tensors
+
+Import the backend and the extension trait that owns the method:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#concrete-operation -->
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+
+let mut backend = CpuBackend::new();
+// The leftmost dimension varies fastest: this is a 2 x 3 column-major tensor.
+let x = TypedTensor::<f64>::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
+)?;
+let weights = TypedTensor::<f64>::from_vec_col_major(
+    vec![3, 2],
+    vec![0.5, -1.0, 1.5, 1.0, 2.0, -0.5],
+)?;
+let projected = x.matmul(&weights, &mut backend)?;
+assert_eq!(projected.shape(), &[2, 2]);
+assert_eq!(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
+```
+<!-- end-snippet-source -->
+
+The important shape is `x.matmul(&weights, &mut backend)`. For dynamic dtypes
+use `TensorOpsExt`; for static scalar types use `TypedTensorOpsExt`.
+
+## Eager tensors
+
+`EagerTensor` methods omit the backend argument because the runtime owns it.
+Tracked values support `backward()` and functional eager transforms:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#eager-operation -->
+```rust
+use tenferro_ad::{EagerRuntime, Tensor};
+
+let runtime = EagerRuntime::new()?;
+let x = runtime.variable_from(Tensor::from_vec_col_major(
+    vec![3],
+    vec![1.0_f64, 2.0, 3.0],
+)?)?;
+let prediction = x.mul(&x)?;
+let loss = prediction.reduce_sum(Some(&[0]))?;
+loss.backward()?;
+assert_eq!(
+    x.grad()?.expect("tracked variable should receive a gradient").as_slice::<f64>()?,
+    &[2.0, 4.0, 6.0],
+);
+```
+<!-- end-snippet-source -->
+
+Common import recipes:
+
+- `tenferro_einsum::EagerEinsumExt` for eager einsum.
+- `tenferro_linalg::EagerTensorLinalgExt` for eager linear algebra.
+- `tenferro_ad::{EagerRuntime, Tensor}` for eager values and runtime AD.
+
+## Traced tensors and extensions
+
+Traced core operations compile into a graph. Standard operation families are
+extensions: import their traced trait and install the same family's extension
+module into the runtime that owns the registered backend engine.
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#traced-extension-operation -->
+```rust
+use tenferro_cpu::{runtime_engine_id, runtime_engine_registration, CpuBackend};
+use tenferro_einsum::TraceContextEinsumExt;
+use tenferro_runtime::program::ProgramInputSpec;
+use tenferro_runtime::{GraphCompiler, Runtime, Tensor, TraceContext};
+
+let a = Tensor::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+)?;
+let b = Tensor::from_vec_col_major(
+    vec![3, 2],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+)?;
+let mut trace = TraceContext::new();
+let a_value = trace.input(ProgramInputSpec::new(a.dtype(), [2.into(), 3.into()]))?;
+let b_value = trace.input(ProgramInputSpec::new(b.dtype(), [3.into(), 2.into()]))?;
+let product = trace.einsum(&[a_value, b_value], "ij,jk->ik")?;
+let graph = trace.finish(&[product])?;
+let program = GraphCompiler::new().compile_traced_graph(&graph)?;
+
+let backend = CpuBackend::new();
+let mut builder = Runtime::builder();
+builder.register_engine(runtime_engine_registration(&backend)?)?;
+builder.install_extension_module(tenferro_einsum::extension_module::<CpuBackend>(
+    runtime_engine_id()?,
+)?)?;
+let runtime = builder.build()?;
+let mut outputs = runtime.run_compiled(&program, &[&a, &b])?;
+let result = outputs.remove(0);
+assert_eq!(result.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
+```
+<!-- end-snippet-source -->
+
+Import recipes:
+
+- `tenferro_einsum::TraceContextEinsumExt` or
+  `tenferro_einsum::TracedTensorEinsumExt` for einsum.
+- `tenferro_linalg::TracedTensorLinalgExt` for traced linear algebra.
+- `tenferro_ad::TracedTensorAdExt` for `grad`, `vjp`, and `jvp` transforms.
+
+If a method is present in the guide but Rust reports E0599, check the owning
+crate's root re-exports and bring its `*Ext` trait into the local module.

--- a/.claude/skills/tenferro-compute/references/api-cheatsheet.md
+++ b/.claude/skills/tenferro-compute/references/api-cheatsheet.md
@@ -105,8 +105,9 @@ assert_eq!(result.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
 
 Import recipes:
 
-- `tenferro_einsum::TraceContextEinsumExt` or
-  `tenferro_einsum::TracedTensorEinsumExt` for einsum.
+- `tenferro_einsum::TraceContextEinsumExt` for `TraceContext::einsum` graph
+  construction; use `tenferro_einsum::TracedTensorEinsumExt` when the receiver
+  is an already traced tensor.
 - `tenferro_linalg::TracedTensorLinalgExt` for traced linear algebra.
 - `tenferro_ad::TracedTensorAdExt` for `grad`, `vjp`, and `jvp` transforms.
 

--- a/.claude/skills/tenferro-compute/references/crate-selection.md
+++ b/.claude/skills/tenferro-compute/references/crate-selection.md
@@ -1,0 +1,75 @@
+# Crate selection
+
+There is deliberately no facade crate. Add the direct crates that own the
+value layer, execution backend, and operation family you use.
+
+## Choose by tier
+
+| Program | Minimum direct crates | Add when needed |
+| --- | --- | --- |
+| Concrete `Tensor`/`TypedTensor` | `tenferro-runtime`, `tenferro-cpu` | `tenferro-einsum`, `tenferro-linalg`, or `tenferro-fft` for extensions |
+| Eager forward/AD | `tenferro-ad`, `tenferro-cpu` | `tenferro-einsum`/`tenferro-linalg` with `autodiff` for those families |
+| Traced graph | `tenferro-runtime`, `tenferro-cpu` | `tenferro-ad` for graph transforms and the operation crate for extensions |
+| CUDA | the matching value/operation crates plus `tenferro-gpu` with `cuda` | Add `cuda` to crates whose operation surface needs it |
+| XLA/PJRT | `tenferro-runtime`, `tenferro-xla` with `pjrt` | A PJRT plugin and the operation crates used by the graph |
+
+A minimal release dependency block for a CPU concrete program is:
+
+```toml
+[dependencies]
+tenferro-runtime = "0.2"
+tenferro-cpu = "0.2"
+```
+
+For eager AD and linear algebra, add the owning crates and opt into the
+operation family's AD rules:
+
+```toml
+[dependencies]
+tenferro-ad = "0.2"
+tenferro-runtime = "0.2"
+tenferro-cpu = "0.2"
+tenferro-linalg = { version = "0.2", features = ["autodiff"] }
+```
+
+The exact current publishable package set is discoverable without compiling:
+
+```text
+cargo metadata --no-deps --format-version 1
+```
+
+At this revision it contains 14 publishable `tenferro-*` packages. The
+`tenferro-tutorial-code` package is a private CI helper, not a downstream
+runtime dependency.
+
+## CPU provider features
+
+At least one of `cpu-faer` or `cpu-blas` must be compiled. They are additive;
+`cpu-blas` may be enabled alongside `cpu-faer`, and the default provider is BLAS
+when it is compiled, otherwise faer. For a BLAS build choose one provider
+feature such as `blas-openblas`, `blas-mkl`, or `blas-accelerate`; those provider
+choices are mutually exclusive.
+
+```toml
+[dependencies]
+tenferro-runtime = { version = "0.2", default-features = false, features = ["cpu-blas"] }
+tenferro-cpu = { version = "0.2", default-features = false, features = ["cpu-blas", "blas-openblas"] }
+tenferro-linalg = { version = "0.2", default-features = false, features = ["cpu-blas", "blas-openblas"] }
+```
+
+Do not enable two BLAS provider implementations in one dependency graph.
+
+## Scratch-crate workspace boundary
+
+When experimenting inside a checkout, put an empty workspace table in the
+scratch crate so Cargo does not enroll it in tenferro's parent workspace:
+
+```toml
+[workspace]
+
+[dependencies]
+tenferro-runtime = { path = "../tenferro-rs/crates/tenferro-runtime" }
+```
+
+Use crates.io versions for a real downstream project. Do not copy the workspace
+path layout into a published package.

--- a/.claude/skills/tenferro-compute/references/crate-selection.md
+++ b/.claude/skills/tenferro-compute/references/crate-selection.md
@@ -17,8 +17,8 @@ A minimal release dependency block for a CPU concrete program is:
 
 ```toml
 [dependencies]
-tenferro-runtime = "0.2"
-tenferro-cpu = "0.2"
+tenferro-runtime = { version = "0.2", default-features = false, features = ["cpu-faer"] }
+tenferro-cpu = { version = "0.2", default-features = false, features = ["cpu-faer"] }
 ```
 
 For eager AD and linear algebra, add the owning crates and opt into the
@@ -26,10 +26,10 @@ operation family's AD rules:
 
 ```toml
 [dependencies]
-tenferro-ad = "0.2"
-tenferro-runtime = "0.2"
-tenferro-cpu = "0.2"
-tenferro-linalg = { version = "0.2", features = ["autodiff"] }
+tenferro-ad = { version = "0.2", default-features = false, features = ["cpu-faer"] }
+tenferro-runtime = { version = "0.2", default-features = false, features = ["cpu-faer"] }
+tenferro-cpu = { version = "0.2", default-features = false, features = ["cpu-faer"] }
+tenferro-linalg = { version = "0.2", default-features = false, features = ["autodiff", "cpu-faer"] }
 ```
 
 The exact current publishable package set is discoverable without compiling:
@@ -38,9 +38,10 @@ The exact current publishable package set is discoverable without compiling:
 cargo metadata --no-deps --format-version 1
 ```
 
-At this revision it contains 14 publishable `tenferro-*` packages. The
-`tenferro-tutorial-code` package is a private CI helper, not a downstream
-runtime dependency.
+The `publish` field identifies the packages intended for downstream use; the
+`tenferro-tutorial-code` package is a private CI helper, not a runtime
+dependency. Do not hard-code a package count in tooling or skill text; query
+metadata at the revision you are using.
 
 ## CPU provider features
 
@@ -61,8 +62,18 @@ Do not enable two BLAS provider implementations in one dependency graph.
 
 ## Scratch-crate workspace boundary
 
-When experimenting inside a checkout, put an empty workspace table in the
-scratch crate so Cargo does not enroll it in tenferro's parent workspace:
+When experimenting with a checkout, use a sibling layout so the scratch
+crate is its own workspace:
+
+```text
+work/
+├── tenferro-rs/
+└── scratch/
+    └── Cargo.toml
+```
+
+The scratch `Cargo.toml` then needs an empty workspace table and a path back to
+the checkout:
 
 ```toml
 [workspace]
@@ -71,5 +82,7 @@ scratch crate so Cargo does not enroll it in tenferro's parent workspace:
 tenferro-runtime = { path = "../tenferro-rs/crates/tenferro-runtime" }
 ```
 
-Use crates.io versions for a real downstream project. Do not copy the workspace
-path layout into a published package.
+If the scratch crate is placed inside the checkout instead, keep the empty
+`[workspace]` table so Cargo does not enroll it in the parent workspace. Use
+crates.io versions for a real downstream project; do not copy checkout paths
+into a published package.

--- a/.claude/skills/tenferro-compute/references/performance-idioms.md
+++ b/.claude/skills/tenferro-compute/references/performance-idioms.md
@@ -1,0 +1,62 @@
+# Performance idioms
+
+## Reuse owners
+
+Construct one backend for a related sequence of operations. `CpuBackend` owns
+threading, placement, pools, and runtime caches; repeatedly constructing it
+throws away those resources. For traced work, likewise reuse the compiler and
+runtime across executions when their shape and registration contracts match.
+
+## Compile once, run many
+
+A traced graph is a reusable program. Build its input metadata, compile once,
+register the backend and extensions once, and pass new concrete inputs to the
+same runtime:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#compile-once-run-many -->
+```rust
+use tenferro_cpu::{runtime_engine_id, runtime_engine_registration, CpuBackend};
+use tenferro_einsum::TraceContextEinsumExt;
+use tenferro_runtime::program::ProgramInputSpec;
+use tenferro_runtime::{GraphCompiler, Runtime, Tensor, TraceContext};
+
+let mut trace = TraceContext::new();
+let input = trace.input(ProgramInputSpec::new(tenferro_runtime::DType::F64, [2.into()]))?;
+let output = trace.einsum(&[input], "i->i")?;
+let graph = trace.finish(&[output])?;
+// Compile the shape-specialized program once.
+let program = GraphCompiler::new().compile_traced_graph(&graph)?;
+
+// Reuse one backend, extension registration, and runtime for repeated inputs.
+let backend = CpuBackend::new();
+let mut builder = Runtime::builder();
+builder.register_engine(runtime_engine_registration(&backend)?)?;
+builder.install_extension_module(tenferro_einsum::extension_module::<CpuBackend>(
+    runtime_engine_id()?,
+)?)?;
+let runtime = builder.build()?;
+for (input, expected) in [
+    (vec![1.0_f64, 2.0], vec![1.0, 2.0]),
+    (vec![3.0_f64, 4.0], vec![3.0, 4.0]),
+] {
+    let value = Tensor::from_vec_col_major(vec![2], input)?;
+    let mut outputs = runtime.run_compiled(&program, &[&value])?;
+    assert_eq!(outputs.remove(0).as_slice::<f64>()?, &expected);
+}
+```
+<!-- end-snippet-source -->
+
+The compiled program is shape-specialized. Recompile when the input shape or
+other compile-time metadata changes.
+
+## Threading
+
+Use `CpuBackend::with_threads` or the documented backend configuration rather
+than creating an independent Rayon pool inside an operation. `cpu-faer` follows
+tenferro's CPU context; BLAS/LAPACK provider threads are configured by their
+provider environment variables. Avoid outer parallel loops that oversubscribe
+the provider.
+
+For long-running processes, use the documented runtime/backend cache stats and
+clear operations. Do not defeat cache ownership by constructing a fresh backend
+for every iteration.

--- a/.claude/skills/tenferro-compute/references/performance-idioms.md
+++ b/.claude/skills/tenferro-compute/references/performance-idioms.md
@@ -10,8 +10,8 @@ runtime across executions when their shape and registration contracts match.
 ## Compile once, run many
 
 A traced graph is a reusable program. Build its input metadata, compile once,
-register the backend and extensions once, and pass new concrete inputs to the
-same runtime:
+register the backend and extensions once, and reuse the compiled program,
+backend, and runtime while passing new concrete inputs:
 
 <!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#compile-once-run-many -->
 ```rust
@@ -51,11 +51,12 @@ other compile-time metadata changes.
 
 ## Threading
 
-Use `CpuBackend::with_threads` or the documented backend configuration rather
-than creating an independent Rayon pool inside an operation. `cpu-faer` follows
-tenferro's CPU context; BLAS/LAPACK provider threads are configured by their
-provider environment variables. Avoid outer parallel loops that oversubscribe
-the provider.
+Use `CpuBackend::with_threads(n)` or the documented backend configuration
+rather than creating an independent Rayon pool inside an operation.
+`cpu-faer` follows tenferro's CPU context; BLAS/LAPACK provider threads are
+configured with variables such as `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, or
+`VECLIB_MAXIMUM_THREADS`. Avoid outer parallel loops that oversubscribe the
+provider.
 
 For long-running processes, use the documented runtime/backend cache stats and
 clear operations. Do not defeat cache ownership by constructing a fresh backend

--- a/.claude/skills/tenferro-compute/references/pitfalls.md
+++ b/.claude/skills/tenferro-compute/references/pitfalls.md
@@ -32,6 +32,8 @@ is in the [traced API example](api-cheatsheet.md#traced-tensors-and-extensions).
 
 - A scratch crate inside the checkout needs an empty `[workspace]` table.
 - `cpu-faer` and `cpu-blas` are CPU capability features; at least one is needed.
+- Use `CpuBackend::with_threads(n)` for faer/native CPU work; configure BLAS
+  provider threads with the provider's environment variables.
 - Choose exactly one BLAS provider feature (`blas-openblas`, `blas-mkl`, or
   `blas-accelerate`) when using `cpu-blas`.
 - CUDA is explicit: enable `tenferro-gpu`'s `cuda` feature and upload CPU

--- a/.claude/skills/tenferro-compute/references/pitfalls.md
+++ b/.claude/skills/tenferro-compute/references/pitfalls.md
@@ -1,0 +1,38 @@
+# Pitfalls
+
+## Column-major input
+
+tenferro owns compact dense buffers in column-major order. For shape `[2, 3]`,
+the physical sequence `[a00, a10, a01, a11, a02, a12]` is correct. A row-major
+literal has the wrong values in the right shape; construction does not detect
+that semantic mistake. Reorder external NumPy/PyTorch/JAX buffers explicitly
+before `from_vec_col_major`. The checked column-major example is in the [API
+cheatsheet](api-cheatsheet.md#direct-concrete-tensors).
+
+## Einsum syntax
+
+Use the explicit arrow in every equation: `"ij,jk->ik"`. The tenferro dialect
+is intentionally smaller than NumPy's: `...` ellipsis is not supported, and
+`"i->ii"` is a tenferro extension rather than a general NumPy spelling. Read
+the `tenferro-einsum` guide before porting a large equation.
+
+## Extension registration
+
+A traced extension operation needs both sides of the runtime boundary:
+
+1. register `tenferro_cpu::runtime_engine_registration(&backend)`;
+2. install the matching operation module, for example
+   `tenferro_einsum::extension_module::<CpuBackend>(runtime_engine_id()?)`.
+
+A missing module is a runtime error, not a signal to silently construct another
+backend or fall back to a concrete implementation. The complete checked setup
+is in the [traced API example](api-cheatsheet.md#traced-tensors-and-extensions).
+
+## Cargo setup traps
+
+- A scratch crate inside the checkout needs an empty `[workspace]` table.
+- `cpu-faer` and `cpu-blas` are CPU capability features; at least one is needed.
+- Choose exactly one BLAS provider feature (`blas-openblas`, `blas-mkl`, or
+  `blas-accelerate`) when using `cpu-blas`.
+- CUDA is explicit: enable `tenferro-gpu`'s `cuda` feature and upload CPU
+  tensors before CUDA operations. There is no implicit transfer.

--- a/.kimi/skills/tenferro-compute/SKILL.md
+++ b/.kimi/skills/tenferro-compute/SKILL.md
@@ -35,8 +35,9 @@ not when changing tenferro itself.
   fall back to CPU.
 - Traced standard extensions need an explicitly installed extension module and
   a matching registered runtime engine.
-- Keep a scratch crate outside the parent workspace with an empty `[workspace]`
-  table, and enable exactly one BLAS provider when using `cpu-blas`.
+- Keep a scratch crate in its own Cargo workspace (use an empty
+  `[workspace]` table when it lives inside a checkout), and enable exactly one
+  BLAS provider when using `cpu-blas`.
 
 The executable Rust examples in the references are extracted from
 `docs/tutorial-code/src/bin/tenferro_compute_skill.rs` and compiled by the

--- a/.kimi/skills/tenferro-compute/SKILL.md
+++ b/.kimi/skills/tenferro-compute/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: tenferro-compute
+description: Write Rust programs that use tenferro for tensor computation, autodiff, einsum, linear algebra, and explicit backend execution.
+---
+
+# tenferro-compute
+
+Load this skill when the task is to **use** tenferro from downstream Rust code,
+not when changing tenferro itself.
+
+## Fast path
+
+1. Choose the API tier: direct concrete tensors, eager tensors, or traced
+   graphs. The same operation has different receivers and arities at each tier.
+2. Add the direct crates for that tier. There is no root `tenferro` facade;
+   import operation families such as `tenferro-einsum` and `tenferro-linalg`
+   directly.
+3. Bring the operation's public `*Ext` trait into scope. An E0599 saying that
+   a method does not exist usually means the right extension trait is missing.
+4. Read only the relevant reference below before writing the program.
+
+| Need | Read |
+| --- | --- |
+| Crates, features, CPU providers, scratch crates | [crate selection](references/crate-selection.md) |
+| Tier arities and extension-trait imports | [API cheatsheet](references/api-cheatsheet.md) |
+| Backend/executor reuse and compile-once/run-many | [performance idioms](references/performance-idioms.md) |
+| Column-major data, einsum syntax, registration, and setup traps | [pitfalls](references/pitfalls.md) |
+
+## Non-negotiable defaults
+
+- Dense flat buffers are column-major: the leftmost dimension varies fastest.
+- Bind one backend/runtime/compiler and reuse it across related work.
+- Compile traced programs once outside repeated execution loops.
+- CPU/GPU transfers are explicit; unsupported GPU operations do not silently
+  fall back to CPU.
+- Traced standard extensions need an explicitly installed extension module and
+  a matching registered runtime engine.
+- Keep a scratch crate outside the parent workspace with an empty `[workspace]`
+  table, and enable exactly one BLAS provider when using `cpu-blas`.
+
+The executable Rust examples in the references are extracted from
+`docs/tutorial-code/src/bin/tenferro_compute_skill.rs` and compiled by the
+existing tutorial-binary test.

--- a/.kimi/skills/tenferro-compute/references/api-cheatsheet.md
+++ b/.kimi/skills/tenferro-compute/references/api-cheatsheet.md
@@ -1,0 +1,114 @@
+# API cheatsheet
+
+Choose the tier before choosing the method. Direct operations receive an
+explicit mutable backend; eager operations run through an `EagerRuntime`; traced
+operations build a graph and execute it later.
+
+## Direct concrete tensors
+
+Import the backend and the extension trait that owns the method:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#concrete-operation -->
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+
+let mut backend = CpuBackend::new();
+// The leftmost dimension varies fastest: this is a 2 x 3 column-major tensor.
+let x = TypedTensor::<f64>::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
+)?;
+let weights = TypedTensor::<f64>::from_vec_col_major(
+    vec![3, 2],
+    vec![0.5, -1.0, 1.5, 1.0, 2.0, -0.5],
+)?;
+let projected = x.matmul(&weights, &mut backend)?;
+assert_eq!(projected.shape(), &[2, 2]);
+assert_eq!(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
+```
+<!-- end-snippet-source -->
+
+The important shape is `x.matmul(&weights, &mut backend)`. For dynamic dtypes
+use `TensorOpsExt`; for static scalar types use `TypedTensorOpsExt`.
+
+## Eager tensors
+
+`EagerTensor` methods omit the backend argument because the runtime owns it.
+Tracked values support `backward()` and functional eager transforms:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#eager-operation -->
+```rust
+use tenferro_ad::{EagerRuntime, Tensor};
+
+let runtime = EagerRuntime::new()?;
+let x = runtime.variable_from(Tensor::from_vec_col_major(
+    vec![3],
+    vec![1.0_f64, 2.0, 3.0],
+)?)?;
+let prediction = x.mul(&x)?;
+let loss = prediction.reduce_sum(Some(&[0]))?;
+loss.backward()?;
+assert_eq!(
+    x.grad()?.expect("tracked variable should receive a gradient").as_slice::<f64>()?,
+    &[2.0, 4.0, 6.0],
+);
+```
+<!-- end-snippet-source -->
+
+Common import recipes:
+
+- `tenferro_einsum::EagerEinsumExt` for eager einsum.
+- `tenferro_linalg::EagerTensorLinalgExt` for eager linear algebra.
+- `tenferro_ad::{EagerRuntime, Tensor}` for eager values and runtime AD.
+
+## Traced tensors and extensions
+
+Traced core operations compile into a graph. Standard operation families are
+extensions: import their traced trait and install the same family's extension
+module into the runtime that owns the registered backend engine.
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#traced-extension-operation -->
+```rust
+use tenferro_cpu::{runtime_engine_id, runtime_engine_registration, CpuBackend};
+use tenferro_einsum::TraceContextEinsumExt;
+use tenferro_runtime::program::ProgramInputSpec;
+use tenferro_runtime::{GraphCompiler, Runtime, Tensor, TraceContext};
+
+let a = Tensor::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+)?;
+let b = Tensor::from_vec_col_major(
+    vec![3, 2],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+)?;
+let mut trace = TraceContext::new();
+let a_value = trace.input(ProgramInputSpec::new(a.dtype(), [2.into(), 3.into()]))?;
+let b_value = trace.input(ProgramInputSpec::new(b.dtype(), [3.into(), 2.into()]))?;
+let product = trace.einsum(&[a_value, b_value], "ij,jk->ik")?;
+let graph = trace.finish(&[product])?;
+let program = GraphCompiler::new().compile_traced_graph(&graph)?;
+
+let backend = CpuBackend::new();
+let mut builder = Runtime::builder();
+builder.register_engine(runtime_engine_registration(&backend)?)?;
+builder.install_extension_module(tenferro_einsum::extension_module::<CpuBackend>(
+    runtime_engine_id()?,
+)?)?;
+let runtime = builder.build()?;
+let mut outputs = runtime.run_compiled(&program, &[&a, &b])?;
+let result = outputs.remove(0);
+assert_eq!(result.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
+```
+<!-- end-snippet-source -->
+
+Import recipes:
+
+- `tenferro_einsum::TraceContextEinsumExt` or
+  `tenferro_einsum::TracedTensorEinsumExt` for einsum.
+- `tenferro_linalg::TracedTensorLinalgExt` for traced linear algebra.
+- `tenferro_ad::TracedTensorAdExt` for `grad`, `vjp`, and `jvp` transforms.
+
+If a method is present in the guide but Rust reports E0599, check the owning
+crate's root re-exports and bring its `*Ext` trait into the local module.

--- a/.kimi/skills/tenferro-compute/references/api-cheatsheet.md
+++ b/.kimi/skills/tenferro-compute/references/api-cheatsheet.md
@@ -105,8 +105,9 @@ assert_eq!(result.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
 
 Import recipes:
 
-- `tenferro_einsum::TraceContextEinsumExt` or
-  `tenferro_einsum::TracedTensorEinsumExt` for einsum.
+- `tenferro_einsum::TraceContextEinsumExt` for `TraceContext::einsum` graph
+  construction; use `tenferro_einsum::TracedTensorEinsumExt` when the receiver
+  is an already traced tensor.
 - `tenferro_linalg::TracedTensorLinalgExt` for traced linear algebra.
 - `tenferro_ad::TracedTensorAdExt` for `grad`, `vjp`, and `jvp` transforms.
 

--- a/.kimi/skills/tenferro-compute/references/crate-selection.md
+++ b/.kimi/skills/tenferro-compute/references/crate-selection.md
@@ -1,0 +1,75 @@
+# Crate selection
+
+There is deliberately no facade crate. Add the direct crates that own the
+value layer, execution backend, and operation family you use.
+
+## Choose by tier
+
+| Program | Minimum direct crates | Add when needed |
+| --- | --- | --- |
+| Concrete `Tensor`/`TypedTensor` | `tenferro-runtime`, `tenferro-cpu` | `tenferro-einsum`, `tenferro-linalg`, or `tenferro-fft` for extensions |
+| Eager forward/AD | `tenferro-ad`, `tenferro-cpu` | `tenferro-einsum`/`tenferro-linalg` with `autodiff` for those families |
+| Traced graph | `tenferro-runtime`, `tenferro-cpu` | `tenferro-ad` for graph transforms and the operation crate for extensions |
+| CUDA | the matching value/operation crates plus `tenferro-gpu` with `cuda` | Add `cuda` to crates whose operation surface needs it |
+| XLA/PJRT | `tenferro-runtime`, `tenferro-xla` with `pjrt` | A PJRT plugin and the operation crates used by the graph |
+
+A minimal release dependency block for a CPU concrete program is:
+
+```toml
+[dependencies]
+tenferro-runtime = "0.2"
+tenferro-cpu = "0.2"
+```
+
+For eager AD and linear algebra, add the owning crates and opt into the
+operation family's AD rules:
+
+```toml
+[dependencies]
+tenferro-ad = "0.2"
+tenferro-runtime = "0.2"
+tenferro-cpu = "0.2"
+tenferro-linalg = { version = "0.2", features = ["autodiff"] }
+```
+
+The exact current publishable package set is discoverable without compiling:
+
+```text
+cargo metadata --no-deps --format-version 1
+```
+
+At this revision it contains 14 publishable `tenferro-*` packages. The
+`tenferro-tutorial-code` package is a private CI helper, not a downstream
+runtime dependency.
+
+## CPU provider features
+
+At least one of `cpu-faer` or `cpu-blas` must be compiled. They are additive;
+`cpu-blas` may be enabled alongside `cpu-faer`, and the default provider is BLAS
+when it is compiled, otherwise faer. For a BLAS build choose one provider
+feature such as `blas-openblas`, `blas-mkl`, or `blas-accelerate`; those provider
+choices are mutually exclusive.
+
+```toml
+[dependencies]
+tenferro-runtime = { version = "0.2", default-features = false, features = ["cpu-blas"] }
+tenferro-cpu = { version = "0.2", default-features = false, features = ["cpu-blas", "blas-openblas"] }
+tenferro-linalg = { version = "0.2", default-features = false, features = ["cpu-blas", "blas-openblas"] }
+```
+
+Do not enable two BLAS provider implementations in one dependency graph.
+
+## Scratch-crate workspace boundary
+
+When experimenting inside a checkout, put an empty workspace table in the
+scratch crate so Cargo does not enroll it in tenferro's parent workspace:
+
+```toml
+[workspace]
+
+[dependencies]
+tenferro-runtime = { path = "../tenferro-rs/crates/tenferro-runtime" }
+```
+
+Use crates.io versions for a real downstream project. Do not copy the workspace
+path layout into a published package.

--- a/.kimi/skills/tenferro-compute/references/crate-selection.md
+++ b/.kimi/skills/tenferro-compute/references/crate-selection.md
@@ -17,8 +17,8 @@ A minimal release dependency block for a CPU concrete program is:
 
 ```toml
 [dependencies]
-tenferro-runtime = "0.2"
-tenferro-cpu = "0.2"
+tenferro-runtime = { version = "0.2", default-features = false, features = ["cpu-faer"] }
+tenferro-cpu = { version = "0.2", default-features = false, features = ["cpu-faer"] }
 ```
 
 For eager AD and linear algebra, add the owning crates and opt into the
@@ -26,10 +26,10 @@ operation family's AD rules:
 
 ```toml
 [dependencies]
-tenferro-ad = "0.2"
-tenferro-runtime = "0.2"
-tenferro-cpu = "0.2"
-tenferro-linalg = { version = "0.2", features = ["autodiff"] }
+tenferro-ad = { version = "0.2", default-features = false, features = ["cpu-faer"] }
+tenferro-runtime = { version = "0.2", default-features = false, features = ["cpu-faer"] }
+tenferro-cpu = { version = "0.2", default-features = false, features = ["cpu-faer"] }
+tenferro-linalg = { version = "0.2", default-features = false, features = ["autodiff", "cpu-faer"] }
 ```
 
 The exact current publishable package set is discoverable without compiling:
@@ -38,9 +38,10 @@ The exact current publishable package set is discoverable without compiling:
 cargo metadata --no-deps --format-version 1
 ```
 
-At this revision it contains 14 publishable `tenferro-*` packages. The
-`tenferro-tutorial-code` package is a private CI helper, not a downstream
-runtime dependency.
+The `publish` field identifies the packages intended for downstream use; the
+`tenferro-tutorial-code` package is a private CI helper, not a runtime
+dependency. Do not hard-code a package count in tooling or skill text; query
+metadata at the revision you are using.
 
 ## CPU provider features
 
@@ -61,8 +62,18 @@ Do not enable two BLAS provider implementations in one dependency graph.
 
 ## Scratch-crate workspace boundary
 
-When experimenting inside a checkout, put an empty workspace table in the
-scratch crate so Cargo does not enroll it in tenferro's parent workspace:
+When experimenting with a checkout, use a sibling layout so the scratch
+crate is its own workspace:
+
+```text
+work/
+├── tenferro-rs/
+└── scratch/
+    └── Cargo.toml
+```
+
+The scratch `Cargo.toml` then needs an empty workspace table and a path back to
+the checkout:
 
 ```toml
 [workspace]
@@ -71,5 +82,7 @@ scratch crate so Cargo does not enroll it in tenferro's parent workspace:
 tenferro-runtime = { path = "../tenferro-rs/crates/tenferro-runtime" }
 ```
 
-Use crates.io versions for a real downstream project. Do not copy the workspace
-path layout into a published package.
+If the scratch crate is placed inside the checkout instead, keep the empty
+`[workspace]` table so Cargo does not enroll it in the parent workspace. Use
+crates.io versions for a real downstream project; do not copy checkout paths
+into a published package.

--- a/.kimi/skills/tenferro-compute/references/performance-idioms.md
+++ b/.kimi/skills/tenferro-compute/references/performance-idioms.md
@@ -1,0 +1,62 @@
+# Performance idioms
+
+## Reuse owners
+
+Construct one backend for a related sequence of operations. `CpuBackend` owns
+threading, placement, pools, and runtime caches; repeatedly constructing it
+throws away those resources. For traced work, likewise reuse the compiler and
+runtime across executions when their shape and registration contracts match.
+
+## Compile once, run many
+
+A traced graph is a reusable program. Build its input metadata, compile once,
+register the backend and extensions once, and pass new concrete inputs to the
+same runtime:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#compile-once-run-many -->
+```rust
+use tenferro_cpu::{runtime_engine_id, runtime_engine_registration, CpuBackend};
+use tenferro_einsum::TraceContextEinsumExt;
+use tenferro_runtime::program::ProgramInputSpec;
+use tenferro_runtime::{GraphCompiler, Runtime, Tensor, TraceContext};
+
+let mut trace = TraceContext::new();
+let input = trace.input(ProgramInputSpec::new(tenferro_runtime::DType::F64, [2.into()]))?;
+let output = trace.einsum(&[input], "i->i")?;
+let graph = trace.finish(&[output])?;
+// Compile the shape-specialized program once.
+let program = GraphCompiler::new().compile_traced_graph(&graph)?;
+
+// Reuse one backend, extension registration, and runtime for repeated inputs.
+let backend = CpuBackend::new();
+let mut builder = Runtime::builder();
+builder.register_engine(runtime_engine_registration(&backend)?)?;
+builder.install_extension_module(tenferro_einsum::extension_module::<CpuBackend>(
+    runtime_engine_id()?,
+)?)?;
+let runtime = builder.build()?;
+for (input, expected) in [
+    (vec![1.0_f64, 2.0], vec![1.0, 2.0]),
+    (vec![3.0_f64, 4.0], vec![3.0, 4.0]),
+] {
+    let value = Tensor::from_vec_col_major(vec![2], input)?;
+    let mut outputs = runtime.run_compiled(&program, &[&value])?;
+    assert_eq!(outputs.remove(0).as_slice::<f64>()?, &expected);
+}
+```
+<!-- end-snippet-source -->
+
+The compiled program is shape-specialized. Recompile when the input shape or
+other compile-time metadata changes.
+
+## Threading
+
+Use `CpuBackend::with_threads` or the documented backend configuration rather
+than creating an independent Rayon pool inside an operation. `cpu-faer` follows
+tenferro's CPU context; BLAS/LAPACK provider threads are configured by their
+provider environment variables. Avoid outer parallel loops that oversubscribe
+the provider.
+
+For long-running processes, use the documented runtime/backend cache stats and
+clear operations. Do not defeat cache ownership by constructing a fresh backend
+for every iteration.

--- a/.kimi/skills/tenferro-compute/references/performance-idioms.md
+++ b/.kimi/skills/tenferro-compute/references/performance-idioms.md
@@ -10,8 +10,8 @@ runtime across executions when their shape and registration contracts match.
 ## Compile once, run many
 
 A traced graph is a reusable program. Build its input metadata, compile once,
-register the backend and extensions once, and pass new concrete inputs to the
-same runtime:
+register the backend and extensions once, and reuse the compiled program,
+backend, and runtime while passing new concrete inputs:
 
 <!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#compile-once-run-many -->
 ```rust
@@ -51,11 +51,12 @@ other compile-time metadata changes.
 
 ## Threading
 
-Use `CpuBackend::with_threads` or the documented backend configuration rather
-than creating an independent Rayon pool inside an operation. `cpu-faer` follows
-tenferro's CPU context; BLAS/LAPACK provider threads are configured by their
-provider environment variables. Avoid outer parallel loops that oversubscribe
-the provider.
+Use `CpuBackend::with_threads(n)` or the documented backend configuration
+rather than creating an independent Rayon pool inside an operation.
+`cpu-faer` follows tenferro's CPU context; BLAS/LAPACK provider threads are
+configured with variables such as `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, or
+`VECLIB_MAXIMUM_THREADS`. Avoid outer parallel loops that oversubscribe the
+provider.
 
 For long-running processes, use the documented runtime/backend cache stats and
 clear operations. Do not defeat cache ownership by constructing a fresh backend

--- a/.kimi/skills/tenferro-compute/references/pitfalls.md
+++ b/.kimi/skills/tenferro-compute/references/pitfalls.md
@@ -32,6 +32,8 @@ is in the [traced API example](api-cheatsheet.md#traced-tensors-and-extensions).
 
 - A scratch crate inside the checkout needs an empty `[workspace]` table.
 - `cpu-faer` and `cpu-blas` are CPU capability features; at least one is needed.
+- Use `CpuBackend::with_threads(n)` for faer/native CPU work; configure BLAS
+  provider threads with the provider's environment variables.
 - Choose exactly one BLAS provider feature (`blas-openblas`, `blas-mkl`, or
   `blas-accelerate`) when using `cpu-blas`.
 - CUDA is explicit: enable `tenferro-gpu`'s `cuda` feature and upload CPU

--- a/.kimi/skills/tenferro-compute/references/pitfalls.md
+++ b/.kimi/skills/tenferro-compute/references/pitfalls.md
@@ -1,0 +1,38 @@
+# Pitfalls
+
+## Column-major input
+
+tenferro owns compact dense buffers in column-major order. For shape `[2, 3]`,
+the physical sequence `[a00, a10, a01, a11, a02, a12]` is correct. A row-major
+literal has the wrong values in the right shape; construction does not detect
+that semantic mistake. Reorder external NumPy/PyTorch/JAX buffers explicitly
+before `from_vec_col_major`. The checked column-major example is in the [API
+cheatsheet](api-cheatsheet.md#direct-concrete-tensors).
+
+## Einsum syntax
+
+Use the explicit arrow in every equation: `"ij,jk->ik"`. The tenferro dialect
+is intentionally smaller than NumPy's: `...` ellipsis is not supported, and
+`"i->ii"` is a tenferro extension rather than a general NumPy spelling. Read
+the `tenferro-einsum` guide before porting a large equation.
+
+## Extension registration
+
+A traced extension operation needs both sides of the runtime boundary:
+
+1. register `tenferro_cpu::runtime_engine_registration(&backend)`;
+2. install the matching operation module, for example
+   `tenferro_einsum::extension_module::<CpuBackend>(runtime_engine_id()?)`.
+
+A missing module is a runtime error, not a signal to silently construct another
+backend or fall back to a concrete implementation. The complete checked setup
+is in the [traced API example](api-cheatsheet.md#traced-tensors-and-extensions).
+
+## Cargo setup traps
+
+- A scratch crate inside the checkout needs an empty `[workspace]` table.
+- `cpu-faer` and `cpu-blas` are CPU capability features; at least one is needed.
+- Choose exactly one BLAS provider feature (`blas-openblas`, `blas-mkl`, or
+  `blas-accelerate`) when using `cpu-blas`.
+- CUDA is explicit: enable `tenferro-gpu`'s `cuda` feature and upload CPU
+  tensors before CUDA operations. There is no implicit transfer.

--- a/.opencode/commands/tenferro-compute.md
+++ b/.opencode/commands/tenferro-compute.md
@@ -1,0 +1,16 @@
+---
+description: Write downstream Rust tensor programs with tenferro using the canonical bundled skill.
+---
+
+Use `$ARGUMENTS` as the initial user request if present.
+
+Read the canonical downstream-usage skill first:
+
+@.agents/skills/tenferro-compute/SKILL.md
+
+Then consult the focused references as needed:
+
+- @.agents/skills/tenferro-compute/references/crate-selection.md
+- @.agents/skills/tenferro-compute/references/api-cheatsheet.md
+- @.agents/skills/tenferro-compute/references/performance-idioms.md
+- @.agents/skills/tenferro-compute/references/pitfalls.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,7 @@ Additionally, verify the following before pushing:
 - **Side review**: Re-read `REPOSITORY_RULES.md` and review the local diff against repository rules before creating a PR. Fix any findings, or explicitly document residual risks.
 - **Sample code verification**: All code examples in `README.md` and `docs/getting-started/` must compile and run correctly. Extract and test any changed examples.
 - **Design document updates**: When code changes affect architecture or specifications, update the corresponding documents in `docs/architecture/`, `docs/spec/`, or `docs/design/`, and update any affected diagrams under `docs/assets/` or embedded in Markdown. Stale documentation is worse than no documentation.
+- **Agent skill freshness**: When a PR changes public API surface, feature flags, crate boundaries, or documented idioms, review `.agents/skills/tenferro-compute/` and the other shipped skill mirrors, and update them in the same PR when they no longer match.
 - **Work log updates**: For nontrivial refactors, cleanup streams, AI-assisted implementation, or explicit tradeoff decisions, add or update a work log under `docs/worklogs/` and link it from the PR body.
 
 ### Local Rust Build Acceleration

--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ specifications live at <https://tensor4all.org/tenferro-rs/>. Start with
 [Getting Started](https://tensor4all.org/tenferro-rs/getting-started/index.html);
 PyTorch/JAX users can also jump in through the
 [PyTorch and JAX mapping](https://tensor4all.org/tenferro-rs/getting-started/pytorch-jax-mapping.html).
+Agents and users writing downstream Rust should load the bundled
+[tenferro-compute skill](https://github.com/tensor4all/tenferro-rs/blob/main/.agents/skills/tenferro-compute/SKILL.md)
+for API-tier, crate, import, and pitfall guidance.
 
 Selected deep dives:
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -1,6 +1,8 @@
 project:
   type: website
   output-dir: ../target/docs-site
+  resources:
+    - llms.txt
   render:
     - index.md
     - storage-ownership.md

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,29 @@
+# tenferro
+
+> tenferro is a Rust-native tensor computation stack with opt-in autodiff for scientific workloads: typed tensors, PyTorch-style eager execution, JAX-style traced graphs, einsum, linear algebra, and explicit CPU, CUDA, and experimental WebGPU backend control.
+
+## Getting started
+
+- [Getting Started](https://tensor4all.org/tenferro-rs/getting-started/): Walks through tenferro's tensor layer, execution model, and backend/device choices, including a first CPU program.
+- [PyTorch and JAX Mapping](https://tensor4all.org/tenferro-rs/getting-started/pytorch-jax-mapping.html): Translates common `torch` and `jax.numpy` operations into tenferro's direct, eager, and traced APIs.
+- [Choosing a Tensor API](https://tensor4all.org/tenferro-rs/guides/choosing-an-api.html): Explains how to select the tensor API by value type, execution timing, and backend/device.
+
+## Guides
+
+- [Einsum](https://tensor4all.org/tenferro-rs/guides/einsum.html): Covers the `tenferro-einsum` extension crate, its concrete/eager/traced traits, planning, syntax, and runtime registration.
+- [Linear Algebra](https://tensor4all.org/tenferro-rs/guides/linear-algebra.html): Covers the `tenferro-linalg` operation crate and its direct, eager, and traced execution surfaces.
+- [Autodiff](https://tensor4all.org/tenferro-rs/guides/autodiff.html): Describes eager `backward()` and functional or traced `grad`, `vjp`, and `jvp` workflows.
+- [Parallelism and Caching](https://tensor4all.org/tenferro-rs/guides/parallelism-and-caching.html): Describes CPU thread control, provider oversubscription, executor reuse, and cache management.
+- [Memory Order](https://tensor4all.org/tenferro-rs/guides/memory-order.html): Specifies contiguous column-major storage and leftmost-dimension-fastest layout.
+- [Devices and GPU](https://tensor4all.org/tenferro-rs/guides/devices-and-gpu.html): Documents explicit CPU/GPU placement and transfer boundaries plus CUDA and WebGPU capability coverage.
+- [Troubleshooting](https://tensor4all.org/tenferro-rs/guides/troubleshooting.html): Covers feature selection, BLAS providers, CUDA setup, workspace traps, and common runtime failures.
+
+## Specification
+
+- [API Conventions](https://tensor4all.org/tenferro-rs/spec/api-conventions.html): Normative public API naming, module shape, feature naming, and documentation-surface conventions.
+- [Tensor Semantics](https://tensor4all.org/tenferro-rs/spec/tensor-semantics.html): Defines dense tensor metadata, storage, placement, typed views, and backend boundaries.
+- [Backend Contract](https://tensor4all.org/tenferro-rs/spec/backend-contract.html): Defines the execution pipeline from traced values and extension registration through compiled backend execution.
+
+## Agent skills
+
+- [tenferro-compute skill](https://github.com/tensor4all/tenferro-rs/blob/main/.agents/skills/tenferro-compute/SKILL.md): Helps downstream coding agents choose API tiers, crates, extension-trait imports, performance idioms, and known pitfalls.

--- a/docs/tutorial-code/Cargo.toml
+++ b/docs/tutorial-code/Cargo.toml
@@ -94,6 +94,11 @@ path = "src/bin/extension_snippets.rs"
 required-features = ["doc-snippets"]
 
 [[bin]]
+name = "tenferro_compute_skill"
+path = "src/bin/tenferro_compute_skill.rs"
+required-features = ["doc-snippets"]
+
+[[bin]]
 name = "apple_shared_fft"
 path = "src/bin/apple_shared_fft.rs"
 required-features = ["apple-shared"]

--- a/docs/tutorial-code/src/bin/tenferro_compute_skill.rs
+++ b/docs/tutorial-code/src/bin/tenferro_compute_skill.rs
@@ -1,18 +1,5 @@
 //! Executable examples for the bundled `tenferro-compute` downstream skill.
 
-#![allow(dead_code, unused_imports, unused_variables, unused_mut)]
-
-fn assert_close(actual: &[f64], expected: &[f64]) {
-    assert_eq!(actual.len(), expected.len());
-    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
-        let error = (actual - expected).abs();
-        assert!(
-            error < 1.0e-12,
-            "value {index}: actual={actual}, expected={expected}, error={error}"
-        );
-    }
-}
-
 #[rustfmt::skip]
 fn concrete_operation_and_column_major() -> Result<(), Box<dyn std::error::Error>> {
     // snippet-start:concrete-operation

--- a/docs/tutorial-code/src/bin/tenferro_compute_skill.rs
+++ b/docs/tutorial-code/src/bin/tenferro_compute_skill.rs
@@ -1,0 +1,134 @@
+//! Executable examples for the bundled `tenferro-compute` downstream skill.
+
+#![allow(dead_code, unused_imports, unused_variables, unused_mut)]
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        let error = (actual - expected).abs();
+        assert!(
+            error < 1.0e-12,
+            "value {index}: actual={actual}, expected={expected}, error={error}"
+        );
+    }
+}
+
+fn concrete_operation_and_column_major() -> Result<(), Box<dyn std::error::Error>> {
+    // snippet-start:concrete-operation
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+
+let mut backend = CpuBackend::new();
+// The leftmost dimension varies fastest: this is a 2 x 3 column-major tensor.
+let x = TypedTensor::<f64>::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
+)?;
+let weights = TypedTensor::<f64>::from_vec_col_major(
+    vec![3, 2],
+    vec![0.5, -1.0, 1.5, 1.0, 2.0, -0.5],
+)?;
+let projected = x.matmul(&weights, &mut backend)?;
+assert_eq!(projected.shape(), &[2, 2]);
+assert_eq!(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
+    // snippet-end:concrete-operation
+    Ok(())
+}
+
+fn eager_operation() -> Result<(), Box<dyn std::error::Error>> {
+    // snippet-start:eager-operation
+use tenferro_ad::{EagerRuntime, Tensor};
+
+let runtime = EagerRuntime::new()?;
+let x = runtime.variable_from(Tensor::from_vec_col_major(
+    vec![3],
+    vec![1.0_f64, 2.0, 3.0],
+)?)?;
+let prediction = x.mul(&x)?;
+let loss = prediction.reduce_sum(Some(&[0]))?;
+loss.backward()?;
+assert_eq!(
+    x.grad()?.expect("tracked variable should receive a gradient").as_slice::<f64>()?,
+    &[2.0, 4.0, 6.0],
+);
+    // snippet-end:eager-operation
+    Ok(())
+}
+
+fn traced_operation_with_extension_registration() -> Result<(), Box<dyn std::error::Error>> {
+    // snippet-start:traced-extension-operation
+use tenferro_cpu::{runtime_engine_id, runtime_engine_registration, CpuBackend};
+use tenferro_einsum::TraceContextEinsumExt;
+use tenferro_runtime::program::ProgramInputSpec;
+use tenferro_runtime::{GraphCompiler, Runtime, Tensor, TraceContext};
+
+let a = Tensor::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+)?;
+let b = Tensor::from_vec_col_major(
+    vec![3, 2],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+)?;
+let mut trace = TraceContext::new();
+let a_value = trace.input(ProgramInputSpec::new(a.dtype(), [2.into(), 3.into()]))?;
+let b_value = trace.input(ProgramInputSpec::new(b.dtype(), [3.into(), 2.into()]))?;
+let product = trace.einsum(&[a_value, b_value], "ij,jk->ik")?;
+let graph = trace.finish(&[product])?;
+let program = GraphCompiler::new().compile_traced_graph(&graph)?;
+
+let backend = CpuBackend::new();
+let mut builder = Runtime::builder();
+builder.register_engine(runtime_engine_registration(&backend)?)?;
+builder.install_extension_module(tenferro_einsum::extension_module::<CpuBackend>(
+    runtime_engine_id()?,
+)?)?;
+let runtime = builder.build()?;
+let mut outputs = runtime.run_compiled(&program, &[&a, &b])?;
+let result = outputs.remove(0);
+assert_eq!(result.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
+    // snippet-end:traced-extension-operation
+    Ok(())
+}
+
+fn compile_once_run_many() -> Result<(), Box<dyn std::error::Error>> {
+    // snippet-start:compile-once-run-many
+use tenferro_cpu::{runtime_engine_id, runtime_engine_registration, CpuBackend};
+use tenferro_einsum::TraceContextEinsumExt;
+use tenferro_runtime::program::ProgramInputSpec;
+use tenferro_runtime::{GraphCompiler, Runtime, Tensor, TraceContext};
+
+let mut trace = TraceContext::new();
+let input = trace.input(ProgramInputSpec::new(tenferro_runtime::DType::F64, [2.into()]))?;
+let output = trace.einsum(&[input], "i->i")?;
+let graph = trace.finish(&[output])?;
+// Compile the shape-specialized program once.
+let program = GraphCompiler::new().compile_traced_graph(&graph)?;
+
+// Reuse one backend, extension registration, and runtime for repeated inputs.
+let backend = CpuBackend::new();
+let mut builder = Runtime::builder();
+builder.register_engine(runtime_engine_registration(&backend)?)?;
+builder.install_extension_module(tenferro_einsum::extension_module::<CpuBackend>(
+    runtime_engine_id()?,
+)?)?;
+let runtime = builder.build()?;
+for (input, expected) in [
+    (vec![1.0_f64, 2.0], vec![1.0, 2.0]),
+    (vec![3.0_f64, 4.0], vec![3.0, 4.0]),
+] {
+    let value = Tensor::from_vec_col_major(vec![2], input)?;
+    let mut outputs = runtime.run_compiled(&program, &[&value])?;
+    assert_eq!(outputs.remove(0).as_slice::<f64>()?, &expected);
+}
+    // snippet-end:compile-once-run-many
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    concrete_operation_and_column_major()?;
+    eager_operation()?;
+    traced_operation_with_extension_registration()?;
+    compile_once_run_many()?;
+    Ok(())
+}

--- a/docs/tutorial-code/src/bin/tenferro_compute_skill.rs
+++ b/docs/tutorial-code/src/bin/tenferro_compute_skill.rs
@@ -13,6 +13,7 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
     }
 }
 
+#[rustfmt::skip]
 fn concrete_operation_and_column_major() -> Result<(), Box<dyn std::error::Error>> {
     // snippet-start:concrete-operation
 use tenferro_cpu::CpuBackend;
@@ -35,6 +36,7 @@ assert_eq!(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
     Ok(())
 }
 
+#[rustfmt::skip]
 fn eager_operation() -> Result<(), Box<dyn std::error::Error>> {
     // snippet-start:eager-operation
 use tenferro_ad::{EagerRuntime, Tensor};
@@ -55,6 +57,7 @@ assert_eq!(
     Ok(())
 }
 
+#[rustfmt::skip]
 fn traced_operation_with_extension_registration() -> Result<(), Box<dyn std::error::Error>> {
     // snippet-start:traced-extension-operation
 use tenferro_cpu::{runtime_engine_id, runtime_engine_registration, CpuBackend};
@@ -91,6 +94,7 @@ assert_eq!(result.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
     Ok(())
 }
 
+#[rustfmt::skip]
 fn compile_once_run_many() -> Result<(), Box<dyn std::error::Error>> {
     // snippet-start:compile-once-run-many
 use tenferro_cpu::{runtime_engine_id, runtime_engine_registration, CpuBackend};

--- a/docs/tutorial-code/tests/tutorial_binaries.rs
+++ b/docs/tutorial-code/tests/tutorial_binaries.rs
@@ -68,6 +68,10 @@ fn tutorial_binaries_run_successfully() {
         "extension_snippets",
         env!("CARGO_BIN_EXE_extension_snippets"),
     );
+    run_tutorial(
+        "tenferro_compute_skill",
+        env!("CARGO_BIN_EXE_tenferro_compute_skill"),
+    );
     #[cfg(feature = "apple-shared")]
     {
         run_tutorial("apple_shared_fft", env!("CARGO_BIN_EXE_apple_shared_fft"));

--- a/docs/worklogs/2026-08-07-issues-1610-1613-agent-discoverability.md
+++ b/docs/worklogs/2026-08-07-issues-1610-1613-agent-discoverability.md
@@ -1,0 +1,66 @@
+# Work log: downstream skill and llms.txt discoverability (#1610 + #1613)
+
+## Summary
+
+Implemented the accepted combined batch after #1609: a canonical
+`tenferro-compute` downstream-usage skill with Claude/Kimi mirrors and an
+OpenCode entry point, five executable named snippet regions, a freshness
+checker, and a curated `docs/llms.txt` index published by the Quarto site.
+
+## Context read
+
+- Accepted implementation plans and audit comments on #1610 and #1613.
+- Existing skills under `.agents/skills/`, `.claude/skills/`, `.kimi/skills/`,
+  and `.opencode/commands/`.
+- `scripts/check-doc-snippets.py`, `scripts/check-docs-site.py`,
+  `scripts/build_docs_site.sh`, and the tutorial binary manifest/test.
+- Existing API-choice, PyTorch/JAX mapping, einsum, parallelism/caching,
+  troubleshooting, and CPU-provider documentation.
+- The updated `antheducation/tenferro-rs:add-llms-txt` prototype at commit
+  `561a6d1346845b1661715f3bfe81bb47f523eb44`, preserving its curated-index
+  attribution while retaining the current repository's complete Quarto render
+  and sidebar configuration.
+
+## Decisions
+
+- `.agents/skills/tenferro-compute/` is authoritative. Portable Markdown
+  files are copied byte-for-byte to Claude and Kimi mirrors; the OpenCode entry
+  points at all four canonical references. The OpenAI metadata remains in the
+  canonical `agents/` directory because it is adapter-specific.
+- The existing snippet synchronizer now discovers only the new canonical skill
+  Markdown and checks its Rust fences alongside guides and tutorials. All five
+  runnable examples come from named regions in one tutorial binary; no second
+  compiler or documentation parser was added.
+- `docs/llms.txt` is a tracked, curated 14-entry source. The build copies it to
+  the site root, while `check-docs-site.py` validates its Quarto resource,
+  descriptions, unique URLs, repository-relative documentation targets, and
+  canonical skill target. No Sourcey, crawler, YAML parser, or `llms-full.txt`
+  was added.
+- The skill teaches current direct crates and extension traits, column-major
+  input, backend/runtime reuse, compile-once/run-many, explicit extension
+  registration, einsum syntax, scratch-workspace setup, and CPU/BLAS feature
+  choices without adding an API layer.
+
+## Verification
+
+- RED: skill mirror test initially failed because the checker and canonical
+  skill did not exist; snippet discovery initially failed to include skill
+  Markdown.
+- `python3 scripts/test-check-agent-skills.py` → passed.
+- `python3 scripts/test-check-doc-snippets.py` → passed.
+- `python3 scripts/check-agent-skills.py` → passed.
+- `python3 scripts/check-doc-snippets.py --check` → passed.
+- `cargo check --manifest-path docs/tutorial-code/Cargo.toml
+  --no-default-features --features cpu-faer,doc-snippets --bin
+  tenferro_compute_skill` → passed.
+- `cargo run --manifest-path docs/tutorial-code/Cargo.toml
+  --no-default-features --features cpu-faer,doc-snippets --bin
+  tenferro_compute_skill` → passed.
+- `python3 scripts/test-check-docs-site.py` → passed, including missing-target
+  and duplicate-URL regressions.
+
+## Remaining validation
+
+Run the full tutorial-binary release test, docs-site build and comparison,
+`python3 scripts/check-docs-site.py`, docs CI profile, repository-rules review,
+and hosted CI before merging the combined PR.

--- a/docs/worklogs/2026-08-07-issues-1610-1613-agent-discoverability.md
+++ b/docs/worklogs/2026-08-07-issues-1610-1613-agent-discoverability.md
@@ -33,9 +33,11 @@ checker, and a curated `docs/llms.txt` index published by the Quarto site.
   compiler or documentation parser was added.
 - `docs/llms.txt` is a tracked, curated 14-entry source. The build copies it to
   the site root, while `check-docs-site.py` validates its Quarto resource,
-  descriptions, unique URLs, repository-relative documentation targets, and
-  canonical skill target. No Sourcey, crawler, YAML parser, or `llms-full.txt`
-  was added.
+  descriptions, unique URLs, repository-relative documentation targets,
+  canonical skill target, and the built root copy when a site output exists.
+  The build invokes the skill mirror checker and passes its configurable output
+  directory to Quarto, so custom output validation covers the actual rendered
+  site. No Sourcey, crawler, YAML parser, or `llms-full.txt` was added.
 - The skill teaches current direct crates and extension traits, column-major
   input, backend/runtime reuse, compile-once/run-many, explicit extension
   registration, einsum syntax, scratch-workspace setup, and CPU/BLAS feature
@@ -62,16 +64,19 @@ checker, and a curated `docs/llms.txt` index published by the Quarto site.
 - `cargo run --manifest-path docs/tutorial-code/Cargo.toml
   --no-default-features --features cpu-faer,doc-snippets --bin
   tenferro_compute_skill` → passed.
-- `python3 scripts/test-check-docs-site.py` → passed, including missing-target
-  and duplicate-URL regressions.
-- `bash scripts/build_docs_site.sh /tmp/tenferro-site-1610-1613` → passed;
-  `cmp docs/llms.txt /tmp/tenferro-site-1610-1613/llms.txt` passed and the
+- `python3 scripts/test-check-docs-site.py` → passed, including missing-target,
+  duplicate-URL, and missing-built-root regressions.
+- `python3 scripts/test-doc-consistency.py` → passed, including the docs-build
+  skill-check contract.
+- `bash scripts/build_docs_site.sh /tmp/tenferro-site-1610-1613-review` →
+  passed with Quarto output in the requested directory; root `llms.txt`, the
+  rendered top page, and `guides/choosing-an-api.html` existed, `cmp
+  docs/llms.txt /tmp/tenferro-site-1610-1613-review/llms.txt` passed, and the
   built-site checker verified 14 workspace library crates.
 - `cargo fmt --all --check` → passed after marking the source-region holder
   functions `rustfmt::skip` so extracted snippets retain their display shape.
 
 ## Remaining validation
 
-Run the full tutorial-binary release test, docs-site build and comparison,
-`python3 scripts/check-docs-site.py`, docs CI profile, repository-rules review,
-and hosted CI before merging the combined PR.
+Run the full tutorial-binary release test, docs CI profile,
+repository-rules review, and hosted CI before merging the combined PR.

--- a/docs/worklogs/2026-08-07-issues-1610-1613-agent-discoverability.md
+++ b/docs/worklogs/2026-08-07-issues-1610-1613-agent-discoverability.md
@@ -86,6 +86,9 @@ checker, and a curated `docs/llms.txt` index published by the Quarto site.
   'python3 scripts/check-agent-skills.py'` → passed.
 - `python3 scripts/ci/run_profile.py docs` → passed; the repository-rules
   subtest emitted transient LLM retry warnings but exited successfully.
+- Final `python3 scripts/repository-rules-review.py --base origin/main
+  --head HEAD --output-json /tmp/repository-rules-review-1610-1613-final.json`
+  → pass with no findings.
 - `cargo fmt --all --check` → passed after marking the source-region holder
   functions `rustfmt::skip` so extracted snippets retain their display shape.
 

--- a/docs/worklogs/2026-08-07-issues-1610-1613-agent-discoverability.md
+++ b/docs/worklogs/2026-08-07-issues-1610-1613-agent-discoverability.md
@@ -48,6 +48,11 @@ checker, and a curated `docs/llms.txt` index published by the Quarto site.
   tier/configuration explanations; those points were verified against the
   manifests and corrected in the references. The revision-specific package
   count was removed from the skill text.
+- Independent specification and quality reviews found three validation gaps:
+  missing built-root `llms.txt` checking, custom docs output not being passed to
+  Quarto, and mirror checking not being part of the docs build. They also found
+  a missing-canonical-file exception path. The checker, build script, focused
+  tests, and docs-profile contract now cover all four points.
 
 ## Verification
 
@@ -73,6 +78,14 @@ checker, and a curated `docs/llms.txt` index published by the Quarto site.
   rendered top page, and `guides/choosing-an-api.html` existed, `cmp
   docs/llms.txt /tmp/tenferro-site-1610-1613-review/llms.txt` passed, and the
   built-site checker verified 14 workspace library crates.
+- `cargo test --manifest-path docs/tutorial-code/Cargo.toml --release
+  --no-default-features --features cpu-faer,doc-snippets
+  tutorial_binaries_run_successfully -- --exact` → passed (all 15 tutorial
+  binaries compiled and the exact runtime test passed).
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --doc-snippets --test
+  'python3 scripts/check-agent-skills.py'` → passed.
+- `python3 scripts/ci/run_profile.py docs` → passed; the repository-rules
+  subtest emitted transient LLM retry warnings but exited successfully.
 - `cargo fmt --all --check` → passed after marking the source-region holder
   functions `rustfmt::skip` so extracted snippets retain their display shape.
 

--- a/docs/worklogs/2026-08-07-issues-1610-1613-agent-discoverability.md
+++ b/docs/worklogs/2026-08-07-issues-1610-1613-agent-discoverability.md
@@ -39,7 +39,13 @@ checker, and a curated `docs/llms.txt` index published by the Quarto site.
 - The skill teaches current direct crates and extension traits, column-major
   input, backend/runtime reuse, compile-once/run-many, explicit extension
   registration, einsum syntax, scratch-workspace setup, and CPU/BLAS feature
-  choices without adding an API layer.
+  choices without adding an API layer. CPU examples state their provider
+  features explicitly, and scratch-crate layouts are concrete.
+- A source-blind downstream audit checked only the skill artifacts. It found
+  missing explicit CPU feature flags, scratch-layout ambiguity, and two terse
+  tier/configuration explanations; those points were verified against the
+  manifests and corrected in the references. The revision-specific package
+  count was removed from the skill text.
 
 ## Verification
 
@@ -58,6 +64,11 @@ checker, and a curated `docs/llms.txt` index published by the Quarto site.
   tenferro_compute_skill` → passed.
 - `python3 scripts/test-check-docs-site.py` → passed, including missing-target
   and duplicate-URL regressions.
+- `bash scripts/build_docs_site.sh /tmp/tenferro-site-1610-1613` → passed;
+  `cmp docs/llms.txt /tmp/tenferro-site-1610-1613/llms.txt` passed and the
+  built-site checker verified 14 workspace library crates.
+- `cargo fmt --all --check` → passed after marking the source-region holder
+  functions `rustfmt::skip` so extracted snippets retain their display shape.
 
 ## Remaining validation
 

--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -104,6 +104,7 @@ PY
 }
 
 echo "[1/9] Checking user-facing snippets"
+run_python "$ROOT_DIR/scripts/check-agent-skills.py" --root-dir "$ROOT_DIR"
 run_python "$ROOT_DIR/scripts/check-doc-snippets.py" --root-dir "$ROOT_DIR" --check
 run_python "$ROOT_DIR/scripts/check-guide-dependency-snippets.py" --root-dir "$ROOT_DIR"
 
@@ -167,7 +168,7 @@ FOOTER
 echo "[6/9] Rendering design docs if configured"
 if [[ -f "$ROOT_DIR/docs/_quarto.yml" ]]; then
   if command -v quarto >/dev/null 2>&1; then
-    quarto render "$ROOT_DIR/docs"
+    quarto render "$ROOT_DIR/docs" --output-dir "$OUT_DIR"
   else
     echo "  Warning: quarto not found; design docs site skipped."
     if [[ "${CI:-}" == "true" ]]; then
@@ -183,7 +184,8 @@ echo "[7/9] Checking rendered operation surface references"
 run_python "$ROOT_DIR/scripts/check-operation-categories.py" --fail-on-findings --include-rendered
 
 echo "[8/9] Verifying docs site links and API inventory"
-run_python "$ROOT_DIR/scripts/check-docs-site.py" --root-dir "$ROOT_DIR" --site-index "$API_DIR/index.html"
+run_python "$ROOT_DIR/scripts/check-docs-site.py" --root-dir "$ROOT_DIR" \
+  --site-index "$API_DIR/index.html" --docs-site-root "$OUT_DIR"
 
 echo "[9/9] Verifying site top page"
 REPO_TITLE="$(basename "$ROOT_DIR")"

--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -10,6 +10,7 @@ API_INDEX_MD="$ROOT_DIR/docs/api/index.md"
 
 rm -rf "$OUT_DIR"
 mkdir -p "$API_DIR"
+cp "$ROOT_DIR/docs/llms.txt" "$OUT_DIR/llms.txt"
 
 render_overview_html() {
   if [[ -f "$API_INDEX_MD" ]]; then

--- a/scripts/check-agent-skills.py
+++ b/scripts/check-agent-skills.py
@@ -39,6 +39,8 @@ def check(root: pathlib.Path) -> list[str]:
             mirror_file = mirror / relative
             if not mirror_file.is_file():
                 errors.append(f"missing mirror file: {mirror_relative / relative}")
+            elif not canonical_file.is_file():
+                continue
             elif canonical_file.read_bytes() != mirror_file.read_bytes():
                 errors.append(f"mirror file does not match canonical: {mirror_relative / relative}")
         if mirror.is_dir():

--- a/scripts/check-agent-skills.py
+++ b/scripts/check-agent-skills.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+CANONICAL_SKILL = pathlib.Path(".agents/skills/tenferro-compute")
+MIRROR_SKILLS = (
+    pathlib.Path(".claude/skills/tenferro-compute"),
+    pathlib.Path(".kimi/skills/tenferro-compute"),
+)
+REFERENCE_FILES = (
+    "references/crate-selection.md",
+    "references/api-cheatsheet.md",
+    "references/performance-idioms.md",
+    "references/pitfalls.md",
+)
+PORTABLE_FILES = ("SKILL.md", *REFERENCE_FILES)
+OPENCODE_ENTRY = pathlib.Path(".opencode/commands/tenferro-compute.md")
+
+
+def check(root: pathlib.Path) -> list[str]:
+    errors: list[str] = []
+    canonical = root / CANONICAL_SKILL
+
+    for relative in ("SKILL.md", "agents/openai.yaml", *REFERENCE_FILES):
+        path = canonical / relative
+        if not path.is_file():
+            errors.append(f"missing canonical skill file: {CANONICAL_SKILL / relative}")
+
+    if not canonical.is_dir():
+        return errors
+
+    for mirror_relative in MIRROR_SKILLS:
+        mirror = root / mirror_relative
+        for relative in PORTABLE_FILES:
+            canonical_file = canonical / relative
+            mirror_file = mirror / relative
+            if not mirror_file.is_file():
+                errors.append(f"missing mirror file: {mirror_relative / relative}")
+            elif canonical_file.read_bytes() != mirror_file.read_bytes():
+                errors.append(f"mirror file does not match canonical: {mirror_relative / relative}")
+        if mirror.is_dir():
+            actual = {
+                path.relative_to(mirror).as_posix()
+                for path in mirror.rglob("*.md")
+                if path.is_file()
+            }
+            unexpected = sorted(actual.difference(PORTABLE_FILES))
+            for relative in unexpected:
+                errors.append(f"unexpected mirror Markdown file: {mirror_relative / relative}")
+
+    entry = root / OPENCODE_ENTRY
+    if not entry.is_file():
+        errors.append(f"missing OpenCode entry: {OPENCODE_ENTRY}")
+    else:
+        entry_text = entry.read_text(encoding="utf-8")
+        for relative in REFERENCE_FILES:
+            reference = (CANONICAL_SKILL / relative).as_posix()
+            if reference not in entry_text:
+                errors.append(f"OpenCode entry is missing reference: {reference}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check bundled tenferro agent-skill mirrors.")
+    parser.add_argument("--root-dir", default=pathlib.Path(__file__).resolve().parents[1])
+    args = parser.parse_args()
+    root = pathlib.Path(args.root_dir).resolve()
+    errors = check(root)
+    if errors:
+        print("agent-skill layout errors:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("agent-skills-ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-doc-snippets.py
+++ b/scripts/check-doc-snippets.py
@@ -78,18 +78,30 @@ def fenced(source: str) -> str:
     return "```rust\n" + source.rstrip() + "\n```\n"
 
 
+def canonical_skill_docs(root: pathlib.Path) -> list[pathlib.Path]:
+    skill_root = root / ".agents" / "skills" / "tenferro-compute"
+    if not skill_root.is_dir():
+        return []
+    return sorted(skill_root.rglob("*.md"))
+
+
 def unmarked_rust_fences(root: pathlib.Path) -> list[str]:
     inventory: list[str] = []
-    for directory in (root / "docs" / "guides", root / "docs" / "tutorials"):
-        for doc in sorted(directory.glob("*.md")):
-            marked = False
-            for line_number, line in enumerate(doc.read_text(encoding="utf-8").splitlines(), 1):
-                if START_RE.search(line):
-                    marked = True
-                elif END_RE.search(line):
-                    marked = False
-                elif line.strip() == "```rust" and not marked:
-                    inventory.append(f"{doc.relative_to(root)}:{line_number}")
+    docs = [
+        doc
+        for directory in (root / "docs" / "guides", root / "docs" / "tutorials")
+        for doc in sorted(directory.glob("*.md"))
+    ]
+    docs.extend(canonical_skill_docs(root))
+    for doc in docs:
+        marked = False
+        for line_number, line in enumerate(doc.read_text(encoding="utf-8").splitlines(), 1):
+            if START_RE.search(line):
+                marked = True
+            elif END_RE.search(line):
+                marked = False
+            elif line.strip() == "```rust" and not marked:
+                inventory.append(f"{doc.relative_to(root)}:{line_number}")
     return inventory
 
 
@@ -144,6 +156,7 @@ def user_facing_docs(root: pathlib.Path) -> list[pathlib.Path]:
         if relative.parts and relative.parts[0] in excluded_parts:
             continue
         docs.append(path)
+    docs.extend(canonical_skill_docs(root))
     return docs
 
 

--- a/scripts/check-docs-site.py
+++ b/scripts/check-docs-site.py
@@ -114,7 +114,7 @@ def llms_source_path(root: pathlib.Path, url: str) -> pathlib.Path | None:
     return None
 
 
-def check_llms_index(root: pathlib.Path) -> list[str]:
+def check_llms_index(root: pathlib.Path, docs_site_root: pathlib.Path | None = None) -> list[str]:
     index = root / "docs" / "llms.txt"
     if not index.is_file():
         return ["docs/llms.txt is missing"]
@@ -145,6 +145,8 @@ def check_llms_index(root: pathlib.Path) -> list[str]:
         errors.append(f"docs/llms.txt must link {LLMS_SKILL_PATH}")
     elif not (root / LLMS_SKILL_PATH).is_file():
         errors.append(f"docs/llms.txt skill target does not exist: {LLMS_SKILL_PATH}")
+    if docs_site_root is not None and docs_site_root.exists() and not (docs_site_root / "llms.txt").is_file():
+        errors.append(f"built docs site is missing root llms.txt: {docs_site_root / 'llms.txt'}")
     return errors
 
 
@@ -295,12 +297,6 @@ def main() -> int:
     )
     if snippet_check.returncode != 0:
         return snippet_check.returncode
-    llms_errors = check_llms_index(root)
-    if llms_errors:
-        print("llms.txt validation failed:", file=sys.stderr)
-        for error in llms_errors:
-            print(f"- {error}", file=sys.stderr)
-        return 1
     guide_dependency_check = subprocess.run(
         [
             sys.executable,
@@ -322,6 +318,13 @@ def main() -> int:
         if args.docs_site_root
         else root / "target" / "docs-site"
     )
+
+    llms_errors = check_llms_index(root, docs_site_root)
+    if llms_errors:
+        print("llms.txt validation failed:", file=sys.stderr)
+        for error in llms_errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
 
     crates = load_workspace_libs(root)
     missing_doc = [pkg for _member, pkg, doc_dir in crates if not (doc_root / doc_dir / "index.html").exists()]

--- a/scripts/check-docs-site.py
+++ b/scripts/check-docs-site.py
@@ -16,6 +16,11 @@ except ModuleNotFoundError:  # pragma: no cover - exercised on Python < 3.11
     tomllib = None
 
 
+LLMS_SITE_PREFIX = "/tenferro-rs/"
+LLMS_LINK_RE = re.compile(r"^\s*-\s+\[([^]]+)\]\(([^)]+)\):\s*(\S.*)$", re.MULTILINE)
+LLMS_SKILL_PATH = ".agents/skills/tenferro-compute/SKILL.md"
+
+
 class LinkCollector(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
@@ -90,6 +95,57 @@ def missing_rendered_html_links(site_root: pathlib.Path) -> list[tuple[pathlib.P
             if not target.is_file():
                 missing.append((page, href, target))
     return missing
+
+
+def llms_source_path(root: pathlib.Path, url: str) -> pathlib.Path | None:
+    parsed = urlsplit(url)
+    if parsed.netloc == "tensor4all.org" and parsed.path.startswith(LLMS_SITE_PREFIX):
+        relative = unquote(parsed.path[len(LLMS_SITE_PREFIX) :])
+        if relative.endswith("/"):
+            relative += "index.md"
+        elif relative.endswith(".html"):
+            relative = relative[:-5] + ".md"
+        else:
+            return None
+        return root / "docs" / relative
+    github_prefix = "/tensor4all/tenferro-rs/blob/main/"
+    if parsed.netloc == "github.com" and parsed.path.startswith(github_prefix):
+        return root / unquote(parsed.path[len(github_prefix) :])
+    return None
+
+
+def check_llms_index(root: pathlib.Path) -> list[str]:
+    index = root / "docs" / "llms.txt"
+    if not index.is_file():
+        return ["docs/llms.txt is missing"]
+
+    quarto = root / "docs" / "_quarto.yml"
+    if not quarto.is_file() or not re.search(r"(?m)^\s*-\s*llms\.txt\s*$", quarto.read_text(encoding="utf-8")):
+        return ["docs/_quarto.yml must list llms.txt under project resources"]
+
+    errors: list[str] = []
+    seen_urls: set[str] = set()
+    matches = list(LLMS_LINK_RE.finditer(index.read_text(encoding="utf-8")))
+    if not matches:
+        return ["docs/llms.txt has no described Markdown links"]
+    for match in matches:
+        label, url, description = match.groups()
+        if url in seen_urls:
+            errors.append(f"docs/llms.txt repeats URL: {url}")
+        seen_urls.add(url)
+        if not description.strip():
+            errors.append(f"docs/llms.txt has an empty description for: {label}")
+        target = llms_source_path(root, url)
+        if target is None:
+            errors.append(f"docs/llms.txt has an unsupported URL: {url}")
+        elif not target.is_file():
+            errors.append(f"docs/llms.txt target does not exist: {url} -> {target.relative_to(root)}")
+
+    if not any(url.endswith(LLMS_SKILL_PATH) for url in seen_urls):
+        errors.append(f"docs/llms.txt must link {LLMS_SKILL_PATH}")
+    elif not (root / LLMS_SKILL_PATH).is_file():
+        errors.append(f"docs/llms.txt skill target does not exist: {LLMS_SKILL_PATH}")
+    return errors
 
 
 def check_eager_functional_ad_docs(root: pathlib.Path) -> list[str]:
@@ -239,6 +295,12 @@ def main() -> int:
     )
     if snippet_check.returncode != 0:
         return snippet_check.returncode
+    llms_errors = check_llms_index(root)
+    if llms_errors:
+        print("llms.txt validation failed:", file=sys.stderr)
+        for error in llms_errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
     guide_dependency_check = subprocess.run(
         [
             sys.executable,

--- a/scripts/test-check-agent-skills.py
+++ b/scripts/test-check-agent-skills.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "check_agent_skills", ROOT / "scripts" / "check-agent-skills.py"
+)
+assert SPEC and SPEC.loader
+CHECKER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECKER)
+
+
+def write(path: pathlib.Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def make_skill_root(root: pathlib.Path) -> None:
+    canonical = root / ".agents" / "skills" / "tenferro-compute"
+    required = ["SKILL.md", *CHECKER.REFERENCE_FILES]
+    for relative in required:
+        write(canonical / relative, f"canonical {relative}\n")
+    write(canonical / "agents" / "openai.yaml", "interface:\n  display_name: compute\n")
+
+    for mirror in (root / ".claude" / "skills", root / ".kimi" / "skills"):
+        for relative in required:
+            write(mirror / "tenferro-compute" / relative, f"canonical {relative}\n")
+
+    opencode = root / ".opencode" / "commands" / "tenferro-compute.md"
+    write(
+        opencode,
+        "\n".join(
+            f"@.agents/skills/tenferro-compute/{relative}"
+            for relative in CHECKER.REFERENCE_FILES
+        )
+        + "\n",
+    )
+
+
+def test_complete_skill_layout_passes() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        make_skill_root(root)
+        assert CHECKER.check(root) == []
+
+
+def test_missing_mirror_file_fails() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        make_skill_root(root)
+        (root / ".kimi" / "skills" / "tenferro-compute" / "SKILL.md").unlink()
+        errors = CHECKER.check(root)
+        assert any("missing mirror file" in error for error in errors)
+
+
+def test_mirror_content_drift_fails() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        make_skill_root(root)
+        write(
+            root / ".claude" / "skills" / "tenferro-compute" / "SKILL.md",
+            "stale\n",
+        )
+        errors = CHECKER.check(root)
+        assert any("does not match canonical" in error for error in errors)
+
+
+def test_opencode_missing_reference_fails() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        make_skill_root(root)
+        opencode = root / ".opencode" / "commands" / "tenferro-compute.md"
+        opencode.write_text("@.agents/skills/tenferro-compute/SKILL.md\n", encoding="utf-8")
+        errors = CHECKER.check(root)
+        assert any("OpenCode entry is missing" in error for error in errors)
+
+
+if __name__ == "__main__":
+    for name, value in sorted(globals().items()):
+        if name.startswith("test_"):
+            value()
+    print("check-agent-skills-tests-ok")

--- a/scripts/test-check-agent-skills.py
+++ b/scripts/test-check-agent-skills.py
@@ -48,6 +48,15 @@ def test_complete_skill_layout_passes() -> None:
         assert CHECKER.check(root) == []
 
 
+def test_missing_canonical_file_reports_without_raising() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        make_skill_root(root)
+        (root / ".agents" / "skills" / "tenferro-compute" / "SKILL.md").unlink()
+        errors = CHECKER.check(root)
+        assert any("missing canonical skill file" in error for error in errors)
+
+
 def test_missing_mirror_file_fails() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = pathlib.Path(tmp)

--- a/scripts/test-check-doc-snippets.py
+++ b/scripts/test-check-doc-snippets.py
@@ -111,6 +111,28 @@ def test_no_unmarked_plain_rust_fences_remain() -> None:
     assert inventory == [], "unmarked Rust fences remain: " + ", ".join(inventory)
 
 
+def test_canonical_skill_markdown_is_discovered() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        skill = root / ".agents" / "skills" / "tenferro-compute"
+        skill.mkdir(parents=True)
+        doc = skill / "SKILL.md"
+        doc.write_text("# Skill\n", encoding="utf-8")
+        assert doc in CHECKER.user_facing_docs(root)
+
+
+def test_unmarked_skill_rust_fence_is_reported() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        skill = root / ".agents" / "skills" / "tenferro-compute"
+        skill.mkdir(parents=True)
+        doc = skill / "references" / "pitfalls.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text("```rust\nlet answer = 42;\n```\n", encoding="utf-8")
+        inventory = CHECKER.unmarked_rust_fences(root)
+        assert any(item.startswith(f"{doc.relative_to(root)}:") for item in inventory)
+
+
 if __name__ == "__main__":
     for name, value in sorted(globals().items()):
         if name.startswith("test_"):

--- a/scripts/test-check-docs-site.py
+++ b/scripts/test-check-docs-site.py
@@ -58,12 +58,22 @@ def make_minimal_docs_root(root: pathlib.Path) -> None:
         """
         project:
           type: website
+          resources:
+            - llms.txt
           render:
             - index.md
             - spec/**/*.md
         """,
     )
     write(root / "docs/index.md", "# Home\n")
+    write(root / ".agents/skills/tenferro-compute/SKILL.md", "# Skill\n")
+    write(
+        root / "docs/llms.txt",
+        """
+        - [Extension](https://tensor4all.org/tenferro-rs/spec/extension-op.html): The extension specification.
+        - [Skill](https://github.com/tensor4all/tenferro-rs/blob/main/.agents/skills/tenferro-compute/SKILL.md): Downstream usage guidance.
+        """,
+    )
     write(root / "docs/spec/extension-op.md", "[dynamic shapes](../design/dynamic-symbolic-shapes.md)\n")
     write(
         root / "target/docs-site/spec/extension-op.html",
@@ -71,28 +81,61 @@ def make_minimal_docs_root(root: pathlib.Path) -> None:
     )
 
 
+def run_checker(root: pathlib.Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/check-docs-site.py"),
+            "--root-dir",
+            str(root),
+            "--quiet",
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
 def test_rendered_internal_link_outside_render_set_fails() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         fake_root = pathlib.Path(tmp)
         make_minimal_docs_root(fake_root)
-
-        result = subprocess.run(
-            [
-                sys.executable,
-                str(ROOT / "scripts" / "check-docs-site.py"),
-                "--root-dir",
-                str(fake_root),
-                "--quiet",
-            ],
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-
+        result = run_checker(fake_root)
         assert result.returncode != 0, "rendered links outside the Quarto render set should fail"
         assert "outside the rendered docs set" in result.stderr
 
 
+def test_llms_missing_target_fails() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        fake_root = pathlib.Path(tmp)
+        make_minimal_docs_root(fake_root)
+        write(
+            fake_root / "docs/llms.txt",
+            "- [Missing](https://tensor4all.org/tenferro-rs/spec/missing.html): Not present.\n"
+            "- [Skill](https://github.com/tensor4all/tenferro-rs/blob/main/.agents/skills/tenferro-compute/SKILL.md): Skill.\n",
+        )
+        result = run_checker(fake_root)
+        assert result.returncode != 0
+        assert "target does not exist" in result.stderr
+
+
+def test_llms_duplicate_url_fails() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        fake_root = pathlib.Path(tmp)
+        make_minimal_docs_root(fake_root)
+        write(
+            fake_root / "docs/llms.txt",
+            "- [One](https://tensor4all.org/tenferro-rs/spec/extension-op.html): One.\n"
+            "- [Two](https://tensor4all.org/tenferro-rs/spec/extension-op.html): Two.\n"
+            "- [Skill](https://github.com/tensor4all/tenferro-rs/blob/main/.agents/skills/tenferro-compute/SKILL.md): Skill.\n",
+        )
+        result = run_checker(fake_root)
+        assert result.returncode != 0
+        assert "repeats URL" in result.stderr
+
+
 if __name__ == "__main__":
     test_rendered_internal_link_outside_render_set_fails()
+    test_llms_missing_target_fails()
+    test_llms_duplicate_url_fails()

--- a/scripts/test-check-docs-site.py
+++ b/scripts/test-check-docs-site.py
@@ -39,6 +39,7 @@ def make_minimal_docs_root(root: pathlib.Path) -> None:
     write(root / "crates/demo/src/lib.rs", "pub fn demo() {}\n")
     write(root / "target/doc/demo_crate/index.html", "<html></html>\n")
     write(root / "target/docs-site/api/index.html", '<a href="../demo_crate/index.html">demo</a>\n')
+    write(root / "target/docs-site/llms.txt", "# llms\n")
     write(
         root / "scripts/check-doc-snippets.py",
         """
@@ -120,6 +121,16 @@ def test_llms_missing_target_fails() -> None:
         assert "target does not exist" in result.stderr
 
 
+def test_built_llms_missing_fails() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        fake_root = pathlib.Path(tmp)
+        make_minimal_docs_root(fake_root)
+        (fake_root / "target/docs-site/llms.txt").unlink()
+        result = run_checker(fake_root)
+        assert result.returncode != 0
+        assert "built docs site is missing root llms.txt" in result.stderr
+
+
 def test_llms_duplicate_url_fails() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         fake_root = pathlib.Path(tmp)
@@ -138,4 +149,5 @@ def test_llms_duplicate_url_fails() -> None:
 if __name__ == "__main__":
     test_rendered_internal_link_outside_render_set_fails()
     test_llms_missing_target_fails()
+    test_built_llms_missing_fails()
     test_llms_duplicate_url_fails()

--- a/scripts/test-doc-consistency.py
+++ b/scripts/test-doc-consistency.py
@@ -264,6 +264,7 @@ def test_docs_ci_runs_docs_script_tests() -> None:
     assert "python3 scripts/ci/run_profile.py docs" in text
     assert "python3 scripts/test-check-docs-site.py" in profiles
     assert "python3 scripts/test-doc-consistency.py" in profiles
+    assert 'run_python "$ROOT_DIR/scripts/check-agent-skills.py" --root-dir "$ROOT_DIR"' in build_docs_site
     assert "python3 scripts/test-repository-rules-review.py" in profiles
     assert "python3 scripts/check-guide-dependency-snippets.py" in profiles
     assert "python3 scripts/check-operation-categories.py --fail-on-findings" in profiles


### PR DESCRIPTION
## Type

- [x] Implementation of accepted issue
- [x] Documentation

## Related issue

Fixes #1610
Fixes #1613

## Summary

This is the approved #1610+#1613 batch, landed after #1609.

- Adds the canonical `tenferro-compute` downstream-usage skill with four
  progressive-disclosure references, Claude/Kimi mirrors, and an OpenCode entry.
- Adds named, executable skill examples to the existing tutorial/snippet
  mechanism and checks them in the release tutorial test.
- Links the skill from `README.md` and adds the AGENTS skill-freshness checklist.
- Adds a curated 14-entry `docs/llms.txt`, publishes it as a Quarto resource,
  and validates source and built-site copies, links, descriptions, and URLs.
- Adds focused checker tests and keeps the standalone extension workspaces and
  public API unchanged.

The `llms.txt` curation preserves the contributor prototype attribution:
https://github.com/antheducation/tenferro-rs/tree/add-llms-txt (prototype commit
`561a6d1346845b1661715f3bfe81bb47f523eb44`).

## Work log

- `docs/worklogs/2026-08-07-issues-1610-1613-agent-discoverability.md`

## Validation

- `bash scripts/check-pr-fast.sh --coverage-reviewed --doc-snippets --test 'python3 scripts/check-agent-skills.py'`
- `cargo test --manifest-path docs/tutorial-code/Cargo.toml --release --no-default-features --features cpu-faer,doc-snippets tutorial_binaries_run_successfully -- --exact`
- `python3 scripts/ci/run_profile.py docs`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1610-1613-final.json`
- `cargo fmt --all --check`
