### PR TITLE
release: prepare tenferro v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.4.0"
 rust-version = "1.96"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -53,10 +53,10 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "9da9b9f63e688eaf1bf4a78b718a01ac858b1f9f", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "9da9b9f63e688eaf1bf4a78b718a01ac858b1f9f", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "9da9b9f63e688eaf1bf4a78b718a01ac858b1f9f", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "9da9b9f63e688eaf1bf4a78b718a01ac858b1f9f", version = "0.3.0", features = ["parallel"] }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "b29e7601ba090aa5eafc65b9bde5d9450282e0d8", version = "0.4.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "b29e7601ba090aa5eafc65b9bde5d9450282e0d8", version = "0.4.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "b29e7601ba090aa5eafc65b9bde5d9450282e0d8", version = "0.4.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "b29e7601ba090aa5eafc65b9bde5d9450282e0d8", version = "0.4.0", features = ["parallel"] }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -73,7 +73,7 @@ Violating any of these aborts the release.
 
 1. `git worktree add <fresh-path> vX.Y.Z`; confirm the tree is clean and
    `python3 scripts/check-publish-layout.py` passes unchanged.
-2. Publish publishable crates in dependency order. As of 2026-07 the order
+2. Publish publishable crates in dependency order. As of 2026-08 the order
    is:
 
    ```text
@@ -82,10 +82,10 @@ Violating any of these aborts the release.
    tenferro-tensor-core
    tenferro-tensor
    tenferro-internal-cpu-kernels
-   tenferro-cpu
-   tenferro-gpu
    tenferro-internal-ops
    tenferro-runtime
+   tenferro-cpu
+   tenferro-gpu
    tenferro-xla
    tenferro-ad
    tenferro-einsum

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -132,8 +132,11 @@ Agents must stop after validation and must never execute a publication.
      --approve-new-package tenferro-internal-cpu-kernels
    ```
 
-   Never infer this approval from a general release request. The helper also
-   rejects an approval argument for a package that crates.io reports is not new.
+   Never infer this approval from a general release request. On restart, keep
+   the exact command unchanged: the helper accepts that approval after the
+   package exists only when crates.io also has the target version, whose archive
+   must still pass all checks before it is skipped. It rejects the approval as
+   stale when the package exists but the target version does not.
 4. After the preflight passes, the human operator repeats the same exact command
    with `--execute`:
 
@@ -147,10 +150,15 @@ Agents must stop after validation and must never execute a publication.
    generated `.crate` file list and normalized metadata (name, version,
    description, license, repository, homepage, documentation, README,
    `rust-version`, keywords, categories, and `include`/`exclude`), verifies
-   `.cargo_vcs_info.json` equals the clean tagged commit, runs
-   `cargo publish --dry-run`, and inspects that generated archive again. It
-   packages, dry-runs, and publishes one crate at a time, waiting for every
-   prerequisite archive to be visible with matching tag provenance before
+   `.cargo_vcs_info.json` equals the clean tagged commit, and compares every
+   source-derived regular archive file byte-for-byte with the tagged package
+   tree and requires the file list to equal `cargo package --list` for that tag.
+   Cargo's normalized `Cargo.toml`, generated `Cargo.lock`, and VCS file are
+   validated as generated files; `Cargo.toml.orig` must equal the tagged
+   source manifest. Unmapped, changed, or required missing files abort. The
+   helper then runs `cargo publish --dry-run` and inspects that generated archive
+   again. It packages, dry-runs, and publishes one crate at a time, waiting for
+   every prerequisite archive to be visible with matching tag provenance before
    packaging its dependents. Do not pre-package the whole workspace: lower-layer
    registry versions must exist before dependent packages can resolve.
 5. The helper is restart-safe and fail-closed: it skips an already-published

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -71,8 +71,21 @@ Violating any of these aborts the release.
 
 ## Phase 3 — Publish From The Tag
 
-1. `git worktree add <fresh-path> vX.Y.Z`; confirm the tree is clean and
-   `python3 scripts/check-publish-layout.py` passes unchanged.
+Only a human maintainer with crates.io ownership runs the publication helper.
+Agents must stop after validation and must never execute a publication.
+
+1. Fetch the remote state and create a detached worktree at the pushed tag:
+
+   ```bash
+   git fetch origin main --tags
+   git worktree add --detach <fresh-path> vX.Y.Z
+   cd <fresh-path>
+   ```
+
+   Do not make any changes in this worktree. The helper fetches `origin` again
+   and aborts before publication unless the worktree is clean and detached,
+   `HEAD` is the exact pushed remote `vX.Y.Z` tag commit, and that commit is an
+   ancestor of `origin/main`.
 2. Publish publishable crates in dependency order. As of 2026-08 the order
    is:
 
@@ -99,14 +112,53 @@ Violating any of these aborts the release.
    package. When workspace membership or dependencies change, recompute the
    order from `cargo metadata` (topological sort of workspace members over
    their `tenferro-*` dependencies) instead of trusting this list.
-3. For each crate run `cargo publish -p <crate>`. A dependent crate fails
-   until the registry index has its dependencies; wait roughly 30 seconds
-   and retry before treating a failure as real.
-4. If any crate cannot publish without a manifest change: stop publishing,
-   fix the manifest on `main` through Phase 1, and restart at Phase 2 with
-   the next patch version. Crates already published stay published; the
-   remaining crates ship only at the new version, so prefer aborting before
-   any crate has been published when possible.
+3. Run the fail-closed preflight without `--execute` first. It structurally
+   parses every git dependency in `[workspace.dependencies]`, checks its exact
+   registry package/version and pinned-revision manifest, queries crates.io,
+   validates the remote tag/clean checkout invariants, and verifies provenance
+   for any target versions already present on crates.io:
+
+   ```bash
+   python3 scripts/release-publish.py X.Y.Z
+   ```
+
+   **New-package gate:** `tenferro-internal-cpu-kernels` is new for v0.4.0.
+   The command above must abort before publishing anything unless the user's
+   approval names exactly `tenferro-internal-cpu-kernels`. After recording that
+   exact approval, the human operator asserts it concretely with:
+
+   ```bash
+   python3 scripts/release-publish.py X.Y.Z \
+     --approve-new-package tenferro-internal-cpu-kernels
+   ```
+
+   Never infer this approval from a general release request. The helper also
+   rejects an approval argument for a package that crates.io reports is not new.
+4. After the preflight passes, the human operator repeats the same exact command
+   with `--execute`:
+
+   ```bash
+   python3 scripts/release-publish.py X.Y.Z \
+     --approve-new-package tenferro-internal-cpu-kernels \
+     --execute
+   ```
+
+   Before each `cargo publish`, the helper runs `cargo package`, inspects the
+   generated `.crate` file list and normalized metadata (name, version,
+   description, license, repository, homepage, documentation, README,
+   `rust-version`, keywords, categories, and `include`/`exclude`), verifies
+   `.cargo_vcs_info.json` equals the clean tagged commit, runs
+   `cargo publish --dry-run`, and inspects that generated archive again. It
+   packages, dry-runs, and publishes one crate at a time, waiting for every
+   prerequisite archive to be visible with matching tag provenance before
+   packaging its dependents. Do not pre-package the whole workspace: lower-layer
+   registry versions must exist before dependent packages can resolve.
+5. The helper is restart-safe and fail-closed: it skips an already-published
+   target version only after downloading its registry archive and verifying its
+   provenance against the tag. Any missing approval, metadata/provenance
+   mismatch, network ambiguity, command failure, or required manifest change
+   aborts publication. Fix manifest problems on `main` through Phase 1 and
+   restart at Phase 2 with the next patch version.
 
 ## Phase 4 — Verify And Close
 

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -146,24 +146,25 @@ Agents must stop after validation and must never execute a publication.
      --execute
    ```
 
-   Before each `cargo publish`, the helper runs `cargo package`, inspects the
-   generated `.crate` file list and normalized metadata (name, version,
-   description, license, repository, homepage, documentation, README,
-   `rust-version`, keywords, categories, and `include`/`exclude`), verifies
+   Before each `cargo publish`, the helper waits for every prerequisite registry
+   archive, then runs `cargo package` and inspects that exact local `.crate` file.
+   It checks the file list and normalized metadata (name, version, description,
+   license, repository, homepage, documentation, README, `rust-version`,
+   keywords, categories, and `include`/`exclude`), verifies
    `.cargo_vcs_info.json` equals the clean tagged commit, and compares every
    source-derived regular archive file byte-for-byte with the tagged package
-   tree and requires the file list to equal `cargo package --list` for that tag.
-   Cargo's normalized `Cargo.toml`, generated `Cargo.lock`, and VCS file are
-   validated as generated files; `Cargo.toml.orig` must equal the tagged
-   source manifest. Unmapped, changed, or required missing files abort. The
-   helper then runs `cargo publish --dry-run` and inspects that generated archive
-   again. It packages, dry-runs, and publishes one crate at a time, waiting for
-   every prerequisite archive to be visible with matching tag provenance before
-   packaging its dependents. Do not pre-package the whole workspace: lower-layer
-   registry versions must exist before dependent packages can resolve.
+   tree. The file list must equal `cargo package --list` for that tag.
+   `Cargo.toml.orig` must equal the tagged source manifest. The helper retains
+   every regular file's exact bytes, including Cargo's normalized `Cargo.toml`,
+   generated `Cargo.lock`, and VCS file, and requires the dry-run and downloaded
+   registry archives to match them exactly. Unmapped, changed, or required
+   missing files abort. It packages, dry-runs, and publishes one crate at a time.
+   Do not pre-package the whole workspace: lower-layer registry versions must
+   exist before dependent packages can resolve.
 5. The helper is restart-safe and fail-closed: it skips an already-published
-   target version only after downloading its registry archive and verifying its
-   provenance against the tag. Any missing approval, metadata/provenance
+   target version only after recreating the exact local archive from the clean
+   tag, then downloading its registry archive and matching every regular file's
+   bytes as well as tagged-source provenance. Any missing approval, metadata/provenance
    mismatch, network ambiguity, command failure, or required manifest change
    aborts publication. Fix manifest problems on `main` through Phase 1 and
    restart at Phase 2 with the next patch version.

--- a/crates/tenferro-ad/Cargo.toml
+++ b/crates/tenferro-ad/Cargo.toml
@@ -44,11 +44,11 @@ webgpu = ["dep:tenferro-gpu", "tenferro-gpu/webgpu"]
 rocm = ["dep:tenferro-gpu", "tenferro-gpu/rocm"]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.2.0", default-features = false }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.2.0", default-features = false, features = ["autodiff"] }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.2.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.2.0", default-features = false, optional = true }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false, features = ["autodiff"] }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
 computegraph.workspace = true
 lru.workspace = true
 num-complex.workspace = true

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -45,10 +45,10 @@ blas-mkl = [
 ]
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.2.0" }
-tenferro-internal-cpu-kernels = { path = "../tenferro-internal-cpu-kernels", version = "0.2.0" }
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.2.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0" }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
+tenferro-internal-cpu-kernels = { path = "../tenferro-internal-cpu-kernels", version = "0.4.0" }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0" }
 num-complex.workspace = true
 num-traits.workspace = true
 rayon.workspace = true

--- a/crates/tenferro-einsum/Cargo.toml
+++ b/crates/tenferro-einsum/Cargo.toml
@@ -65,13 +65,13 @@ rocm = [
 ]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.2.0", default-features = false }
-tenferro-ad = { path = "../tenferro-ad", version = "0.2.0", default-features = false, optional = true }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.2.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.2.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.2.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.2.0", default-features = false, optional = true }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-ad = { path = "../tenferro-ad", version = "0.4.0", default-features = false, optional = true }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
 computegraph.workspace = true
 lru.workspace = true
 omeco.workspace = true
@@ -79,7 +79,7 @@ smallvec.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.2.0", default-features = false }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
 criterion.workspace = true
 num-complex.workspace = true
 

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -44,13 +44,13 @@ webgpu = [
 ]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.2.0", default-features = false }
-tenferro-ad = { path = "../tenferro-ad", version = "0.2.0", default-features = false, optional = true }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.2.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.2.0", default-features = false, optional = true }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.2.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.2.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-ad = { path = "../tenferro-ad", version = "0.4.0", default-features = false, optional = true }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
 libloading = { workspace = true, optional = true }
 computegraph.workspace = true
 num-complex.workspace = true

--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -54,10 +54,10 @@ webgpu = [
 rocm = []
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.2.0" }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.2.0", default-features = false }
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.2.0", default-features = false }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
 cubecl = { workspace = true, optional = true }
 cubecl-cuda = { workspace = true, optional = true }
 cubecl-common = { workspace = true, optional = true }

--- a/crates/tenferro-internal-cpu-kernels/Cargo.toml
+++ b/crates/tenferro-internal-cpu-kernels/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 name = "tenferro_internal_cpu_kernels"
 
 [dependencies]
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0" }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0" }
 num-complex.workspace = true
 num-traits.workspace = true
 strided-kernel.workspace = true

--- a/crates/tenferro-internal-ops/Cargo.toml
+++ b/crates/tenferro-internal-ops/Cargo.toml
@@ -29,9 +29,9 @@ webgpu = []
 rocm = []
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.2.0" }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0", default-features = false }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.2.0" }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
 computegraph.workspace = true
 num-complex.workspace = true
 thiserror.workspace = true

--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -74,13 +74,13 @@ rocm = ["tenferro-ad?/rocm", "tenferro-internal-ops/rocm"]
 webgpu = ["dep:tenferro-gpu", "tenferro-gpu/webgpu"]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.2.0", default-features = false }
-tenferro-ad = { path = "../tenferro-ad", version = "0.2.0", default-features = false, optional = true }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.2.0", default-features = false, optional = true }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.2.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.2.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.2.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-ad = { path = "../tenferro-ad", version = "0.4.0", default-features = false, optional = true }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
 cblas-sys = { workspace = true, optional = true }
 cblas-inject = { workspace = true, optional = true }
 computegraph = { workspace = true, optional = true }

--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -31,9 +31,9 @@ blas-accelerate = ["tenferro-cpu/blas-accelerate"]
 blas-mkl = ["tenferro-cpu/blas-mkl"]
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.2.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.2.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0", default-features = false }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
 computegraph.workspace = true
 lru.workspace = true
 num-complex.workspace = true
@@ -43,7 +43,7 @@ thiserror.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.2.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
 
 [[bench]]
 name = "elementwise_fusion"

--- a/crates/tenferro-tensor/Cargo.toml
+++ b/crates/tenferro-tensor/Cargo.toml
@@ -25,12 +25,12 @@ name = "tenferro_tensor"
 default = []
 
 [dependencies]
-tenferro-tensor-core = { path = "../tenferro-tensor-core", version = "0.2.0" }
+tenferro-tensor-core = { path = "../tenferro-tensor-core", version = "0.4.0" }
 num-traits.workspace = true
 num-complex.workspace = true
 smallvec.workspace = true
 strided-kernel.workspace = true
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.2.0" }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/tenferro-xla/Cargo.toml
+++ b/crates/tenferro-xla/Cargo.toml
@@ -27,17 +27,17 @@ default = []
 pjrt = ["dep:libloading"]
 
 [dependencies]
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.2.0", default-features = false }
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.2.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0", default-features = false }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
 computegraph.workspace = true
 libloading = { workspace = true, optional = true }
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.2.0", default-features = false, features = ["cpu-faer"] }
-tenferro-einsum = { path = "../tenferro-einsum", version = "0.2.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false, features = ["cpu-faer"] }
+tenferro-einsum = { path = "../tenferro-einsum", version = "0.4.0", default-features = false }
 
 [[test]]
 name = "integration"

--- a/docs/worklogs/2026-07-04-release-publish-workflow.md
+++ b/docs/worklogs/2026-07-04-release-publish-workflow.md
@@ -81,3 +81,23 @@ current workspace symbols; tensor-core verification passed. No dependency,
 README, service, facade, feature-default, or MSRV-matrix change was made.
 Residual: publish deep crates only after matching dependencies are available on
 crates.io; package verification should then be rerun.
+
+## 2026-08-09 v0.4 final-review hardening
+
+Added `scripts/release-publish.py` as the fail-closed human operator path for
+Phase 3. It verifies the clean detached checkout against the pushed remote tag
+and `origin/main`, structurally validates every workspace git pin against both
+its revision manifest and exact crates.io version, and requires exact approval
+for each package that is new to crates.io. In particular, v0.4 publication
+cannot proceed without an approval assertion naming
+`tenferro-internal-cpu-kernels` exactly.
+
+Publication now proceeds one DAG node at a time. Each node is packaged and its
+actual archive files, normalized metadata, README, and tagged-commit provenance
+are checked before and after `cargo publish --dry-run`; dependent packaging
+starts only after prerequisite registry archives are visible with matching
+provenance. A restarted run skips an existing target version only after the
+same registry-archive provenance check. Focused tests use injected transports
+and in-memory archives, so unit tests perform no network access. Live validation
+also confirmed all current strided, CubeCL, Cubek, and computegraph pin
+manifests and declared registry versions.

--- a/docs/worklogs/2026-07-04-release-publish-workflow.md
+++ b/docs/worklogs/2026-07-04-release-publish-workflow.md
@@ -101,3 +101,23 @@ same registry-archive provenance check. Focused tests use injected transports
 and in-memory archives, so unit tests perform no network access. Live validation
 also confirmed all current strided, CubeCL, Cubek, and computegraph pin
 manifests and declared registry versions.
+
+### Final-review round 1 corrections
+
+Restart approval now distinguishes package existence from exact target-version
+existence. The documented approval remains valid after the newly approved crate
+has published, but only when its target version exists and its downloaded
+archive passes full verification; an existing package without that version is a
+stale approval and aborts.
+
+Archive provenance no longer trusts the VCS marker alone. Every source-derived
+regular archive member is mapped to the tagged package tree and compared
+byte-for-byte, and the archive list must equal Cargo's tagged package selection.
+Normalized `Cargo.toml`, generated `Cargo.lock`, and
+`.cargo_vcs_info.json` have explicit generated-file handling, while
+`Cargo.toml.orig` must match the tagged source manifest. This intentionally does
+not require source files omitted by Cargo's packaging rules. Injected command,
+registry, archive, source-tree, clock, checkout, metadata, and order hooks cover
+restart, propagation, failure, and irreversible-command ordering without
+network access or publication. These tests and the publish-layout tests run in
+the normal `ci-config` profile.

--- a/docs/worklogs/2026-07-04-release-publish-workflow.md
+++ b/docs/worklogs/2026-07-04-release-publish-workflow.md
@@ -121,3 +121,19 @@ registry, archive, source-tree, clock, checkout, metadata, and order hooks cover
 restart, propagation, failure, and irreversible-command ordering without
 network access or publication. These tests and the publish-layout tests run in
 the normal `ci-config` profile.
+
+### Final-review round 2 corrections
+
+Every registry comparison now starts from a newly generated and inspected local
+archive from the clean tag. The helper retains the complete regular-file byte
+map and requires both dry-run and crates.io archives to match it exactly, closing
+the gap for normalized dependency changes, `Cargo.lock`, and semantically valid
+but byte-different VCS metadata. Resume follows the same DAG sequence: attest
+prerequisite registry archives, create the local exact-tag archive, then compare
+the downloaded target before skip.
+
+Tar member prefix, traversal, and duplicate validation now runs before directory
+entries are skipped. Network response truncation and HTTP protocol/read errors
+are converted to bounded, actionable release failures. Focused regressions cover
+generated-file mutations, malicious traversal directories, HTTP failures, exact
+resume comparison, and prerequisite-before-dependent packaging.

--- a/scripts/check-publish-layout.py
+++ b/scripts/check-publish-layout.py
@@ -109,25 +109,36 @@ def phase3_publication_order(
 ) -> list[str] | None:
     heading = "## Phase 3 — Publish From The Tag"
     lines = release_text.splitlines()
-    headings = [index for index, line in enumerate(lines) if line == heading]
+    headings: list[int] = []
+    active_marker: tuple[str, int] | None = None
+    for index, line in enumerate(lines):
+        fence = re.match(r"^(`{3,}|~{3,})(.*)$", line.strip())
+        if active_marker is not None:
+            marker_char, marker_len = active_marker
+            if (
+                fence
+                and fence.group(1)[0] == marker_char
+                and len(fence.group(1)) >= marker_len
+                and not fence.group(2).strip()
+            ):
+                active_marker = None
+        elif fence:
+            marker = fence.group(1)
+            active_marker = (marker[0], len(marker))
+        elif line == heading:
+            headings.append(index)
+
     if len(headings) != 1:
         errors.append("release workflow must contain exactly one exact Phase 3 heading")
         return None
 
-    start = headings[0] + 1
-    end = next(
-        (
-            index
-            for index in range(start, len(lines))
-            if re.match(r"^#{1,6}(?:[ \t]+|$)", lines[index])
-        ),
-        len(lines),
-    )
     text_fences: list[list[str]] = []
     active_fence: tuple[str, int, str, list[str]] | None = None
-    for line in lines[start:end]:
+    for line in lines[headings[0] + 1 :]:
         fence = re.match(r"^(`{3,}|~{3,})(.*)$", line.strip())
         if active_fence is None:
+            if re.match(r"^#{1,6}(?:[ \t]+|$)", line):
+                break
             if fence:
                 marker, info = fence.groups()
                 active_fence = (marker[0], len(marker), info.strip(), [])

--- a/scripts/check-publish-layout.py
+++ b/scripts/check-publish-layout.py
@@ -125,7 +125,7 @@ def phase3_publication_order(
         elif fence:
             marker = fence.group(1)
             active_marker = (marker[0], len(marker))
-        elif line == heading:
+        elif re.fullmatch(rf" {{0,3}}{re.escape(heading)}", line):
             headings.append(index)
 
     if len(headings) != 1:
@@ -137,7 +137,7 @@ def phase3_publication_order(
     for line in lines[headings[0] + 1 :]:
         fence = re.match(r"^(`{3,}|~{3,})(.*)$", line.strip())
         if active_fence is None:
-            if re.match(r"^#{1,6}(?:[ \t]+|$)", line):
+            if re.match(r"^ {0,3}#{1,6}(?:[ \t]+|$)", line):
                 break
             if fence:
                 marker, info = fence.groups()
@@ -251,15 +251,24 @@ def check_workspace_metadata(root_text: str, errors: list[str]) -> None:
 
 
 def check_workspace_dependencies(root_text: str, errors: list[str]) -> None:
-    for line_no, line in enumerate(root_text.splitlines(), start=1):
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
+    try:
+        manifest = tomllib.loads(root_text)
+    except tomllib.TOMLDecodeError as error:
+        errors.append(f"Cargo.toml has invalid TOML: {error}")
+        return
+    dependencies = manifest.get("workspace", {}).get("dependencies", {})
+    if not isinstance(dependencies, dict):
+        errors.append("Cargo.toml [workspace.dependencies] must be a table")
+        return
+    for name, dependency in dependencies.items():
+        if not isinstance(dependency, dict) or "git" not in dependency:
             continue
-        if "git =" in stripped and "version =" not in stripped:
-            errors.append(
-                f"Cargo.toml:{line_no}: git dependency must include a version "
-                "requirement for crates.io packaging"
-            )
+        for key in ("version", "rev"):
+            if not isinstance(dependency.get(key), str) or not dependency[key]:
+                errors.append(
+                    f"Cargo.toml workspace git dependency {name!r} must include "
+                    f"a {key} for crates.io packaging"
+                )
 
 
 def workspace_version(root_text: str) -> str:

--- a/scripts/check-publish-layout.py
+++ b/scripts/check-publish-layout.py
@@ -8,6 +8,7 @@ registry version Cargo needs for packaging.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 import tomllib
@@ -95,28 +96,70 @@ def markdown_section(text: str, heading: str) -> str:
 
 
 def publishable_crates(metadata: dict) -> set[str]:
+    workspace_members = set(metadata["workspace_members"])
     return {
         package["name"]
         for package in metadata["packages"]
-        if Path(package["manifest_path"]).parent.parent == ROOT / "crates"
-        and package["name"].startswith("tenferro-")
-        and package.get("publish") != []
+        if package["id"] in workspace_members and package.get("publish") != []
     }
+
+
+def phase3_publication_order(
+    release_text: str, errors: list[str]
+) -> list[str] | None:
+    heading = "## Phase 3 — Publish From The Tag"
+    lines = release_text.splitlines()
+    headings = [index for index, line in enumerate(lines) if line == heading]
+    if len(headings) != 1:
+        errors.append("release workflow must contain exactly one exact Phase 3 heading")
+        return None
+
+    start = headings[0] + 1
+    end = next(
+        (
+            index
+            for index in range(start, len(lines))
+            if re.match(r"^#{1,6}(?:[ \t]+|$)", lines[index])
+        ),
+        len(lines),
+    )
+    text_fences: list[list[str]] = []
+    active_fence: tuple[str, int, str, list[str]] | None = None
+    for line in lines[start:end]:
+        fence = re.match(r"^(`{3,}|~{3,})(.*)$", line.strip())
+        if active_fence is None:
+            if fence:
+                marker, info = fence.groups()
+                active_fence = (marker[0], len(marker), info.strip(), [])
+            continue
+
+        marker_char, marker_len, info, contents = active_fence
+        if (
+            fence
+            and fence.group(1)[0] == marker_char
+            and len(fence.group(1)) >= marker_len
+            and not fence.group(2).strip()
+        ):
+            if info == "text":
+                text_fences.append(contents)
+            active_fence = None
+        else:
+            contents.append(line)
+
+    if active_fence is not None or len(text_fences) != 1:
+        errors.append(
+            "release workflow Phase 3 must contain exactly one complete text fence"
+        )
+        return None
+    return [line.strip() for line in text_fences[0] if line.strip()]
 
 
 def check_release_order(
     metadata: dict, release_text: str, errors: list[str]
 ) -> None:
-    phase = markdown_section(release_text, "Phase 3 — Publish From The Tag")
-    fenced = phase.split("```text", 1)
-    if len(fenced) != 2 or "```" not in fenced[1]:
-        errors.append("release workflow must contain a Phase 3 text publish-order block")
+    order = phase3_publication_order(release_text, errors)
+    if order is None:
         return
-    order = [
-        line.strip()
-        for line in fenced[1].split("```", 1)[0].splitlines()
-        if line.strip()
-    ]
     expected = publishable_crates(metadata)
     if len(order) != len(set(order)):
         errors.append("release publish order must not contain duplicate crates")

--- a/scripts/check-publish-layout.py
+++ b/scripts/check-publish-layout.py
@@ -104,6 +104,46 @@ def publishable_crates(metadata: dict) -> set[str]:
     }
 
 
+def check_release_order(
+    metadata: dict, release_text: str, errors: list[str]
+) -> None:
+    phase = markdown_section(release_text, "Phase 3 — Publish From The Tag")
+    fenced = phase.split("```text", 1)
+    if len(fenced) != 2 or "```" not in fenced[1]:
+        errors.append("release workflow must contain a Phase 3 text publish-order block")
+        return
+    order = [
+        line.strip()
+        for line in fenced[1].split("```", 1)[0].splitlines()
+        if line.strip()
+    ]
+    expected = publishable_crates(metadata)
+    if len(order) != len(set(order)):
+        errors.append("release publish order must not contain duplicate crates")
+    missing = sorted(expected - set(order))
+    unexpected = sorted(set(order) - expected)
+    if missing:
+        errors.append(f"release publish order is missing crates: {missing}")
+    if unexpected:
+        errors.append(f"release publish order has unexpected crates: {unexpected}")
+    if missing or unexpected or len(order) != len(set(order)):
+        return
+
+    positions = {crate: index for index, crate in enumerate(order)}
+    for package in metadata["packages"]:
+        crate = package["name"]
+        if crate not in expected:
+            continue
+        for dependency in package["dependencies"]:
+            dependency_name = dependency["name"]
+            if dependency["kind"] != "dev" and dependency_name in expected:
+                if positions[dependency_name] > positions[crate]:
+                    errors.append(
+                        f"release publish order must place dependency "
+                        f"{dependency_name!r} before {crate!r}"
+                    )
+
+
 def check_workspace_members(metadata: dict, root_text: str, errors: list[str]) -> None:
     packages = {package["name"]: package for package in metadata["packages"]}
 
@@ -349,7 +389,11 @@ def main() -> int:
     errors: list[str] = []
     root_text = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
     metadata = cargo_metadata()
+    release_text = (ROOT / "ai/contribution-workflows/release-publish.md").read_text(
+        encoding="utf-8"
+    )
     check_workspace_members(metadata, root_text, errors)
+    check_release_order(metadata, release_text, errors)
     check_workspace_metadata(root_text, errors)
     check_workspace_dependencies(root_text, errors)
     check_package_metadata(root_text, errors)

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -81,6 +81,9 @@ PROFILE_COMMANDS: dict[str, tuple[str, ...]] = {
         "python3 scripts/check-coverage.py coverage.json",
     ),
     "ci-config": (
+        "python3 scripts/test-release-publish.py",
+        "python3 scripts/test-check-publish-layout.py",
+        "python3 scripts/check-publish-layout.py",
         "python3 scripts/test-storage-ownership-contracts-v2.py",
         _STORAGE_OWNERSHIP_CHECKER,
         "python3 -m unittest discover -s scripts/ci/tests -v",

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -107,7 +107,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "9da9b9f63e688eaf1bf4a78b718a01ac858b1f9f"
+        revision = "b29e7601ba090aa5eafc65b9bde5d9450282e0d8"
         for name in (
             "strided-view",
             "strided-traits",

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -132,6 +132,15 @@ class RunProfileTests(unittest.TestCase):
             commands.index("bash scripts/build_docs_site.sh"),
         )
 
+    def test_ci_config_runs_release_publication_checks(self) -> None:
+        commands = commands_for("ci-config")
+        for command in (
+            "python3 scripts/test-release-publish.py",
+            "python3 scripts/test-check-publish-layout.py",
+            "python3 scripts/check-publish-layout.py",
+        ):
+            self.assertIn(command, commands)
+
     def test_ci_config_checks_storage_ownership_contract_ledger(self) -> None:
         commands = commands_for("ci-config")
         self.assertIn(

--- a/scripts/release-publish.py
+++ b/scripts/release-publish.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+"""Fail-closed operator helper for publishing a tagged tenferro release."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import runpy
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import tomllib
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import NamedTuple
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CRATES_IO_API = "https://crates.io/api/v1/crates"
+EXACT_VERSION = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
+EXACT_REV = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+class ReleaseError(RuntimeError):
+    """A release invariant failed."""
+
+
+class GitDependency(NamedTuple):
+    name: str
+    package: str
+    version: str
+    git: str
+    rev: str
+
+
+class ArchiveInspection(NamedTuple):
+    metadata: dict
+    files: tuple[str, ...]
+
+
+def run(
+    command: list[str], *, cwd: Path = ROOT, capture: bool = True
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            command,
+            cwd=cwd,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE if capture else None,
+            stderr=subprocess.PIPE if capture else None,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or "").strip()
+        raise ReleaseError(f"{' '.join(command)} failed: {detail}") from error
+
+
+def parse_workspace_git_dependencies(manifest_text: str) -> list[GitDependency]:
+    try:
+        manifest = tomllib.loads(manifest_text)
+    except tomllib.TOMLDecodeError as error:
+        raise ReleaseError(f"Cargo.toml is invalid TOML: {error}") from error
+    dependencies = manifest.get("workspace", {}).get("dependencies", {})
+    if not isinstance(dependencies, dict):
+        raise ReleaseError("[workspace.dependencies] must be a table")
+
+    result: list[GitDependency] = []
+    for name, value in dependencies.items():
+        if not isinstance(value, dict) or "git" not in value:
+            continue
+        package = value.get("package", name)
+        version = value.get("version")
+        git = value.get("git")
+        rev = value.get("rev")
+        if not all(isinstance(item, str) and item for item in (package, version, git, rev)):
+            raise ReleaseError(
+                f"workspace git dependency {name!r} must declare package identity, "
+                "an exact registry version, git, and rev"
+            )
+        registry_version = version.removeprefix("=")
+        if EXACT_VERSION.fullmatch(registry_version) is None:
+            raise ReleaseError(
+                f"workspace git dependency {name!r} version must be exact, found {version!r}"
+            )
+        if EXACT_REV.fullmatch(rev) is None:
+            raise ReleaseError(
+                f"workspace git dependency {name!r} rev must be a 40-digit commit, "
+                f"found {rev!r}"
+            )
+        result.append(
+            GitDependency(name, package, registry_version, git, rev.lower())
+        )
+    return result
+
+
+def validate_revision_manifest(
+    dependency: GitDependency, manifests: Mapping[str, str]
+) -> None:
+    parsed: dict[str, dict] = {}
+    workspace_versions: list[str] = []
+    for path, text in manifests.items():
+        try:
+            manifest = tomllib.loads(text)
+        except tomllib.TOMLDecodeError as error:
+            raise ReleaseError(
+                f"{dependency.git}@{dependency.rev}:{path} is invalid TOML: {error}"
+            ) from error
+        parsed[path] = manifest
+        workspace_version = manifest.get("workspace", {}).get("package", {}).get("version")
+        if isinstance(workspace_version, str):
+            workspace_versions.append(workspace_version)
+
+    matches: list[tuple[str, object]] = []
+    for path, manifest in parsed.items():
+        package = manifest.get("package", {})
+        if package.get("name") == dependency.package:
+            matches.append((path, package.get("version")))
+    if len(matches) != 1:
+        raise ReleaseError(
+            f"{dependency.git}@{dependency.rev} must contain exactly one package "
+            f"named {dependency.package!r}, found {len(matches)}"
+        )
+
+    path, declared = matches[0]
+    if declared == {"workspace": True}:
+        versions = set(workspace_versions)
+        if len(versions) != 1:
+            raise ReleaseError(
+                f"{dependency.git}@{dependency.rev}:{path} inherits an ambiguous "
+                "workspace package version"
+            )
+        declared = versions.pop()
+    if declared != dependency.version:
+        raise ReleaseError(
+            f"{dependency.git}@{dependency.rev}:{path} declares version {declared}, "
+            f"expected registry version {dependency.version}"
+        )
+
+
+def fetch_revision_manifests(dependency: GitDependency) -> dict[str, str]:
+    with tempfile.TemporaryDirectory(prefix="tenferro-release-git-") as directory:
+        checkout = Path(directory)
+        run(["git", "init", "--quiet"], cwd=checkout)
+        run(
+            ["git", "fetch", "--quiet", "--depth=1", dependency.git, dependency.rev],
+            cwd=checkout,
+        )
+        paths = run(
+            ["git", "ls-tree", "-r", "--name-only", "FETCH_HEAD"], cwd=checkout
+        ).stdout.splitlines()
+        manifests: dict[str, str] = {}
+        for path in paths:
+            if Path(path).name == "Cargo.toml":
+                manifests[path] = run(
+                    ["git", "show", f"FETCH_HEAD:{path}"], cwd=checkout
+                ).stdout
+        return manifests
+
+
+Transport = Callable[[str], tuple[int, bytes]]
+
+
+def crates_io_transport(url: str) -> tuple[int, bytes]:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "tenferro-release-publish/0.4 (+https://github.com/tensor4all/tenferro-rs)"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30.0) as response:
+            return response.status, response.read()
+    except urllib.error.HTTPError as error:
+        return error.code, error.read()
+    except OSError as error:
+        raise ReleaseError(f"crates.io request failed for {url}: {error}") from error
+
+
+class CratesIoClient:
+    def __init__(self, transport: Transport = crates_io_transport):
+        self.transport = transport
+
+    @staticmethod
+    def _url(*parts: str) -> str:
+        return "/".join(
+            [CRATES_IO_API, *(urllib.parse.quote(part, safe="") for part in parts)]
+        )
+
+    def _exists(self, url: str) -> bool:
+        status, _ = self.transport(url)
+        if status == 200:
+            return True
+        if status == 404:
+            return False
+        raise ReleaseError(f"crates.io query returned HTTP {status}: {url}")
+
+    def package_exists(self, package: str) -> bool:
+        return self._exists(self._url(package))
+
+    def version_exists(self, package: str, version: str) -> bool:
+        return self._exists(self._url(package, version))
+
+    def download(self, package: str, version: str) -> bytes:
+        url = self._url(package, version, "download")
+        status, body = self.transport(url)
+        if status != 200:
+            raise ReleaseError(
+                f"crates.io archive download returned HTTP {status}: {package} {version}"
+            )
+        return body
+
+
+def validate_new_package_approvals(
+    package_exists: Mapping[str, bool], approvals: set[str]
+) -> None:
+    new_packages = {package for package, exists in package_exists.items() if not exists}
+    missing = sorted(new_packages - approvals)
+    if missing:
+        raise ReleaseError(
+            "new crates.io packages require exact user approval before any publication: "
+            f"{missing}; rerun with one --approve-new-package PACKAGE per approved package"
+        )
+    stale = sorted(approvals - new_packages)
+    if stale:
+        raise ReleaseError(f"approval named packages that are not new: {stale}")
+
+
+def _read_archive_member(archive: tarfile.TarFile, name: str) -> bytes:
+    member = archive.extractfile(name)
+    if member is None:
+        raise ReleaseError(f"crate archive member is not a regular file: {name}")
+    return member.read()
+
+
+def inspect_crate_archive(
+    archive_data: bytes, expected_name: str, expected_version: str, expected_commit: str
+) -> ArchiveInspection:
+    try:
+        with tarfile.open(fileobj=io.BytesIO(archive_data), mode="r:gz") as archive:
+            files = tuple(sorted(member.name for member in archive.getmembers() if member.isfile()))
+            prefix = f"{expected_name}-{expected_version}/"
+            manifest_name = prefix + "Cargo.toml"
+            vcs_name = prefix + ".cargo_vcs_info.json"
+            if manifest_name not in files or vcs_name not in files:
+                raise ReleaseError(
+                    f"crate archive must contain {manifest_name} and {vcs_name}"
+                )
+            manifest = tomllib.loads(
+                _read_archive_member(archive, manifest_name).decode("utf-8")
+            )
+            vcs = json.loads(_read_archive_member(archive, vcs_name))
+    except (tarfile.TarError, UnicodeDecodeError, tomllib.TOMLDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseError(f"invalid .crate archive: {error}") from error
+
+    package = manifest.get("package", {})
+    required_strings = (
+        "name",
+        "version",
+        "description",
+        "license",
+        "repository",
+        "homepage",
+        "documentation",
+        "readme",
+        "rust-version",
+    )
+    for key in required_strings:
+        if not isinstance(package.get(key), str) or not package[key].strip():
+            raise ReleaseError(f"packaged Cargo.toml package.{key} must be a non-empty string")
+    if package["name"] != expected_name or package["version"] != expected_version:
+        raise ReleaseError(
+            f"crate archive identity is {package['name']} {package['version']}, "
+            f"expected {expected_name} {expected_version}"
+        )
+    for key in ("keywords", "categories"):
+        values = package.get(key)
+        if not isinstance(values, list) or not values or any(
+            not isinstance(value, str) or not value for value in values
+        ):
+            raise ReleaseError(f"packaged Cargo.toml package.{key} must be non-empty strings")
+    for key in ("include", "exclude"):
+        values = package.get(key)
+        if values is not None and (
+            not isinstance(values, list)
+            or any(not isinstance(value, str) or not value for value in values)
+        ):
+            raise ReleaseError(f"packaged Cargo.toml package.{key} must be a string list")
+    readme = prefix + package["readme"].lstrip("./")
+    if readme not in files:
+        raise ReleaseError(f"crate archive is missing declared README {readme}")
+
+    git = vcs.get("git", {})
+    if git.get("sha1") != expected_commit or git.get("dirty", False) is not False:
+        raise ReleaseError(
+            "crate archive provenance does not equal the clean tagged commit: "
+            f"{git!r}, expected sha1 {expected_commit} and dirty false"
+        )
+    return ArchiveInspection(package, files)
+
+
+def print_inspection(crate: str, inspection: ArchiveInspection) -> None:
+    keys = (
+        "name",
+        "version",
+        "description",
+        "license",
+        "repository",
+        "homepage",
+        "documentation",
+        "readme",
+        "rust-version",
+        "keywords",
+        "categories",
+        "include",
+        "exclude",
+    )
+    print(f"{crate}: packaged metadata")
+    print(json.dumps({key: inspection.metadata.get(key) for key in keys}, indent=2))
+    print(f"{crate}: archive files ({len(inspection.files)})")
+    for path in inspection.files:
+        print(f"  {path}")
+
+
+def verify_release_checkout(version: str) -> str:
+    if EXACT_VERSION.fullmatch(version) is None:
+        raise ReleaseError(f"release version must be exact, found {version!r}")
+    run(["git", "fetch", "origin", "main"], capture=False)
+    if run(["git", "status", "--porcelain"]).stdout:
+        raise ReleaseError("release worktree must be clean, including untracked files")
+    symbolic = subprocess.run(
+        ["git", "symbolic-ref", "-q", "HEAD"], cwd=ROOT, stdout=subprocess.PIPE
+    )
+    if symbolic.returncode == 0:
+        raise ReleaseError("release worktree must be detached at the tag")
+
+    tag = f"v{version}"
+    lines = run(
+        ["git", "ls-remote", "--tags", "origin", f"refs/tags/{tag}", f"refs/tags/{tag}^{{}}"]
+    ).stdout.splitlines()
+    refs = {line.split()[1]: line.split()[0] for line in lines if len(line.split()) == 2}
+    remote_commit = refs.get(f"refs/tags/{tag}^{{}}") or refs.get(f"refs/tags/{tag}")
+    if remote_commit is None:
+        raise ReleaseError(f"origin does not have tag {tag}")
+    head = run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    if head != remote_commit:
+        raise ReleaseError(
+            f"HEAD {head} is not exact pushed remote tag {tag} commit {remote_commit}"
+        )
+    run(["git", "merge-base", "--is-ancestor", head, "origin/main"])
+
+    root_manifest = tomllib.loads((ROOT / "Cargo.toml").read_text(encoding="utf-8"))
+    declared = root_manifest.get("workspace", {}).get("package", {}).get("version")
+    if declared != version:
+        raise ReleaseError(
+            f"tag version {version} does not match workspace package version {declared!r}"
+        )
+    return head
+
+
+def cargo_metadata() -> dict:
+    return json.loads(
+        run(["cargo", "metadata", "--no-deps", "--format-version", "1"]).stdout
+    )
+
+
+def publication_order(release_text: str) -> list[str]:
+    checker = runpy.run_path(str(ROOT / "scripts/check-publish-layout.py"))
+    errors: list[str] = []
+    order = checker["phase3_publication_order"](release_text, errors)
+    if order is None or errors:
+        raise ReleaseError("; ".join(errors))
+    return order
+
+
+def inspect_registry_archive(
+    client: CratesIoClient, crate: str, version: str, commit: str
+) -> ArchiveInspection:
+    return inspect_crate_archive(client.download(crate, version), crate, version, commit)
+
+
+def await_registry_archive(
+    client: CratesIoClient,
+    crate: str,
+    version: str,
+    commit: str,
+    *,
+    attempts: int = 40,
+    delay: float = 30.0,
+) -> ArchiveInspection:
+    for attempt in range(attempts):
+        if client.version_exists(crate, version):
+            try:
+                return inspect_registry_archive(client, crate, version, commit)
+            except ReleaseError:
+                if attempt + 1 == attempts:
+                    raise
+        if attempt + 1 < attempts:
+            time.sleep(delay)
+    raise ReleaseError(
+        f"{crate} {version} did not become visible with matching provenance on crates.io"
+    )
+
+
+def archive_path(metadata: dict, crate: str, version: str) -> Path:
+    return Path(metadata["target_directory"]) / "package" / f"{crate}-{version}.crate"
+
+
+def build_and_inspect_archive(
+    metadata: dict, crate: str, version: str, commit: str, command: list[str]
+) -> ArchiveInspection:
+    path = archive_path(metadata, crate, version)
+    path.unlink(missing_ok=True)
+    run(command, capture=False)
+    if not path.is_file():
+        raise ReleaseError(f"Cargo did not create expected archive {path}")
+    inspection = inspect_crate_archive(path.read_bytes(), crate, version, commit)
+    print_inspection(crate, inspection)
+    return inspection
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="exact release version without the v prefix")
+    parser.add_argument(
+        "--approve-new-package",
+        action="append",
+        default=[],
+        metavar="PACKAGE",
+        help="assert the user explicitly approved this exact new crates.io package",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="perform irreversible cargo publish commands after all preflights",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        commit = verify_release_checkout(args.version)
+        run([sys.executable, "scripts/check-publish-layout.py"], capture=False)
+        root_text = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+        git_dependencies = parse_workspace_git_dependencies(root_text)
+        client = CratesIoClient()
+        revision_cache: dict[tuple[str, str], dict[str, str]] = {}
+        for dependency in git_dependencies:
+            cache_key = (dependency.git, dependency.rev)
+            if cache_key not in revision_cache:
+                revision_cache[cache_key] = fetch_revision_manifests(dependency)
+            validate_revision_manifest(dependency, revision_cache[cache_key])
+            if not client.version_exists(dependency.package, dependency.version):
+                raise ReleaseError(
+                    f"workspace git dependency {dependency.name!r} declares missing "
+                    f"crates.io package/version {dependency.package} {dependency.version}"
+                )
+            print(
+                f"git dependency verified: {dependency.name} -> {dependency.package} "
+                f"{dependency.version} at {dependency.rev}"
+            )
+
+        metadata = cargo_metadata()
+        packages = {package["name"]: package for package in metadata["packages"]}
+        release_text = (ROOT / "ai/contribution-workflows/release-publish.md").read_text(
+            encoding="utf-8"
+        )
+        order = publication_order(release_text)
+        package_exists = {crate: client.package_exists(crate) for crate in order}
+        validate_new_package_approvals(package_exists, set(args.approve_new_package))
+
+        already_published: set[str] = set()
+        for crate in order:
+            package = packages[crate]
+            if package["version"] != args.version:
+                raise ReleaseError(
+                    f"{crate} version {package['version']} does not match {args.version}"
+                )
+            if client.version_exists(crate, args.version):
+                inspection = inspect_registry_archive(
+                    client, crate, args.version, commit
+                )
+                print_inspection(crate, inspection)
+                already_published.add(crate)
+                print(f"{crate} {args.version}: already published from this tag; skip")
+
+        if not args.execute:
+            print("preflight passed; no packages published (rerun with --execute)")
+            return 0
+
+        for crate in order:
+            if crate in already_published:
+                continue
+            package = packages[crate]
+            prerequisites = sorted(
+                dependency["name"]
+                for dependency in package["dependencies"]
+                if dependency.get("kind") != "dev" and dependency["name"] in packages
+            )
+            for prerequisite in prerequisites:
+                await_registry_archive(
+                    client, prerequisite, args.version, commit
+                )
+
+            build_and_inspect_archive(
+                metadata,
+                crate,
+                args.version,
+                commit,
+                ["cargo", "package", "-p", crate, "--locked"],
+            )
+            build_and_inspect_archive(
+                metadata,
+                crate,
+                args.version,
+                commit,
+                [
+                    "cargo",
+                    "publish",
+                    "--dry-run",
+                    "-p",
+                    crate,
+                    "--locked",
+                    "--registry",
+                    "crates-io",
+                ],
+            )
+            run(
+                [
+                    "cargo",
+                    "publish",
+                    "-p",
+                    crate,
+                    "--locked",
+                    "--registry",
+                    "crates-io",
+                ],
+                capture=False,
+            )
+            inspection = await_registry_archive(
+                client, crate, args.version, commit
+            )
+            print_inspection(crate, inspection)
+        return 0
+    except ReleaseError as error:
+        print(f"release-publish: abort: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release-publish.py
+++ b/scripts/release-publish.py
@@ -18,12 +18,14 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Callable, Mapping
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import NamedTuple
 
 
 ROOT = Path(__file__).resolve().parents[1]
 CRATES_IO_API = "https://crates.io/api/v1/crates"
+COMMAND_TIMEOUT = 30 * 60.0
+NETWORK_TIMEOUT = 30.0
 EXACT_VERSION = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
 EXACT_REV = re.compile(r"^[0-9a-fA-F]{40}$")
 
@@ -46,20 +48,45 @@ class ArchiveInspection(NamedTuple):
 
 
 def run(
-    command: list[str], *, cwd: Path = ROOT, capture: bool = True
-) -> subprocess.CompletedProcess[str]:
+    command: list[str],
+    *,
+    cwd: Path = ROOT,
+    capture: bool = True,
+    check: bool = True,
+    text: bool = True,
+    timeout: float = COMMAND_TIMEOUT,
+) -> subprocess.CompletedProcess:
     try:
         return subprocess.run(
             command,
             cwd=cwd,
-            check=True,
-            text=True,
+            check=check,
+            text=text,
+            timeout=timeout,
             stdout=subprocess.PIPE if capture else None,
             stderr=subprocess.PIPE if capture else None,
         )
+    except FileNotFoundError as error:
+        raise ReleaseError(f"command not found: {command[0]}") from error
+    except subprocess.TimeoutExpired as error:
+        raise ReleaseError(
+            f"{' '.join(command)} timed out after {timeout:g} seconds"
+        ) from error
+    except UnicodeDecodeError as error:
+        raise ReleaseError(
+            f"{' '.join(command)} returned output that is not valid UTF-8: {error}"
+        ) from error
     except subprocess.CalledProcessError as error:
-        detail = (error.stderr or error.stdout or "").strip()
-        raise ReleaseError(f"{' '.join(command)} failed: {detail}") from error
+        output = error.stderr or error.stdout or b""
+        detail = (
+            output.decode("utf-8", errors="replace")
+            if isinstance(output, bytes)
+            else output
+        ).strip()
+        suffix = f": {detail}" if detail else ""
+        raise ReleaseError(f"{' '.join(command)} failed{suffix}") from error
+    except OSError as error:
+        raise ReleaseError(f"could not run {' '.join(command)}: {error}") from error
 
 
 def parse_workspace_git_dependencies(manifest_text: str) -> list[GitDependency]:
@@ -67,7 +94,10 @@ def parse_workspace_git_dependencies(manifest_text: str) -> list[GitDependency]:
         manifest = tomllib.loads(manifest_text)
     except tomllib.TOMLDecodeError as error:
         raise ReleaseError(f"Cargo.toml is invalid TOML: {error}") from error
-    dependencies = manifest.get("workspace", {}).get("dependencies", {})
+    workspace = manifest.get("workspace", {})
+    if not isinstance(workspace, dict):
+        raise ReleaseError("[workspace] must be a table")
+    dependencies = workspace.get("dependencies", {})
     if not isinstance(dependencies, dict):
         raise ReleaseError("[workspace.dependencies] must be a table")
 
@@ -113,13 +143,27 @@ def validate_revision_manifest(
                 f"{dependency.git}@{dependency.rev}:{path} is invalid TOML: {error}"
             ) from error
         parsed[path] = manifest
-        workspace_version = manifest.get("workspace", {}).get("package", {}).get("version")
+        workspace = manifest.get("workspace", {})
+        if not isinstance(workspace, dict):
+            raise ReleaseError(
+                f"{dependency.git}@{dependency.rev}:{path} [workspace] must be a table"
+            )
+        workspace_package = workspace.get("package", {})
+        if not isinstance(workspace_package, dict):
+            raise ReleaseError(
+                f"{dependency.git}@{dependency.rev}:{path} [workspace.package] must be a table"
+            )
+        workspace_version = workspace_package.get("version")
         if isinstance(workspace_version, str):
             workspace_versions.append(workspace_version)
 
     matches: list[tuple[str, object]] = []
     for path, manifest in parsed.items():
         package = manifest.get("package", {})
+        if not isinstance(package, dict):
+            raise ReleaseError(
+                f"{dependency.git}@{dependency.rev}:{path} [package] must be a table"
+            )
         if package.get("name") == dependency.package:
             matches.append((path, package.get("version")))
     if len(matches) != 1:
@@ -144,21 +188,27 @@ def validate_revision_manifest(
         )
 
 
-def fetch_revision_manifests(dependency: GitDependency) -> dict[str, str]:
-    with tempfile.TemporaryDirectory(prefix="tenferro-release-git-") as directory:
+def fetch_revision_manifests(
+    dependency: GitDependency, *, runner: Callable = run
+) -> dict[str, str]:
+    try:
+        temporary = tempfile.TemporaryDirectory(prefix="tenferro-release-git-")
+    except OSError as error:
+        raise ReleaseError(f"could not create temporary git checkout: {error}") from error
+    with temporary as directory:
         checkout = Path(directory)
-        run(["git", "init", "--quiet"], cwd=checkout)
-        run(
+        runner(["git", "init", "--quiet"], cwd=checkout)
+        runner(
             ["git", "fetch", "--quiet", "--depth=1", dependency.git, dependency.rev],
             cwd=checkout,
         )
-        paths = run(
+        paths = runner(
             ["git", "ls-tree", "-r", "--name-only", "FETCH_HEAD"], cwd=checkout
         ).stdout.splitlines()
         manifests: dict[str, str] = {}
         for path in paths:
             if Path(path).name == "Cargo.toml":
-                manifests[path] = run(
+                manifests[path] = runner(
                     ["git", "show", f"FETCH_HEAD:{path}"], cwd=checkout
                 ).stdout
         return manifests
@@ -173,11 +223,16 @@ def crates_io_transport(url: str) -> tuple[int, bytes]:
         headers={"User-Agent": "tenferro-release-publish/0.4 (+https://github.com/tensor4all/tenferro-rs)"},
     )
     try:
-        with urllib.request.urlopen(request, timeout=30.0) as response:
+        with urllib.request.urlopen(request, timeout=NETWORK_TIMEOUT) as response:
             return response.status, response.read()
     except urllib.error.HTTPError as error:
-        return error.code, error.read()
-    except OSError as error:
+        try:
+            return error.code, error.read()
+        except OSError as read_error:
+            raise ReleaseError(
+                f"crates.io error response could not be read for {url}: {read_error}"
+            ) from read_error
+    except (OSError, TimeoutError) as error:
         raise ReleaseError(f"crates.io request failed for {url}: {error}") from error
 
 
@@ -191,8 +246,24 @@ class CratesIoClient:
             [CRATES_IO_API, *(urllib.parse.quote(part, safe="") for part in parts)]
         )
 
+    def _request(self, url: str) -> tuple[int, bytes]:
+        try:
+            result = self.transport(url)
+        except ReleaseError:
+            raise
+        except (OSError, TimeoutError) as error:
+            raise ReleaseError(f"crates.io request failed for {url}: {error}") from error
+        if (
+            not isinstance(result, tuple)
+            or len(result) != 2
+            or not isinstance(result[0], int)
+            or not isinstance(result[1], bytes)
+        ):
+            raise ReleaseError(f"crates.io transport returned an invalid response for {url}")
+        return result
+
     def _exists(self, url: str) -> bool:
-        status, _ = self.transport(url)
+        status, _ = self._request(url)
         if status == 200:
             return True
         if status == 404:
@@ -207,7 +278,7 @@ class CratesIoClient:
 
     def download(self, package: str, version: str) -> bytes:
         url = self._url(package, version, "download")
-        status, body = self.transport(url)
+        status, body = self._request(url)
         if status != 200:
             raise ReleaseError(
                 f"crates.io archive download returned HTTP {status}: {package} {version}"
@@ -216,8 +287,21 @@ class CratesIoClient:
 
 
 def validate_new_package_approvals(
-    package_exists: Mapping[str, bool], approvals: set[str]
+    package_exists: Mapping[str, bool],
+    version_exists: Mapping[str, bool],
+    approvals: set[str],
 ) -> None:
+    if package_exists.keys() != version_exists.keys():
+        raise ReleaseError("package and target-version registry results do not match")
+    inconsistent = sorted(
+        package
+        for package, exists in package_exists.items()
+        if not exists and version_exists[package]
+    )
+    if inconsistent:
+        raise ReleaseError(
+            f"crates.io reported target versions for missing packages: {inconsistent}"
+        )
     new_packages = {package for package, exists in package_exists.items() if not exists}
     missing = sorted(new_packages - approvals)
     if missing:
@@ -225,39 +309,100 @@ def validate_new_package_approvals(
             "new crates.io packages require exact user approval before any publication: "
             f"{missing}; rerun with one --approve-new-package PACKAGE per approved package"
         )
-    stale = sorted(approvals - new_packages)
+    unknown = sorted(approvals - package_exists.keys())
+    if unknown:
+        raise ReleaseError(f"approval named packages outside the publication order: {unknown}")
+    stale = sorted(
+        package
+        for package in approvals
+        if package_exists[package] and not version_exists[package]
+    )
     if stale:
-        raise ReleaseError(f"approval named packages that are not new: {stale}")
+        raise ReleaseError(
+            "approval named existing packages whose target version does not exist: "
+            f"{stale}"
+        )
 
 
-def _read_archive_member(archive: tarfile.TarFile, name: str) -> bytes:
-    member = archive.extractfile(name)
-    if member is None:
-        raise ReleaseError(f"crate archive member is not a regular file: {name}")
-    return member.read()
+TaggedSourceReader = Callable[[str], bytes | None]
+
+
+def _read_archive_member(archive: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:
+    extracted = archive.extractfile(member)
+    if extracted is None:
+        raise ReleaseError(f"crate archive member is not a regular file: {member.name}")
+    return extracted.read()
 
 
 def inspect_crate_archive(
-    archive_data: bytes, expected_name: str, expected_version: str, expected_commit: str
+    archive_data: bytes,
+    expected_name: str,
+    expected_version: str,
+    expected_commit: str,
+    package_root: str,
+    source_reader: TaggedSourceReader,
+    expected_files: set[str],
 ) -> ArchiveInspection:
+    prefix = f"{expected_name}-{expected_version}/"
     try:
         with tarfile.open(fileobj=io.BytesIO(archive_data), mode="r:gz") as archive:
-            files = tuple(sorted(member.name for member in archive.getmembers() if member.isfile()))
-            prefix = f"{expected_name}-{expected_version}/"
-            manifest_name = prefix + "Cargo.toml"
-            vcs_name = prefix + ".cargo_vcs_info.json"
-            if manifest_name not in files or vcs_name not in files:
+            contents: dict[str, bytes] = {}
+            full_names: list[str] = []
+            for member in archive.getmembers():
+                if member.isdir():
+                    continue
+                if not member.isfile():
+                    raise ReleaseError(
+                        f"crate archive has unsupported non-regular member {member.name!r}"
+                    )
+                if not member.name.startswith(prefix):
+                    raise ReleaseError(
+                        f"crate archive member is outside expected prefix {prefix!r}: "
+                        f"{member.name!r}"
+                    )
+                relative = member.name[len(prefix) :]
+                path = PurePosixPath(relative)
+                if (
+                    not relative
+                    or path.is_absolute()
+                    or ".." in path.parts
+                    or relative in contents
+                ):
+                    raise ReleaseError(f"invalid crate archive member path: {member.name!r}")
+                contents[relative] = _read_archive_member(archive, member)
+                full_names.append(member.name)
+
+            actual_files = set(contents)
+            missing_expected = sorted(expected_files - actual_files)
+            unexpected = sorted(actual_files - expected_files)
+            if missing_expected or unexpected:
                 raise ReleaseError(
-                    f"crate archive must contain {manifest_name} and {vcs_name}"
+                    "crate archive file list differs from Cargo's tagged package selection: "
+                    f"missing {missing_expected}, unexpected {unexpected}"
                 )
-            manifest = tomllib.loads(
-                _read_archive_member(archive, manifest_name).decode("utf-8")
-            )
-            vcs = json.loads(_read_archive_member(archive, vcs_name))
-    except (tarfile.TarError, UnicodeDecodeError, tomllib.TOMLDecodeError, json.JSONDecodeError) as error:
+            required = {"Cargo.toml", "Cargo.toml.orig", ".cargo_vcs_info.json"}
+            missing = sorted(required - actual_files)
+            if missing:
+                raise ReleaseError(f"crate archive is missing required files: {missing}")
+            manifest = tomllib.loads(contents["Cargo.toml"].decode("utf-8"))
+            vcs = json.loads(contents[".cargo_vcs_info.json"].decode("utf-8"))
+    except ReleaseError:
+        raise
+    except (
+        OSError,
+        EOFError,
+        tarfile.TarError,
+        UnicodeDecodeError,
+        tomllib.TOMLDecodeError,
+        json.JSONDecodeError,
+    ) as error:
         raise ReleaseError(f"invalid .crate archive: {error}") from error
 
-    package = manifest.get("package", {})
+    if not isinstance(manifest, dict) or not isinstance(vcs, dict):
+        raise ReleaseError("invalid .crate archive: metadata roots must be objects")
+    package = manifest.get("package")
+    if not isinstance(package, dict):
+        raise ReleaseError("packaged Cargo.toml must contain a [package] table")
     required_strings = (
         "name",
         "version",
@@ -290,17 +435,62 @@ def inspect_crate_archive(
             or any(not isinstance(value, str) or not value for value in values)
         ):
             raise ReleaseError(f"packaged Cargo.toml package.{key} must be a string list")
-    readme = prefix + package["readme"].lstrip("./")
-    if readme not in files:
-        raise ReleaseError(f"crate archive is missing declared README {readme}")
 
-    git = vcs.get("git", {})
+    readme = package["readme"].lstrip("./")
+    if readme not in contents:
+        raise ReleaseError(f"crate archive is missing declared README {prefix + readme}")
+    license_file = package.get("license-file")
+    if license_file is not None and (
+        not isinstance(license_file, str) or not license_file.strip()
+    ):
+        raise ReleaseError("packaged Cargo.toml package.license-file must be a string")
+    if isinstance(license_file, str) and license_file not in contents:
+        raise ReleaseError(
+            f"crate archive is missing declared license file {prefix + license_file}"
+        )
+
+    git = vcs.get("git")
+    if not isinstance(git, dict):
+        raise ReleaseError("crate archive .cargo_vcs_info.json must contain a git object")
     if git.get("sha1") != expected_commit or git.get("dirty", False) is not False:
         raise ReleaseError(
             "crate archive provenance does not equal the clean tagged commit: "
             f"{git!r}, expected sha1 {expected_commit} and dirty false"
         )
-    return ArchiveInspection(package, files)
+
+    generated = {".cargo_vcs_info.json", "Cargo.toml", "Cargo.lock"}
+    external = {readme}
+    if isinstance(license_file, str):
+        external.add(license_file)
+    package_root = package_root.strip("/")
+    for relative, archived in contents.items():
+        if relative in generated:
+            continue
+        source_path = (
+            f"{package_root}/Cargo.toml"
+            if relative == "Cargo.toml.orig"
+            else f"{package_root}/{relative}"
+        )
+        try:
+            source = source_reader(source_path)
+            if source is None and relative in external:
+                source_path = relative
+                source = source_reader(source_path)
+        except ReleaseError:
+            raise
+        except (OSError, TimeoutError) as error:
+            raise ReleaseError(
+                f"could not read tagged source for archive member {relative}: {error}"
+            ) from error
+        if source is None:
+            raise ReleaseError(
+                f"crate archive member {relative!r} has no mapped file in tagged package tree"
+            )
+        if archived != source:
+            raise ReleaseError(
+                f"crate archive member {relative!r} differs from tagged source {source_path!r}"
+            )
+    return ArchiveInspection(package, tuple(sorted(full_names)))
 
 
 def print_inspection(crate: str, inspection: ArchiveInspection) -> None:
@@ -326,35 +516,59 @@ def print_inspection(crate: str, inspection: ArchiveInspection) -> None:
         print(f"  {path}")
 
 
-def verify_release_checkout(version: str) -> str:
+def verify_release_checkout(
+    version: str, *, runner: Callable = run, root: Path = ROOT
+) -> str:
     if EXACT_VERSION.fullmatch(version) is None:
         raise ReleaseError(f"release version must be exact, found {version!r}")
-    run(["git", "fetch", "origin", "main"], capture=False)
-    if run(["git", "status", "--porcelain"]).stdout:
+    runner(["git", "fetch", "origin", "main"], cwd=root, capture=False)
+    if runner(["git", "status", "--porcelain"], cwd=root).stdout:
         raise ReleaseError("release worktree must be clean, including untracked files")
-    symbolic = subprocess.run(
-        ["git", "symbolic-ref", "-q", "HEAD"], cwd=ROOT, stdout=subprocess.PIPE
+    symbolic = runner(
+        ["git", "symbolic-ref", "-q", "HEAD"], cwd=root, check=False
     )
     if symbolic.returncode == 0:
         raise ReleaseError("release worktree must be detached at the tag")
+    if symbolic.returncode != 1:
+        raise ReleaseError("git could not determine whether the release checkout is detached")
 
     tag = f"v{version}"
-    lines = run(
-        ["git", "ls-remote", "--tags", "origin", f"refs/tags/{tag}", f"refs/tags/{tag}^{{}}"]
+    lines = runner(
+        [
+            "git",
+            "ls-remote",
+            "--tags",
+            "origin",
+            f"refs/tags/{tag}",
+            f"refs/tags/{tag}^{{}}",
+        ],
+        cwd=root,
     ).stdout.splitlines()
     refs = {line.split()[1]: line.split()[0] for line in lines if len(line.split()) == 2}
     remote_commit = refs.get(f"refs/tags/{tag}^{{}}") or refs.get(f"refs/tags/{tag}")
     if remote_commit is None:
         raise ReleaseError(f"origin does not have tag {tag}")
-    head = run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    head = runner(["git", "rev-parse", "HEAD"], cwd=root).stdout.strip()
     if head != remote_commit:
         raise ReleaseError(
             f"HEAD {head} is not exact pushed remote tag {tag} commit {remote_commit}"
         )
-    run(["git", "merge-base", "--is-ancestor", head, "origin/main"])
+    runner(
+        ["git", "merge-base", "--is-ancestor", head, "origin/main"], cwd=root
+    )
 
-    root_manifest = tomllib.loads((ROOT / "Cargo.toml").read_text(encoding="utf-8"))
-    declared = root_manifest.get("workspace", {}).get("package", {}).get("version")
+    try:
+        root_manifest = tomllib.loads(
+            (root / "Cargo.toml").read_text(encoding="utf-8")
+        )
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise ReleaseError(f"could not parse release Cargo.toml: {error}") from error
+    workspace = root_manifest.get("workspace")
+    declared = (
+        workspace.get("package", {}).get("version")
+        if isinstance(workspace, dict)
+        else None
+    )
     if declared != version:
         raise ReleaseError(
             f"tag version {version} does not match workspace package version {declared!r}"
@@ -362,25 +576,112 @@ def verify_release_checkout(version: str) -> str:
     return head
 
 
-def cargo_metadata() -> dict:
-    return json.loads(
-        run(["cargo", "metadata", "--no-deps", "--format-version", "1"]).stdout
+def cargo_metadata(*, runner: Callable = run, root: Path = ROOT) -> dict:
+    try:
+        metadata = json.loads(
+            runner(
+                ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+                cwd=root,
+            ).stdout
+        )
+    except (TypeError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseError(f"cargo metadata returned invalid JSON: {error}") from error
+    if not isinstance(metadata, dict):
+        raise ReleaseError("cargo metadata JSON root must be an object")
+    return metadata
+
+
+def tagged_source_reader(
+    commit: str, *, runner: Callable = run, root: Path = ROOT
+) -> TaggedSourceReader:
+    paths = set(
+        runner(
+            ["git", "ls-tree", "-r", "--name-only", commit], cwd=root
+        ).stdout.splitlines()
     )
 
+    def read_source(path: str) -> bytes | None:
+        if path not in paths:
+            return None
+        output = runner(
+            ["git", "show", f"{commit}:{path}"], cwd=root, text=False
+        ).stdout
+        if not isinstance(output, bytes):
+            raise ReleaseError(f"git show returned non-binary output for {path}")
+        return output
 
-def publication_order(release_text: str) -> list[str]:
-    checker = runpy.run_path(str(ROOT / "scripts/check-publish-layout.py"))
-    errors: list[str] = []
-    order = checker["phase3_publication_order"](release_text, errors)
+    return read_source
+
+
+def publication_order(release_text: str, *, root: Path = ROOT) -> list[str]:
+    try:
+        checker = runpy.run_path(str(root / "scripts/check-publish-layout.py"))
+        parser = checker["phase3_publication_order"]
+        errors: list[str] = []
+        order = parser(release_text, errors)
+    except (OSError, SyntaxError, KeyError, TypeError) as error:
+        raise ReleaseError(f"could not parse release publication order: {error}") from error
     if order is None or errors:
-        raise ReleaseError("; ".join(errors))
+        raise ReleaseError("; ".join(errors) or "release publication order is missing")
+    if not isinstance(order, list) or any(not isinstance(crate, str) for crate in order):
+        raise ReleaseError("release publication order parser returned invalid data")
     return order
 
 
+def cargo_package_files(
+    crate: str, *, runner: Callable = run, root: Path = ROOT
+) -> set[str]:
+    lines = runner(
+        ["cargo", "package", "--list", "-p", crate, "--locked"], cwd=root
+    ).stdout.splitlines()
+    files: set[str] = set()
+    for line in lines:
+        path = PurePosixPath(line)
+        if (
+            not line
+            or path.is_absolute()
+            or ".." in path.parts
+            or line in files
+        ):
+            raise ReleaseError(
+                f"cargo package --list returned an invalid path for {crate}: {line!r}"
+            )
+        files.add(line)
+    if not files:
+        raise ReleaseError(f"cargo package --list returned no files for {crate}")
+    return files
+
+
+def package_root(package: Mapping[str, object], *, root: Path = ROOT) -> str:
+    manifest = package.get("manifest_path")
+    if not isinstance(manifest, str):
+        raise ReleaseError("cargo metadata package is missing manifest_path")
+    try:
+        return Path(manifest).resolve().parent.relative_to(root.resolve()).as_posix()
+    except ValueError as error:
+        raise ReleaseError(f"package manifest is outside release checkout: {manifest}") from error
+
+
 def inspect_registry_archive(
-    client: CratesIoClient, crate: str, version: str, commit: str
+    client: CratesIoClient,
+    crate: str,
+    version: str,
+    commit: str,
+    package_dir: str,
+    source_reader: TaggedSourceReader,
+    expected_files: set[str],
+    *,
+    archive_inspector: Callable = inspect_crate_archive,
 ) -> ArchiveInspection:
-    return inspect_crate_archive(client.download(crate, version), crate, version, commit)
+    return archive_inspector(
+        client.download(crate, version),
+        crate,
+        version,
+        commit,
+        package_dir,
+        source_reader,
+        expected_files,
+    )
 
 
 def await_registry_archive(
@@ -388,39 +689,299 @@ def await_registry_archive(
     crate: str,
     version: str,
     commit: str,
+    package_dir: str,
+    source_reader: TaggedSourceReader,
+    expected_files: set[str],
     *,
+    archive_inspector: Callable = inspect_crate_archive,
     attempts: int = 40,
     delay: float = 30.0,
+    sleeper: Callable[[float], None] = time.sleep,
 ) -> ArchiveInspection:
+    if attempts < 1 or delay < 0:
+        raise ReleaseError("registry propagation attempts must be positive and delay non-negative")
+    last_mismatch: ReleaseError | None = None
     for attempt in range(attempts):
         if client.version_exists(crate, version):
             try:
-                return inspect_registry_archive(client, crate, version, commit)
-            except ReleaseError:
-                if attempt + 1 == attempts:
-                    raise
+                return inspect_registry_archive(
+                    client,
+                    crate,
+                    version,
+                    commit,
+                    package_dir,
+                    source_reader,
+                    expected_files,
+                    archive_inspector=archive_inspector,
+                )
+            except ReleaseError as error:
+                last_mismatch = error
         if attempt + 1 < attempts:
-            time.sleep(delay)
+            sleeper(delay)
+    detail = f"; last archive error: {last_mismatch}" if last_mismatch else ""
     raise ReleaseError(
         f"{crate} {version} did not become visible with matching provenance on crates.io"
+        f" after {attempts} attempts{detail}"
     )
 
 
-def archive_path(metadata: dict, crate: str, version: str) -> Path:
-    return Path(metadata["target_directory"]) / "package" / f"{crate}-{version}.crate"
+def archive_path(metadata: Mapping[str, object], crate: str, version: str) -> Path:
+    target = metadata.get("target_directory")
+    if not isinstance(target, str):
+        raise ReleaseError("cargo metadata is missing target_directory")
+    return Path(target) / "package" / f"{crate}-{version}.crate"
 
 
 def build_and_inspect_archive(
-    metadata: dict, crate: str, version: str, commit: str, command: list[str]
+    metadata: Mapping[str, object],
+    crate: str,
+    version: str,
+    commit: str,
+    package_dir: str,
+    source_reader: TaggedSourceReader,
+    expected_files: set[str],
+    command: list[str],
+    *,
+    runner: Callable = run,
+    root: Path = ROOT,
+    archive_inspector: Callable = inspect_crate_archive,
 ) -> ArchiveInspection:
     path = archive_path(metadata, crate, version)
-    path.unlink(missing_ok=True)
-    run(command, capture=False)
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as error:
+        raise ReleaseError(f"could not remove stale Cargo archive {path}: {error}") from error
+    runner(command, cwd=root, capture=False)
     if not path.is_file():
         raise ReleaseError(f"Cargo did not create expected archive {path}")
-    inspection = inspect_crate_archive(path.read_bytes(), crate, version, commit)
+    try:
+        archive_data = path.read_bytes()
+    except OSError as error:
+        raise ReleaseError(f"could not read Cargo archive {path}: {error}") from error
+    inspection = archive_inspector(
+        archive_data,
+        crate,
+        version,
+        commit,
+        package_dir,
+        source_reader,
+        expected_files,
+    )
     print_inspection(crate, inspection)
     return inspection
+
+
+def _read_text(path: Path, description: str) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise ReleaseError(f"could not read {description} {path}: {error}") from error
+
+
+def publish_release(
+    version: str,
+    approvals: set[str],
+    execute: bool,
+    *,
+    root: Path = ROOT,
+    runner: Callable = run,
+    client: CratesIoClient | None = None,
+    checkout_verifier: Callable = verify_release_checkout,
+    metadata_loader: Callable = cargo_metadata,
+    order_loader: Callable = publication_order,
+    package_files_loader: Callable = cargo_package_files,
+    revision_fetcher: Callable = fetch_revision_manifests,
+    archive_inspector: Callable = inspect_crate_archive,
+    source_reader_factory: Callable = tagged_source_reader,
+    attempts: int = 40,
+    delay: float = 30.0,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> None:
+    commit = checkout_verifier(version, runner=runner, root=root)
+    runner(
+        [sys.executable, "scripts/check-publish-layout.py"],
+        cwd=root,
+        capture=False,
+    )
+    root_text = _read_text(root / "Cargo.toml", "workspace manifest")
+    git_dependencies = parse_workspace_git_dependencies(root_text)
+    registry = client or CratesIoClient()
+    revision_cache: dict[tuple[str, str], dict[str, str]] = {}
+    for dependency in git_dependencies:
+        cache_key = (dependency.git, dependency.rev)
+        if cache_key not in revision_cache:
+            revision_cache[cache_key] = revision_fetcher(
+                dependency, runner=runner
+            )
+        validate_revision_manifest(dependency, revision_cache[cache_key])
+        if not registry.version_exists(dependency.package, dependency.version):
+            raise ReleaseError(
+                f"workspace git dependency {dependency.name!r} declares missing "
+                f"crates.io package/version {dependency.package} {dependency.version}"
+            )
+        print(
+            f"git dependency verified: {dependency.name} -> {dependency.package} "
+            f"{dependency.version} at {dependency.rev}"
+        )
+
+    metadata = metadata_loader(runner=runner, root=root)
+    package_data = metadata.get("packages")
+    if not isinstance(package_data, list) or any(
+        not isinstance(package, dict) for package in package_data
+    ):
+        raise ReleaseError("cargo metadata packages must be a list of objects")
+    packages: dict[str, dict] = {}
+    for package in package_data:
+        name = package.get("name")
+        if not isinstance(name, str) or name in packages:
+            raise ReleaseError("cargo metadata package names must be unique strings")
+        packages[name] = package
+
+    release_text = _read_text(
+        root / "ai/contribution-workflows/release-publish.md", "release workflow"
+    )
+    order = order_loader(release_text)
+    if not isinstance(order, list) or any(not isinstance(crate, str) for crate in order):
+        raise ReleaseError("release publication order must be a list of package names")
+    if len(order) != len(set(order)):
+        raise ReleaseError("release publication order must not contain duplicates")
+    missing_packages = sorted(set(order) - packages.keys())
+    if missing_packages:
+        raise ReleaseError(f"publication order names missing metadata packages: {missing_packages}")
+
+    package_exists = {crate: registry.package_exists(crate) for crate in order}
+    version_exists = {
+        crate: registry.version_exists(crate, version) for crate in order
+    }
+    validate_new_package_approvals(package_exists, version_exists, approvals)
+    source_reader = source_reader_factory(commit, runner=runner, root=root)
+
+    already_published: set[str] = set()
+    expected_files_by_crate: dict[str, set[str]] = {}
+    for crate in order:
+        package = packages[crate]
+        package_version = package.get("version")
+        if package_version != version:
+            raise ReleaseError(
+                f"{crate} version {package_version!r} does not match {version}"
+            )
+        if version_exists[crate]:
+            expected_files = package_files_loader(crate, runner=runner, root=root)
+            expected_files_by_crate[crate] = expected_files
+            inspection = inspect_registry_archive(
+                registry,
+                crate,
+                version,
+                commit,
+                package_root(package, root=root),
+                source_reader,
+                expected_files,
+                archive_inspector=archive_inspector,
+            )
+            print_inspection(crate, inspection)
+            already_published.add(crate)
+            print(f"{crate} {version}: already published from this tag; skip")
+
+    if not execute:
+        print("preflight passed; no packages published (rerun with --execute)")
+        return
+
+    for crate in order:
+        if crate in already_published:
+            continue
+        package = packages[crate]
+        dependencies = package.get("dependencies")
+        if not isinstance(dependencies, list) or any(
+            not isinstance(dependency, dict) for dependency in dependencies
+        ):
+            raise ReleaseError(f"cargo metadata dependencies are invalid for {crate}")
+        prerequisites = sorted(
+            dependency["name"]
+            for dependency in dependencies
+            if dependency.get("kind") != "dev"
+            and isinstance(dependency.get("name"), str)
+            and dependency["name"] in order
+        )
+        for prerequisite in prerequisites:
+            await_registry_archive(
+                registry,
+                prerequisite,
+                version,
+                commit,
+                package_root(packages[prerequisite], root=root),
+                source_reader,
+                expected_files_by_crate[prerequisite],
+                archive_inspector=archive_inspector,
+                attempts=attempts,
+                delay=delay,
+                sleeper=sleeper,
+            )
+
+        package_dir = package_root(package, root=root)
+        expected_files = package_files_loader(crate, runner=runner, root=root)
+        expected_files_by_crate[crate] = expected_files
+        build_and_inspect_archive(
+            metadata,
+            crate,
+            version,
+            commit,
+            package_dir,
+            source_reader,
+            expected_files,
+            ["cargo", "package", "-p", crate, "--locked"],
+            runner=runner,
+            root=root,
+            archive_inspector=archive_inspector,
+        )
+        build_and_inspect_archive(
+            metadata,
+            crate,
+            version,
+            commit,
+            package_dir,
+            source_reader,
+            expected_files,
+            [
+                "cargo",
+                "publish",
+                "--dry-run",
+                "-p",
+                crate,
+                "--locked",
+                "--registry",
+                "crates-io",
+            ],
+            runner=runner,
+            root=root,
+            archive_inspector=archive_inspector,
+        )
+        runner(
+            [
+                "cargo",
+                "publish",
+                "-p",
+                crate,
+                "--locked",
+                "--registry",
+                "crates-io",
+            ],
+            cwd=root,
+            capture=False,
+        )
+        inspection = await_registry_archive(
+            registry,
+            crate,
+            version,
+            commit,
+            package_dir,
+            source_reader,
+            expected_files,
+            archive_inspector=archive_inspector,
+            attempts=attempts,
+            delay=delay,
+            sleeper=sleeper,
+        )
+        print_inspection(crate, inspection)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -441,108 +1002,11 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        commit = verify_release_checkout(args.version)
-        run([sys.executable, "scripts/check-publish-layout.py"], capture=False)
-        root_text = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
-        git_dependencies = parse_workspace_git_dependencies(root_text)
-        client = CratesIoClient()
-        revision_cache: dict[tuple[str, str], dict[str, str]] = {}
-        for dependency in git_dependencies:
-            cache_key = (dependency.git, dependency.rev)
-            if cache_key not in revision_cache:
-                revision_cache[cache_key] = fetch_revision_manifests(dependency)
-            validate_revision_manifest(dependency, revision_cache[cache_key])
-            if not client.version_exists(dependency.package, dependency.version):
-                raise ReleaseError(
-                    f"workspace git dependency {dependency.name!r} declares missing "
-                    f"crates.io package/version {dependency.package} {dependency.version}"
-                )
-            print(
-                f"git dependency verified: {dependency.name} -> {dependency.package} "
-                f"{dependency.version} at {dependency.rev}"
-            )
-
-        metadata = cargo_metadata()
-        packages = {package["name"]: package for package in metadata["packages"]}
-        release_text = (ROOT / "ai/contribution-workflows/release-publish.md").read_text(
-            encoding="utf-8"
+        publish_release(
+            args.version,
+            set(args.approve_new_package),
+            args.execute,
         )
-        order = publication_order(release_text)
-        package_exists = {crate: client.package_exists(crate) for crate in order}
-        validate_new_package_approvals(package_exists, set(args.approve_new_package))
-
-        already_published: set[str] = set()
-        for crate in order:
-            package = packages[crate]
-            if package["version"] != args.version:
-                raise ReleaseError(
-                    f"{crate} version {package['version']} does not match {args.version}"
-                )
-            if client.version_exists(crate, args.version):
-                inspection = inspect_registry_archive(
-                    client, crate, args.version, commit
-                )
-                print_inspection(crate, inspection)
-                already_published.add(crate)
-                print(f"{crate} {args.version}: already published from this tag; skip")
-
-        if not args.execute:
-            print("preflight passed; no packages published (rerun with --execute)")
-            return 0
-
-        for crate in order:
-            if crate in already_published:
-                continue
-            package = packages[crate]
-            prerequisites = sorted(
-                dependency["name"]
-                for dependency in package["dependencies"]
-                if dependency.get("kind") != "dev" and dependency["name"] in packages
-            )
-            for prerequisite in prerequisites:
-                await_registry_archive(
-                    client, prerequisite, args.version, commit
-                )
-
-            build_and_inspect_archive(
-                metadata,
-                crate,
-                args.version,
-                commit,
-                ["cargo", "package", "-p", crate, "--locked"],
-            )
-            build_and_inspect_archive(
-                metadata,
-                crate,
-                args.version,
-                commit,
-                [
-                    "cargo",
-                    "publish",
-                    "--dry-run",
-                    "-p",
-                    crate,
-                    "--locked",
-                    "--registry",
-                    "crates-io",
-                ],
-            )
-            run(
-                [
-                    "cargo",
-                    "publish",
-                    "-p",
-                    crate,
-                    "--locked",
-                    "--registry",
-                    "crates-io",
-                ],
-                capture=False,
-            )
-            inspection = await_registry_archive(
-                client, crate, args.version, commit
-            )
-            print_inspection(crate, inspection)
         return 0
     except ReleaseError as error:
         print(f"release-publish: abort: {error}", file=sys.stderr)

--- a/scripts/release-publish.py
+++ b/scripts/release-publish.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import http.client
 import io
 import json
 import re
@@ -45,6 +46,7 @@ class GitDependency(NamedTuple):
 class ArchiveInspection(NamedTuple):
     metadata: dict
     files: tuple[str, ...]
+    contents: dict[str, bytes]
 
 
 def run(
@@ -228,11 +230,11 @@ def crates_io_transport(url: str) -> tuple[int, bytes]:
     except urllib.error.HTTPError as error:
         try:
             return error.code, error.read()
-        except OSError as read_error:
+        except (OSError, EOFError, http.client.HTTPException) as read_error:
             raise ReleaseError(
                 f"crates.io error response could not be read for {url}: {read_error}"
             ) from read_error
-    except (OSError, TimeoutError) as error:
+    except (OSError, TimeoutError, EOFError, http.client.HTTPException) as error:
         raise ReleaseError(f"crates.io request failed for {url}: {error}") from error
 
 
@@ -251,7 +253,7 @@ class CratesIoClient:
             result = self.transport(url)
         except ReleaseError:
             raise
-        except (OSError, TimeoutError) as error:
+        except (OSError, TimeoutError, EOFError, http.client.HTTPException) as error:
             raise ReleaseError(f"crates.io request failed for {url}: {error}") from error
         if (
             not isinstance(result, tuple)
@@ -342,34 +344,44 @@ def inspect_crate_archive(
     package_root: str,
     source_reader: TaggedSourceReader,
     expected_files: set[str],
+    expected_contents: Mapping[str, bytes] | None = None,
 ) -> ArchiveInspection:
     prefix = f"{expected_name}-{expected_version}/"
     try:
         with tarfile.open(fileobj=io.BytesIO(archive_data), mode="r:gz") as archive:
             contents: dict[str, bytes] = {}
             full_names: list[str] = []
+            member_paths: set[str] = set()
+            archive_root = prefix.removesuffix("/")
             for member in archive.getmembers():
+                if member.name == archive_root and member.isdir():
+                    relative = ""
+                elif member.name.startswith(prefix):
+                    relative = member.name[len(prefix) :]
+                else:
+                    raise ReleaseError(
+                        f"crate archive member is outside expected prefix {prefix!r}: "
+                        f"{member.name!r}"
+                    )
+                parts = relative.split("/") if relative else []
+                path = PurePosixPath(relative)
+                if (
+                    (not relative and not member.isdir())
+                    or path.is_absolute()
+                    or any(part in {"", ".", ".."} for part in parts)
+                ):
+                    raise ReleaseError(f"invalid crate archive member path: {member.name!r}")
+                canonical = path.as_posix() if relative else ""
+                if canonical in member_paths:
+                    raise ReleaseError(f"duplicate crate archive member path: {member.name!r}")
+                member_paths.add(canonical)
                 if member.isdir():
                     continue
                 if not member.isfile():
                     raise ReleaseError(
                         f"crate archive has unsupported non-regular member {member.name!r}"
                     )
-                if not member.name.startswith(prefix):
-                    raise ReleaseError(
-                        f"crate archive member is outside expected prefix {prefix!r}: "
-                        f"{member.name!r}"
-                    )
-                relative = member.name[len(prefix) :]
-                path = PurePosixPath(relative)
-                if (
-                    not relative
-                    or path.is_absolute()
-                    or ".." in path.parts
-                    or relative in contents
-                ):
-                    raise ReleaseError(f"invalid crate archive member path: {member.name!r}")
-                contents[relative] = _read_archive_member(archive, member)
+                contents[canonical] = _read_archive_member(archive, member)
                 full_names.append(member.name)
 
             actual_files = set(contents)
@@ -384,6 +396,21 @@ def inspect_crate_archive(
             missing = sorted(required - actual_files)
             if missing:
                 raise ReleaseError(f"crate archive is missing required files: {missing}")
+            if expected_contents is not None:
+                differing = sorted(
+                    relative
+                    for relative in actual_files
+                    if expected_contents.get(relative) != contents[relative]
+                )
+                if set(expected_contents) != actual_files:
+                    raise ReleaseError(
+                        "crate archive file set differs from exact local tagged archive"
+                    )
+                if differing:
+                    raise ReleaseError(
+                        "crate archive members differ from exact local tagged archive: "
+                        f"{differing}"
+                    )
             manifest = tomllib.loads(contents["Cargo.toml"].decode("utf-8"))
             vcs = json.loads(contents[".cargo_vcs_info.json"].decode("utf-8"))
     except ReleaseError:
@@ -490,7 +517,7 @@ def inspect_crate_archive(
             raise ReleaseError(
                 f"crate archive member {relative!r} differs from tagged source {source_path!r}"
             )
-    return ArchiveInspection(package, tuple(sorted(full_names)))
+    return ArchiveInspection(package, tuple(sorted(full_names)), contents)
 
 
 def print_inspection(crate: str, inspection: ArchiveInspection) -> None:
@@ -670,6 +697,7 @@ def inspect_registry_archive(
     package_dir: str,
     source_reader: TaggedSourceReader,
     expected_files: set[str],
+    expected_contents: Mapping[str, bytes],
     *,
     archive_inspector: Callable = inspect_crate_archive,
 ) -> ArchiveInspection:
@@ -681,6 +709,7 @@ def inspect_registry_archive(
         package_dir,
         source_reader,
         expected_files,
+        expected_contents,
     )
 
 
@@ -692,6 +721,7 @@ def await_registry_archive(
     package_dir: str,
     source_reader: TaggedSourceReader,
     expected_files: set[str],
+    expected_contents: Mapping[str, bytes],
     *,
     archive_inspector: Callable = inspect_crate_archive,
     attempts: int = 40,
@@ -712,6 +742,7 @@ def await_registry_archive(
                     package_dir,
                     source_reader,
                     expected_files,
+                    expected_contents,
                     archive_inspector=archive_inspector,
                 )
             except ReleaseError as error:
@@ -742,6 +773,7 @@ def build_and_inspect_archive(
     expected_files: set[str],
     command: list[str],
     *,
+    expected_contents: Mapping[str, bytes] | None = None,
     runner: Callable = run,
     root: Path = ROOT,
     archive_inspector: Callable = inspect_crate_archive,
@@ -766,6 +798,7 @@ def build_and_inspect_archive(
         package_dir,
         source_reader,
         expected_files,
+        expected_contents,
     )
     print_inspection(crate, inspection)
     return inspection
@@ -856,8 +889,8 @@ def publish_release(
     validate_new_package_approvals(package_exists, version_exists, approvals)
     source_reader = source_reader_factory(commit, runner=runner, root=root)
 
-    already_published: set[str] = set()
-    expected_files_by_crate: dict[str, set[str]] = {}
+    positions = {crate: index for index, crate in enumerate(order)}
+    prerequisites_by_crate: dict[str, list[str]] = {}
     for crate in order:
         package = packages[crate]
         package_version = package.get("version")
@@ -865,31 +898,6 @@ def publish_release(
             raise ReleaseError(
                 f"{crate} version {package_version!r} does not match {version}"
             )
-        if version_exists[crate]:
-            expected_files = package_files_loader(crate, runner=runner, root=root)
-            expected_files_by_crate[crate] = expected_files
-            inspection = inspect_registry_archive(
-                registry,
-                crate,
-                version,
-                commit,
-                package_root(package, root=root),
-                source_reader,
-                expected_files,
-                archive_inspector=archive_inspector,
-            )
-            print_inspection(crate, inspection)
-            already_published.add(crate)
-            print(f"{crate} {version}: already published from this tag; skip")
-
-    if not execute:
-        print("preflight passed; no packages published (rerun with --execute)")
-        return
-
-    for crate in order:
-        if crate in already_published:
-            continue
-        package = packages[crate]
         dependencies = package.get("dependencies")
         if not isinstance(dependencies, list) or any(
             not isinstance(dependency, dict) for dependency in dependencies
@@ -900,9 +908,31 @@ def publish_release(
             for dependency in dependencies
             if dependency.get("kind") != "dev"
             and isinstance(dependency.get("name"), str)
-            and dependency["name"] in order
+            and dependency["name"] in positions
         )
-        for prerequisite in prerequisites:
+        misplaced = [
+            prerequisite
+            for prerequisite in prerequisites
+            if positions[prerequisite] >= positions[crate]
+        ]
+        if misplaced:
+            raise ReleaseError(
+                f"publication order places {crate} before prerequisites {misplaced}"
+            )
+        prerequisites_by_crate[crate] = prerequisites
+
+    expected_files_by_crate: dict[str, set[str]] = {}
+    expected_contents_by_crate: dict[str, dict[str, bytes]] = {}
+    for crate in order:
+        if not execute and not version_exists[crate]:
+            continue
+        package = packages[crate]
+        for prerequisite in prerequisites_by_crate[crate]:
+            if prerequisite not in expected_contents_by_crate:
+                raise ReleaseError(
+                    f"cannot attest {crate}: prerequisite {prerequisite} {version} "
+                    "has no exact local tagged archive"
+                )
             await_registry_archive(
                 registry,
                 prerequisite,
@@ -911,6 +941,7 @@ def publish_release(
                 package_root(packages[prerequisite], root=root),
                 source_reader,
                 expected_files_by_crate[prerequisite],
+                expected_contents_by_crate[prerequisite],
                 archive_inspector=archive_inspector,
                 attempts=attempts,
                 delay=delay,
@@ -920,7 +951,7 @@ def publish_release(
         package_dir = package_root(package, root=root)
         expected_files = package_files_loader(crate, runner=runner, root=root)
         expected_files_by_crate[crate] = expected_files
-        build_and_inspect_archive(
+        local_inspection = build_and_inspect_archive(
             metadata,
             crate,
             version,
@@ -933,6 +964,24 @@ def publish_release(
             root=root,
             archive_inspector=archive_inspector,
         )
+        expected_contents_by_crate[crate] = local_inspection.contents
+
+        if version_exists[crate]:
+            inspection = inspect_registry_archive(
+                registry,
+                crate,
+                version,
+                commit,
+                package_dir,
+                source_reader,
+                expected_files,
+                local_inspection.contents,
+                archive_inspector=archive_inspector,
+            )
+            print_inspection(crate, inspection)
+            print(f"{crate} {version}: already published from this tag; skip")
+            continue
+
         build_and_inspect_archive(
             metadata,
             crate,
@@ -951,6 +1000,7 @@ def publish_release(
                 "--registry",
                 "crates-io",
             ],
+            expected_contents=local_inspection.contents,
             runner=runner,
             root=root,
             archive_inspector=archive_inspector,
@@ -976,12 +1026,16 @@ def publish_release(
             package_dir,
             source_reader,
             expected_files,
+            local_inspection.contents,
             archive_inspector=archive_inspector,
             attempts=attempts,
             delay=delay,
             sleeper=sleeper,
         )
         print_inspection(crate, inspection)
+
+    if not execute:
+        print("preflight passed; no packages published (rerun with --execute)")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/test-check-publish-layout.py
+++ b/scripts/test-check-publish-layout.py
@@ -36,6 +36,68 @@ VALID_EXPLICIT_FEATURES = VALID_ALL_FEATURES.replace(
 )
 
 
+class ReleaseOrderTests(unittest.TestCase):
+    def metadata(self) -> dict:
+        root = CHECKER.ROOT
+        return {
+            "packages": [
+                {
+                    "name": "tenferro-core-ops",
+                    "manifest_path": str(root / "crates/tenferro-core-ops/Cargo.toml"),
+                    "publish": None,
+                    "dependencies": [
+                        {"name": "tenferro-runtime", "kind": "dev"},
+                    ],
+                },
+                {
+                    "name": "tenferro-runtime",
+                    "manifest_path": str(root / "crates/tenferro-runtime/Cargo.toml"),
+                    "publish": None,
+                    "dependencies": [
+                        {"name": "tenferro-core-ops", "kind": None},
+                        {"name": "tenferro-hidden", "kind": None},
+                    ],
+                },
+                {
+                    "name": "tenferro-hidden",
+                    "manifest_path": str(root / "crates/tenferro-hidden/Cargo.toml"),
+                    "publish": [],
+                    "dependencies": [],
+                },
+            ]
+        }
+
+    def release_text(self, order: list[str]) -> str:
+        crates = "\n".join(order)
+        return f"## Phase 3 — Publish From The Tag\n\n```text\n{crates}\n```\n"
+
+    def test_accepts_topological_order_excluding_dev_and_nonpublishable(
+        self,
+    ) -> None:
+        errors: list[str] = []
+        CHECKER.check_release_order(
+            self.metadata(),
+            self.release_text(["tenferro-core-ops", "tenferro-runtime"]),
+            errors,
+        )
+        self.assertEqual(errors, [])
+
+    def test_rejects_dependency_after_dependent(self) -> None:
+        errors: list[str] = []
+        CHECKER.check_release_order(
+            self.metadata(),
+            self.release_text(["tenferro-runtime", "tenferro-core-ops"]),
+            errors,
+        )
+        self.assertEqual(
+            errors,
+            [
+                "release publish order must place dependency "
+                "'tenferro-core-ops' before 'tenferro-runtime'"
+            ],
+        )
+
+
 class PublishMetadataTests(unittest.TestCase):
     def check(self, manifest: str) -> list[str]:
         errors: list[str] = []

--- a/scripts/test-check-publish-layout.py
+++ b/scripts/test-check-publish-layout.py
@@ -174,6 +174,24 @@ class ReleaseOrderTests(unittest.TestCase):
         CHECKER.check_release_order(self.metadata(), release_text, errors)
         self.assertEqual(errors, [])
 
+    def test_ignores_heading_like_content_inside_non_order_fence(self) -> None:
+        errors: list[str] = []
+        release_text = """\
+## Phase 3 — Publish From The Tag
+
+```bash
+# Build command
+cargo build
+```
+
+```text
+tenferro-core-ops
+tenferro-runtime
+```
+"""
+        CHECKER.check_release_order(self.metadata(), release_text, errors)
+        self.assertEqual(errors, [])
+
     def test_rejects_missing_ambiguous_and_malformed_text_fences(self) -> None:
         valid = self.release_text(["tenferro-core-ops", "tenferro-runtime"])
         cases = (

--- a/scripts/test-check-publish-layout.py
+++ b/scripts/test-check-publish-layout.py
@@ -39,32 +39,37 @@ VALID_EXPLICIT_FEATURES = VALID_ALL_FEATURES.replace(
 class ReleaseOrderTests(unittest.TestCase):
     def metadata(self) -> dict:
         root = CHECKER.ROOT
+        packages = [
+            {
+                "id": "core-id",
+                "name": "tenferro-core-ops",
+                "manifest_path": str(root / "crates/tenferro-core-ops/Cargo.toml"),
+                "publish": None,
+                "dependencies": [
+                    {"name": "tenferro-runtime", "kind": "dev"},
+                ],
+            },
+            {
+                "id": "runtime-id",
+                "name": "tenferro-runtime",
+                "manifest_path": str(root / "crates/tenferro-runtime/Cargo.toml"),
+                "publish": None,
+                "dependencies": [
+                    {"name": "tenferro-core-ops", "kind": None},
+                    {"name": "tenferro-hidden", "kind": None},
+                ],
+            },
+            {
+                "id": "hidden-id",
+                "name": "tenferro-hidden",
+                "manifest_path": str(root / "crates/tenferro-hidden/Cargo.toml"),
+                "publish": [],
+                "dependencies": [],
+            },
+        ]
         return {
-            "packages": [
-                {
-                    "name": "tenferro-core-ops",
-                    "manifest_path": str(root / "crates/tenferro-core-ops/Cargo.toml"),
-                    "publish": None,
-                    "dependencies": [
-                        {"name": "tenferro-runtime", "kind": "dev"},
-                    ],
-                },
-                {
-                    "name": "tenferro-runtime",
-                    "manifest_path": str(root / "crates/tenferro-runtime/Cargo.toml"),
-                    "publish": None,
-                    "dependencies": [
-                        {"name": "tenferro-core-ops", "kind": None},
-                        {"name": "tenferro-hidden", "kind": None},
-                    ],
-                },
-                {
-                    "name": "tenferro-hidden",
-                    "manifest_path": str(root / "crates/tenferro-hidden/Cargo.toml"),
-                    "publish": [],
-                    "dependencies": [],
-                },
-            ]
+            "packages": packages,
+            "workspace_members": [package["id"] for package in packages],
         }
 
     def release_text(self, order: list[str]) -> str:
@@ -96,6 +101,98 @@ class ReleaseOrderTests(unittest.TestCase):
                 "'tenferro-core-ops' before 'tenferro-runtime'"
             ],
         )
+
+    def test_checks_optional_and_build_dependencies(self) -> None:
+        cases = (
+            {"name": "tenferro-core-ops", "kind": None, "optional": True},
+            {"name": "tenferro-core-ops", "kind": "build", "optional": False},
+        )
+        for dependency in cases:
+            with self.subTest(dependency=dependency):
+                metadata = self.metadata()
+                metadata["packages"][1]["dependencies"] = [dependency]
+                errors: list[str] = []
+                CHECKER.check_release_order(
+                    metadata,
+                    self.release_text(["tenferro-runtime", "tenferro-core-ops"]),
+                    errors,
+                )
+                self.assertEqual(
+                    errors,
+                    [
+                        "release publish order must place dependency "
+                        "'tenferro-core-ops' before 'tenferro-runtime'"
+                    ],
+                )
+
+    def test_rejects_missing_unexpected_and_duplicate_membership(self) -> None:
+        cases = {
+            "missing": (
+                ["tenferro-core-ops"],
+                "release publish order is missing crates: ['tenferro-runtime']",
+            ),
+            "unexpected": (
+                ["tenferro-core-ops", "tenferro-runtime", "other"],
+                "release publish order has unexpected crates: ['other']",
+            ),
+            "duplicate": (
+                ["tenferro-core-ops", "tenferro-runtime", "tenferro-runtime"],
+                "release publish order must not contain duplicate crates",
+            ),
+        }
+        for name, (order, expected) in cases.items():
+            with self.subTest(name=name):
+                errors: list[str] = []
+                CHECKER.check_release_order(
+                    self.metadata(), self.release_text(order), errors
+                )
+                self.assertIn(expected, errors)
+
+    def test_requires_exact_unique_phase_heading(self) -> None:
+        valid = self.release_text(["tenferro-core-ops", "tenferro-runtime"])
+        cases = (
+            valid.replace(
+                "## Phase 3 — Publish From The Tag",
+                "## Phase 3 — Publish From The Tag Extra",
+            ),
+            valid + "\n## Phase 3 — Publish From The Tag\n",
+        )
+        for release_text in cases:
+            with self.subTest(release_text=release_text):
+                errors: list[str] = []
+                CHECKER.check_release_order(self.metadata(), release_text, errors)
+                self.assertEqual(
+                    errors,
+                    ["release workflow must contain exactly one exact Phase 3 heading"],
+                )
+
+    def test_stops_phase_at_the_next_heading(self) -> None:
+        errors: list[str] = []
+        release_text = self.release_text(
+            ["tenferro-core-ops", "tenferro-runtime"]
+        ) + "\n### Other Section\n\n```text\nunrelated\n```\n"
+        CHECKER.check_release_order(self.metadata(), release_text, errors)
+        self.assertEqual(errors, [])
+
+    def test_rejects_missing_ambiguous_and_malformed_text_fences(self) -> None:
+        valid = self.release_text(["tenferro-core-ops", "tenferro-runtime"])
+        cases = (
+            valid.replace("```text", "```bash"),
+            valid + "\n```text\nunrelated\n```\n",
+            valid.removesuffix("```\n"),
+            valid + "\n```\n",
+        )
+        for release_text in cases:
+            with self.subTest(release_text=release_text):
+                errors: list[str] = []
+                CHECKER.check_release_order(self.metadata(), release_text, errors)
+                self.assertEqual(
+                    errors,
+                    [
+                        "release workflow Phase 3 must contain exactly one "
+                        "complete text fence"
+                    ],
+                )
 
 
 class PublishMetadataTests(unittest.TestCase):
@@ -195,28 +292,35 @@ class PublishMetadataTests(unittest.TestCase):
                     any("docs.rs" in error for error in self.check(manifest))
                 )
 
-    def test_discovers_only_publishable_nested_crates(self) -> None:
-        root = CHECKER.ROOT
+    def test_discovers_publishable_workspace_members_without_heuristics(
+        self,
+    ) -> None:
         metadata = {
+            "workspace_members": ["publishable-id", "hidden-id"],
             "packages": [
                 {
-                    "name": "tenferro-fixture",
-                    "manifest_path": str(root / "crates/tenferro-fixture/Cargo.toml"),
+                    "id": "publishable-id",
+                    "name": "future-crate",
+                    "manifest_path": "/anywhere/future/Cargo.toml",
                     "publish": None,
                 },
                 {
+                    "id": "hidden-id",
                     "name": "tenferro-hidden",
-                    "manifest_path": str(root / "crates/tenferro-hidden/Cargo.toml"),
+                    "manifest_path": "/crates/tenferro-hidden/Cargo.toml",
                     "publish": [],
                 },
                 {
-                    "name": "tenferro-nested",
-                    "manifest_path": str(root / "crates/tenferro-nested/deep/Cargo.toml"),
+                    "id": "nonmember-id",
+                    "name": "tenferro-nonmember",
+                    "manifest_path": str(
+                        CHECKER.ROOT / "crates/tenferro-nonmember/Cargo.toml"
+                    ),
                     "publish": None,
                 },
-            ]
+            ],
         }
-        self.assertEqual(CHECKER.publishable_crates(metadata), {"tenferro-fixture"})
+        self.assertEqual(CHECKER.publishable_crates(metadata), {"future-crate"})
 
 
 if __name__ == "__main__":

--- a/scripts/test-check-publish-layout.py
+++ b/scripts/test-check-publish-layout.py
@@ -166,11 +166,37 @@ class ReleaseOrderTests(unittest.TestCase):
                     ["release workflow must contain exactly one exact Phase 3 heading"],
                 )
 
+    def test_accepts_phase_heading_indented_by_up_to_three_spaces(self) -> None:
+        for indent in range(4):
+            with self.subTest(indent=indent):
+                errors: list[str] = []
+                release_text = self.release_text(
+                    ["tenferro-core-ops", "tenferro-runtime"]
+                ).replace(
+                    "## Phase 3 — Publish From The Tag",
+                    f"{' ' * indent}## Phase 3 — Publish From The Tag",
+                )
+                CHECKER.check_release_order(self.metadata(), release_text, errors)
+                self.assertEqual(errors, [])
+
     def test_stops_phase_at_the_next_heading(self) -> None:
+        for indent in range(4):
+            with self.subTest(indent=indent):
+                errors: list[str] = []
+                release_text = self.release_text(
+                    ["tenferro-core-ops", "tenferro-runtime"]
+                ) + f"\n{' ' * indent}### Other Section\n\n```text\nunrelated\n```\n"
+                CHECKER.check_release_order(self.metadata(), release_text, errors)
+                self.assertEqual(errors, [])
+
+    def test_ignores_indented_heading_like_content_inside_fence(self) -> None:
         errors: list[str] = []
         release_text = self.release_text(
             ["tenferro-core-ops", "tenferro-runtime"]
-        ) + "\n### Other Section\n\n```text\nunrelated\n```\n"
+        ).replace(
+            "```text",
+            "```bash\n   ### Not a heading\n```\n\n```text",
+        )
         CHECKER.check_release_order(self.metadata(), release_text, errors)
         self.assertEqual(errors, [])
 
@@ -211,6 +237,40 @@ tenferro-runtime
                         "complete text fence"
                     ],
                 )
+
+
+class WorkspaceDependencyTests(unittest.TestCase):
+    def test_structurally_accepts_commented_multiline_git_dependency(self) -> None:
+        manifest = """\
+[workspace.dependencies]
+local = { path = "local" }
+
+# Registry fallback used by cargo publish.
+[workspace.dependencies.strided]
+git = "https://example.invalid/strided.git"
+rev = "0123456789abcdef0123456789abcdef01234567"
+version = "0.4.0" # exact registry version
+"""
+        errors: list[str] = []
+        CHECKER.check_workspace_dependencies(manifest, errors)
+        self.assertEqual(errors, [])
+
+    def test_structurally_rejects_missing_version_or_rev(self) -> None:
+        for missing in ("version", "rev"):
+            with self.subTest(missing=missing):
+                fields = {
+                    "version": 'version = "0.4.0"',
+                    "rev": 'rev = "0123456789abcdef0123456789abcdef01234567"',
+                }
+                fields.pop(missing)
+                manifest = """\
+[workspace.dependencies.strided]
+git = "https://example.invalid/strided.git"
+%s
+""" % "\n".join(fields.values())
+                errors: list[str] = []
+                CHECKER.check_workspace_dependencies(manifest, errors)
+                self.assertTrue(any(missing in error for error in errors))
 
 
 class PublishMetadataTests(unittest.TestCase):

--- a/scripts/test-release-publish.py
+++ b/scripts/test-release-publish.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import http.client
 import importlib.util
 import io
 import json
@@ -135,6 +136,7 @@ include = ["src/**", "README.md"]
         commit: str = COMMIT,
         dirty: bool = False,
         changes: dict[str, bytes | None] | None = None,
+        extra_members: tuple[tarfile.TarInfo, ...] = (),
     ) -> bytes:
         prefix = "tenferro-fixture-0.4.0/"
         files: dict[str, bytes] = {
@@ -158,6 +160,8 @@ include = ["src/**", "README.md"]
                 info = tarfile.TarInfo(prefix + name)
                 info.size = len(data)
                 archive.addfile(info, io.BytesIO(data))
+            for info in extra_members:
+                archive.addfile(info)
         return output.getvalue()
 
     @staticmethod
@@ -168,7 +172,11 @@ include = ["src/**", "README.md"]
             "README.md": b"fixture\n",
         }.get(path)
 
-    def inspect(self, archive: bytes) -> RELEASE.ArchiveInspection:
+    def inspect(
+        self,
+        archive: bytes,
+        expected_contents: dict[str, bytes] | None = None,
+    ) -> RELEASE.ArchiveInspection:
         return RELEASE.inspect_crate_archive(
             archive,
             "tenferro-fixture",
@@ -184,12 +192,59 @@ include = ["src/**", "README.md"]
                 "README.md",
                 "src/lib.rs",
             },
+            expected_contents,
         )
 
     def test_attests_metadata_generated_files_and_tagged_source_bytes(self) -> None:
         inspection = self.inspect(self.archive())
         self.assertEqual(inspection.metadata["rust-version"], "1.96")
         self.assertIn("tenferro-fixture-0.4.0/README.md", inspection.files)
+        self.assertEqual(inspection.contents["Cargo.lock"], b"# generated\n")
+
+    def test_registry_archive_must_match_local_generated_files_exactly(self) -> None:
+        local = self.inspect(self.archive())
+        mutations = (
+            {
+                "Cargo.toml": self.NORMALIZED_MANIFEST
+                + b'\n[dependencies.injected]\nversion = "9"\n'
+            },
+            {"Cargo.lock": b"not valid = [toml"},
+            {"Cargo.lock": b"# different but valid\nversion = 4\n"},
+            {
+                ".cargo_vcs_info.json": json.dumps(
+                    {"git": {"sha1": self.COMMIT, "dirty": False}, "extra": True}
+                ).encode()
+            },
+        )
+        for changes in mutations:
+            with self.subTest(changes=changes):
+                with self.assertRaisesRegex(
+                    RELEASE.ReleaseError, "differ.*exact local tagged archive"
+                ):
+                    self.inspect(
+                        self.archive(changes=changes),
+                        expected_contents=local.contents,
+                    )
+
+    def test_rejects_directory_traversal_before_skipping_directory(self) -> None:
+        malicious = tarfile.TarInfo("tenferro-fixture-0.4.0/../escape")
+        malicious.type = tarfile.DIRTYPE
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "invalid crate archive member path"):
+            self.inspect(self.archive(extra_members=(malicious,)))
+
+    def test_validates_directory_prefix_and_duplicates(self) -> None:
+        outside = tarfile.TarInfo("outside")
+        outside.type = tarfile.DIRTYPE
+        duplicate = tarfile.TarInfo("tenferro-fixture-0.4.0/src")
+        duplicate.type = tarfile.DIRTYPE
+        cases = (
+            ((outside,), "outside expected prefix"),
+            ((duplicate, duplicate), "duplicate crate archive member path"),
+        )
+        for members, message in cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(RELEASE.ReleaseError, message):
+                    self.inspect(self.archive(extra_members=members))
 
     def test_rejects_dirty_wrong_commit_tampered_unmapped_and_missing_source(self) -> None:
         cases = (
@@ -230,6 +285,15 @@ class RegistryAndApprovalTests(unittest.TestCase):
         self.assertFalse(client.package_exists("new-package"))
         self.assertEqual(len(calls), 2)
 
+    def test_default_transport_converts_incomplete_response_reads(self) -> None:
+        response = mock.MagicMock()
+        response.__enter__.return_value = response
+        response.status = 200
+        response.read.side_effect = http.client.IncompleteRead(b"partial", 10)
+        with mock.patch.object(RELEASE.urllib.request, "urlopen", return_value=response):
+            with self.assertRaisesRegex(RELEASE.ReleaseError, "crates.io request failed"):
+                RELEASE.crates_io_transport("https://example.invalid/archive")
+
     def test_new_package_approval_supports_exact_published_resume_only(self) -> None:
         packages = {"new": False, "resumed": True, "stale": True}
         versions = {"new": False, "resumed": True, "stale": False}
@@ -240,11 +304,18 @@ class RegistryAndApprovalTests(unittest.TestCase):
             RELEASE.validate_new_package_approvals(packages, versions, {"new", "stale"})
 
     def test_transport_failures_are_actionable(self) -> None:
-        def transport(_url: str) -> tuple[int, bytes]:
-            raise TimeoutError("offline")
+        failures = (
+            TimeoutError("offline"),
+            http.client.IncompleteRead(b"partial", 10),
+            http.client.HTTPException("broken response"),
+        )
+        for failure in failures:
+            with self.subTest(failure=failure):
+                def transport(_url: str) -> tuple[int, bytes]:
+                    raise failure
 
-        with self.assertRaisesRegex(RELEASE.ReleaseError, "crates.io request failed"):
-            RELEASE.CratesIoClient(transport).package_exists("fixture")
+                with self.assertRaisesRegex(RELEASE.ReleaseError, "crates.io request failed"):
+                    RELEASE.CratesIoClient(transport).package_exists("fixture")
 
 
 class CommandAndCheckoutTests(unittest.TestCase):
@@ -385,9 +456,14 @@ class OrchestrationTests(unittest.TestCase):
                     client.package_versions["crate-a"] = True
                 return subprocess.CompletedProcess(command, 0, "", "")
 
-            def inspect(data: bytes, *_args: object) -> RELEASE.ArchiveInspection:
+            def inspect(data: bytes, *args: object) -> RELEASE.ArchiveInspection:
                 events.append(f"inspect:{data.decode()}")
-                return RELEASE.ArchiveInspection({}, ())
+                expected_contents = args[-1]
+                if expected_contents is not None:
+                    self.assertEqual(expected_contents, {"Cargo.toml": b"generated"})
+                return RELEASE.ArchiveInspection(
+                    {}, (), {"Cargo.toml": b"generated"}
+                )
 
             RELEASE.publish_release(
                 self.VERSION,
@@ -426,21 +502,40 @@ class OrchestrationTests(unittest.TestCase):
             root = Path(directory)
             self.workspace(root)
             metadata = self.metadata(root, ["new-crate"])
+            archive = root / "target/package/new-crate-0.4.0.crate"
+
+            def runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                if command[:2] == ["cargo", "package"]:
+                    events.append("package")
+                    archive.parent.mkdir(parents=True, exist_ok=True)
+                    archive.write_bytes(b"exact-tag")
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            def inspect(data: bytes, *args: object) -> RELEASE.ArchiveInspection:
+                expected_contents = args[-1]
+                events.append(f"inspect:{data.decode()}")
+                if data == b"new-crate":
+                    self.assertEqual(
+                        expected_contents, {"Cargo.toml": b"exact-tag-generated"}
+                    )
+                else:
+                    self.assertIsNone(expected_contents)
+                return RELEASE.ArchiveInspection(
+                    {}, (), {"Cargo.toml": b"exact-tag-generated"}
+                )
+
             RELEASE.publish_release(
                 self.VERSION,
                 {"new-crate"},
-                True,
+                False,
                 root=root,
-                runner=lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, "", ""),
+                runner=runner,
                 client=FakeClient({"new-crate": True}, events),
                 checkout_verifier=lambda *_args, **_kwargs: self.COMMIT,
                 metadata_loader=lambda **_kwargs: metadata,
                 order_loader=lambda _text: ["new-crate"],
                 package_files_loader=lambda *_args, **_kwargs: {"Cargo.toml"},
-                archive_inspector=lambda data, *_args: events.append(
-                    f"inspect:{data.decode()}"
-                )
-                or RELEASE.ArchiveInspection({}, ()),
+                archive_inspector=inspect,
                 source_reader_factory=lambda *_args, **_kwargs: lambda _path: None,
                 attempts=1,
                 delay=0,
@@ -449,10 +544,63 @@ class OrchestrationTests(unittest.TestCase):
             events,
             [
                 "exists:new-crate",
+                "package",
+                "inspect:exact-tag",
                 "download:new-crate",
                 "inspect:new-crate",
             ],
         )
+
+    def test_resume_packages_only_after_prerequisite_archive_is_attested(self) -> None:
+        events: list[str] = []
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.workspace(root)
+            metadata = self.metadata(root, ["crate-a", "crate-b"])
+            metadata["packages"][1]["dependencies"] = [
+                {"name": "crate-a", "kind": "normal"}
+            ]
+
+            def runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                if command[:2] == ["cargo", "package"]:
+                    crate = command[command.index("-p") + 1]
+                    events.append(f"package:{crate}")
+                    archive = root / f"target/package/{crate}-0.4.0.crate"
+                    archive.parent.mkdir(parents=True, exist_ok=True)
+                    archive.write_bytes(f"local:{crate}".encode())
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            def inspect(data: bytes, *args: object) -> RELEASE.ArchiveInspection:
+                crate = args[0]
+                expected_contents = args[-1]
+                events.append(f"inspect:{data.decode()}")
+                contents = {"Cargo.toml": f"generated:{crate}".encode()}
+                if data.startswith(b"crate-"):
+                    self.assertEqual(expected_contents, contents)
+                return RELEASE.ArchiveInspection({}, (), contents)
+
+            RELEASE.publish_release(
+                self.VERSION,
+                set(),
+                False,
+                root=root,
+                runner=runner,
+                client=FakeClient({"crate-a": True, "crate-b": True}, events),
+                checkout_verifier=lambda *_args, **_kwargs: self.COMMIT,
+                metadata_loader=lambda **_kwargs: metadata,
+                order_loader=lambda _text: ["crate-a", "crate-b"],
+                package_files_loader=lambda *_args, **_kwargs: {"Cargo.toml"},
+                archive_inspector=inspect,
+                source_reader_factory=lambda *_args, **_kwargs: lambda _path: None,
+                attempts=1,
+                delay=0,
+            )
+
+        prerequisite_attestations = [
+            index for index, event in enumerate(events) if event == "inspect:crate-a"
+        ]
+        self.assertEqual(len(prerequisite_attestations), 2)
+        self.assertLess(prerequisite_attestations[-1], events.index("package:crate-b"))
 
     def test_propagation_retries_then_succeeds(self) -> None:
         events: list[str] = []
@@ -475,12 +623,18 @@ class OrchestrationTests(unittest.TestCase):
             "crates/crate-a",
             lambda _path: None,
             {"Cargo.toml"},
-            archive_inspector=lambda *_args: RELEASE.ArchiveInspection({}, ()),
+            {"Cargo.toml": b"generated"},
+            archive_inspector=lambda *_args: RELEASE.ArchiveInspection(
+                {}, (), {"Cargo.toml": b"generated"}
+            ),
             attempts=3,
             delay=0,
             sleeper=lambda _delay: events.append("sleep"),
         )
-        self.assertEqual(inspection, RELEASE.ArchiveInspection({}, ()))
+        self.assertEqual(
+            inspection,
+            RELEASE.ArchiveInspection({}, (), {"Cargo.toml": b"generated"}),
+        )
         self.assertEqual(events.count("sleep"), 2)
         self.assertEqual(events[-1], "download:crate-a")
 
@@ -496,7 +650,10 @@ class OrchestrationTests(unittest.TestCase):
                 "crates/crate-a",
                 lambda _path: None,
                 {"Cargo.toml"},
-                archive_inspector=lambda *_args: RELEASE.ArchiveInspection({}, ()),
+                {"Cargo.toml": b"generated"},
+                archive_inspector=lambda *_args: RELEASE.ArchiveInspection(
+                    {}, (), {"Cargo.toml": b"generated"}
+                ),
                 attempts=3,
                 delay=0,
                 sleeper=lambda _delay: events.append("sleep"),

--- a/scripts/test-release-publish.py
+++ b/scripts/test-release-publish.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import subprocess
 import tarfile
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT = Path(__file__).with_name("release-publish.py")
@@ -109,9 +112,8 @@ version = "0.3.0"
 
 class ArchiveTests(unittest.TestCase):
     COMMIT = "abcdef0123456789abcdef0123456789abcdef01"
-
-    def archive(self, *, commit: str = COMMIT, dirty: bool = False) -> bytes:
-        manifest = """\
+    ORIGINAL_MANIFEST = b"[package]\nname = \"tenferro-fixture\"\nversion.workspace = true\n"
+    NORMALIZED_MANIFEST = b"""\
 [package]
 name = "tenferro-fixture"
 version = "0.4.0"
@@ -126,39 +128,93 @@ keywords = ["tensor"]
 categories = ["science"]
 include = ["src/**", "README.md"]
 """
-        files = {
-            "tenferro-fixture-0.4.0/Cargo.toml": manifest.encode(),
-            "tenferro-fixture-0.4.0/README.md": b"fixture\n",
-            "tenferro-fixture-0.4.0/src/lib.rs": b"",
-            "tenferro-fixture-0.4.0/.cargo_vcs_info.json": json.dumps(
+
+    def archive(
+        self,
+        *,
+        commit: str = COMMIT,
+        dirty: bool = False,
+        changes: dict[str, bytes | None] | None = None,
+    ) -> bytes:
+        prefix = "tenferro-fixture-0.4.0/"
+        files: dict[str, bytes] = {
+            "Cargo.toml": self.NORMALIZED_MANIFEST,
+            "Cargo.toml.orig": self.ORIGINAL_MANIFEST,
+            "Cargo.lock": b"# generated\n",
+            "README.md": b"fixture\n",
+            "src/lib.rs": b"pub fn fixture() {}\n",
+            ".cargo_vcs_info.json": json.dumps(
                 {"git": {"sha1": commit, "dirty": dirty}}
             ).encode(),
         }
+        for name, data in (changes or {}).items():
+            if data is None:
+                files.pop(name, None)
+            else:
+                files[name] = data
         output = io.BytesIO()
         with tarfile.open(fileobj=output, mode="w:gz") as archive:
             for name, data in files.items():
-                info = tarfile.TarInfo(name)
+                info = tarfile.TarInfo(prefix + name)
                 info.size = len(data)
                 archive.addfile(info, io.BytesIO(data))
         return output.getvalue()
 
-    def test_inspects_archive_metadata_files_and_exact_provenance(self) -> None:
-        inspection = RELEASE.inspect_crate_archive(
-            self.archive(), "tenferro-fixture", "0.4.0", self.COMMIT
+    @staticmethod
+    def reader(path: str) -> bytes | None:
+        return {
+            "crates/tenferro-fixture/Cargo.toml": ArchiveTests.ORIGINAL_MANIFEST,
+            "crates/tenferro-fixture/src/lib.rs": b"pub fn fixture() {}\n",
+            "README.md": b"fixture\n",
+        }.get(path)
+
+    def inspect(self, archive: bytes) -> RELEASE.ArchiveInspection:
+        return RELEASE.inspect_crate_archive(
+            archive,
+            "tenferro-fixture",
+            "0.4.0",
+            self.COMMIT,
+            "crates/tenferro-fixture",
+            self.reader,
+            {
+                ".cargo_vcs_info.json",
+                "Cargo.lock",
+                "Cargo.toml",
+                "Cargo.toml.orig",
+                "README.md",
+                "src/lib.rs",
+            },
         )
+
+    def test_attests_metadata_generated_files_and_tagged_source_bytes(self) -> None:
+        inspection = self.inspect(self.archive())
         self.assertEqual(inspection.metadata["rust-version"], "1.96")
         self.assertIn("tenferro-fixture-0.4.0/README.md", inspection.files)
 
-    def test_rejects_dirty_or_wrong_commit_archive(self) -> None:
-        for archive in (
+    def test_rejects_dirty_wrong_commit_tampered_unmapped_and_missing_source(self) -> None:
+        cases = (
             self.archive(dirty=True),
             self.archive(commit="0" * 40),
-        ):
+            self.archive(changes={"src/lib.rs": b"tampered\n"}),
+            self.archive(changes={"unexpected.bin": b"unmapped\n"}),
+            self.archive(changes={"Cargo.toml.orig": None}),
+            self.archive(changes={"README.md": None}),
+        )
+        for archive in cases:
             with self.subTest():
                 with self.assertRaises(RELEASE.ReleaseError):
-                    RELEASE.inspect_crate_archive(
-                        archive, "tenferro-fixture", "0.4.0", self.COMMIT
-                    )
+                    self.inspect(archive)
+
+    def test_rejects_malformed_toml_json_and_archive(self) -> None:
+        cases = (
+            self.archive(changes={"Cargo.toml": b"not = [toml"}),
+            self.archive(changes={".cargo_vcs_info.json": b"{"}),
+            b"not a crate archive",
+        )
+        for archive in cases:
+            with self.subTest():
+                with self.assertRaisesRegex(RELEASE.ReleaseError, "invalid .crate archive"):
+                    self.inspect(archive)
 
 
 class RegistryAndApprovalTests(unittest.TestCase):
@@ -174,13 +230,278 @@ class RegistryAndApprovalTests(unittest.TestCase):
         self.assertFalse(client.package_exists("new-package"))
         self.assertEqual(len(calls), 2)
 
-    def test_new_package_approval_must_name_exact_missing_package(self) -> None:
-        existing = {"old-package": True, "new-package": False}
-        with self.assertRaisesRegex(RELEASE.ReleaseError, "new-package"):
-            RELEASE.validate_new_package_approvals(existing, set())
-        RELEASE.validate_new_package_approvals(existing, {"new-package"})
-        with self.assertRaisesRegex(RELEASE.ReleaseError, "not new"):
-            RELEASE.validate_new_package_approvals(existing, {"old-package", "new-package"})
+    def test_new_package_approval_supports_exact_published_resume_only(self) -> None:
+        packages = {"new": False, "resumed": True, "stale": True}
+        versions = {"new": False, "resumed": True, "stale": False}
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "new"):
+            RELEASE.validate_new_package_approvals(packages, versions, set())
+        RELEASE.validate_new_package_approvals(packages, versions, {"new", "resumed"})
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "target version does not exist"):
+            RELEASE.validate_new_package_approvals(packages, versions, {"new", "stale"})
+
+    def test_transport_failures_are_actionable(self) -> None:
+        def transport(_url: str) -> tuple[int, bytes]:
+            raise TimeoutError("offline")
+
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "crates.io request failed"):
+            RELEASE.CratesIoClient(transport).package_exists("fixture")
+
+
+class CommandAndCheckoutTests(unittest.TestCase):
+    def test_command_failures_are_converted_and_timeout_is_bounded(self) -> None:
+        with mock.patch.object(
+            RELEASE.subprocess, "run", side_effect=FileNotFoundError("missing")
+        ):
+            with self.assertRaisesRegex(RELEASE.ReleaseError, "command not found"):
+                RELEASE.run(["missing-command"])
+        timeout = subprocess.TimeoutExpired(["cargo", "package"], 1)
+        with mock.patch.object(RELEASE.subprocess, "run", side_effect=timeout):
+            with self.assertRaisesRegex(RELEASE.ReleaseError, "timed out"):
+                RELEASE.run(["cargo", "package"], timeout=1)
+
+    def test_checkout_requires_detached_exact_remote_tag_on_main(self) -> None:
+        commit = "a" * 40
+        calls: list[tuple[str, ...]] = []
+
+        def runner(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append(tuple(command))
+            outputs = {
+                ("git", "status", "--porcelain"): "",
+                ("git", "ls-remote", "--tags", "origin", "refs/tags/v0.4.0", "refs/tags/v0.4.0^{}"): f"{commit}\trefs/tags/v0.4.0\n",
+                ("git", "rev-parse", "HEAD"): commit + "\n",
+            }
+            if command[:4] == ["git", "symbolic-ref", "-q", "HEAD"]:
+                return subprocess.CompletedProcess(command, 1, "", "")
+            return subprocess.CompletedProcess(command, 0, outputs.get(tuple(command), ""), "")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "Cargo.toml").write_text(
+                '[workspace.package]\nversion = "0.4.0"\n', encoding="utf-8"
+            )
+            self.assertEqual(
+                RELEASE.verify_release_checkout("0.4.0", runner=runner, root=root),
+                commit,
+            )
+        self.assertIn(("git", "merge-base", "--is-ancestor", commit, "origin/main"), calls)
+
+    def test_checkout_rejects_attached_head(self) -> None:
+        def runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            stdout = "refs/heads/main\n" if command[1] == "symbolic-ref" else ""
+            return subprocess.CompletedProcess(command, 0, stdout, "")
+
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(RELEASE.ReleaseError, "detached"):
+                RELEASE.verify_release_checkout("0.4.0", runner=runner, root=Path(directory))
+
+    def test_checkout_rejects_wrong_remote_tag(self) -> None:
+        commit = "a" * 40
+
+        def runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            if command[1] == "symbolic-ref":
+                return subprocess.CompletedProcess(command, 1, "", "")
+            if command[1] == "ls-remote":
+                return subprocess.CompletedProcess(
+                    command, 0, f"{commit}\trefs/tags/v0.4.0\n", ""
+                )
+            if command[1:] == ["rev-parse", "HEAD"]:
+                return subprocess.CompletedProcess(command, 0, "b" * 40 + "\n", "")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(RELEASE.ReleaseError, "not exact pushed remote tag"):
+                RELEASE.verify_release_checkout("0.4.0", runner=runner, root=Path(directory))
+
+    def test_cargo_metadata_rejects_malformed_json(self) -> None:
+        runner = lambda command, **_kwargs: subprocess.CompletedProcess(
+            command, 0, "{", ""
+        )
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "invalid JSON"):
+            RELEASE.cargo_metadata(runner=runner)
+
+
+class FakeClient:
+    def __init__(self, package_versions: dict[str, bool], events: list[str]) -> None:
+        self.package_versions = package_versions
+        self.events = events
+
+    def package_exists(self, package: str) -> bool:
+        return package in self.package_versions
+
+    def version_exists(self, package: str, _version: str) -> bool:
+        self.events.append(f"exists:{package}")
+        return self.package_versions.get(package, False)
+
+    def download(self, package: str, _version: str) -> bytes:
+        self.events.append(f"download:{package}")
+        return package.encode()
+
+
+class OrchestrationTests(unittest.TestCase):
+    VERSION = "0.4.0"
+    COMMIT = "a" * 40
+
+    @staticmethod
+    def metadata(root: Path, crates: list[str]) -> dict:
+        return {
+            "target_directory": str(root / "target"),
+            "packages": [
+                {
+                    "name": crate,
+                    "version": "0.4.0",
+                    "manifest_path": str(root / "crates" / crate / "Cargo.toml"),
+                    "dependencies": [],
+                }
+                for crate in crates
+            ],
+        }
+
+    @staticmethod
+    def workspace(root: Path) -> None:
+        (root / "Cargo.toml").write_text("[workspace.dependencies]\n", encoding="utf-8")
+        workflow = root / "ai/contribution-workflows/release-publish.md"
+        workflow.parent.mkdir(parents=True)
+        workflow.write_text("unused", encoding="utf-8")
+
+    def test_exact_package_inspect_dry_run_publish_wait_order(self) -> None:
+        events: list[str] = []
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.workspace(root)
+            metadata = self.metadata(root, ["crate-a"])
+            archive = root / "target/package/crate-a-0.4.0.crate"
+            client = FakeClient({}, events)
+
+            def runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+                if command[:2] == ["cargo", "package"]:
+                    events.append("package")
+                    archive.parent.mkdir(parents=True, exist_ok=True)
+                    archive.write_bytes(b"package")
+                elif command[:3] == ["cargo", "publish", "--dry-run"]:
+                    events.append("dry-run")
+                    archive.write_bytes(b"dry-run")
+                elif command[:2] == ["cargo", "publish"]:
+                    events.append("publish")
+                    client.package_versions["crate-a"] = True
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            def inspect(data: bytes, *_args: object) -> RELEASE.ArchiveInspection:
+                events.append(f"inspect:{data.decode()}")
+                return RELEASE.ArchiveInspection({}, ())
+
+            RELEASE.publish_release(
+                self.VERSION,
+                {"crate-a"},
+                True,
+                root=root,
+                runner=runner,
+                client=client,
+                checkout_verifier=lambda *_args, **_kwargs: self.COMMIT,
+                metadata_loader=lambda **_kwargs: metadata,
+                order_loader=lambda _text: ["crate-a"],
+                package_files_loader=lambda *_args, **_kwargs: {"Cargo.toml"},
+                archive_inspector=inspect,
+                source_reader_factory=lambda *_args, **_kwargs: lambda _path: None,
+                attempts=1,
+                delay=0,
+            )
+        self.assertEqual(
+            events,
+            [
+                "exists:crate-a",
+                "package",
+                "inspect:package",
+                "dry-run",
+                "inspect:dry-run",
+                "publish",
+                "exists:crate-a",
+                "download:crate-a",
+                "inspect:crate-a",
+            ],
+        )
+
+    def test_resume_accepts_new_package_approval_and_attests_before_skip(self) -> None:
+        events: list[str] = []
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.workspace(root)
+            metadata = self.metadata(root, ["new-crate"])
+            RELEASE.publish_release(
+                self.VERSION,
+                {"new-crate"},
+                True,
+                root=root,
+                runner=lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, "", ""),
+                client=FakeClient({"new-crate": True}, events),
+                checkout_verifier=lambda *_args, **_kwargs: self.COMMIT,
+                metadata_loader=lambda **_kwargs: metadata,
+                order_loader=lambda _text: ["new-crate"],
+                package_files_loader=lambda *_args, **_kwargs: {"Cargo.toml"},
+                archive_inspector=lambda data, *_args: events.append(
+                    f"inspect:{data.decode()}"
+                )
+                or RELEASE.ArchiveInspection({}, ()),
+                source_reader_factory=lambda *_args, **_kwargs: lambda _path: None,
+                attempts=1,
+                delay=0,
+            )
+        self.assertEqual(
+            events,
+            [
+                "exists:new-crate",
+                "download:new-crate",
+                "inspect:new-crate",
+            ],
+        )
+
+    def test_propagation_retries_then_succeeds(self) -> None:
+        events: list[str] = []
+
+        class PropagatingClient(FakeClient):
+            def __init__(self) -> None:
+                super().__init__({"crate-a": True}, events)
+                self.checks = 0
+
+            def version_exists(self, package: str, version: str) -> bool:
+                self.checks += 1
+                events.append(f"exists:{package}")
+                return self.checks == 3
+
+        inspection = RELEASE.await_registry_archive(
+            PropagatingClient(),
+            "crate-a",
+            self.VERSION,
+            self.COMMIT,
+            "crates/crate-a",
+            lambda _path: None,
+            {"Cargo.toml"},
+            archive_inspector=lambda *_args: RELEASE.ArchiveInspection({}, ()),
+            attempts=3,
+            delay=0,
+            sleeper=lambda _delay: events.append("sleep"),
+        )
+        self.assertEqual(inspection, RELEASE.ArchiveInspection({}, ()))
+        self.assertEqual(events.count("sleep"), 2)
+        self.assertEqual(events[-1], "download:crate-a")
+
+    def test_propagation_retries_then_times_out(self) -> None:
+        events: list[str] = []
+        client = FakeClient({}, events)
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "did not become visible"):
+            RELEASE.await_registry_archive(
+                client,
+                "crate-a",
+                self.VERSION,
+                self.COMMIT,
+                "crates/crate-a",
+                lambda _path: None,
+                {"Cargo.toml"},
+                archive_inspector=lambda *_args: RELEASE.ArchiveInspection({}, ()),
+                attempts=3,
+                delay=0,
+                sleeper=lambda _delay: events.append("sleep"),
+            )
+        self.assertEqual(events.count("sleep"), 2)
 
 
 if __name__ == "__main__":

--- a/scripts/test-release-publish.py
+++ b/scripts/test-release-publish.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Focused tests for the fail-closed crates.io release helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import tarfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("release-publish.py")
+SPEC = importlib.util.spec_from_file_location("release_publish", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot import {SCRIPT}")
+RELEASE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RELEASE)
+
+
+class GitDependencyTests(unittest.TestCase):
+    def test_parses_commented_multiline_workspace_git_dependencies(self) -> None:
+        manifest = """\
+[workspace.dependencies]
+local = { path = "local" }
+
+# Cargo replaces this source with the registry version during publication.
+[workspace.dependencies.strided]
+package = "strided-view" # registry package
+version = "0.4.0"
+git = "https://example.invalid/strided.git"
+rev = "0123456789abcdef0123456789abcdef01234567"
+"""
+        self.assertEqual(
+            RELEASE.parse_workspace_git_dependencies(manifest),
+            [
+                RELEASE.GitDependency(
+                    name="strided",
+                    package="strided-view",
+                    version="0.4.0",
+                    git="https://example.invalid/strided.git",
+                    rev="0123456789abcdef0123456789abcdef01234567",
+                )
+            ],
+        )
+
+    def test_accepts_cargo_exact_version_operator(self) -> None:
+        manifest = """\
+[workspace.dependencies.fixture]
+git = "https://example.invalid/repo"
+version = "=0.4.0"
+rev = "0123456789abcdef0123456789abcdef01234567"
+"""
+        self.assertEqual(
+            RELEASE.parse_workspace_git_dependencies(manifest)[0].version,
+            "0.4.0",
+        )
+
+    def test_rejects_git_dependency_without_exact_registry_identity(self) -> None:
+        base = """\
+[workspace.dependencies]
+strided = { git = "https://example.invalid/repo", %s }
+"""
+        cases = (
+            'rev = "0123456789abcdef0123456789abcdef01234567"',
+            'version = "^0.4", rev = "0123456789abcdef0123456789abcdef01234567"',
+            'version = "0.4.0", rev = "main"',
+        )
+        for fields in cases:
+            with self.subTest(fields=fields):
+                with self.assertRaises(RELEASE.ReleaseError):
+                    RELEASE.parse_workspace_git_dependencies(base % fields)
+
+    def test_validates_package_and_workspace_version_at_pinned_revision(self) -> None:
+        dependency = RELEASE.GitDependency(
+            "view",
+            "strided-view",
+            "0.4.0",
+            "https://example.invalid/strided.git",
+            "0123456789abcdef0123456789abcdef01234567",
+        )
+        manifests = {
+            "Cargo.toml": """\
+[workspace]
+members = ["strided-view"]
+[workspace.package]
+version = "0.4.0"
+""",
+            "strided-view/Cargo.toml": """\
+[package]
+name = "strided-view"
+version.workspace = true
+""",
+        }
+        RELEASE.validate_revision_manifest(dependency, manifests)
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "declares version 0.3.0"):
+            RELEASE.validate_revision_manifest(
+                dependency,
+                {
+                    "strided-view/Cargo.toml": """\
+[package]
+name = "strided-view"
+version = "0.3.0"
+"""
+                },
+            )
+
+
+class ArchiveTests(unittest.TestCase):
+    COMMIT = "abcdef0123456789abcdef0123456789abcdef01"
+
+    def archive(self, *, commit: str = COMMIT, dirty: bool = False) -> bytes:
+        manifest = """\
+[package]
+name = "tenferro-fixture"
+version = "0.4.0"
+description = "Fixture package"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/tensor4all/tenferro-rs"
+homepage = "https://tensor4all.org/tenferro-rs/"
+documentation = "https://docs.rs/tenferro-fixture"
+readme = "README.md"
+rust-version = "1.96"
+keywords = ["tensor"]
+categories = ["science"]
+include = ["src/**", "README.md"]
+"""
+        files = {
+            "tenferro-fixture-0.4.0/Cargo.toml": manifest.encode(),
+            "tenferro-fixture-0.4.0/README.md": b"fixture\n",
+            "tenferro-fixture-0.4.0/src/lib.rs": b"",
+            "tenferro-fixture-0.4.0/.cargo_vcs_info.json": json.dumps(
+                {"git": {"sha1": commit, "dirty": dirty}}
+            ).encode(),
+        }
+        output = io.BytesIO()
+        with tarfile.open(fileobj=output, mode="w:gz") as archive:
+            for name, data in files.items():
+                info = tarfile.TarInfo(name)
+                info.size = len(data)
+                archive.addfile(info, io.BytesIO(data))
+        return output.getvalue()
+
+    def test_inspects_archive_metadata_files_and_exact_provenance(self) -> None:
+        inspection = RELEASE.inspect_crate_archive(
+            self.archive(), "tenferro-fixture", "0.4.0", self.COMMIT
+        )
+        self.assertEqual(inspection.metadata["rust-version"], "1.96")
+        self.assertIn("tenferro-fixture-0.4.0/README.md", inspection.files)
+
+    def test_rejects_dirty_or_wrong_commit_archive(self) -> None:
+        for archive in (
+            self.archive(dirty=True),
+            self.archive(commit="0" * 40),
+        ):
+            with self.subTest():
+                with self.assertRaises(RELEASE.ReleaseError):
+                    RELEASE.inspect_crate_archive(
+                        archive, "tenferro-fixture", "0.4.0", self.COMMIT
+                    )
+
+
+class RegistryAndApprovalTests(unittest.TestCase):
+    def test_registry_queries_are_injected_and_do_not_need_network(self) -> None:
+        calls: list[str] = []
+
+        def transport(url: str) -> tuple[int, bytes]:
+            calls.append(url)
+            return (200, b"{}") if url.endswith("/strided-view/0.4.0") else (404, b"")
+
+        client = RELEASE.CratesIoClient(transport)
+        self.assertTrue(client.version_exists("strided-view", "0.4.0"))
+        self.assertFalse(client.package_exists("new-package"))
+        self.assertEqual(len(calls), 2)
+
+    def test_new_package_approval_must_name_exact_missing_package(self) -> None:
+        existing = {"old-package": True, "new-package": False}
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "new-package"):
+            RELEASE.validate_new_package_approvals(existing, set())
+        RELEASE.validate_new_package_approvals(existing, {"new-package"})
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "not new"):
+            RELEASE.validate_new_package_approvals(existing, {"old-package", "new-package"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- bump all fourteen publishable tenferro crates and internal dependency requirements to `0.4.0`
- pin strided dependencies to the published strided-rs `v0.4.0` commit (`b29e7601ba090aa5eafc65b9bde5d9450282e0d8`)
- make the documented publication order machine-checkable and add a fail-closed, restart-safe tagged-release helper
- attest local, dry-run, and registry archives byte-for-byte, including generated manifests, lockfiles, and VCS metadata
- add focused release-helper, tar-safety, network-failure, DAG, and CI-profile coverage

## Release safety

Publication remains a separate post-merge/tag maintainer phase. The helper requires a clean detached pushed tag reachable from `origin/main`, validates all git-pin registry versions, packages in dependency order, and requires exact approval for the new `tenferro-internal-cpu-kernels` package.

## Verification

- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `python3 scripts/ci/run_profile.py coverage` (`191/191` files passed)
- `python3 scripts/ci/run_profile.py clippy ci-config docs`
- `python3 scripts/check-publish-layout.py`
- `python3 scripts/test-check-publish-layout.py` (21 tests)
- `python3 scripts/test-release-publish.py` (24 tests)
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/tenferro-v0.4-rules-review.json` (pass, zero findings)
- independent specification and code-quality re-reviews of the exact archive-attestation candidate (no findings)

## Work log

- [`docs/worklogs/2026-07-04-release-publish-workflow.md`](https://github.com/tensor4all/tenferro-rs/blob/release/v0.4.0-prep/docs/worklogs/2026-07-04-release-publish-workflow.md)
