### PR TITLE
docs(errors): add actionable remedy clauses

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -954,6 +954,10 @@ diff-scoped review bot.
   boundaries. Converting a typed error to `String` is permitted only for
   display/logging, vendor/FFI arguments, final serialization, or an explicit
   message-only external protocol boundary.
+- When a documented alternative API, explicit conversion, feature, or
+  supported-value set provides one reliable remediation, append it to the
+  diagnosis as `<what failed>; <what to do>`. Do not invent a remedy for an
+  arbitrary failure when no universal next action exists.
 
 ## Documentation Policy
 

--- a/crates/tenferro-cpu/src/analytic.rs
+++ b/crates/tenferro-cpu/src/analytic.rs
@@ -271,6 +271,15 @@ where
     Ok(T::typed_tensor_into_tensor(out))
 }
 
+fn unsupported_analytic_dtype_message(dtype: DType) -> String {
+    let remedy = matches!(dtype, DType::I32 | DType::I64)
+        .then_some("; convert to F64 with TensorOpsExt::convert before this operation");
+    format!(
+        "CPU backend does not support this operation for {dtype:?}; supported dtypes: F32/F64/C32/C64{}",
+        remedy.unwrap_or("")
+    )
+}
+
 fn require_cpu_capability(
     op_kind: PrimitiveOpKind,
     op: &'static str,
@@ -288,7 +297,7 @@ fn require_cpu_capability(
         Err(crate::Error::unsupported_dtype(
             op,
             dtype,
-            format!("CPU backend does not support this operation for {dtype:?}"),
+            unsupported_analytic_dtype_message(dtype),
         ))
     }
 }

--- a/crates/tenferro-cpu/src/capability.rs
+++ b/crates/tenferro-cpu/src/capability.rs
@@ -154,6 +154,8 @@ const CPU_CAPABILITIES: &[OperationCapability] = &[
     same_dtype(PrimitiveOpKind::Sign, DType::F64, N),
     same_dtype(PrimitiveOpKind::Sign, DType::I32, N),
     same_dtype(PrimitiveOpKind::Sign, DType::I64, N),
+    same_dtype(PrimitiveOpKind::Sign, DType::C32, N),
+    same_dtype(PrimitiveOpKind::Sign, DType::C64, N),
     same_dtype(PrimitiveOpKind::Maximum, DType::F32, N),
     same_dtype(PrimitiveOpKind::Maximum, DType::F64, N),
     same_dtype(PrimitiveOpKind::Maximum, DType::I32, N),

--- a/crates/tenferro-cpu/src/dot_runtime.rs
+++ b/crates/tenferro-cpu/src/dot_runtime.rs
@@ -916,7 +916,7 @@ fn allocate_canonical_operand(
         dtype => Err(Error::unsupported_dtype(
             OP,
             dtype,
-            "CPU contraction providers support floating and complex dtypes",
+            crate::cpu_contraction_unsupported_dtype_message(dtype),
         )),
     }
 }

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -65,7 +65,7 @@ fn allocate_dot_output(
         dtype => Err(crate::Error::unsupported_dtype(
             "dot_general",
             dtype,
-            "CPU contraction providers support floating and complex dtypes",
+            crate::cpu_contraction_unsupported_dtype_message(dtype),
         )),
     }
 }

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -258,7 +258,7 @@ pub(crate) fn scatter_with_pool(
         "scatter",
         operand,
         updates,
-        "Bool data tensors are not supported by additive scatter",
+        "Bool data tensors are not supported by additive scatter; supported data dtypes: F32/F64/I32/I64/C32/C64",
         |op, upd| typed_scatter(
             buffers,
             cache,
@@ -820,12 +820,12 @@ fn try_index_tensor(tensor: &Tensor) -> crate::Result<IndexTensor> {
         Tensor::Bool(_) => Err(crate::Error::invalid_argument(
             "index_tensor",
             "configuration",
-            "bool index tensors are not supported",
+            "bool index tensors are not supported; supported index dtypes: I32/I64/F32/F64",
         )),
         Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::invalid_argument(
             "index_tensor",
             "configuration",
-            "complex index tensors are not supported",
+            "complex index tensors are not supported; supported index dtypes: I32/I64/F32/F64",
         )),
     }
 }

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -93,6 +93,16 @@ use strided_kernel::{col_major_strides as kernel_col_major_strides, StridedView}
 use crate::buffer_pool::BufferPool;
 pub(crate) use tenferro_tensor::*;
 
+pub(crate) fn cpu_contraction_unsupported_dtype_message(dtype: DType) -> String {
+    let remedy = matches!(dtype, DType::I32 | DType::I64).then_some(format!(
+        "; convert {dtype:?} to F64 with TensorOpsExt::convert before contraction"
+    ));
+    format!(
+        "CPU contraction providers support F32/F64/C32/C64{}",
+        remedy.unwrap_or_default()
+    )
+}
+
 pub(crate) fn erased_raw_strided_mut<'a>(
     dtype: strided_kernel::KernelDType,
     data: &'a mut [u8],

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -13,6 +13,29 @@ use tenferro_tensor::{
     DType, Tensor, TensorRank, TensorRead, TensorScalar, TensorView, TypedTensor, TypedTensorView,
 };
 
+fn unsupported_dtype_with_supported(
+    op: &'static str,
+    dtype: DType,
+    supported: &'static str,
+) -> crate::Error {
+    crate::Error::unsupported(
+        op,
+        format!("unsupported dtype {dtype:?}; supported dtypes: {supported}"),
+    )
+}
+
+fn unsupported_sum_squares_dtype(op: &'static str, dtype: DType) -> crate::Error {
+    let remedy = matches!(dtype, DType::I32 | DType::I64)
+        .then_some("; convert to F64 with TensorOpsExt::convert before reduction");
+    crate::Error::unsupported(
+        op,
+        format!(
+            "unsupported dtype {dtype:?}; supported dtypes: F32/F64{}",
+            remedy.unwrap_or_default()
+        ),
+    )
+}
+
 fn validate_axes(op: &'static str, axes: &[usize], rank: usize) -> crate::Result<()> {
     let mut seen = vec![false; rank];
     for &axis in axes {
@@ -198,9 +221,10 @@ pub(crate) fn reduce_sum(
             axes,
             exec_context,
         )?)),
-        Tensor::Bool(_) => Err(crate::Error::unsupported(
+        Tensor::Bool(_) => Err(unsupported_dtype_with_supported(
             "reduce_sum",
-            "unsupported dtype Bool",
+            DType::Bool,
+            "F32/F64/I32/I64/C32/C64",
         )),
         Tensor::C32(t) => Ok(Tensor::C32(typed_reduce_sum(t, axes, exec_context)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_reduce_sum(t, axes, exec_context)?)),
@@ -254,9 +278,10 @@ pub(crate) fn reduce_sum_read(
             "reduce_sum",
             exec_context,
         )?)),
-        TensorRead::View(TensorView::Bool(_)) => Err(crate::Error::unsupported(
+        TensorRead::View(TensorView::Bool(_)) => Err(unsupported_dtype_with_supported(
             "reduce_sum",
-            "unsupported dtype Bool",
+            DType::Bool,
+            "F32/F64/I32/I64/C32/C64",
         )),
         TensorRead::View(TensorView::C32(t)) => Ok(Tensor::C32(typed_reduce_view_erased(
             buffers,
@@ -289,9 +314,9 @@ pub(crate) fn reduce_sum_squares(
     exec_context: &ExecContext,
 ) -> crate::Result<Tensor> {
     if !matches!(input.dtype(), DType::F32 | DType::F64) {
-        return Err(crate::Error::unsupported(
+        return Err(unsupported_sum_squares_dtype(
             "reduce_sum_squares",
-            format!("unsupported dtype {:?}", input.dtype()),
+            input.dtype(),
         ));
     }
     validate_axes("reduce_sum_squares", axes, input.shape().len())?;
@@ -314,9 +339,9 @@ pub(crate) fn reduce_sum_squares(
             "reduce_sum_squares",
             exec_context,
         )?)),
-        _ => Err(crate::Error::unsupported(
+        _ => Err(unsupported_sum_squares_dtype(
             "reduce_sum_squares",
-            format!("unsupported dtype {:?}", input.dtype()),
+            input.dtype(),
         )),
     }
 }
@@ -328,9 +353,9 @@ pub(crate) fn reduce_sum_squares_read(
     exec_context: &ExecContext,
 ) -> crate::Result<Tensor> {
     if !matches!(input.dtype(), DType::F32 | DType::F64) {
-        return Err(crate::Error::unsupported(
+        return Err(unsupported_sum_squares_dtype(
             "reduce_sum_squares",
-            format!("unsupported dtype {:?}", input.dtype()),
+            input.dtype(),
         ));
     }
     validate_axes("reduce_sum_squares", axes, input.shape().len())?;
@@ -360,9 +385,9 @@ pub(crate) fn reduce_sum_squares_read(
             "reduce_sum_squares",
             exec_context,
         )?)),
-        _ => Err(crate::Error::unsupported(
+        _ => Err(unsupported_sum_squares_dtype(
             "reduce_sum_squares",
-            format!("unsupported dtype {:?}", input.dtype()),
+            input.dtype(),
         )),
     }
 }
@@ -395,9 +420,10 @@ pub(crate) fn reduce_prod(
             axes,
             exec_context,
         )?)),
-        Tensor::Bool(_) => Err(crate::Error::unsupported(
+        Tensor::Bool(_) => Err(unsupported_dtype_with_supported(
             "reduce_prod",
-            "unsupported dtype Bool",
+            DType::Bool,
+            "F32/F64/I32/I64/C32/C64",
         )),
         Tensor::C32(t) => Ok(Tensor::C32(typed_reduce_prod(t, axes, exec_context)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_reduce_prod(t, axes, exec_context)?)),
@@ -451,9 +477,10 @@ pub(crate) fn reduce_prod_read(
             "reduce_prod",
             exec_context,
         )?)),
-        TensorRead::View(TensorView::Bool(_)) => Err(crate::Error::unsupported(
+        TensorRead::View(TensorView::Bool(_)) => Err(unsupported_dtype_with_supported(
             "reduce_prod",
-            "unsupported dtype Bool",
+            DType::Bool,
+            "F32/F64/I32/I64/C32/C64",
         )),
         TensorRead::View(TensorView::C32(t)) => Ok(Tensor::C32(typed_reduce_view_erased(
             buffers,
@@ -490,9 +517,10 @@ pub fn reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         Tensor::F64(tensor) => Ok(Tensor::F64(typed_reduce_max(tensor, axes)?)),
         Tensor::I32(tensor) => Ok(Tensor::I32(typed_reduce_max_integer(tensor, axes)?)),
         Tensor::I64(tensor) => Ok(Tensor::I64(typed_reduce_max_integer(tensor, axes)?)),
-        Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::unsupported(
+        Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => Err(unsupported_dtype_with_supported(
             "reduce_max",
-            format!("unsupported dtype {:?}", input.dtype()),
+            input.dtype(),
+            "F32/F64/I32/I64",
         )),
     }
 }
@@ -555,9 +583,10 @@ pub(crate) fn reduce_max_read(
                 "reduce_max",
             )?))
         }
-        view => Err(crate::Error::unsupported(
+        view => Err(unsupported_dtype_with_supported(
             "reduce_max",
-            format!("unsupported dtype {:?}", view.dtype()),
+            view.dtype(),
+            "F32/F64/I32/I64",
         )),
     }
 }
@@ -578,9 +607,10 @@ pub fn reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         Tensor::F64(tensor) => Ok(Tensor::F64(typed_reduce_min(tensor, axes)?)),
         Tensor::I32(tensor) => Ok(Tensor::I32(typed_reduce_min_integer(tensor, axes)?)),
         Tensor::I64(tensor) => Ok(Tensor::I64(typed_reduce_min_integer(tensor, axes)?)),
-        Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::unsupported(
+        Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => Err(unsupported_dtype_with_supported(
             "reduce_min",
-            format!("unsupported dtype {:?}", input.dtype()),
+            input.dtype(),
+            "F32/F64/I32/I64",
         )),
     }
 }
@@ -643,9 +673,10 @@ pub(crate) fn reduce_min_read(
                 "reduce_min",
             )?))
         }
-        view => Err(crate::Error::unsupported(
+        view => Err(unsupported_dtype_with_supported(
             "reduce_min",
-            format!("unsupported dtype {:?}", view.dtype()),
+            view.dtype(),
+            "F32/F64/I32/I64",
         )),
     }
 }

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -2090,8 +2090,8 @@ fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
         Err(crate::Error::UnsupportedDType {
             op: "exp",
             dtype: DType::I64,
-            ..
-        })
+            message,
+        }) if message == "CPU backend does not support this operation for I64; supported dtypes: F32/F64/C32/C64; convert to F64 with TensorOpsExt::convert before this operation"
     ));
     assert!(matches!(
         crate::analytic::exp_read_with_pool(
@@ -2101,10 +2101,22 @@ fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
         Err(crate::Error::UnsupportedDType {
             op: "exp",
             dtype: DType::I64,
-            ..
-        })
+            message,
+        }) if message == "CPU backend does not support this operation for I64; supported dtypes: F32/F64/C32/C64; convert to F64 with TensorOpsExt::convert before this operation"
     ));
     assert!(crate::analytic::pow(&real, &base).is_err());
+}
+
+#[test]
+fn contraction_unsupported_dtype_message_lists_recovery() {
+    assert_eq!(
+        crate::cpu_contraction_unsupported_dtype_message(DType::I64),
+        "CPU contraction providers support F32/F64/C32/C64; convert I64 to F64 with TensorOpsExt::convert before contraction"
+    );
+    assert_eq!(
+        crate::cpu_contraction_unsupported_dtype_message(DType::Bool),
+        "CPU contraction providers support F32/F64/C32/C64"
+    );
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
@@ -728,6 +728,45 @@ fn test_reduce_sum_squares_f32_and_f64() {
 }
 
 #[test]
+fn unsupported_reduction_dtype_messages_prescribe_known_recovery() {
+    let i64s = Tensor::from_vec_col_major(vec![2], vec![1_i64, 2]).unwrap();
+    let mut buffers = crate::buffer_pool::BufferPool::new();
+    let error = reduce_sum_squares(
+        &mut buffers,
+        &i64s,
+        &[0],
+        &strided_kernel::ExecContext::serial(),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        crate::Error::Unsupported {
+            op: "reduce_sum_squares",
+            message,
+        } if message == "unsupported dtype I64; supported dtypes: F32/F64; convert to F64 with TensorOpsExt::convert before reduction"
+    ));
+
+    let complex = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+        )
+        .unwrap(),
+    );
+    let mut backend = CpuBackend::new();
+    let error = backend
+        .reduce_max_read(TensorRead::from_tensor(&complex), &[0])
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        crate::Error::Unsupported {
+            op: "reduce_max",
+            message,
+        } if message == "unsupported dtype C64; supported dtypes: F32/F64/I32/I64"
+    ));
+}
+
+#[test]
 fn test_reduce_sum_squares_read_accepts_noncompact_view() {
     let source =
         TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, -2.0, 3.0, -4.0, 5.0, -6.0])

--- a/crates/tenferro-cpu/src/tests/cpu_tests/capability.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/capability.rs
@@ -56,6 +56,11 @@ fn cpu_capability_table_reports_core_elementwise_reduction_and_dot_support() {
     assert_eq!(neg_i32.result, SupportLevel::Native);
     assert_eq!(neg_i32.write_output, SupportLevel::FallbackCopy);
 
+    let sign_c64 = backend
+        .capability(CapabilityQuery::new(PrimitiveOpKind::Sign, DType::C64))
+        .expect("CPU sign/c64 should be described");
+    assert_eq!(sign_c64.result, SupportLevel::Native);
+
     let neg_i32 = backend
         .require_capability(
             CapabilityQuery::new(PrimitiveOpKind::Neg, DType::I32),

--- a/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
@@ -176,25 +176,31 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
     );
 
     let bools = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]).unwrap();
-    assert!(matches!(
-        backend.reduce_sum_read(
+    let sum_error = backend
+        .reduce_sum_read(
             TensorRead::from_view(TensorView::Bool(bools.as_view())),
-            &[0]
-        ),
-        Err(crate::Error::Unsupported {
+            &[0],
+        )
+        .unwrap_err();
+    assert!(matches!(
+        sum_error,
+        crate::Error::Unsupported {
             op: "reduce_sum",
-            ..
-        })
+            message,
+        } if message == "unsupported dtype Bool; supported dtypes: F32/F64/I32/I64/C32/C64"
     ));
-    assert!(matches!(
-        backend.reduce_prod_read(
+    let prod_error = backend
+        .reduce_prod_read(
             TensorRead::from_view(TensorView::Bool(bools.as_view())),
-            &[0]
-        ),
-        Err(crate::Error::Unsupported {
+            &[0],
+        )
+        .unwrap_err();
+    assert!(matches!(
+        prod_error,
+        crate::Error::Unsupported {
             op: "reduce_prod",
-            ..
-        })
+            message,
+        } if message == "unsupported dtype Bool; supported dtypes: F32/F64/I32/I64/C32/C64"
     ));
     assert_eq!(
         backend
@@ -591,14 +597,65 @@ fn equal_bool_add_and_mul_report_unsupported_dtype_not_mismatch() {
         Err(crate::Error::Unsupported {
             op: "add",
             message,
-        }) if message == "unsupported dtype Bool"
+        }) if message == "unsupported dtype Bool; supported dtypes: F32/F64/I32/I64/C32/C64"
     ));
     assert!(matches!(
         mul(&lhs, &rhs),
         Err(crate::Error::Unsupported {
             op: "mul",
             message,
-        }) if message == "unsupported dtype Bool"
+        }) if message == "unsupported dtype Bool; supported dtypes: F32/F64/I32/I64/C32/C64"
+    ));
+}
+
+#[test]
+fn unsupported_elementwise_dtype_messages_list_operation_sets() {
+    let bool_tensor = Tensor::Bool(TypedTensor::from_vec_col_major(vec![1], vec![true]).unwrap());
+    let i64_tensor = Tensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap();
+
+    assert!(matches!(
+        rem(&bool_tensor, &bool_tensor),
+        Err(crate::Error::Unsupported { op: "rem", message })
+            if message == "unsupported dtype Bool; supported dtypes: F32/F64/I32/I64"
+    ));
+    assert!(matches!(
+        maximum(&bool_tensor, &bool_tensor),
+        Err(crate::Error::Unsupported {
+            op: "maximum",
+            message,
+        }) if message == "unsupported dtype Bool; supported dtypes: F32/F64/I32/I64"
+    ));
+    assert!(matches!(
+        minimum(&bool_tensor, &bool_tensor),
+        Err(crate::Error::Unsupported {
+            op: "minimum",
+            message,
+        }) if message == "unsupported dtype Bool; supported dtypes: F32/F64/I32/I64"
+    ));
+    assert!(matches!(
+        clamp(&bool_tensor, &bool_tensor, &bool_tensor),
+        Err(crate::Error::Unsupported { op: "clamp", message })
+            if message == "unsupported dtype Bool; supported dtypes: F32/F64"
+    ));
+    assert!(matches!(
+        neg(&bool_tensor),
+        Err(crate::Error::Unsupported { op: "neg", message })
+            if message == "unsupported dtype Bool; supported dtypes: F32/F64/I32/I64/C32/C64"
+    ));
+    assert!(matches!(
+        abs(&bool_tensor),
+        Err(crate::Error::Unsupported { op: "abs", message })
+            if message == "unsupported dtype Bool; supported dtypes: F32/F64/I32/I64/C32/C64"
+    ));
+    assert!(matches!(
+        sign(&bool_tensor),
+        Err(crate::Error::Unsupported { op: "sign", message })
+            if message == "unsupported dtype Bool; supported dtypes: F32/F64/I32/I64/C32/C64"
+    ));
+    assert!(matches!(
+        conj(&i64_tensor),
+        Err(crate::Error::Unsupported { op: "conj", message })
+            if message == "unsupported dtype I64; supported dtypes: F32/F64/C32/C64; convert to F64 with TensorOpsExt::convert before this operation"
     ));
 }
 

--- a/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
@@ -80,6 +80,49 @@ fn test_scatter_accepts_i64_indices() {
 }
 
 #[test]
+fn test_scatter_bool_error_lists_supported_data_dtypes() {
+    let operand =
+        Tensor::Bool(TypedTensor::from_vec_col_major(vec![3, 3], vec![false; 9]).unwrap());
+    let scatter_indices =
+        Tensor::from_vec_col_major(vec![3, 2], vec![0_i64, 1, 2, 0, 1, 2]).unwrap();
+    let updates = Tensor::Bool(TypedTensor::from_vec_col_major(vec![3], vec![true; 3]).unwrap());
+
+    let error = scatter(
+        &operand,
+        &scatter_indices,
+        &updates,
+        &diagonal_scatter_config(),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        crate::Error::Unsupported {
+            op: "scatter",
+            message,
+        } if message == "Bool data tensors are not supported by additive scatter; supported data dtypes: F32/F64/I32/I64/C32/C64"
+    ));
+}
+
+#[test]
+fn test_bool_index_error_lists_supported_index_dtypes() {
+    let operand =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![10.0, 20.0, 30.0]).unwrap());
+    let indices = Tensor::Bool(TypedTensor::from_vec_col_major(vec![1, 1], vec![true]).unwrap());
+
+    let error = gather(&operand, &indices, &simple_gather_config()).unwrap_err();
+    assert!(matches!(
+        error,
+        crate::Error::Validation {
+            op: "index_tensor",
+            source: tenferro_tensor::ValidationError::InvalidArgument {
+                argument: "configuration",
+                message,
+            },
+        } if message == "bool index tensors are not supported; supported index dtypes: I32/I64/F32/F64"
+    ));
+}
+
+#[test]
 fn test_scatter_to_diagonal() {
     let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3]).unwrap());
     let scatter_indices =

--- a/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
@@ -113,19 +113,42 @@ fn ternary_dtype_error(op: &'static str, dtypes: [DType; 3]) -> crate::Error {
     } else if dtypes[0] != dtypes[2] {
         dtype_pair_error(op, dtypes[0], dtypes[2])
     } else {
-        crate::Error::unsupported(
-            op,
-            format!("unsupported dtype {:?} for all three inputs", dtypes[0]),
-        )
+        dtype_pair_error(op, dtypes[0], dtypes[0])
     }
 }
 
 fn dtype_pair_error(op: &'static str, lhs: DType, rhs: DType) -> crate::Error {
     if lhs == rhs {
-        crate::Error::unsupported(op, format!("unsupported dtype {lhs:?}"))
+        let supported = match op {
+            "clamp" => "F32/F64",
+            "maximum" | "minimum" | "rem" => "F32/F64/I32/I64",
+            "add" | "mul" | "sub" => "F32/F64/I32/I64/C32/C64",
+            _ => unreachable!("dtype_pair_error has no supported-dtype contract for {op}"),
+        };
+        crate::Error::unsupported(
+            op,
+            format!("unsupported dtype {lhs:?}; supported dtypes: {supported}"),
+        )
     } else {
         crate::Error::dtype_mismatch(op, lhs, rhs)
     }
+}
+
+fn unary_dtype_error(
+    op: &'static str,
+    dtype: DType,
+    supported: &'static str,
+    recommend_f64: bool,
+) -> crate::Error {
+    let remedy = (recommend_f64 && matches!(dtype, DType::I32 | DType::I64))
+        .then_some("; convert to F64 with TensorOpsExt::convert before this operation");
+    crate::Error::unsupported(
+        op,
+        format!(
+            "unsupported dtype {dtype:?}; supported dtypes: {supported}{}",
+            remedy.unwrap_or("")
+        ),
+    )
 }
 
 fn tensor_pair_error(op: &'static str, lhs: &Tensor, rhs: &Tensor) -> crate::Error {
@@ -1427,7 +1450,10 @@ fn execute_erased_fused_outputs(
             .collect(),
         _ => Err(crate::Error::unsupported(
             ELEMENTWISE_FUSION_OP,
-            format!("unsupported dtype {}", dtype.label()),
+            format!(
+                "unsupported dtype {}; supported dtypes: F32/F64/I32/I64/Bool/C32/C64",
+                dtype.label()
+            ),
         )),
     }
 }
@@ -2689,9 +2715,11 @@ pub fn neg_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate::Result<
         Tensor::F64(t) => Ok(Tensor::F64(typed_neg_with_pool(buffers, t)?)),
         Tensor::I32(t) => Ok(Tensor::I32(typed_wrapping_neg_with_pool(buffers, t)?)),
         Tensor::I64(t) => Ok(Tensor::I64(typed_wrapping_neg_with_pool(buffers, t)?)),
-        Tensor::Bool(_) => Err(crate::Error::unsupported(
+        Tensor::Bool(_) => Err(unary_dtype_error(
             "neg",
-            format!("unsupported dtype {:?}", input.dtype()),
+            input.dtype(),
+            "F32/F64/I32/I64/C32/C64",
+            false,
         )),
         Tensor::C32(t) => Ok(Tensor::C32(typed_neg_with_pool(buffers, t)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_neg_with_pool(buffers, t)?)),
@@ -2741,9 +2769,11 @@ pub fn neg_read_with_pool(
             &t,
             |x| -x,
         )?)),
-        _ => Err(crate::Error::unsupported(
+        _ => Err(unary_dtype_error(
             "neg",
-            format!("unsupported dtype {dtype:?}"),
+            dtype,
+            "F32/F64/I32/I64/C32/C64",
+            false,
         )),
     }
 }
@@ -2773,9 +2803,11 @@ pub fn conj_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate::Result
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_conj_with_pool(buffers, t)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_conj_with_pool(buffers, t)?)),
-        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => Err(crate::Error::unsupported(
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => Err(unary_dtype_error(
             "conj",
-            format!("unsupported dtype {:?}", input.dtype()),
+            input.dtype(),
+            "F32/F64/C32/C64",
+            true,
         )),
         Tensor::C32(t) => Ok(Tensor::C32(typed_conj_with_pool(buffers, t)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_conj_with_pool(buffers, t)?)),
@@ -2813,10 +2845,7 @@ pub fn conj_read_with_pool(
             &t,
             |x| x.conj_elem(),
         )?)),
-        _ => Err(crate::Error::unsupported(
-            "conj",
-            format!("unsupported dtype {dtype:?}"),
-        )),
+        _ => Err(unary_dtype_error("conj", dtype, "F32/F64/C32/C64", true)),
     }
 }
 
@@ -2848,9 +2877,11 @@ pub fn abs_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate::Result<
         Tensor::F64(t) => Ok(Tensor::F64(typed_abs_with_pool(buffers, t)?)),
         Tensor::I32(t) => Ok(Tensor::I32(typed_wrapping_abs_with_pool(buffers, t)?)),
         Tensor::I64(t) => Ok(Tensor::I64(typed_wrapping_abs_with_pool(buffers, t)?)),
-        Tensor::Bool(_) => Err(crate::Error::unsupported(
+        Tensor::Bool(_) => Err(unary_dtype_error(
             "abs",
-            format!("unsupported dtype {:?}", input.dtype()),
+            input.dtype(),
+            "F32/F64/I32/I64/C32/C64",
+            false,
         )),
         Tensor::C32(t) => Ok(Tensor::F32(typed_complex_abs_with_pool(buffers, t)?)),
         Tensor::C64(t) => Ok(Tensor::F64(typed_complex_abs_with_pool(buffers, t)?)),
@@ -2890,9 +2921,11 @@ pub fn abs_read_with_pool(
         )?)),
         CpuReadView::C32(t) => Ok(Tensor::F32(typed_complex_abs_view_with_pool(buffers, &t)?)),
         CpuReadView::C64(t) => Ok(Tensor::F64(typed_complex_abs_view_with_pool(buffers, &t)?)),
-        _ => Err(crate::Error::unsupported(
+        _ => Err(unary_dtype_error(
             "abs",
-            format!("unsupported dtype {dtype:?}"),
+            dtype,
+            "F32/F64/I32/I64/C32/C64",
+            false,
         )),
     }
 }
@@ -2923,9 +2956,11 @@ pub fn sign_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate::Result
         Tensor::F64(t) => Ok(Tensor::F64(typed_sign_with_pool(buffers, t)?)),
         Tensor::I32(t) => Ok(Tensor::I32(typed_integer_sign_with_pool(buffers, t)?)),
         Tensor::I64(t) => Ok(Tensor::I64(typed_integer_sign_with_pool(buffers, t)?)),
-        Tensor::Bool(_) => Err(crate::Error::unsupported(
+        Tensor::Bool(_) => Err(unary_dtype_error(
             "sign",
-            format!("unsupported dtype {:?}", input.dtype()),
+            input.dtype(),
+            "F32/F64/I32/I64/C32/C64",
+            false,
         )),
         Tensor::C32(t) => Ok(Tensor::C32(typed_sign_with_pool(buffers, t)?)),
         Tensor::C64(t) => Ok(Tensor::C64(typed_sign_with_pool(buffers, t)?)),
@@ -2975,9 +3010,11 @@ pub fn sign_read_with_pool(
             &t,
             |x| x.sign_elem(),
         )?)),
-        _ => Err(crate::Error::unsupported(
+        _ => Err(unary_dtype_error(
             "sign",
-            format!("unsupported dtype {dtype:?}"),
+            dtype,
+            "F32/F64/I32/I64/C32/C64",
+            false,
         )),
     }
 }

--- a/crates/tenferro-tensor-core/src/error.rs
+++ b/crates/tenferro-tensor-core/src/error.rs
@@ -133,11 +133,11 @@ pub enum ValidationError {
         argument: &'static str,
         message: String,
     },
-    #[error("view is not slice-contiguous")]
+    #[error("view is not slice-contiguous; materialize with to_contiguous before requesting a borrowed slice")]
     NonContiguousViewAsSlice,
     #[error("view metadata is out of borrowed-slice bounds")]
     ViewOutOfBounds,
-    #[error("mutable tensor layout may overlap physical elements")]
+    #[error("mutable tensor layout may overlap physical elements; materialize a contiguous owner before requesting mutable access")]
     OverlappingMutableLayout,
     #[error("integer overflow while validating tensor metadata")]
     IntegerOverflow,

--- a/crates/tenferro-tensor-core/tests/core.rs
+++ b/crates/tenferro-tensor-core/tests/core.rs
@@ -179,6 +179,10 @@ fn reshape_view_as_requires_compact_layout() {
     let non_compact = TensorLayout::<Rank<2>>::from_parts([2, 3], [2, 1], 0, 6).unwrap();
     let err = non_compact.reshape_view_as::<Rank<1>>([6], 6).unwrap_err();
     assert!(matches!(err, ValidationError::NonContiguousViewAsSlice));
+    assert_eq!(
+        err.to_string(),
+        "view is not slice-contiguous; materialize with to_contiguous before requesting a borrowed slice"
+    );
 }
 
 #[test]
@@ -350,10 +354,12 @@ fn layout_reports_overflow_for_unreachable_offset_arithmetic() {
 #[test]
 fn mutable_layout_rejects_zero_stride_broadcast() {
     let layout = TensorLayout::<DynRank>::from_parts(vec![2].into(), vec![0].into(), 0, 1).unwrap();
-    assert!(matches!(
-        layout.validate_mutable_no_overlap(),
-        Err(ValidationError::OverlappingMutableLayout)
-    ));
+    let err = layout.validate_mutable_no_overlap().unwrap_err();
+    assert!(matches!(err, ValidationError::OverlappingMutableLayout));
+    assert_eq!(
+        err.to_string(),
+        "mutable tensor layout may overlap physical elements; materialize a contiguous owner before requesting mutable access"
+    );
 }
 
 #[test]

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -84,6 +84,58 @@ Typed accessors must match the tensor dtype. If `as_slice::<f64>()` fails,
 check whether the tensor was created from `f32`, complex values, or another
 supported scalar type.
 
+## view is not slice-contiguous
+
+A view cannot be exposed as a borrowed slice unless its layout is contiguous.
+Materialize a compact owner with `to_contiguous` before requesting the slice:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/execution_snippets.rs#troubleshooting_11 -->
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::backend::TensorViewCanonicalization;
+use tenferro_tensor::TypedTensor;
+
+let source = TypedTensor::<f64>::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+)?;
+let transposed = source.as_view().transpose_view([1, 0])?;
+let error = transposed.as_slice().unwrap_err();
+assert!(error
+    .to_string()
+    .contains("view is not contiguous column-major"));
+
+let mut backend = CpuBackend::new();
+let compact = backend.to_contiguous(&transposed)?;
+assert_eq!(compact.as_slice()?, &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
+```
+<!-- end-snippet-source -->
+
+## mutable tensor layout may overlap physical elements
+
+Mutable views must not alias one physical element from multiple logical
+positions. Materialize or construct a contiguous owner before requesting
+mutable access:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/execution_snippets.rs#troubleshooting_12 -->
+```rust
+use tenferro_tensor::{TypedTensor, TypedTensorViewMut};
+
+let mut data = [1.0_f64, 2.0];
+let error = TypedTensorViewMut::from_slice(vec![2], vec![0], 0, &mut data).unwrap_err();
+assert!(error
+    .to_string()
+    .contains("mutable tensor layout may overlap physical elements"));
+
+let mut owner = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0])?;
+{
+    let mut view = owner.as_view_mut();
+    *view.get_mut(&[0]).ok_or("index in contiguous owner")? = 3.0;
+}
+assert_eq!(owner.as_slice()?, &[3.0, 2.0]);
+```
+<!-- end-snippet-source -->
+
 ## Column-Major and Row-Major Confusion
 
 `Tensor::from_vec_col_major` expects tenferro's physical column-major order.

--- a/docs/tutorial-code/src/bin/execution_snippets.rs
+++ b/docs/tutorial-code/src/bin/execution_snippets.rs
@@ -165,6 +165,55 @@ assert_eq!(gpu_x.shape(), &[2]);
 
     snippet_troubleshooting_10()?;
 
+    snippet_troubleshooting_11()?;
+
+    // snippet source: docs/guides/troubleshooting.md:87
+    fn snippet_troubleshooting_11() -> Result<(), Box<dyn std::error::Error>> {
+        // snippet-start:troubleshooting_11
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::backend::TensorViewCanonicalization;
+use tenferro_tensor::TypedTensor;
+
+let source = TypedTensor::<f64>::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+)?;
+let transposed = source.as_view().transpose_view([1, 0])?;
+let error = transposed.as_slice().unwrap_err();
+assert!(error
+    .to_string()
+    .contains("view is not contiguous column-major"));
+
+let mut backend = CpuBackend::new();
+let compact = backend.to_contiguous(&transposed)?;
+assert_eq!(compact.as_slice()?, &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
+        // snippet-end:troubleshooting_11
+        Ok(())
+    }
+
+    snippet_troubleshooting_12()?;
+
+    // snippet source: docs/guides/troubleshooting.md:114
+    fn snippet_troubleshooting_12() -> Result<(), Box<dyn std::error::Error>> {
+        // snippet-start:troubleshooting_12
+use tenferro_tensor::{TypedTensor, TypedTensorViewMut};
+
+let mut data = [1.0_f64, 2.0];
+let error = TypedTensorViewMut::from_slice(vec![2], vec![0], 0, &mut data).unwrap_err();
+assert!(error
+    .to_string()
+    .contains("mutable tensor layout may overlap physical elements"));
+
+let mut owner = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0])?;
+{
+    let mut view = owner.as_view_mut();
+    *view.get_mut(&[0]).ok_or("index in contiguous owner")? = 3.0;
+}
+assert_eq!(owner.as_slice()?, &[3.0, 2.0]);
+        // snippet-end:troubleshooting_12
+        Ok(())
+    }
+
     // snippet source: docs/guides/troubleshooting.md:54
     fn snippet_troubleshooting_10() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:troubleshooting_10

--- a/docs/worklogs/2026-08-07-issue-1611-remedy-clauses.md
+++ b/docs/worklogs/2026-08-07-issue-1611-remedy-clauses.md
@@ -1,0 +1,59 @@
+# Work log: issue #1611 remedy clauses
+
+## Context
+
+Issue #1611 requires error messages to prescribe a reliable next action when
+one exists, without changing error variants or adding machine-readable error
+codes. The accepted plan limits this work to the structured-error rule, CPU
+unsupported-dtype families, and the two tensor contiguity messages.
+
+## References checked
+
+- `REPOSITORY_RULES.md` Structured Error Classification
+- `crates/tenferro-tensor-core/src/error.rs`
+- `crates/tenferro-cpu/src/reduction.rs`
+- `crates/tenferro-cpu/src/analytic.rs`
+- `crates/tenferro-cpu/src/exec_session.rs` and `src/dot_runtime.rs`
+- `crates/tenferro-internal-cpu-kernels/src/elementwise.rs`
+- `docs/guides/troubleshooting.md`
+- checked conversion rules in `crates/tenferro-tensor/src/validate/mod.rs`
+
+## Implementation decisions
+
+- Keep all existing error variants and classifications unchanged.
+- List operation-specific supported dtypes instead of introducing a global
+  dtype registry.
+- Recommend `TensorOpsExt::convert` only for source/target pairs accepted by
+  the existing checked promotion lattice. Bool and complex ordered/index
+  cases list supported values without promising a semantic conversion.
+- Keep the concrete tensor remedy callable for runtime tensors; eager and
+  traced users retain their existing inherent `convert` methods.
+- Align the existing CPU `Sign` capability descriptors with the already
+  implemented C32/C64 dispatch so supported-dtype messages and capability
+  queries agree.
+- Use the existing named tutorial-snippet mechanism for troubleshooting
+  examples; no second Markdown compiler or checker was added.
+- Keep the high-level `TypedTensorView::as_slice` example keyed to its
+  existing `view is not contiguous column-major` diagnostic, while the
+  tensor-core `NonContiguousViewAsSlice` variant retains its separate
+  `view is not slice-contiguous` remedy text and classification.
+
+## Verification
+
+- `cargo test -p tenferro-tensor-core --test core`
+- `cargo test -p tenferro-cpu --lib`
+- `cargo test -p tenferro-tensor error`
+- `cargo test --workspace --release`
+- `python3 scripts/check-doc-snippets.py --check`
+- `python3 scripts/ci/run_profile.py fmt clippy`
+- `python3 scripts/ci/run_profile.py docs`
+- `cargo llvm-cov --workspace --exclude tenferro-tutorial-code --profile ci --json --output-path /tmp/coverage-1611-ci.json` plus `scripts/check-coverage.py` (191/191 files)
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1611.json` (pass, 0 findings)
+- `cargo fmt --all --check`
+- `git diff --check`
+
+## Residual risks
+
+Dtype remedies remain intentionally operation-specific. Messages do not claim
+that conversions are lossless; callers must choose a target appropriate to the
+operation and their numeric semantics.


### PR DESCRIPTION
## Type

- [x] Implementation of accepted issue
- [x] Documentation

## Related issue

Fixes #1611

## Summary

Add reliable, operation-specific remedy clauses to the structured error paths covered by the accepted #1611 plan.

- Require `<diagnosis>; <remedy>` when an existing documented API, conversion, feature, or supported-value set gives a reliable next action.
- Update CPU unsupported-dtype diagnostics with each operation's actual supported dtypes and callable conversion guidance only where the existing conversion lattice supports it.
- Add exact actionable text for `NonContiguousViewAsSlice` and `OverlappingMutableLayout` without changing error variants or classifications.
- Add troubleshooting guidance backed by the existing compiled named-snippet mechanism.

## Work log

`docs/worklogs/2026-08-07-issue-1611-remedy-clauses.md`

## Scope and classification

This is the accepted repository-remediation plan for #1611, not new feature work. The scoped findings were classified as **Auto Fix**: they repair existing diagnostics and documentation contracts without adding public APIs, error codes, registries, dependencies, or duplicate validation.

The rule inventory reused and tightened the existing `REPOSITORY_RULES.md` Structured Error Classification section rather than adding a parallel policy. A neighborhood scan covered CPU `unsupported`/`unsupported_dtype` sites, internal elementwise diagnostics, tensor-core contiguity/overlap variants, conversion validation, and the adjacent troubleshooting/snippet paths. Related findings requiring a new policy or unreliable guessed remedy were intentionally left unchanged.

## Verification

- `python3 scripts/ci/run_profile.py fmt clippy`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --exclude tenferro-tutorial-code --profile ci --json --output-path /tmp/coverage-1611-ci.json`
- `python3 scripts/check-coverage.py /tmp/coverage-1611-ci.json` (191/191 files passed)
- `python3 scripts/ci/run_profile.py docs`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-tensor-core'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1611-final.json` (pass, 0 findings)
- `git diff --check`

The docs build reports the optional Graphviz dependency graph as skipped because `dot` is not installed; all required docs-site, API inventory, snippet, and guide checks pass. CUDA/GPU checks are not applicable because this change does not modify GPU code or placement behavior.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
