### PR TITLE
feat: add crate-local preludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,9 @@ tenferro-linalg = "0.2"
 <!-- snippet-source: docs/tutorial-code/src/bin/direct_linalg_quickstart.rs -->
 ```rust
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
-use tenferro_linalg::LinalgBackend;
-use tenferro_runtime::{
-    BackendSessionHost, TensorRead, TensorView, TypedTensor, TypedTensorOpsExt,
-};
+use tenferro_linalg::prelude::*;
+use tenferro_runtime::prelude::*;
+use tenferro_runtime::{TensorRead, TensorView};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());

--- a/crates/tenferro-ad/Cargo.toml
+++ b/crates/tenferro-ad/Cargo.toml
@@ -74,3 +74,7 @@ harness = false
 [[test]]
 name = "integration"
 path = "tests/integration.rs"
+
+[[test]]
+name = "prelude"
+path = "tests/prelude.rs"

--- a/crates/tenferro-ad/src/lib.rs
+++ b/crates/tenferro-ad/src/lib.rs
@@ -36,6 +36,7 @@ pub(crate) mod eager_exec;
 pub(crate) mod eager_ops;
 pub(crate) mod eager_ops_elementwise;
 pub mod extension;
+pub mod prelude;
 // semantic_compat removed in Unification 7.
 pub mod semantic_extension;
 pub mod semantic_transform;

--- a/crates/tenferro-ad/src/prelude.rs
+++ b/crates/tenferro-ad/src/prelude.rs
@@ -1,0 +1,7 @@
+//! Common eager and traced automatic-differentiation entry points.
+
+pub use crate::{
+    AdContext, AdContextBuilder, CpuPlacementBoundEager, EagerNoGradGuard, EagerRuntime,
+    EagerTensor, TracedTensorAdExt,
+};
+pub use tenferro_runtime::{Tensor, TracedTensor};

--- a/crates/tenferro-ad/tests/prelude.rs
+++ b/crates/tenferro-ad/tests/prelude.rs
@@ -1,0 +1,9 @@
+use tenferro_ad::prelude::*;
+
+#[test]
+fn prelude_calls_traced_ad_operation() {
+    let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap();
+    let loss = (&x * &x).unwrap();
+    let gradient = loss.grad(&x).unwrap();
+    assert_eq!(gradient.rank, 0);
+}

--- a/crates/tenferro-einsum/Cargo.toml
+++ b/crates/tenferro-einsum/Cargo.toml
@@ -104,3 +104,7 @@ harness = false
 [[test]]
 name = "integration"
 path = "tests/integration.rs"
+
+[[test]]
+name = "prelude"
+path = "tests/prelude.rs"

--- a/crates/tenferro-einsum/src/lib.rs
+++ b/crates/tenferro-einsum/src/lib.rs
@@ -72,6 +72,7 @@ mod extension;
 pub mod lowering;
 mod optimize;
 mod planning;
+pub mod prelude;
 mod subscripts;
 mod syntax;
 mod tensordot;

--- a/crates/tenferro-einsum/src/prelude.rs
+++ b/crates/tenferro-einsum/src/prelude.rs
@@ -1,0 +1,18 @@
+//! Einsum and tensordot extension traits for concrete, eager, and traced values.
+
+pub use crate::{
+    ContractionTree, EinsumOptimize, EinsumSubscripts, TensorDotAxes, TensorEinsumExt,
+    TensorEinsumIntoExt, TensorReadEinsumExt, TensorReadEinsumIntoExt, TensorTensordotExt,
+    TraceContextEinsumExt, TracedTensorEinsumExt, TypedTensorEinsumExt, TypedTensorEinsumIntoExt,
+    TypedTensorReadEinsumExt, TypedTensorReadEinsumIntoExt, TypedTensorTensordotExt,
+};
+pub use tenferro_runtime::{
+    DType, Tensor, TensorBackend, TensorRead, TensorScalar, TensorView, TraceContext, TraceValue,
+    TracedTensor, TypedTensor, TypedTensorView,
+};
+pub use tenferro_tensor::{DotGeneralAccumulation, TensorWrite, TypedTensorWrite};
+
+#[cfg(feature = "autodiff")]
+pub use crate::{EagerEinsumExt, EagerTensorEinsumExt};
+#[cfg(feature = "autodiff")]
+pub use tenferro_ad::{EagerRuntime, EagerTensor};

--- a/crates/tenferro-einsum/tests/prelude.rs
+++ b/crates/tenferro-einsum/tests/prelude.rs
@@ -1,0 +1,29 @@
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::prelude::*;
+
+#[test]
+fn prelude_calls_concrete_einsum() {
+    let lhs = Tensor::from_vec_col_major([2, 3], vec![1.0_f64; 6]).unwrap();
+    let rhs = Tensor::from_vec_col_major([3, 2], vec![1.0_f64; 6]).unwrap();
+    let mut backend = CpuBackend::new();
+    let result = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend).unwrap();
+    assert_eq!(result.shape(), &[2, 2]);
+}
+
+#[cfg(feature = "autodiff")]
+#[test]
+fn prelude_calls_eager_einsum() {
+    let runtime = EagerRuntime::with_cpu_backend(CpuBackend::new()).unwrap();
+    let lhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major([2, 3], vec![1.0_f64; 6]).unwrap(),
+        runtime.clone(),
+    )
+    .unwrap();
+    let rhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major([3, 2], vec![1.0_f64; 6]).unwrap(),
+        runtime,
+    )
+    .unwrap();
+    let result = [&lhs, &rhs].einsum("ij,jk->ik").unwrap();
+    assert_eq!(result.shape(), &[2, 2]);
+}

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -67,3 +67,7 @@ required-features = ["webgpu"]
 name = "webgpu_metal_fft"
 path = "tests/webgpu_metal_fft.rs"
 required-features = ["webgpu"]
+
+[[test]]
+name = "prelude"
+path = "tests/prelude.rs"

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -154,6 +154,7 @@ mod cache;
 mod cpu;
 #[cfg(feature = "autodiff")]
 mod eager_ext;
+pub mod prelude;
 mod spec;
 #[cfg(feature = "webgpu")]
 mod webgpu;

--- a/crates/tenferro-fft/src/prelude.rs
+++ b/crates/tenferro-fft/src/prelude.rs
@@ -1,0 +1,10 @@
+//! FFT extension traits and common transform types.
+
+pub use crate::{FftBackend, FftNorm, TensorFftExt, TensorReadFftExt, TracedTensorFftExt};
+pub use tenferro_runtime::{Tensor, TensorRead, TracedTensor};
+pub use tenferro_tensor::BackendSessionHost;
+
+#[cfg(feature = "autodiff")]
+pub use crate::EagerTensorFftExt;
+#[cfg(feature = "autodiff")]
+pub use tenferro_ad::{EagerRuntime, EagerTensor};

--- a/crates/tenferro-fft/tests/prelude.rs
+++ b/crates/tenferro-fft/tests/prelude.rs
@@ -1,0 +1,34 @@
+use num_complex::Complex64;
+use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_fft::prelude::*;
+
+#[test]
+fn prelude_calls_concrete_fft_operation() {
+    let input = Tensor::from_vec_col_major([4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let mut backend = CpuBackend::new();
+    let spectrum = backend
+        .with_backend_session(|session| {
+            with_cpu_exec_session(session, |exec_session| {
+                input.fft(None, -1, FftNorm::Backward, exec_session)
+            })
+            .expect("CpuBackend must expose a CPU execution session")
+        })
+        .unwrap();
+    assert_eq!(
+        spectrum.as_slice::<Complex64>().unwrap()[0],
+        Complex64::new(10.0, 0.0)
+    );
+}
+
+#[cfg(feature = "autodiff")]
+#[test]
+fn prelude_calls_eager_fft_operation() {
+    let runtime = EagerRuntime::with_cpu_backend(CpuBackend::new()).unwrap();
+    let input = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major([4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
+        runtime,
+    )
+    .unwrap();
+    let spectrum = input.rfft(None, -1, FftNorm::Backward).unwrap();
+    assert_eq!(spectrum.shape(), &[3]);
+}

--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -114,3 +114,7 @@ required-features = ["autodiff", "__bench_unification_semantic_ad_api"]
 [[test]]
 name = "integration"
 path = "tests/integration.rs"
+
+[[test]]
+name = "prelude"
+path = "tests/prelude.rs"

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -50,6 +50,7 @@ pub mod error;
 mod extension;
 #[cfg(feature = "cuda")]
 mod gpu;
+pub mod prelude;
 mod tensor_ext;
 mod traced;
 mod validation;

--- a/crates/tenferro-linalg/src/prelude.rs
+++ b/crates/tenferro-linalg/src/prelude.rs
@@ -1,0 +1,15 @@
+//! Linear algebra extension traits and their method-resolution types.
+
+pub use crate::{EighOptions, QrOptions, SvdOptions};
+pub use crate::{
+    LinalgBackend, LinalgScalar, TensorLinalgExt, TensorReadLinalgExt, TracedTensorLinalgExt,
+    TypedEig, TypedFullPivLu, TypedLu, TypedSvd, TypedTensorLinalgExt,
+};
+
+pub use tenferro_runtime::{Tensor, TensorRead, TracedTensor, TypedTensor};
+pub use tenferro_tensor::BackendSessionHost;
+
+#[cfg(feature = "autodiff")]
+pub use crate::EagerTensorLinalgExt;
+#[cfg(feature = "autodiff")]
+pub use tenferro_ad::{EagerRuntime, EagerTensor};

--- a/crates/tenferro-linalg/tests/prelude.rs
+++ b/crates/tenferro-linalg/tests/prelude.rs
@@ -1,0 +1,28 @@
+use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_linalg::prelude::*;
+
+#[test]
+fn prelude_calls_concrete_linalg_operation() {
+    let input = Tensor::from_vec_col_major([2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap();
+    let mut backend = CpuBackend::new();
+    let (_u, singular_values, _vt) = backend
+        .with_backend_session(|session| {
+            with_cpu_exec_session(session, |exec_session| input.svd(exec_session))
+                .expect("CpuBackend must expose a CPU execution session")
+        })
+        .unwrap();
+    assert_eq!(singular_values.shape(), &[2]);
+}
+
+#[cfg(feature = "autodiff")]
+#[test]
+fn prelude_calls_eager_linalg_operation() {
+    let runtime = EagerRuntime::with_cpu_backend(CpuBackend::new()).unwrap();
+    let input = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major([2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap(),
+        runtime,
+    )
+    .unwrap();
+    let (_u, singular_values, _vt) = input.svd().unwrap();
+    assert_eq!(singular_values.shape(), &[2]);
+}

--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -52,3 +52,7 @@ harness = false
 [[test]]
 name = "integration"
 path = "tests/integration.rs"
+
+[[test]]
+name = "prelude"
+path = "tests/prelude.rs"

--- a/crates/tenferro-runtime/src/lib.rs
+++ b/crates/tenferro-runtime/src/lib.rs
@@ -48,6 +48,7 @@ pub mod extension_cache;
 mod extension_execution_context;
 pub mod graph;
 mod metadata;
+pub mod prelude;
 pub mod program;
 pub mod runtime;
 #[doc(hidden)]

--- a/crates/tenferro-runtime/src/prelude.rs
+++ b/crates/tenferro-runtime/src/prelude.rs
@@ -1,0 +1,7 @@
+//! Common runtime tensor and graph types plus backend-explicit operations.
+
+pub use crate::{
+    CompareDir, DType, GraphCompiler, Runtime, Tensor, TensorBackend, TensorOpsExt, TensorScalar,
+    TraceContext, TraceValue, TracedGraph, TracedTensor, TypedTensor, TypedTensorMaskOpsExt,
+    TypedTensorOpsExt,
+};

--- a/crates/tenferro-runtime/tests/prelude.rs
+++ b/crates/tenferro-runtime/tests/prelude.rs
@@ -1,0 +1,11 @@
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::prelude::*;
+
+#[test]
+fn prelude_calls_backend_explicit_tensor_operation() {
+    let lhs = Tensor::from_vec_col_major([2], vec![1.0_f64, 2.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major([2], vec![3.0_f64, 4.0]).unwrap();
+    let mut backend = CpuBackend::new();
+    let sum = lhs.add(&rhs, &mut backend).unwrap();
+    assert_eq!(sum.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+}

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -58,6 +58,7 @@ pub mod capability;
 pub mod config;
 pub mod dispatch;
 pub mod error;
+pub mod prelude;
 pub mod types;
 pub mod validate;
 

--- a/crates/tenferro-tensor/src/prelude.rs
+++ b/crates/tenferro-tensor/src/prelude.rs
@@ -1,0 +1,6 @@
+//! Common tensor types for constructing and inspecting values.
+
+pub use crate::{
+    DType, DynRank, Rank, Tensor, TensorRead, TensorScalar, TensorView, TypedTensor,
+    TypedTensorView,
+};

--- a/crates/tenferro-tensor/tests/prelude.rs
+++ b/crates/tenferro-tensor/tests/prelude.rs
@@ -1,0 +1,12 @@
+use tenferro_tensor::prelude::*;
+
+#[test]
+fn prelude_constructs_owned_typed_and_erased_values() {
+    let typed = TypedTensor::<f64, Rank<2>>::from_vec_col_major([2, 2], vec![1.0; 4]).unwrap();
+    let view = typed.as_view();
+    assert_eq!(view.shape(), &[2, 2]);
+
+    let tensor = Tensor::from_vec_col_major([2], vec![1.0_f64, 2.0]).unwrap();
+    let read = TensorRead::from_tensor(&tensor);
+    assert_eq!(read.dtype(), DType::F64);
+}

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -134,10 +134,9 @@ tenferro-linalg = { path = "/path/to/tenferro-rs/crates/tenferro-linalg", featur
 <!-- snippet-source: docs/tutorial-code/src/bin/direct_linalg_quickstart.rs -->
 ```rust
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
-use tenferro_linalg::LinalgBackend;
-use tenferro_runtime::{
-    BackendSessionHost, TensorRead, TensorView, TypedTensor, TypedTensorOpsExt,
-};
+use tenferro_linalg::prelude::*;
+use tenferro_runtime::prelude::*;
+use tenferro_runtime::{TensorRead, TensorView};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -2,6 +2,16 @@
 
 This page is a translation guide for readers who already know `torch` or `jax.numpy`: find the tenferro equivalent quickly, then read [Core Concepts](./core-concepts.md) for tenferro's own mental model.
 
+## Import styles
+
+A focused module can keep its dependencies explicit with direct imports such as
+`use tenferro_runtime::{Tensor, TensorOpsExt};` and
+`use tenferro_linalg::{LinalgBackend, TensorLinalgExt};`. A tutorial or a
+module that uses several operation families can use the equivalent crate-local
+preludes: `use tenferro_runtime::prelude::*;` and
+`use tenferro_linalg::prelude::*;`. These imports only affect name lookup;
+backend and device choices remain explicit.
+
 ## Concept mapping
 
 | Concept | PyTorch | JAX | tenferro |

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -24,6 +24,17 @@ Quick reference:
 | Immediate forward execution in one runtime, optionally `backward()` or functional `grad`/`vjp`/`jvp` | `EagerTensor` + `EagerRuntime` |
 | `grad`, `vjp`, `jvp`, HVP via composition, graph reuse | `TracedTensor` + `GraphCompiler` + `Runtime::run_compiled` |
 
+## Import Style
+
+Use direct imports when a small module should make its dependencies explicit:
+`use tenferro_runtime::{Tensor, TensorOpsExt};` and
+`use tenferro_linalg::{LinalgBackend, TensorLinalgExt};`. For tutorials or
+modules using several operation traits, the equivalent crate-local preludes are
+`use tenferro_runtime::prelude::*;` and `use tenferro_linalg::prelude::*;`.
+There is no facade prelude: keep each operation family imported from its own
+crate. The prelude imports extension traits and common associated types; it
+does not change backend selection or execution semantics.
+
 ## Tensor Types
 
 `TypedTensor<T, R = DynRank>` owns runtime tensor data with a compile-time

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,10 +33,9 @@ compilation, CUDA, or experimental WebGPU only when the workflow needs them.
 <!-- snippet-source: docs/tutorial-code/src/bin/direct_linalg_quickstart.rs -->
 ```rust
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
-use tenferro_linalg::LinalgBackend;
-use tenferro_runtime::{
-    BackendSessionHost, TensorRead, TensorView, TypedTensor, TypedTensorOpsExt,
-};
+use tenferro_linalg::prelude::*;
+use tenferro_runtime::prelude::*;
+use tenferro_runtime::{TensorRead, TensorView};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());

--- a/docs/tutorial-code/src/bin/direct_linalg_quickstart.rs
+++ b/docs/tutorial-code/src/bin/direct_linalg_quickstart.rs
@@ -1,8 +1,7 @@
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
-use tenferro_linalg::LinalgBackend;
-use tenferro_runtime::{
-    BackendSessionHost, TensorRead, TensorView, TypedTensor, TypedTensorOpsExt,
-};
+use tenferro_linalg::prelude::*;
+use tenferro_runtime::prelude::*;
+use tenferro_runtime::{TensorRead, TensorView};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());

--- a/docs/worklogs/2026-08-07-issue-1612-prelude.md
+++ b/docs/worklogs/2026-08-07-issue-1612-prelude.md
@@ -1,0 +1,60 @@
+# Work log: issue #1612 crate preludes
+
+## Context
+
+Issue #1612 accepted crate-local preludes for six user-facing crates so
+examples can import operation traits without a facade crate. The change must
+preserve existing feature gates and backend-explicit execution while making
+prelude exports discoverable and testable.
+
+## References checked
+
+- Accepted implementation plan on issue #1612
+- `crates/*/src/lib.rs` public exports and extension-trait definitions
+- Six crate manifests and existing `autotests = false` integration-test
+  registrations
+- Existing README/tutorial named-snippet workflow
+- Current docs navigation in `docs/_quarto.yml`
+- Existing eager, concrete, and traced examples in the operation-family crates
+
+## Decisions
+
+- Use one explicit `src/prelude.rs` per user-facing crate and re-export only
+  existing public names; no root facade, compatibility aliases, macros,
+  generators, or dependency-internal globs.
+- Include every public `*Ext` trait in its owning crate's prelude. Common
+  receiver/value types are included only when they make the prelude useful for
+  method resolution and examples.
+- Preserve feature gates on autodiff-gated eager traits and add integration
+  tests that actually call representative eager methods under `autodiff`.
+- Register `tests/prelude.rs` explicitly where the crate disables Cargo's
+  automatic test discovery.
+- Keep direct imports documented as an alternative to crate-local preludes;
+  backend/device selection remains explicit and there is no facade prelude.
+- The current API-choice guide lives at `docs/guides/choosing-an-api.md`, as
+  confirmed by `_quarto.yml`; the accepted plan's older path was not created.
+- Use a small source-contract checker for public `*Ext` parity, without adding
+  a runtime registry or code generator.
+
+## Verification
+
+- Six default-feature prelude tests and three autodiff-feature prelude tests
+- `scripts/check-prelude-contract.py`
+- `scripts/check-no-facade-crate.py`
+- `scripts/check-doc-snippets.py --check`
+- `cargo test -p tenferro-tutorial-code --test tutorial_binaries`
+- `python3 scripts/test-doc-consistency.py`
+- `python3 scripts/ci/run_profile.py fmt clippy`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --exclude tenferro-tutorial-code --profile ci`
+  plus coverage gate: 191/191 files passed
+- `python3 scripts/ci/run_profile.py docs` (docs-site/API inventory passed;
+  optional Graphviz dependency graph skipped because `dot` is unavailable)
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-runtime --test prelude'`
+- Repository-rules review: pass, no kept findings
+
+## Residual risks
+
+CUDA, ROCm, WebGPU, and macOS-only feature combinations were not exercised
+locally. No backend implementation or feature declaration was changed; hosted
+CI remains the required cross-platform verification boundary.

--- a/scripts/check-prelude-contract.py
+++ b/scripts/check-prelude-contract.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Keep every public extension trait reachable from its crate prelude."""
+
+from pathlib import Path
+import re
+import sys
+
+CRATES = (
+    "tenferro-tensor",
+    "tenferro-runtime",
+    "tenferro-einsum",
+    "tenferro-linalg",
+    "tenferro-fft",
+    "tenferro-ad",
+)
+TRAIT_RE = re.compile(r"\bpub\s+trait\s+([A-Za-z_][A-Za-z0-9_]*Ext)\b")
+USE_RE = re.compile(r"\bpub\s+use\s+[^;]+;")
+NAME_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*Ext)\b")
+
+
+def public_extension_traits(crate: Path) -> set[str]:
+    names: set[str] = set()
+    for path in (crate / "src").rglob("*.rs"):
+        if "tests" not in path.parts:
+            names.update(TRAIT_RE.findall(path.read_text()))
+    return names
+
+
+def prelude_extension_traits(crate: Path) -> set[str]:
+    text = (crate / "src" / "prelude.rs").read_text()
+    names: set[str] = set()
+    for statement in USE_RE.findall(text):
+        names.update(NAME_RE.findall(statement))
+    return names
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    failed = False
+    for crate_name in CRATES:
+        crate = root / "crates" / crate_name
+        public = public_extension_traits(crate)
+        prelude = prelude_extension_traits(crate)
+        missing = sorted(public - prelude)
+        extra = sorted(prelude - public)
+        if missing or extra:
+            failed = True
+            print(f"{crate_name}: public={sorted(public)} prelude={sorted(prelude)}")
+            if missing:
+                print(f"  missing from prelude: {', '.join(missing)}")
+            if extra:
+                print(f"  not declared public in crate: {', '.join(extra)}")
+        else:
+            print(f"{crate_name}: {len(public)} public *Ext traits covered")
+    return int(failed)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Type

- [x] Implementation of accepted issue
- [x] Documentation

## Related issue

Fixes #1612

## Summary

Add conventional crate-local preludes to the six accepted user-facing crates:

- `tenferro-tensor`
- `tenferro-runtime`
- `tenferro-einsum`
- `tenferro-linalg`
- `tenferro-fft`
- `tenferro-ad`

Each prelude is explicit and documented, preserves existing feature gates, and exports the crate's public extension traits plus the common receiver/value types needed for method resolution. The change adds representative default-feature and autodiff-gated eager integration tests, a focused public-`*Ext` parity checker, and explicit test registrations where Cargo autotests are disabled.

Documentation updates use the preludes in the README quickstart and its existing named-snippet consumers, and explain both direct imports and crate-local prelude imports in the current API-choice and PyTorch/JAX mapping guides. Backend/device selection remains explicit; no facade prelude is introduced.

## Work log

`docs/worklogs/2026-08-07-issue-1612-prelude.md`

## Scope and commit grouping

This follows the accepted plan exactly with two reviewable commits:

1. `feat: add crate preludes` — six prelude modules, public declarations, tests, Cargo test registrations, and the source-contract checker.
2. `docs: use crate preludes in quickstarts` — README/docs migration and work log.

No facade crate, compatibility alias, macro, generator, dependency, operation-function glob export, private/sealed helper exposure, or rustdoc-wide import rewrite was added.

## Verification

- Six default-feature prelude tests passed.
- Autodiff-gated eager prelude tests for einsum, linalg, and FFT passed.
- `python3 scripts/check-prelude-contract.py` passed for all six crates (27 actual public `*Ext` traits).
- `python3 scripts/check-no-facade-crate.py` passed.
- `python3 scripts/check-doc-snippets.py --check` passed.
- `cargo test -p tenferro-tutorial-code --test tutorial_binaries` passed.
- `python3 scripts/test-doc-consistency.py` passed.
- `python3 scripts/ci/run_profile.py fmt clippy` passed.
- `cargo test --workspace --release` passed.
- `cargo llvm-cov --workspace --exclude tenferro-tutorial-code --profile ci --json --output-path /tmp/coverage-1612-ci.json` and coverage gate passed (191/191 files).
- `python3 scripts/ci/run_profile.py docs` passed, including rustdoc and docs-site checks.
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-runtime --test prelude'` passed.
- Local repository-rules review passed with 0 findings.
- `git diff --check` passed.

The docs build skips only the optional Graphviz dependency graph because `dot` is unavailable. CUDA, ROCm, WebGPU, and macOS-only feature combinations remain hosted-CI coverage; no backend implementation or feature declaration was changed.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
