### PR TITLE
fix: correct validation errors and add GEMM regressions

### DIFF
--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -465,9 +465,10 @@ fn typed_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
                     format!("start exceeds limit on axis {axis}"),
                 ));
             }
-            // This boundary check intentionally mirrors CUDA's validator:
-            // CPU and GPU are independent backend leaves, and sharing it via
-            // tenferro-tensor would require a new public validation API.
+            // INVARIANT: This boundary check intentionally mirrors CUDA's
+            // validator. CPU and GPU are independent backend leaves, and
+            // sharing it via tenferro-tensor would require a new public
+            // validation API.
             if limit > dim {
                 return Err(crate::Error::invalid_argument(
                     "slice",

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -465,6 +465,9 @@ fn typed_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
                     format!("start exceeds limit on axis {axis}"),
                 ));
             }
+            // This boundary check intentionally mirrors CUDA's validator:
+            // CPU and GPU are independent backend leaves, and sharing it via
+            // tenferro-tensor would require a new public validation API.
             if limit > dim {
                 return Err(crate::Error::invalid_argument(
                     "slice",

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -466,7 +466,11 @@ fn typed_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
                 ));
             }
             if limit > dim {
-                return Err(crate::Error::axis_out_of_bounds("slice", axis, rank));
+                return Err(crate::Error::invalid_argument(
+                    "slice",
+                    "configuration",
+                    format!("limit {limit} on axis {axis} exceeds dimension size {dim}"),
+                ));
             }
             if stride == 0 {
                 return Err(crate::Error::invalid_argument(

--- a/crates/tenferro-cpu/src/provider/tests.rs
+++ b/crates/tenferro-cpu/src/provider/tests.rs
@@ -175,10 +175,10 @@ use num_complex::{Complex32, Complex64};
 #[cfg(feature = "cpu-faer")]
 use tenferro_tensor::backend::GroupedGemmJob;
 #[cfg(feature = "cpu-faer")]
-use tenferro_tensor::{
-    ContractionScalar, TensorView, TensorViewMut, TypedTensorView, TypedTensorViewMut,
-};
+use tenferro_tensor::{ContractionScalar, TensorView, TypedTensorView};
 use tenferro_tensor::{DType, DotGeneralAccumulation, Tensor, TensorRead, TensorWrite};
+#[cfg(any(feature = "cpu-faer", feature = "cpu-blas"))]
+use tenferro_tensor::{TensorViewMut, TypedTensorViewMut};
 
 #[allow(dead_code)]
 fn assert_object_safe(
@@ -759,6 +759,47 @@ fn native_policy_restores_after_error_and_panic_without_contaminating_ambient_wo
             assert_eq!(participants.thread_ids.lock().unwrap().len(), 2);
         });
     });
+}
+
+#[cfg(feature = "cpu-blas")]
+#[test]
+fn blas_rejects_negative_output_leading_stride_before_provider_mutation() {
+    let lhs = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+    let lhs = TensorRead::from_tensor(&lhs);
+    let rhs = TensorRead::from_tensor(&rhs);
+    let mut storage = [41.0_f64; 4];
+    let output_view = TypedTensorViewMut::from_slice([2, 2], [1, -2], 2, &mut storage).unwrap();
+    let mut output = TensorWrite::from_view(TensorViewMut::F64(output_view));
+    let request = CpuGemmRequest::new(
+        &lhs,
+        &rhs,
+        &mut output,
+        2,
+        2,
+        2,
+        1,
+        CpuBatchedMatrixLayout::new(0, 1, 2, 4),
+        CpuBatchedMatrixLayout::new(0, 1, 2, 4),
+        CpuBatchedMatrixLayout::new(2, 1, -2, 4),
+        DotGeneralAccumulation::overwrite(DType::F64).unwrap(),
+    );
+    let fixture = execution_context_fixture(1);
+
+    let outcome = fixture
+        .with_context(ParallelMode::Sequential, |context| {
+            crate::gemm::execute_blas_gemm_request(context, request)
+        })
+        .unwrap();
+
+    assert_eq!(
+        outcome,
+        CpuProviderOutcome::Unsupported(CpuProviderUnsupported::Layout(
+            crate::provider::CpuOperand::Output,
+        ))
+    );
+    drop(output);
+    assert_eq!(storage, [41.0_f64; 4]);
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -29,7 +29,7 @@ use tenferro_tensor::{
 };
 use tenferro_tensor::{
     DType, Tensor, TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensor,
-    TypedTensorViewMut,
+    TypedTensorView, TypedTensorViewMut,
 };
 
 #[test]

--- a/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
@@ -399,6 +399,33 @@ fn static_erased_indexing_preserves_bool_values_and_empty_shapes() {
 }
 
 #[test]
+fn cpu_slice_limit_over_dimension_is_invalid_configuration() {
+    let mut backend = CpuBackend::new();
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
+    let error = backend
+        .slice(
+            &input,
+            &SliceConfig {
+                starts: vec![0],
+                limits: vec![3],
+                strides: vec![1],
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        crate::Error::Validation {
+            op: "slice",
+            source: tenferro_tensor::ValidationError::InvalidArgument {
+                argument: "configuration",
+                message,
+            },
+        } if message == "limit 3 on axis 0 exceeds dimension size 2"
+    ));
+}
+
+#[test]
 fn cpu_indexing_validation_covers_error_branches() {
     let mut backend = CpuBackend::new();
     let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
@@ -436,7 +463,7 @@ fn cpu_indexing_validation_covers_error_branches() {
         ),
         "slice",
     );
-    expect_axis_oob(
+    expect_invalid_config(
         backend.slice(
             &input,
             &SliceConfig {

--- a/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
@@ -652,6 +652,44 @@ fn test_dot_general_falls_back_for_unfusable_lhs_batch_layout() {
 }
 
 #[test]
+fn test_dot_general_falls_back_for_mixed_batch_orders() {
+    let lhs_storage = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let rhs_storage = [10.0_f64, 20.0, 30.0, 40.0, 50.0, 60.0];
+    let lhs_view =
+        TypedTensorView::from_slice([1, 1, 2, 3], [1, 1, 3, 1], 0, &lhs_storage).unwrap();
+    let rhs_view =
+        TypedTensorView::from_slice([1, 1, 2, 3], [1, 1, 1, 2], 0, &rhs_storage).unwrap();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![2, 3],
+        rhs_batch_dims: vec![2, 3],
+    };
+    let mut backend = CpuBackend::new();
+
+    let output = backend
+        .dot_general_read(
+            TensorRead::from_view(TensorView::F64(lhs_view)),
+            TensorRead::from_view(TensorView::F64(rhs_view)),
+            &config,
+        )
+        .unwrap();
+
+    assert_eq!(output.shape(), &[1, 1, 2, 3]);
+    for b1 in 0..3 {
+        for b0 in 0..2 {
+            let lhs = lhs_storage[b0 * 3 + b1];
+            let rhs = rhs_storage[b0 + b1 * 2];
+            assert_eq!(
+                get_f64(&output, &[0, 0, b0, b1]),
+                lhs * rhs,
+                "mixed batch coordinate ({b0}, {b1})"
+            );
+        }
+    }
+}
+
+#[test]
 fn test_transpose() {
     let t = Tensor::F64(
         TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -6002,7 +6002,11 @@ fn validate_slice(input_shape: &[usize], config: &SliceConfig) -> crate::Result<
                 ));
             }
             if limit > dim {
-                return Err(crate::Error::axis_out_of_bounds("slice", axis, rank));
+                return Err(crate::Error::invalid_argument(
+                    "slice",
+                    "configuration",
+                    format!("limit {limit} on axis {axis} exceeds dimension size {dim}"),
+                ));
             }
             if stride == 0 {
                 return Err(crate::Error::invalid_argument(

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -6001,9 +6001,10 @@ fn validate_slice(input_shape: &[usize], config: &SliceConfig) -> crate::Result<
                     format!("start exceeds limit on axis {axis}"),
                 ));
             }
-            // This boundary check intentionally mirrors CPU's validator:
-            // CPU and GPU are independent backend leaves, and sharing it via
-            // tenferro-tensor would require a new public validation API.
+            // INVARIANT: This boundary check intentionally mirrors CPU's
+            // validator. CPU and GPU are independent backend leaves, and
+            // sharing it via tenferro-tensor would require a new public
+            // validation API.
             if limit > dim {
                 return Err(crate::Error::invalid_argument(
                     "slice",

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -6001,6 +6001,9 @@ fn validate_slice(input_shape: &[usize], config: &SliceConfig) -> crate::Result<
                     format!("start exceeds limit on axis {axis}"),
                 ));
             }
+            // This boundary check intentionally mirrors CPU's validator:
+            // CPU and GPU are independent backend leaves, and sharing it via
+            // tenferro-tensor would require a new public validation API.
             if limit > dim {
                 return Err(crate::Error::invalid_argument(
                     "slice",

--- a/crates/tenferro-gpu/src/cubecl/tests/indexing_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/indexing_tests.rs
@@ -27,6 +27,49 @@ fn with_cuda_ordinal<T>(mut tensor: TypedTensor<T>, ordinal: usize) -> TypedTens
 }
 
 #[test]
+fn cuda_slice_limit_over_dimension_is_invalid_configuration() {
+    let error = super::super::validate_slice(
+        &[2],
+        &SliceConfig {
+            starts: vec![0],
+            limits: vec![3],
+            strides: vec![1],
+        },
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        Error::Validation {
+            op: "slice",
+            source: ValidationError::InvalidArgument {
+                argument: "configuration",
+                message,
+            },
+        } if message == "limit 3 on axis 0 exceeds dimension size 2"
+    ));
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_slice_limit_over_dimension_matches_cpu_invalid_argument() {
+    let config = SliceConfig {
+        starts: vec![0],
+        limits: vec![3],
+        strides: vec![1],
+    };
+    let input = tensor_f64(vec![2], vec![1.0, 2.0]);
+    let expected = cpu_backend().slice(&input, &config).unwrap_err();
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &input);
+    let actual = gpu.slice(&gpu_input, &config).unwrap_err();
+
+    assert_eq!(actual.kind(), expected.kind());
+    assert_validation_kind(&actual, "slice", ValidationKind::InvalidArgument);
+    assert_error_parity(expected, actual);
+}
+
+#[test]
 #[ignore = "requires CUDA 12.8+ GPU"]
 fn cuda_float_index_validation_matches_cpu() {
     fn check_index(

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -3646,9 +3646,12 @@ pub trait TensorIndexing {
     /// # Errors
     ///
     /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
-    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
-    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
-    /// backend execution or storage access cannot provide the requested result.
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. In
+    /// particular, a limit greater than the corresponding input dimension is
+    /// reported as [`crate::ValidationError::InvalidArgument`] with the
+    /// `"configuration"` argument. It returns [`crate::Error::BackendFailure`]
+    /// or [`crate::Error::BackendSource`] when backend execution or storage
+    /// access cannot provide the requested result.
     fn slice(&mut self, input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor>;
     /// # Errors
     ///

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -284,10 +284,9 @@ impl ContractionScalar {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
-    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
-    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
-    /// backend execution or storage access cannot provide the requested result.
+    /// Returns [`crate::Error::Validation`] with a
+    /// [`crate::ValidationError::DTypeMismatch`] source when `dtype` is `I32`,
+    /// `I64`, or `Bool`, which do not support contraction scalar identities.
     pub fn one(dtype: DType) -> crate::Result<Self> {
         match dtype {
             DType::F32 => Ok(Self::F32(1.0)),
@@ -295,7 +294,7 @@ impl ContractionScalar {
             DType::C32 => Ok(Self::C32(Complex32::new(1.0, 0.0))),
             DType::C64 => Ok(Self::C64(Complex64::new(1.0, 0.0))),
             DType::I32 | DType::I64 | DType::Bool => Err(validation(
-                "dot_general",
+                "ContractionScalar::one",
                 ValidationError::DTypeMismatch {
                     expected: crate::core_dtype(dtype),
                     actual: crate::core_dtype(DType::F32),
@@ -315,10 +314,9 @@ impl ContractionScalar {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
-    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
-    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
-    /// backend execution or storage access cannot provide the requested result.
+    /// Returns [`crate::Error::Validation`] with a
+    /// [`crate::ValidationError::DTypeMismatch`] source when `dtype` is `I32`,
+    /// `I64`, or `Bool`, which do not support contraction scalar identities.
     pub fn zero(dtype: DType) -> crate::Result<Self> {
         match dtype {
             DType::F32 => Ok(Self::F32(0.0)),
@@ -326,7 +324,7 @@ impl ContractionScalar {
             DType::C32 => Ok(Self::C32(Complex32::new(0.0, 0.0))),
             DType::C64 => Ok(Self::C64(Complex64::new(0.0, 0.0))),
             DType::I32 | DType::I64 | DType::Bool => Err(validation(
-                "dot_general",
+                "ContractionScalar::zero",
                 ValidationError::DTypeMismatch {
                     expected: crate::core_dtype(dtype),
                     actual: crate::core_dtype(DType::F32),
@@ -454,19 +452,45 @@ impl<'a> GroupedGemmConfig<'a> {
 }
 
 impl DotGeneralAccumulation {
+    fn identity(
+        op: &'static str,
+        dtype: DType,
+        multiplicative: bool,
+    ) -> crate::Result<ContractionScalar> {
+        let result = if multiplicative {
+            ContractionScalar::one(dtype)
+        } else {
+            ContractionScalar::zero(dtype)
+        };
+        result.map_err(|error| match error {
+            Error::Validation { source, .. } => validation(op, source),
+            error => error,
+        })
+    }
+
     /// Return overwrite semantics, `out = lhs dot rhs`, for `dtype`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{ContractionScalar, DotGeneralAccumulation, DType};
+    ///
+    /// let accum = DotGeneralAccumulation::overwrite(DType::F64).unwrap();
+    /// assert_eq!(accum.alpha, ContractionScalar::F64(1.0));
+    /// assert_eq!(accum.beta, ContractionScalar::F64(0.0));
+    /// ```
+    ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
-    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
-    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
-    /// backend execution or storage access cannot provide the requested result.
+    /// Returns [`crate::Error::Validation`] with a
+    /// [`crate::ValidationError::DTypeMismatch`] source when `dtype` does not
+    /// support contraction scalar identities.
     pub fn overwrite(dtype: DType) -> crate::Result<Self> {
         Ok(Self {
             lhs_conj: false,
             rhs_conj: false,
-            alpha: ContractionScalar::one(dtype)?,
-            beta: ContractionScalar::zero(dtype)?,
+            alpha: Self::identity("DotGeneralAccumulation::overwrite", dtype, true)?,
+            beta: Self::identity("DotGeneralAccumulation::overwrite", dtype, false)?,
         })
     }
 
@@ -484,16 +508,15 @@ impl DotGeneralAccumulation {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
-    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
-    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
-    /// backend execution or storage access cannot provide the requested result.
+    /// Returns [`crate::Error::Validation`] with a
+    /// [`crate::ValidationError::DTypeMismatch`] source when `dtype` does not
+    /// support contraction scalar identities.
     pub fn add_to(dtype: DType) -> crate::Result<Self> {
         Ok(Self {
             lhs_conj: false,
             rhs_conj: false,
-            alpha: ContractionScalar::one(dtype)?,
-            beta: ContractionScalar::one(dtype)?,
+            alpha: Self::identity("DotGeneralAccumulation::add_to", dtype, true)?,
+            beta: Self::identity("DotGeneralAccumulation::add_to", dtype, true)?,
         })
     }
 
@@ -513,14 +536,13 @@ impl DotGeneralAccumulation {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
-    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
-    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
-    /// backend execution or storage access cannot provide the requested result.
+    /// Returns [`crate::Error::Validation`] with a
+    /// [`crate::ValidationError::DTypeMismatch`] source when `alpha` and `beta`
+    /// have different dtypes.
     pub fn scaled(alpha: ContractionScalar, beta: ContractionScalar) -> crate::Result<Self> {
         if alpha.dtype() != beta.dtype() {
             return Err(validation(
-                "dot_general",
+                "DotGeneralAccumulation::scaled",
                 ValidationError::DTypeMismatch {
                     expected: crate::core_dtype(alpha.dtype()),
                     actual: crate::core_dtype(beta.dtype()),

--- a/crates/tenferro-tensor/src/backend/tests.rs
+++ b/crates/tenferro-tensor/src/backend/tests.rs
@@ -18,3 +18,53 @@ fn compact_host_accumulation_slice_selects_only_compact_host_views() {
         .unwrap()
         .is_none());
 }
+
+#[test]
+fn contraction_scalar_identity_errors_name_the_public_constructor() {
+    let one_error = ContractionScalar::one(DType::I32).unwrap_err();
+    assert!(matches!(
+        one_error,
+        Error::Validation {
+            op: "ContractionScalar::one",
+            source: ValidationError::DTypeMismatch { .. },
+        }
+    ));
+
+    let zero_error = ContractionScalar::zero(DType::Bool).unwrap_err();
+    assert!(matches!(
+        zero_error,
+        Error::Validation {
+            op: "ContractionScalar::zero",
+            source: ValidationError::DTypeMismatch { .. },
+        }
+    ));
+
+    let overwrite_error = DotGeneralAccumulation::overwrite(DType::I32).unwrap_err();
+    assert!(matches!(
+        overwrite_error,
+        Error::Validation {
+            op: "DotGeneralAccumulation::overwrite",
+            source: ValidationError::DTypeMismatch { .. },
+        }
+    ));
+
+    let add_to_error = DotGeneralAccumulation::add_to(DType::Bool).unwrap_err();
+    assert!(matches!(
+        add_to_error,
+        Error::Validation {
+            op: "DotGeneralAccumulation::add_to",
+            source: ValidationError::DTypeMismatch { .. },
+        }
+    ));
+
+    let scaled_error =
+        DotGeneralAccumulation::scaled(ContractionScalar::F32(1.0), ContractionScalar::F64(1.0))
+            .unwrap_err();
+    assert!(matches!(
+        scaled_error,
+        Error::Validation {
+            op: "DotGeneralAccumulation::scaled",
+            source: ValidationError::DTypeMismatch { .. },
+        }
+    ));
+}

--- a/docs/worklogs/2026-08-08-issues-1636-1622-1637-bugfix.md
+++ b/docs/worklogs/2026-08-08-issues-1636-1622-1637-bugfix.md
@@ -1,0 +1,91 @@
+# Issues #1636, #1622, and #1637 bug-fix record
+
+## Session summary
+
+This change closes three small, related validation and CPU GEMM regression gaps
+identified during the post-#1591 retirement audit:
+
+- #1636: public contraction-scalar constructors reported the generic
+  `dot_general` operation, and their rustdoc described unrelated backend errors.
+- #1622: CPU and CUDA slice validation classified `limit > dimension` as an
+  axis/rank error instead of an invalid configuration.
+- #1637: exact CPU GEMM coverage was missing for mixed batch layouts and BLAS
+  output views with a negative leading stride.
+
+The production changes remain limited to existing validation and test paths; no
+new public API, backend, dependency, or architectural layer was introduced.
+
+## Context and references read
+
+- `REPOSITORY_RULES.md`
+- `CONTRIBUTING.md`
+- `ai/contribution-workflows/bugfix-pr.md`
+- `docs/design/dot-general-overhead.md`
+- `docs/design/einsum.md`
+- `docs/worklogs/2026-06-06-strided-einsum-kernel-ownership.md`
+- `docs/worklogs/2026-07-03-issue-1285-dot-accumulation.md`
+- `docs/worklogs/2026-07-04-issue-1293-grouped-gemm.md`
+- the current CPU/GPU indexing, provider, and GEMM tests
+
+The implementation was based on the current `origin/main`, not on the stale
+retirement worktree. The #1637 fixtures intentionally exercise the existing
+Faer/default fallback and BLAS provider-contract paths rather than reintroducing
+`strided-einsum2`.
+
+## Decisions
+
+1. Keep constructor-level operation names precise. `ContractionScalar::one`
+   and `zero` identify their own errors. `DotGeneralAccumulation::{overwrite,
+   add_to,scaled}` now do the same; overwrite/add-to remap the typed validation
+   source at their public boundary instead of leaking a nested identity-helper
+   operation.
+2. Preserve the existing typed error model. `limit > dimension` is an
+   `InvalidArgument { argument: "configuration" }` for both CPU and CUDA, with
+   the same diagnostic message. Axis-out-of-bounds remains reserved for an axis
+   that is not present in the input rank.
+3. Keep #1637 as regression coverage, not a production algorithm change. The
+   mixed-batch fixture uses different affine batch strides for the two operands;
+   the BLAS fixture verifies negative output leading stride is rejected before
+   provider mutation and leaves its sentinel buffer unchanged.
+4. Keep CUDA execution coverage hardware-gated. A non-ignored validator test
+   covers the CUDA preflight path on ordinary hosts, while an ignored backend
+   parity test covers the full device path when CUDA 12.8+ hardware is present.
+
+## Alternatives rejected or deferred
+
+- No generic `strided-einsum2` compatibility shim was added: current dot-general
+  ownership is already in `tenferro-cpu`.
+- No new C/API error variant was added: the existing typed
+  `ValidationError::InvalidArgument` and `DTypeMismatch` variants express these
+  cases without widening the public surface.
+- No attempt was made to run ignored CUDA execution tests on a host without the
+  required GPU; that lane remains a CI/hardware verification responsibility.
+- The remaining exact GEMM fixtures from the wider retirement audit stay scoped
+  to #1637 rather than being mixed into this validation fix.
+
+## Verification
+
+Passed during the implementation/review loop:
+
+- `cargo fmt --all`
+- `cargo test -p tenferro-tensor --lib`
+- `cargo test -p tenferro-cpu --lib`
+- `cargo test -p tenferro-gpu --features cuda --lib`
+- `cargo test -p tenferro-cpu --no-default-features --features cpu-blas,provider-inject --test integration provider_inject_dot_general_uses_registered_blas`
+- focused constructor, CPU indexing, CUDA validator, and BLAS negative-stride
+  tests
+- independent specification/correctness review and fresh re-review after the
+  constructor error-label fix
+
+The provider-inject integration build emits pre-existing dead-code warnings for
+unused dual-ABI fixture symbols. CUDA execution tests are ignored when hardware
+is unavailable.
+
+## Remaining risks
+
+- The ignored CUDA backend parity test still requires CUDA 12.8+ hardware and
+  the normal runtime libraries.
+- Direct system-BLAS execution is environment-dependent; the provider-inject
+  fixture supplies deterministic symbol registration for the regression lane.
+- Full workspace release, documentation-site, coverage, and repository-rule
+  gates must be rerun against the final candidate commits before publication.

--- a/docs/worklogs/2026-08-08-issues-1636-1622-1637-bugfix.md
+++ b/docs/worklogs/2026-08-08-issues-1636-1622-1637-bugfix.md
@@ -58,6 +58,11 @@ Faer/default fallback and BLAS provider-contract paths rather than reintroducing
 - No new C/API error variant was added: the existing typed
   `ValidationError::InvalidArgument` and `DTypeMismatch` variants express these
   cases without widening the public surface.
+- The small `limit > dimension` boundary check remains mirrored in the CPU and
+  CUDA leaf crates. They do not share a crate-private validation module; moving
+  it into `tenferro-tensor` would add a new public helper solely for this
+  bug-fix. Source comments and parity tests keep the two boundary contracts
+  synchronized.
 - No attempt was made to run ignored CUDA execution tests on a host without the
   required GPU; that lane remains a CI/hardware verification responsibility.
 - The remaining exact GEMM fixtures from the wider retirement audit stay scoped


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1636
Fixes #1622
Fixes #1637

## Summary

- Correct `ContractionScalar` and `DotGeneralAccumulation` validation operation names and rustdoc error contracts.
- Classify CPU and CUDA slice limits beyond the input dimension as typed invalid configuration errors.
- Add CPU GEMM regressions for mixed batch strides and BLAS negative output leading strides.

## Work log

- [`docs/worklogs/2026-08-08-issues-1636-1622-1637-bugfix.md`](../blob/bugfix/1636-1622-1637/docs/worklogs/2026-08-08-issues-1636-1622-1637-bugfix.md)

## Verification

- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo test -p tenferro-tensor --lib`
- `cargo test -p tenferro-cpu --lib`
- `cargo test -p tenferro-gpu --features cuda --lib`
- `cargo test -p tenferro-cpu --no-default-features --features cpu-blas,provider-inject --test integration provider_inject_dot_general_uses_registered_blas`
- `python3 scripts/ci/run_profile.py clippy`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/check-public-error-docs.py`
- committed `repository-rules-review.py` passed with no findings

`cargo llvm-cov --workspace --release` completed. The checker remains report-only on this host because the repository’s existing CUDA/WebGPU and tutorial files are below their pre-existing thresholds without GPU execution; the new validator and CPU regression tests are covered by the focused lanes. The ignored CUDA backend parity test remains hardware-gated.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] I added the required work log under `docs/worklogs/` and linked it above.
