### PR TITLE
fix: correct release target to v0.3.0

### DIFF
--- a/.agents/skills/tenferro-release-publish/SKILL.md
+++ b/.agents/skills/tenferro-release-publish/SKILL.md
@@ -24,8 +24,7 @@ Keep the interaction incremental:
    cross-crate `version = "..."` requirement) and the full pre-push
    checklist.
 3. Phase 2: tag the merged commit and push the tag.
-4. Phase 3: publish crates in dependency order from a worktree of the tag,
-   waiting for the registry index between crates. Confirm with the user
-   immediately before the first `cargo publish`.
-5. Phase 4: verify crates.io versions and `.cargo_vcs_info.json`
-   provenance, then clean up.
+4. At Phase 3, stop after validation; a human maintainer runs Phase 3
+   publication from the tag.
+5. After human publication, Phase 4 verifies crates.io versions and
+   `.cargo_vcs_info.json` provenance, then cleans up.

--- a/.agents/skills/tenferro-release-publish/SKILL.md
+++ b/.agents/skills/tenferro-release-publish/SKILL.md
@@ -18,7 +18,8 @@ Hard invariants (abort the release if any would be violated):
 
 Keep the interaction incremental:
 
-1. Confirm the target version and that `origin/main` is green and clean.
+1. Derive and present the canonical workflow's SemVer proposal before editing;
+   stop for explicit confirmation when the requested target differs.
 2. Phase 1: version-bump PR (workspace version plus every internal
    cross-crate `version = "..."` requirement) and the full pre-push
    checklist.

--- a/.claude/skills/tenferro-release-publish/SKILL.md
+++ b/.claude/skills/tenferro-release-publish/SKILL.md
@@ -24,8 +24,7 @@ Keep the interaction incremental:
    cross-crate `version = "..."` requirement) and the full pre-push
    checklist.
 3. Phase 2: tag the merged commit and push the tag.
-4. Phase 3: publish crates in dependency order from a worktree of the tag,
-   waiting for the registry index between crates. Confirm with the user
-   immediately before the first `cargo publish`.
-5. Phase 4: verify crates.io versions and `.cargo_vcs_info.json`
-   provenance, then clean up.
+4. At Phase 3, stop after validation; a human maintainer runs Phase 3
+   publication from the tag.
+5. After human publication, Phase 4 verifies crates.io versions and
+   `.cargo_vcs_info.json` provenance, then cleans up.

--- a/.claude/skills/tenferro-release-publish/SKILL.md
+++ b/.claude/skills/tenferro-release-publish/SKILL.md
@@ -18,7 +18,8 @@ Hard invariants (abort the release if any would be violated):
 
 Keep the interaction incremental:
 
-1. Confirm the target version and that `origin/main` is green and clean.
+1. Derive and present the canonical workflow's SemVer proposal before editing;
+   stop for explicit confirmation when the requested target differs.
 2. Phase 1: version-bump PR (workspace version plus every internal
    cross-crate `version = "..."` requirement) and the full pre-push
    checklist.

--- a/.kimi/skills/tenferro-release-publish/SKILL.md
+++ b/.kimi/skills/tenferro-release-publish/SKILL.md
@@ -24,8 +24,7 @@ Keep the interaction incremental:
    cross-crate `version = "..."` requirement) and the full pre-push
    checklist.
 3. Phase 2: tag the merged commit and push the tag.
-4. Phase 3: publish crates in dependency order from a worktree of the tag,
-   waiting for the registry index between crates. Confirm with the user
-   immediately before the first `cargo publish`.
-5. Phase 4: verify crates.io versions and `.cargo_vcs_info.json`
-   provenance, then clean up.
+4. At Phase 3, stop after validation; a human maintainer runs Phase 3
+   publication from the tag.
+5. After human publication, Phase 4 verifies crates.io versions and
+   `.cargo_vcs_info.json` provenance, then cleans up.

--- a/.kimi/skills/tenferro-release-publish/SKILL.md
+++ b/.kimi/skills/tenferro-release-publish/SKILL.md
@@ -18,7 +18,8 @@ Hard invariants (abort the release if any would be violated):
 
 Keep the interaction incremental:
 
-1. Confirm the target version and that `origin/main` is green and clean.
+1. Derive and present the canonical workflow's SemVer proposal before editing;
+   stop for explicit confirmation when the requested target differs.
 2. Phase 1: version-bump PR (workspace version plus every internal
    cross-crate `version = "..."` requirement) and the full pre-push
    checklist.

--- a/.opencode/commands/tenferro-release-publish.md
+++ b/.opencode/commands/tenferro-release-publish.md
@@ -15,6 +15,6 @@ before publishing; never edit manifests at publish time (fix on `main` and
 re-tag instead); git-pinned workspace dependencies must pin revs whose
 declared versions exist on crates.io.
 
-Proceed phase by phase — version-bump PR, tag, dependency-order publish from
-a worktree of the tag, post-publish verification — and confirm with the user
-immediately before the first `cargo publish`.
+Proceed through the version-bump PR and tag, then stop after validation; a
+human maintainer runs Phase 3 publication from the tag. After human publication,
+perform the canonical post-publish verification.

--- a/.opencode/commands/tenferro-release-publish.md
+++ b/.opencode/commands/tenferro-release-publish.md
@@ -5,7 +5,9 @@ description: Release a new tenferro-rs version - bump the workspace version on m
 Use `$ARGUMENTS` as the target version or initial request if present.
 
 Follow `ai/contribution-workflows/release-publish.md` as the canonical
-workflow. Read it fully before acting.
+workflow. Read it fully before acting. Derive and present its SemVer proposal
+before editing; stop for explicit confirmation when the requested target
+differs.
 
 Hard invariants (abort the release if any would be violated): publish only
 from a pushed, tagged, main-lineage commit; land the version bump on `main`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.3.0"
 rust-version = "1.96"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -26,13 +26,34 @@ Violating any of these aborts the release.
    whose declared `version` exists on crates.io, because `cargo publish`
    strips the `git` source and keeps only `version`.
 
-## Phase 0 — Preconditions
+## Phase 0 — SemVer Proposal And Preconditions
 
-- Fresh worktree of the latest `origin/main`; clean tree; CI green on
-  `origin/main`.
-- Pick the new version `X.Y.Z`. Pre-1.0 convention: breaking changes bump
-  the minor version; compatible fixes bump the patch version.
-- Run `python3 scripts/check-publish-layout.py` and fix findings first.
+Complete this phase before changing manifests or making any other release edit.
+
+1. Query crates.io for each existing publishable workspace crate and establish
+   the latest matching published stable baseline and its provenance tag. An
+   approved package that has never been published does not participate in
+   baseline agreement. If the published versions or their provenance do not
+   agree, stop and resolve the mismatch. A newer tag that was not published is
+   an anomaly, not a baseline; stop and resolve it before continuing.
+2. Inspect merged PRs, accepted issues, and release evidence since the matching
+   provenance tag. Classify the highest-impact change as `breaking`, `feature`,
+   or `fix-only`.
+3. Apply this SemVer table to the latest published stable version:
+
+   | Baseline | `breaking` | `feature` | `fix-only` |
+   | --- | --- | --- | --- |
+   | `0.Y.Z` | `0.(Y+1).0` | `0.(Y+1).0` | `0.Y.(Z+1)` |
+   | `X.Y.Z`, `X >= 1` | `(X+1).0.0` | `X.(Y+1).0` | `X.Y.(Z+1)` |
+
+4. Present the baseline and provenance, classified evidence, and one proposed
+   target before changing manifests. If the user supplied a different target,
+   stop for explicit confirmation and a reason; proceed only after recording
+   the confirmed override. Never align independently versioned repositories:
+   a dependency's version is not evidence for this repository's target.
+5. Use a fresh worktree of the latest `origin/main`; require a clean tree and
+   green CI on `origin/main`.
+6. Run `python3 scripts/check-publish-layout.py` and fix findings first.
 
 ## Phase 1 — Version-Bump PR To Main
 

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -145,7 +145,7 @@ Agents must stop after validation and must never execute a publication.
    python3 scripts/release-publish.py X.Y.Z
    ```
 
-   **New-package gate:** `tenferro-internal-cpu-kernels` is new for v0.4.0.
+   **New-package gate:** `tenferro-internal-cpu-kernels` is new for v0.3.0.
    The command above must abort before publishing anything unless the user's
    approval names exactly `tenferro-internal-cpu-kernels`. After recording that
    exact approval, the human operator asserts it concretely with:

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -36,9 +36,11 @@ Complete this phase before changing manifests or making any other release edit.
    baseline agreement. If the published versions or their provenance do not
    agree, stop and resolve the mismatch. A newer tag that was not published is
    an anomaly, not a baseline; stop and resolve it before continuing.
-2. Inspect merged PRs, accepted issues, and release evidence since the matching
-   provenance tag. Classify the highest-impact change as `breaking`, `feature`,
-   or `fix-only`.
+2. Inspect changes actually merged since the matching provenance tag, using
+   merged PRs and release evidence. Classify the highest-impact merged change as
+   `breaking`, `feature`, or `fix-only`. Accepted issues may explain a
+   classification only when linked to merged implementation; unimplemented
+   accepted issues do not affect the release classification.
 3. Apply this SemVer table to the latest published stable version:
 
    | Baseline | `breaking` | `feature` | `fix-only` |

--- a/crates/tenferro-ad/Cargo.toml
+++ b/crates/tenferro-ad/Cargo.toml
@@ -44,11 +44,11 @@ webgpu = ["dep:tenferro-gpu", "tenferro-gpu/webgpu"]
 rocm = ["dep:tenferro-gpu", "tenferro-gpu/rocm"]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false, features = ["autodiff"] }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false, features = ["autodiff"] }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.3.0", default-features = false, optional = true }
 computegraph.workspace = true
 lru.workspace = true
 num-complex.workspace = true

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -45,10 +45,10 @@ blas-mkl = [
 ]
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
-tenferro-internal-cpu-kernels = { path = "../tenferro-internal-cpu-kernels", version = "0.4.0" }
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0" }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.3.0" }
+tenferro-internal-cpu-kernels = { path = "../tenferro-internal-cpu-kernels", version = "0.3.0" }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0" }
 num-complex.workspace = true
 num-traits.workspace = true
 rayon.workspace = true

--- a/crates/tenferro-einsum/Cargo.toml
+++ b/crates/tenferro-einsum/Cargo.toml
@@ -65,13 +65,13 @@ rocm = [
 ]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
-tenferro-ad = { path = "../tenferro-ad", version = "0.4.0", default-features = false, optional = true }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
+tenferro-ad = { path = "../tenferro-ad", version = "0.3.0", default-features = false, optional = true }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.3.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.3.0", default-features = false, optional = true }
 computegraph.workspace = true
 lru.workspace = true
 omeco.workspace = true
@@ -79,7 +79,7 @@ smallvec.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
 criterion.workspace = true
 num-complex.workspace = true
 

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -44,13 +44,13 @@ webgpu = [
 ]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
-tenferro-ad = { path = "../tenferro-ad", version = "0.4.0", default-features = false, optional = true }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
+tenferro-ad = { path = "../tenferro-ad", version = "0.3.0", default-features = false, optional = true }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.3.0", default-features = false, optional = true }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.3.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
 libloading = { workspace = true, optional = true }
 computegraph.workspace = true
 num-complex.workspace = true

--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -54,10 +54,10 @@ webgpu = [
 rocm = []
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.3.0" }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
 cubecl = { workspace = true, optional = true }
 cubecl-cuda = { workspace = true, optional = true }
 cubecl-common = { workspace = true, optional = true }

--- a/crates/tenferro-internal-cpu-kernels/Cargo.toml
+++ b/crates/tenferro-internal-cpu-kernels/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 name = "tenferro_internal_cpu_kernels"
 
 [dependencies]
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0" }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0" }
 num-complex.workspace = true
 num-traits.workspace = true
 strided-kernel.workspace = true

--- a/crates/tenferro-internal-ops/Cargo.toml
+++ b/crates/tenferro-internal-ops/Cargo.toml
@@ -29,9 +29,9 @@ webgpu = []
 rocm = []
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.3.0" }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.3.0" }
 computegraph.workspace = true
 num-complex.workspace = true
 thiserror.workspace = true

--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -74,13 +74,13 @@ rocm = ["tenferro-ad?/rocm", "tenferro-internal-ops/rocm"]
 webgpu = ["dep:tenferro-gpu", "tenferro-gpu/webgpu"]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
-tenferro-ad = { path = "../tenferro-ad", version = "0.4.0", default-features = false, optional = true }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
+tenferro-ad = { path = "../tenferro-ad", version = "0.3.0", default-features = false, optional = true }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.3.0", default-features = false, optional = true }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.3.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false }
 cblas-sys = { workspace = true, optional = true }
 cblas-inject = { workspace = true, optional = true }
 computegraph = { workspace = true, optional = true }

--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -31,9 +31,9 @@ blas-accelerate = ["tenferro-cpu/blas-accelerate"]
 blas-mkl = ["tenferro-cpu/blas-mkl"]
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.3.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
 computegraph.workspace = true
 lru.workspace = true
 num-complex.workspace = true
@@ -43,7 +43,7 @@ thiserror.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false }
 
 [[bench]]
 name = "elementwise_fusion"

--- a/crates/tenferro-tensor/Cargo.toml
+++ b/crates/tenferro-tensor/Cargo.toml
@@ -25,12 +25,12 @@ name = "tenferro_tensor"
 default = []
 
 [dependencies]
-tenferro-tensor-core = { path = "../tenferro-tensor-core", version = "0.4.0" }
+tenferro-tensor-core = { path = "../tenferro-tensor-core", version = "0.3.0" }
 num-traits.workspace = true
 num-complex.workspace = true
 smallvec.workspace = true
 strided-kernel.workspace = true
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.3.0" }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/tenferro-xla/Cargo.toml
+++ b/crates/tenferro-xla/Cargo.toml
@@ -27,17 +27,17 @@ default = []
 pjrt = ["dep:libloading"]
 
 [dependencies]
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
 computegraph.workspace = true
 libloading = { workspace = true, optional = true }
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false, features = ["cpu-faer"] }
-tenferro-einsum = { path = "../tenferro-einsum", version = "0.4.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false, features = ["cpu-faer"] }
+tenferro-einsum = { path = "../tenferro-einsum", version = "0.3.0", default-features = false }
 
 [[test]]
 name = "integration"

--- a/docs/worklogs/2026-07-04-release-publish-workflow.md
+++ b/docs/worklogs/2026-07-04-release-publish-workflow.md
@@ -82,13 +82,13 @@ README, service, facade, feature-default, or MSRV-matrix change was made.
 Residual: publish deep crates only after matching dependencies are available on
 crates.io; package verification should then be rerun.
 
-## 2026-08-09 v0.4 final-review hardening
+## 2026-08-09 v0.3 final-review hardening
 
 Added `scripts/release-publish.py` as the fail-closed human operator path for
 Phase 3. It verifies the clean detached checkout against the pushed remote tag
 and `origin/main`, structurally validates every workspace git pin against both
 its revision manifest and exact crates.io version, and requires exact approval
-for each package that is new to crates.io. In particular, v0.4 publication
+for each package that is new to crates.io. In particular, v0.3 publication
 cannot proceed without an approval assertion naming
 `tenferro-internal-cpu-kernels` exactly.
 

--- a/docs/worklogs/2026-07-04-release-publish-workflow.md
+++ b/docs/worklogs/2026-07-04-release-publish-workflow.md
@@ -145,8 +145,9 @@ independent SemVer target. That allowed a dependency release to be mistaken for
 a reason to align tenferro with an independently versioned repository.
 
 Phase 0 now derives one proposal from the latest matching published stable
-baseline and its provenance tag, then classifies merged evidence since that tag
-as breaking, feature, or fix-only. The explicit pre-1.0 and 1.0+ table makes the
+baseline and its provenance tag, then classifies changes actually merged since
+that tag as breaking, feature, or fix-only. Accepted issues count only when they
+link to merged implementation. The explicit pre-1.0 and 1.0+ table makes the
 result reviewable. A conflicting supplied target requires explicit confirmation
 and a recorded reason before edits. Approved never-published packages are
 excluded from baseline agreement, while unpublished newer tags are treated as
@@ -160,6 +161,21 @@ strided-rs 0.4.0. The response treated that request as sufficient instead of
 deriving and proposing tenferro 0.3.0 from the published 0.2.0 baseline. The
 new documentation contract test was then observed failing before the workflow
 and adapters were updated.
+
+Four fresh GREEN pressure scenarios passed against the updated guidance: a
+0.2.0 feature proposed 0.3.0 and stopped on a requested 0.4.0 conflict; a
+0.2.3 fix proposed 0.2.4; a 1.4.2 breaking change proposed 2.0.0; and an
+explicitly reasoned 0.4.0 override proceeded with a recording requirement.
+
+The initial `ci-config` run passed all Python/config suites but stopped because
+`actionlint` was unavailable. The controller's subsequent run and the fix-round
+run with pinned actionlint 1.7.7 completed the full profile successfully.
+
+A quality-review correction aligned every adapter with the canonical human-only
+boundary: agents stop after validation, and a human maintainer alone runs Phase
+3 publication. Contract tests now assert the exact SemVer rows, ordering of
+provenance before the proposal, the conflict halt, the human-only boundary, and
+byte equality of the three skill adapters.
 
 Validation commands:
 

--- a/docs/worklogs/2026-07-04-release-publish-workflow.md
+++ b/docs/worklogs/2026-07-04-release-publish-workflow.md
@@ -137,3 +137,33 @@ entries are skipped. Network response truncation and HTTP protocol/read errors
 are converted to bounded, actionable release failures. Focused regressions cover
 generated-file mutations, malicious traversal directories, HTTP failures, exact
 resume comparison, and prerequisite-before-dependent packaging.
+
+## 2026-08-09 SemVer proposal gate
+
+The release guidance previously accepted a requested target before deriving an
+independent SemVer target. That allowed a dependency release to be mistaken for
+a reason to align tenferro with an independently versioned repository.
+
+Phase 0 now derives one proposal from the latest matching published stable
+baseline and its provenance tag, then classifies merged evidence since that tag
+as breaking, feature, or fix-only. The explicit pre-1.0 and 1.0+ table makes the
+result reviewable. A conflicting supplied target requires explicit confirmation
+and a recorded reason before edits. Approved never-published packages are
+excluded from baseline agreement, while unpublished newer tags are treated as
+anomalies rather than baselines.
+
+The human-only publication boundary is unchanged: agents stop after validation,
+and only a maintainer with crates.io ownership runs Phase 3 publication.
+
+The RED pressure scenario omitted the skill and requested tenferro 0.4.0 after
+strided-rs 0.4.0. The response treated that request as sufficient instead of
+deriving and proposing tenferro 0.3.0 from the published 0.2.0 baseline. The
+new documentation contract test was then observed failing before the workflow
+and adapters were updated.
+
+Validation commands:
+
+- `python3 scripts/test-release-publish.py`
+- `python3 scripts/ci/run_profile.py ci-config`
+- byte comparisons of the three `SKILL.md` adapters
+- `git diff --check`

--- a/scripts/test-release-publish.py
+++ b/scripts/test-release-publish.py
@@ -25,32 +25,49 @@ SPEC.loader.exec_module(RELEASE)
 
 class ReleaseDocumentationContractTests(unittest.TestCase):
     ROOT = Path(__file__).resolve().parents[1]
+    SKILL_PATHS = (
+        ".agents/skills/tenferro-release-publish/SKILL.md",
+        ".claude/skills/tenferro-release-publish/SKILL.md",
+        ".kimi/skills/tenferro-release-publish/SKILL.md",
+    )
 
     def test_canonical_workflow_requires_semver_proposal_before_edits(self) -> None:
         text = (self.ROOT / "ai/contribution-workflows/release-publish.md").read_text()
+        normalized = " ".join(text.split())
         for phrase in (
             "latest published stable version",
-            "breaking",
-            "feature",
-            "fix-only",
             "before changing manifests",
             "independently versioned",
-            "explicit confirmation",
+            "stop for explicit confirmation and a reason",
+            "unimplemented accepted issues do not affect",
+            "Agents must stop after validation and must never execute a publication.",
         ):
-            self.assertIn(phrase, text)
-
-    def test_release_adapters_reference_the_proposal_gate(self) -> None:
-        paths = (
-            ".agents/skills/tenferro-release-publish/SKILL.md",
-            ".claude/skills/tenferro-release-publish/SKILL.md",
-            ".kimi/skills/tenferro-release-publish/SKILL.md",
-            ".opencode/commands/tenferro-release-publish.md",
+            self.assertIn(phrase, normalized)
+        self.assertIn(
+            "| `0.Y.Z` | `0.(Y+1).0` | `0.(Y+1).0` | `0.Y.(Z+1)` |", text
         )
+        self.assertIn(
+            "| `X.Y.Z`, `X >= 1` | `(X+1).0.0` | `X.(Y+1).0` | `X.Y.(Z+1)` |",
+            text,
+        )
+        self.assertLess(
+            normalized.index("provenance tag"), normalized.index("one proposed")
+        )
+
+    def test_release_adapters_reference_the_proposal_gate_and_human_boundary(self) -> None:
+        paths = (*self.SKILL_PATHS, ".opencode/commands/tenferro-release-publish.md")
         for relative in paths:
             text = (self.ROOT / relative).read_text()
             self.assertIn("ai/contribution-workflows/release-publish.md", text)
             self.assertIn("before editing", text)
             self.assertIn("SemVer proposal", text)
+            self.assertIn("stop after validation", text)
+            self.assertIn("human maintainer runs Phase 3", text)
+
+    def test_release_skill_adapters_are_byte_identical(self) -> None:
+        expected = (self.ROOT / self.SKILL_PATHS[0]).read_bytes()
+        for relative in self.SKILL_PATHS[1:]:
+            self.assertEqual(expected, (self.ROOT / relative).read_bytes())
 
 
 class GitDependencyTests(unittest.TestCase):

--- a/scripts/test-release-publish.py
+++ b/scripts/test-release-publish.py
@@ -44,10 +44,10 @@ class ReleaseDocumentationContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, normalized)
         self.assertIn(
-            "| `0.Y.Z` | `0.(Y+1).0` | `0.(Y+1).0` | `0.Y.(Z+1)` |", text
-        )
-        self.assertIn(
-            "| `X.Y.Z`, `X >= 1` | `(X+1).0.0` | `X.(Y+1).0` | `X.Y.(Z+1)` |",
+            """| Baseline | `breaking` | `feature` | `fix-only` |
+   | --- | --- | --- | --- |
+   | `0.Y.Z` | `0.(Y+1).0` | `0.(Y+1).0` | `0.Y.(Z+1)` |
+   | `X.Y.Z`, `X >= 1` | `(X+1).0.0` | `X.(Y+1).0` | `X.Y.(Z+1)` |""",
             text,
         )
         self.assertLess(
@@ -58,11 +58,20 @@ class ReleaseDocumentationContractTests(unittest.TestCase):
         paths = (*self.SKILL_PATHS, ".opencode/commands/tenferro-release-publish.md")
         for relative in paths:
             text = (self.ROOT / relative).read_text()
+            normalized = " ".join(text.split())
             self.assertIn("ai/contribution-workflows/release-publish.md", text)
             self.assertIn("before editing", text)
             self.assertIn("SemVer proposal", text)
-            self.assertIn("stop after validation", text)
-            self.assertIn("human maintainer runs Phase 3", text)
+            self.assertIn(
+                "stop after validation; a human maintainer runs Phase 3 publication from the tag.",
+                normalized,
+            )
+            for contradictory in (
+                "Phase 3: publish crates in dependency order from a worktree of the tag",
+                "Proceed phase by phase — version-bump PR, tag, dependency-order publish from a worktree of the tag",
+                "confirm with the user immediately before the first `cargo publish`",
+            ):
+                self.assertNotIn(contradictory.lower(), normalized.lower())
 
     def test_release_skill_adapters_are_byte_identical(self) -> None:
         expected = (self.ROOT / self.SKILL_PATHS[0]).read_bytes()

--- a/scripts/test-release-publish.py
+++ b/scripts/test-release-publish.py
@@ -23,6 +23,36 @@ RELEASE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(RELEASE)
 
 
+class ReleaseDocumentationContractTests(unittest.TestCase):
+    ROOT = Path(__file__).resolve().parents[1]
+
+    def test_canonical_workflow_requires_semver_proposal_before_edits(self) -> None:
+        text = (self.ROOT / "ai/contribution-workflows/release-publish.md").read_text()
+        for phrase in (
+            "latest published stable version",
+            "breaking",
+            "feature",
+            "fix-only",
+            "before changing manifests",
+            "independently versioned",
+            "explicit confirmation",
+        ):
+            self.assertIn(phrase, text)
+
+    def test_release_adapters_reference_the_proposal_gate(self) -> None:
+        paths = (
+            ".agents/skills/tenferro-release-publish/SKILL.md",
+            ".claude/skills/tenferro-release-publish/SKILL.md",
+            ".kimi/skills/tenferro-release-publish/SKILL.md",
+            ".opencode/commands/tenferro-release-publish.md",
+        )
+        for relative in paths:
+            text = (self.ROOT / relative).read_text()
+            self.assertIn("ai/contribution-workflows/release-publish.md", text)
+            self.assertIn("before editing", text)
+            self.assertIn("SemVer proposal", text)
+
+
 class GitDependencyTests(unittest.TestCase):
     def test_parses_commented_multiline_workspace_git_dependencies(self) -> None:
         manifest = """\


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs #1645

## Summary

Base: `0ae5e1c769f256c2180a6e0c48eafdd6d878d8f1`  
Branch: `release/v0.3.0-correction`

- correct the unpublished tenferro release target from `0.4.0` to the SemVer-consistent `0.3.0`
- keep all four strided-rs dependencies independently pinned to published `0.4.0` commit `b29e7601ba090aa5eafc65b9bde5d9450282e0d8`
- require an evidence-backed SemVer proposal before release edits and explicit confirmation for conflicting requested versions
- keep Phase 3 publication human-only in the canonical workflow and all runtime adapters
- add RED/GREEN pressure coverage and durable workflow contract tests

No tenferro `0.4.0` crate was published. All fourteen crate names were checked before the mistaken `v0.4.0` GitHub Release and tag were removed.

### Bug-fix scope and neighborhood scan

The existing pre-1.0 release policy already required a minor bump for features; the bug was accepting a dependency-aligned target without deriving tenferro's own next version. The fix adds no public API, dependency, backend, feature flag, or architectural layer. The same-root scan covered the canonical workflow and every `.agents`, `.claude`, `.kimi`, and `.opencode` release adapter; all now share the same human-only publication boundary.

## Work log

- [`docs/worklogs/2026-07-04-release-publish-workflow.md`](https://github.com/tensor4all/tenferro-rs/blob/release/v0.3.0-correction/docs/worklogs/2026-07-04-release-publish-workflow.md)

## Verification

- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `python3 scripts/ci/run_profile.py coverage` (`191/191` files passed)
- `python3 scripts/ci/run_profile.py clippy ci-config docs`
- `python3 scripts/check-publish-layout.py`
- `python3 scripts/test-check-publish-layout.py` (21 tests)
- `python3 scripts/test-release-publish.py` (27 tests)
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/tenferro-v0.3-rules-review.json` (pass, zero findings)
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'python3 scripts/test-release-publish.py'`
- independent task-level specification and quality reviews, followed by final whole-branch review (READY, zero findings)
- fresh skill pressure scenarios: pre-1.0 feature conflict, patch-only, stable breaking, and explicit override

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. (Not applicable.)
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
