### PR TITLE
fix: discover Cargo dry-run release archives

### DIFF
--- a/docs/worklogs/2026-07-04-release-publish-workflow.md
+++ b/docs/worklogs/2026-07-04-release-publish-workflow.md
@@ -202,4 +202,4 @@ TDD regressions model Cargo's staged paths, reject differing copies, and verify
 read-error attribution. A real Cargo 1.97 run on `tenferro-core-ops` confirmed
 that `cargo package`, `tmp-crate`, and `tmp-registry` archives were byte-identical
 and that the repaired helper completed package-to-dry-run attestation without
-uploading. The focused release-helper suite passed with 29 tests.
+uploading. The focused release-helper suite passed with 30 tests.

--- a/docs/worklogs/2026-07-04-release-publish-workflow.md
+++ b/docs/worklogs/2026-07-04-release-publish-workflow.md
@@ -183,3 +183,23 @@ Validation commands:
 - `python3 scripts/ci/run_profile.py ci-config`
 - byte comparisons of the three `SKILL.md` adapters
 - `git diff --check`
+
+## 2026-08-09 Cargo 1.97 dry-run staging fix
+
+The first human v0.3 publication attempt stopped safely before uploading any
+crate. `cargo publish --dry-run` succeeded, but Cargo 1.97 staged its archive at
+both `target/package/tmp-crate/` and `target/package/tmp-registry/` instead of
+retaining `target/package/<crate>-<version>.crate`. The helper removed and then
+checked only the latter path, so it reported a false missing-archive failure.
+
+The shared archive inspection boundary now clears and discovers all three exact
+Cargo locations, rejects a missing archive, requires multiple generated copies
+to be byte-identical, and then applies the existing full archive and expected
+content checks. Read failures identify the exact candidate path. This preserves
+the fail-closed contract rather than skipping dry-run archive attestation.
+
+TDD regressions model Cargo's staged paths, reject differing copies, and verify
+read-error attribution. A real Cargo 1.97 run on `tenferro-core-ops` confirmed
+that `cargo package`, `tmp-crate`, and `tmp-registry` archives were byte-identical
+and that the repaired helper completed package-to-dry-run attestation without
+uploading. The focused release-helper suite passed with 29 tests.

--- a/scripts/release-publish.py
+++ b/scripts/release-publish.py
@@ -797,12 +797,16 @@ def build_and_inspect_archive(
         raise ReleaseError(
             f"Cargo did not create expected archive at any of: {', '.join(map(str, candidates))}"
         )
-    try:
-        archive_data = archives[0].read_bytes()
-        if any(candidate.read_bytes() != archive_data for candidate in archives[1:]):
+    archive_data = None
+    for candidate in archives:
+        try:
+            candidate_data = candidate.read_bytes()
+        except OSError as error:
+            raise ReleaseError(f"could not read Cargo archive {candidate}: {error}") from error
+        if archive_data is None:
+            archive_data = candidate_data
+        elif candidate_data != archive_data:
             raise ReleaseError(f"Cargo created differing archives: {archives}")
-    except OSError as error:
-        raise ReleaseError(f"could not read Cargo archive {archives[0]}: {error}") from error
     inspection = archive_inspector(
         archive_data,
         crate,

--- a/scripts/release-publish.py
+++ b/scripts/release-publish.py
@@ -9,6 +9,7 @@ import io
 import json
 import re
 import runpy
+import stat
 import subprocess
 import sys
 import tarfile
@@ -792,7 +793,21 @@ def build_and_inspect_archive(
             f"could not remove stale Cargo archive {candidate}: {error}"
         ) from error
     runner(command, cwd=root, capture=False)
-    archives = [candidate for candidate in candidates if candidate.is_file()]
+    archives = []
+    for candidate in candidates:
+        try:
+            status = candidate.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            continue
+        except OSError as error:
+            raise ReleaseError(
+                f"could not inspect Cargo archive {candidate}: {error}"
+            ) from error
+        if not stat.S_ISREG(status.st_mode):
+            raise ReleaseError(
+                f"Cargo archive candidate is not a regular file: {candidate}"
+            )
+        archives.append(candidate)
     if not archives:
         raise ReleaseError(
             f"Cargo did not create expected archive at any of: {', '.join(map(str, candidates))}"

--- a/scripts/release-publish.py
+++ b/scripts/release-publish.py
@@ -779,17 +779,30 @@ def build_and_inspect_archive(
     archive_inspector: Callable = inspect_crate_archive,
 ) -> ArchiveInspection:
     path = archive_path(metadata, crate, version)
+    candidates = (
+        path,
+        path.parent / "tmp-crate" / path.name,
+        path.parent / "tmp-registry" / path.name,
+    )
     try:
-        path.unlink(missing_ok=True)
+        for candidate in candidates:
+            candidate.unlink(missing_ok=True)
     except OSError as error:
-        raise ReleaseError(f"could not remove stale Cargo archive {path}: {error}") from error
+        raise ReleaseError(
+            f"could not remove stale Cargo archive {candidate}: {error}"
+        ) from error
     runner(command, cwd=root, capture=False)
-    if not path.is_file():
-        raise ReleaseError(f"Cargo did not create expected archive {path}")
+    archives = [candidate for candidate in candidates if candidate.is_file()]
+    if not archives:
+        raise ReleaseError(
+            f"Cargo did not create expected archive at any of: {', '.join(map(str, candidates))}"
+        )
     try:
-        archive_data = path.read_bytes()
+        archive_data = archives[0].read_bytes()
+        if any(candidate.read_bytes() != archive_data for candidate in archives[1:]):
+            raise ReleaseError(f"Cargo created differing archives: {archives}")
     except OSError as error:
-        raise ReleaseError(f"could not read Cargo archive {path}: {error}") from error
+        raise ReleaseError(f"could not read Cargo archive {archives[0]}: {error}") from error
     inspection = archive_inspector(
         archive_data,
         crate,

--- a/scripts/test-release-publish.py
+++ b/scripts/test-release-publish.py
@@ -506,7 +506,10 @@ class OrchestrationTests(unittest.TestCase):
                     archive.write_bytes(b"package")
                 elif command[:3] == ["cargo", "publish", "--dry-run"]:
                     events.append("dry-run")
-                    archive.write_bytes(b"dry-run")
+                    for staging in ("tmp-crate", "tmp-registry"):
+                        staged = archive.parent / staging / archive.name
+                        staged.parent.mkdir()
+                        staged.write_bytes(b"dry-run")
                 elif command[:2] == ["cargo", "publish"]:
                     events.append("publish")
                     client.package_versions["crate-a"] = True
@@ -551,6 +554,36 @@ class OrchestrationTests(unittest.TestCase):
                 "inspect:crate-a",
             ],
         )
+
+    def test_rejects_differing_dry_run_staging_archives(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            metadata = self.metadata(root, ["crate-a"])
+            archive = root / "target/package/crate-a-0.4.0.crate"
+
+            def runner(
+                command: list[str], **_kwargs: object
+            ) -> subprocess.CompletedProcess[str]:
+                archives = (("tmp-crate", b"first"), ("tmp-registry", b"second"))
+                for staging, contents in archives:
+                    staged = archive.parent / staging / archive.name
+                    staged.parent.mkdir(parents=True)
+                    staged.write_bytes(contents)
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with self.assertRaisesRegex(RELEASE.ReleaseError, "differing archives"):
+                RELEASE.build_and_inspect_archive(
+                    metadata,
+                    "crate-a",
+                    self.VERSION,
+                    self.COMMIT,
+                    "crates/crate-a",
+                    lambda _path: None,
+                    {"Cargo.toml"},
+                    ["cargo", "publish", "--dry-run"],
+                    runner=runner,
+                    root=root,
+                )
 
     def test_resume_accepts_new_package_approval_and_attests_before_skip(self) -> None:
         events: list[str] = []

--- a/scripts/test-release-publish.py
+++ b/scripts/test-release-publish.py
@@ -585,6 +585,46 @@ class OrchestrationTests(unittest.TestCase):
                     root=root,
                 )
 
+    def test_archive_read_failure_names_failing_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            metadata = self.metadata(root, ["crate-a"])
+            archive = root / "target/package/crate-a-0.4.0.crate"
+            failing_archive = archive.parent / "tmp-registry" / archive.name
+
+            def runner(
+                command: list[str], **_kwargs: object
+            ) -> subprocess.CompletedProcess[str]:
+                for staging in ("tmp-crate", "tmp-registry"):
+                    staged = archive.parent / staging / archive.name
+                    staged.parent.mkdir(parents=True)
+                    staged.write_bytes(b"same")
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            original_read_bytes = Path.read_bytes
+
+            def read_bytes(path: Path) -> bytes:
+                if path == failing_archive:
+                    raise OSError("test read failure")
+                return original_read_bytes(path)
+
+            with mock.patch.object(Path, "read_bytes", read_bytes):
+                with self.assertRaisesRegex(
+                    RELEASE.ReleaseError, str(failing_archive)
+                ):
+                    RELEASE.build_and_inspect_archive(
+                        metadata,
+                        "crate-a",
+                        self.VERSION,
+                        self.COMMIT,
+                        "crates/crate-a",
+                        lambda _path: None,
+                        {"Cargo.toml"},
+                        ["cargo", "publish", "--dry-run"],
+                        runner=runner,
+                        root=root,
+                    )
+
     def test_resume_accepts_new_package_approval_and_attests_before_skip(self) -> None:
         events: list[str] = []
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test-release-publish.py
+++ b/scripts/test-release-publish.py
@@ -586,6 +586,49 @@ class OrchestrationTests(unittest.TestCase):
                     root=root,
                 )
 
+    def test_archive_status_failure_names_failing_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            metadata = self.metadata(root, ["crate-a"])
+            archive = root / "target/package/crate-a-0.4.0.crate"
+            failing_archive = archive.parent / "tmp-crate" / archive.name
+
+            def runner(
+                command: list[str], **_kwargs: object
+            ) -> subprocess.CompletedProcess[str]:
+                archive.parent.mkdir(parents=True)
+                archive.write_bytes(b"valid")
+                failing_archive.parent.mkdir()
+                failing_archive.write_bytes(b"same")
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            original_stat = Path.stat
+
+            def stat(path: Path, *, follow_symlinks: bool = True) -> object:
+                if path == failing_archive:
+                    raise OSError("test status failure")
+                return original_stat(path, follow_symlinks=follow_symlinks)
+
+            with mock.patch.object(Path, "stat", stat):
+                with self.assertRaisesRegex(
+                    RELEASE.ReleaseError, re.escape(str(failing_archive))
+                ):
+                    RELEASE.build_and_inspect_archive(
+                        metadata,
+                        "crate-a",
+                        self.VERSION,
+                        self.COMMIT,
+                        "crates/crate-a",
+                        lambda _path: None,
+                        {"Cargo.toml"},
+                        ["cargo", "publish", "--dry-run"],
+                        runner=runner,
+                        root=root,
+                        archive_inspector=lambda *_args: RELEASE.ArchiveInspection(
+                            {}, (), {}
+                        ),
+                    )
+
     def test_archive_read_failure_names_failing_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/scripts/test-release-publish.py
+++ b/scripts/test-release-publish.py
@@ -7,6 +7,7 @@ import http.client
 import importlib.util
 import io
 import json
+import re
 import subprocess
 import tarfile
 import tempfile
@@ -610,7 +611,7 @@ class OrchestrationTests(unittest.TestCase):
 
             with mock.patch.object(Path, "read_bytes", read_bytes):
                 with self.assertRaisesRegex(
-                    RELEASE.ReleaseError, str(failing_archive)
+                    RELEASE.ReleaseError, re.escape(str(failing_archive))
                 ):
                     RELEASE.build_and_inspect_archive(
                         metadata,


### PR DESCRIPTION
## Summary

Base: `fad1736023bf77be732e1f3856c261f10900df29`  
Branch: `fix/release-dry-run-archive`

- discover Cargo 1.97 `publish --dry-run` archives at the standard, `tmp-crate`, and `tmp-registry` staging locations
- clear every exact candidate before execution and fail closed on missing, unreadable, non-regular, or differing archives
- retain full byte-for-byte comparison between `cargo package`, dry-run, and registry archives
- add regressions for staged discovery, differing copies, status failures, and read-error attribution
- record the interrupted v0.3 release attempt and fix in the existing release worklog

## Bug and root cause

The first human v0.3 publication attempt stopped before uploading any crate. Cargo 1.97 completed `cargo publish --dry-run`, but staged byte-identical archives under `target/package/tmp-crate/` and `target/package/tmp-registry/` while removing the standard archive. The helper checked only `target/package/<crate>-<version>.crate`, so it falsely reported that Cargo created no archive.

This is an existing-intent bug fix: it changes no public API, crate metadata, dependency, feature, backend, or publication order. The same-root scan found all production archive-path handling routed through `build_and_inspect_archive`; no sibling implementation remained.

A later independent review also found that `Path.is_file()` could suppress candidate status errors. Discovery now distinguishes absence from I/O failure and rejects symlinks/non-regular candidates.

## Release status

No tenferro `0.3.0` crate was published. After this PR merges and exact-main CI passes, the unpublished `v0.3.0` GitHub Release/tag must be replaced at the fixed merge commit, followed by a fresh detached publication worktree and human-only publication retry.

## Work log

- `docs/worklogs/2026-07-04-release-publish-workflow.md`

## Verification

- TDD RED reproduced the original `Cargo did not create expected archive` failure
- `python3 scripts/test-release-publish.py` — 30 tests passed
- `python3 scripts/test-check-publish-layout.py` — 21 tests passed
- `python3 scripts/check-publish-layout.py`
- `python3 -m py_compile scripts/release-publish.py scripts/test-release-publish.py`
- real Cargo 1.97 `tenferro-core-ops` package-to-`cargo publish --dry-run` attestation — passed; no upload performed
- `PATH="/tmp/actionlint-v1.7.7:$PATH" bash scripts/check-pr-fast.sh --coverage-reviewed --ci-profile ci-config --test 'python3 scripts/test-release-publish.py' --test 'python3 scripts/test-check-publish-layout.py' --test 'python3 scripts/check-publish-layout.py'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/tenferro-release-dry-run-rules-review-final.json` — pass, zero findings
- independent specification, code-quality, final PR, and final diff-impact reviews — READY, zero remaining findings

## Checklist

- [x] Applied the bug-fix scope gate
- [x] Added regression coverage before implementation
- [x] Scanned the same archive-handling neighborhood
- [x] No actual `cargo publish` was executed by an agent
- [x] Worktree is clean

Related: #1647
