### PR TITLE
ci: harden release publication workflow (issue #1650)

### DIFF
--- a/.agents/skills/tenferro-release-publish/SKILL.md
+++ b/.agents/skills/tenferro-release-publish/SKILL.md
@@ -25,6 +25,16 @@ Keep the interaction incremental:
    checklist.
 3. Phase 2: tag the merged commit and push the tag.
 4. At Phase 3, stop after validation; a human maintainer runs Phase 3
-   publication from the tag.
+   publication from the tag. The maintainer can generate a guarded handoff
+   script with
+   `python3 scripts/release-publish.py X.Y.Z --generate-script PATH`
+   that re-runs the fail-closed preflight and requires one exact lowercase
+   `y` at a TTY before invoking the helper with `--execute`; agents never run
+   publication and never type that confirmation. Phase 3 validation is
+   change-aware (`scripts/release-validation-policy.py`): helper-only or
+   publication-metadata-only diffs run focused lanes, and a rerun is skipped
+   only when the exact-SHA CI check passes
+   (`verify_release_ci` in `scripts/release-publish.py`); Rust source or
+   ambiguous diffs run the full validation.
 5. After human publication, Phase 4 verifies crates.io versions and
    `.cargo_vcs_info.json` provenance, then cleans up.

--- a/.claude/skills/tenferro-release-publish/SKILL.md
+++ b/.claude/skills/tenferro-release-publish/SKILL.md
@@ -25,6 +25,16 @@ Keep the interaction incremental:
    checklist.
 3. Phase 2: tag the merged commit and push the tag.
 4. At Phase 3, stop after validation; a human maintainer runs Phase 3
-   publication from the tag.
+   publication from the tag. The maintainer can generate a guarded handoff
+   script with
+   `python3 scripts/release-publish.py X.Y.Z --generate-script PATH`
+   that re-runs the fail-closed preflight and requires one exact lowercase
+   `y` at a TTY before invoking the helper with `--execute`; agents never run
+   publication and never type that confirmation. Phase 3 validation is
+   change-aware (`scripts/release-validation-policy.py`): helper-only or
+   publication-metadata-only diffs run focused lanes, and a rerun is skipped
+   only when the exact-SHA CI check passes
+   (`verify_release_ci` in `scripts/release-publish.py`); Rust source or
+   ambiguous diffs run the full validation.
 5. After human publication, Phase 4 verifies crates.io versions and
    `.cargo_vcs_info.json` provenance, then cleans up.

--- a/.kimi/skills/tenferro-release-publish/SKILL.md
+++ b/.kimi/skills/tenferro-release-publish/SKILL.md
@@ -25,6 +25,16 @@ Keep the interaction incremental:
    checklist.
 3. Phase 2: tag the merged commit and push the tag.
 4. At Phase 3, stop after validation; a human maintainer runs Phase 3
-   publication from the tag.
+   publication from the tag. The maintainer can generate a guarded handoff
+   script with
+   `python3 scripts/release-publish.py X.Y.Z --generate-script PATH`
+   that re-runs the fail-closed preflight and requires one exact lowercase
+   `y` at a TTY before invoking the helper with `--execute`; agents never run
+   publication and never type that confirmation. Phase 3 validation is
+   change-aware (`scripts/release-validation-policy.py`): helper-only or
+   publication-metadata-only diffs run focused lanes, and a rerun is skipped
+   only when the exact-SHA CI check passes
+   (`verify_release_ci` in `scripts/release-publish.py`); Rust source or
+   ambiguous diffs run the full validation.
 5. After human publication, Phase 4 verifies crates.io versions and
    `.cargo_vcs_info.json` provenance, then cleans up.

--- a/.opencode/commands/tenferro-release-publish.md
+++ b/.opencode/commands/tenferro-release-publish.md
@@ -16,5 +16,12 @@ re-tag instead); git-pinned workspace dependencies must pin revs whose
 declared versions exist on crates.io.
 
 Proceed through the version-bump PR and tag, then stop after validation; a
-human maintainer runs Phase 3 publication from the tag. After human publication,
-perform the canonical post-publish verification.
+human maintainer runs Phase 3 publication from the tag. The maintainer can
+generate a guarded handoff script with
+`python3 scripts/release-publish.py X.Y.Z --generate-script PATH` that re-runs the
+preflight and requires one exact lowercase `y` at a TTY before `--execute`;
+agents never run publication and never type that confirmation. Phase 3
+validation is change-aware (`scripts/release-validation-policy.py`); a rerun
+is skipped only when the exact-SHA CI check passes
+(`verify_release_ci` in `scripts/release-publish.py`). After human
+publication, perform the canonical post-publish verification.

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -349,6 +349,55 @@ diff-scoped review bot.
   runners directly on PR updates when an earlier review, lint, docs, or CPU test
   gate can reject the PR first.
 
+## Publication Order And Publish-Safety
+
+Maintainer and release-workflow protocol; intentionally not routed to the
+review bot. The normative cross-repository publication rules live in the
+shared `tensor4all-agent-rules` (`rules/common/repository.md`); this section
+records only the tenferro-specific constraints that must hold in this
+repository.
+
+- A publishable workspace crate must not have a versioned normal, build, or
+  dev dependency on a publishable crate that appears later in the canonical
+  publication order (the Phase 3 list in
+  `ai/contribution-workflows/release-publish.md`). Cargo resolves versioned
+  dependencies during `cargo package` even with `--no-verify`, so a forward
+  reference fails before any publication point of no return.
+- Cross-layer tests may use path-only (unversioned) dev-dependencies on
+  publishable crates: dev-dependencies are stripped from published manifests
+  and never registry-resolve for consumers, so an unversioned path dev-edge is
+  safe even when it points forward in the order (`tenferro-xla` ->
+  `tenferro-einsum`) or closes a cycle (`tenferro-runtime` ->
+  `tenferro-cpu`). A declared dev version must still match the workspace
+  version.
+- The complete dependency graph among publishable crates, including dev and
+  build edges, must not contain a publication cycle over versioned edges
+  (versioned edges are the only ones that registry-resolve at package time).
+- Published crates must remain packageable from their manifests without
+  temporary local `[patch.crates-io]` bootstrap configuration.
+- Release validation is change-aware: a helper-or-workflow-only diff runs the
+  focused `ci-config` lane; a publication-metadata-only diff runs metadata,
+  publish-layout, and archive/dry-run checks; a semantic manifest diff runs
+  affected tests plus the applicable CI tier; Rust source or ambiguous diffs
+  run full validation. `scripts/release-validation-policy.py` classifies the
+  lane from old/new manifest content. Before skipping a rerun on the strength
+  of previously passed CI, verify every required check run for the exact
+  release commit via
+  `gh api repos/tensor4all/tenferro-rs/commits/<SHA>/check-runs --paginate --slurp`
+  and require `head_sha == <SHA>`, `status == "completed"`, and
+  `conclusion == "success"` per required check; anything else fails closed and
+  reruns the applicable tier.
+- Publication is human-only: agents generate a guarded handoff script with
+  `scripts/release-publish.py --generate-script PATH` and never type the
+  publication confirmation. The generated script re-runs the fail-closed
+  preflight, requires one exact lowercase `y` at a TTY, and invokes the helper
+  with `--execute` only after verifying SHA-256 pins of the helper and the
+  canonical workflow; it is written outside the release worktree (mode 0700,
+  `bash -n` clean, restart-safe).
+- `scripts/check-publish-layout.py` enforces the canonical order, forward
+  dependency, and publication-cycle rules; a manifest or release change that
+  would violate them fails the check before tagging.
+
 ## Standard Extension Boundary
 
 - Standard operation families (`tenferro-einsum`, `tenferro-linalg`,

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -91,6 +91,10 @@ Complete this phase before changing manifests or making any other release edit.
 1. `git fetch origin main` and identify the merged bump commit.
 2. `git tag vX.Y.Z <merged-commit> && git push origin vX.Y.Z`.
 3. Recommended: `gh release create vX.Y.Z --generate-notes`.
+4. Record the tag commit SHA (`git rev-parse vX.Y.Z`) and the required CI job
+   names (the workspace gate jobs that must pass before publication, e.g.
+   `workspace-faer`, `workspace-blas`, `extensions`, `docs`, `coverage`,
+   `ci-config`). Phase 3 reuses CI results only for exactly this SHA.
 
 ## Phase 3 — Publish From The Tag
 
@@ -160,8 +164,53 @@ Agents must stop after validation and must never execute a publication.
    package exists only when crates.io also has the target version, whose archive
    must still pass all checks before it is skipped. It rejects the approval as
    stale when the package exists but the target version does not.
+
+   **Generated handoff script (recommended):** instead of typing the two
+   commands below by hand, generate a guarded handoff script that re-runs the
+   same preflight and requires one exact lowercase `y` at a TTY before it
+   invokes the helper with `--execute`:
+
+   ```bash
+   python3 scripts/release-publish.py X.Y.Z \
+     --approve-new-package tenferro-internal-cpu-kernels \
+     --generate-script "$TMPDIR/publish-X.Y.Z.sh"
+   ```
+
+   The generator refuses a path inside the release worktree (the helper aborts
+   on untracked files). The generated script pins SHA-256 checksums of the
+   helper and this workflow, aborts unless stdin is a TTY and the worktree is
+   clean and detached, and carries exactly the `--approve-new-package` values
+   passed at generation. Run it from the release worktree root:
+
+   ```bash
+   cd <fresh-path> && bash "$TMPDIR/publish-X.Y.Z.sh"
+   ```
+
+   Regenerate the script after any helper or workflow change; a checksum
+   mismatch aborts before anything runs.
+
+   **Change-aware revalidation and exact-SHA CI reuse:** classify what
+   actually changed since the previous release with
+   `python3 scripts/release-validation-policy.py --base <prev-tag> --head <this-tag>`
+   (or repeated `--change PATH OLD NEW` triples for explicit old/new content).
+   A helper-or-workflow-only diff needs only the focused `ci-config` lane; a
+   publication-metadata-only diff needs metadata, publish-layout, and
+   archive/dry-run checks; a semantic manifest diff needs affected tests plus
+   the applicable CI tier; Rust source or ambiguous diffs need the full normal
+   validation. Before skipping a rerun on the strength of CI already passed,
+   verify every required check run for the exact tag commit with the canonical
+   query
+   `gh api repos/tensor4all/tenferro-rs/commits/<SHA>/check-runs --paginate --slurp`
+   and require, per required check name, `head_sha == <SHA>`,
+   `status == "completed"`, and `conclusion == "success"`. Any required check
+   that is missing, ran on another commit, is not completed, or did not
+   succeed fails closed: rerun the applicable tier. The release helper encodes
+   this procedure as `verify_release_ci(commit, required_checks)`; the
+   maintainer executes it — it is not part of the helper's automatic preflight
+   (the helper never blocks on CI state by itself).
 4. After the preflight passes, the human operator repeats the same exact command
-   with `--execute`:
+   with `--execute` (or runs the generated handoff script, which does the same
+   after the single exact `y`):
 
    ```bash
    python3 scripts/release-publish.py X.Y.Z \

--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -43,7 +43,11 @@ thiserror.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false }
+# Path-only (unversioned): the versioned form resolves against crates.io during
+# `cargo package` and would fail because tenferro-cpu publishes after
+# tenferro-runtime, forming a publish cycle. Dev-dependencies are stripped from
+# the published manifest, so an unversioned path dev-dependency is sufficient.
+tenferro-cpu = { path = "../tenferro-cpu", default-features = false }
 
 [[bench]]
 name = "elementwise_fusion"

--- a/crates/tenferro-xla/Cargo.toml
+++ b/crates/tenferro-xla/Cargo.toml
@@ -36,8 +36,14 @@ sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false, features = ["cpu-faer"] }
-tenferro-einsum = { path = "../tenferro-einsum", version = "0.3.0", default-features = false }
+# Path-only (unversioned): tenferro-einsum publishes after tenferro-xla, so a
+# versioned dev-dependency would fail registry resolution during `cargo
+# package`. Dev-dependencies are stripped from the published manifest, so an
+# unversioned path dev-dependency is sufficient.
+# `cpu-faer` is enabled because tenferro-einsum links tenferro-cpu (which
+# cannot compile without a provider feature); no test code uses the CPU backend
+# directly.
+tenferro-einsum = { path = "../tenferro-einsum", default-features = false, features = ["cpu-faer"] }
 
 [[test]]
 name = "integration"

--- a/docs/worklogs/2026-08-10-release-publish-safety.md
+++ b/docs/worklogs/2026-08-10-release-publish-safety.md
@@ -1,0 +1,146 @@
+# Release publish safety (issue #1650)
+
+Work log for the release-workflow hardening in issue
+[tensor4all/tenferro-rs#1650](https://github.com/tensor4all/tenferro-rs/issues/1650):
+forbid publication cycles and forward versioned dev-dependencies, fix the two
+violations, generate a guarded human publication script, add change-aware
+release validation, and move reusable policy into the shared agent rules.
+
+## Outcome
+
+- `scripts/check-publish-layout.py` now rejects forward **versioned**
+  normal/build/dev dependencies and publication cycles over versioned edges;
+  unversioned (path-only) dev-dependencies are allowed and explained.
+- The two manifest violations are fixed with path-only dev-dependencies
+  (below), not by moving tests.
+- `scripts/release-publish.py --generate-script` emits a guarded human
+  handoff script; `verify_release_ci` encodes the exact-SHA CI reuse gate.
+- `scripts/release-validation-policy.py` classifies the release-time
+  validation lane.
+- Shared policy added to `tensor4all-agent-rules`
+  (`rules/common/repository.md`), sibling PR #10.
+
+## Decision: path-only dev-dependencies instead of the issue's move-tests approach
+
+**Deviation that needs maintainer sign-off.** The issue prefers moving
+cross-layer tests into `publish = false` test crates. That is infeasible for
+`tenferro-runtime`: its doctests and inline `#[cfg(test)]` unit tests in
+`src/*.rs` use `tenferro_cpu` via the dev-dependency and cannot relocate
+(doctests and private-access tests are crate-local). A test-crate migration of
+roughly 5200 lines was implemented and then reverted; the migration survives
+in the reflog and git history of the pre-branch session if it is ever wanted.
+
+The decisive experiment (run before this work log was written):
+
+- runtime dev-dep `tenferro-cpu = { path, version = "99.99.99" }` →
+  `cargo package -p tenferro-runtime --no-verify --locked` fails to resolve
+  (the exact v0.3.0 failure mode).
+- runtime dev-dep `tenferro-cpu = { path = "../tenferro-cpu",
+  default-features = false }` (path-only) → `cargo package` succeeds
+  (112 files).
+- xla with path-only einsum dev-dep → `cargo package` succeeds (30 files).
+
+Adopted rule: cross-crate dev-dependencies among publishable crates may be
+path-only (unversioned). Dev-dependencies are stripped from published
+manifests and never registry-resolve for consumers, so unversioned forward
+dev-edges (`tenferro-xla` → `tenferro-einsum`) and dev-edges that close a
+cycle (`tenferro-runtime` → `tenferro-cpu`, whose reverse edge is a normal
+dependency) are safe. The checker enforces that only *versioned* edges
+participate in order/cycle constraints.
+
+**Note:** removing the xla `tenferro-cpu` dev-dependency entirely (not just
+unversioning it) broke `cargo test -p tenferro-xla`: the einsum dev-dep links
+`tenferro-cpu`, which cannot compile without a provider feature
+(`CpuBackendKind::default_compiled()` has no no-provider fallback; pre-existing
+latent gap, `cargo check -p tenferro-cpu --no-default-features` fails on
+main). The xla dev-dependency on einsum therefore carries
+`features = ["cpu-faer"]` (a pure feature forward; no test code uses the CPU
+backend directly). The latent `tenferro-cpu` no-provider compile failure is
+left in place as out of scope.
+
+## Reordering cannot fix the violations
+
+Canonical Phase 3 order: `tenferro-runtime` (6) before `tenferro-cpu` (7);
+`tenferro-xla` (9) before `tenferro-einsum` (11). `tenferro-cpu` has a hard
+normal dependency on `tenferro-runtime`, and user crates must precede
+extensions, so no reordering can satisfy a versioned forward/cyclic dev-edge.
+
+## Generated handoff script (`--generate-script`)
+
+Design, verified by executing the generated script against a stub helper in
+tests:
+
+- Output path must be outside the release worktree (the release helper aborts
+  on untracked files; the script must not dirty the immutable tag checkout).
+- The helper and canonical workflow are pinned with SHA-256 checksums computed
+  at generation with Python `hashlib` (no external `sha256sum` binary) and
+  re-verified by the script before anything else runs; a later helper change
+  cannot silently alter publication behavior.
+- Script is mode 0700 (chmod at generation + runtime re-check), non-append,
+  deterministic, `bash -n` clean (generator runs the parse check).
+- Guards, in order: checksum pin → owner-only mode → TTY → clean detached
+  worktree (helper re-verifies the exact pushed tag and main lineage
+  authoritatively) → fail-closed preflight without `--execute` → one exact
+  lowercase `y` (single `read`; `n`/`Y`/EOF abort) → helper invocation with
+  `--execute` carrying exactly the `--approve-new-package` values passed at
+  generation.
+- Restart-safe: a failed/aborted run can be re-run; the helper skips
+  already-published target versions only after full re-attestation.
+
+## Change-aware validation and exact-SHA CI reuse
+
+- `scripts/release-validation-policy.py` classifies the diff between the
+  previous release and the tag into lanes by old/new manifest content:
+  helper-or-workflow-only → focused `ci-config` lane (no full workspace, no
+  CPU/GPU); publication-metadata-only (version, description, homepage,
+  keywords, categories, documentation, readme in `[package]` or
+  `[workspace.package]`) → metadata + publish-layout + archive/dry-run only;
+  semantic manifest (dependency source/version/features, targets, build.rs,
+  native libs, profiles, added/removed manifests) → affected tests plus the
+  applicable CI tier; rust source or ambiguous → full validation. Mixed sets
+  take the strongest lane.
+- Before skipping a rerun on the strength of previously passed CI, verify
+  every required check run for the exact release commit with the canonical
+  query `gh api repos/tensor4all/tenferro-rs/commits/<SHA>/check-runs
+  --paginate`, requiring per check `head_sha == <SHA>`, `status ==
+  "completed"`, `conclusion == "success"`; anything else fails closed and
+  reruns. `verify_release_ci(commit, required_checks)` in
+  `scripts/release-publish.py` encodes this with the injected-runner pattern;
+  the human maintainer records the tag SHA and required job names at Phase 2.
+
+## Shared rule placement
+
+Cross-repository policy lives in `tensor4all-agent-rules`
+(`rules/common/repository.md`, "Publication And Release Safety") — sibling PR
+#10, with the tenferro review case documented in the commit message. The
+tenferro `REPOSITORY_RULES.md` section keeps only tenferro-specific
+constraints (crate names, canonical order, approvals, checker names) and
+references the shared rules without vendoring their normative text. Sibling
+repos (Tensor4all.jl, BubbleTeaCI, tidu-rs, chainrules-rs) were checked for
+conflicting publication guidance: none found; the shared rules are generic and
+do not impose tenferro topology.
+
+## Deviation summary for the maintainer
+
+1. Path-only dev-dependencies replace the move-tests approach (see above).
+2. `tenferro-xla` keeps a path-only `tenferro-einsum` dev-dependency with
+   `cpu-faer` forwarded for buildability.
+3. The latent `tenferro-cpu` no-provider-feature compile failure is noted but
+   not fixed here.
+
+## Post-review corrections (reviewer-gpt)
+
+- Removed the now-obsolete `[patch.crates-io]` bootstrap (`--no-verify`
+  + `--config`) for runtime/xla from `publish_release`: the path-only
+  dev-dependencies made it unnecessary, and it contradicted the
+  packageable-as-is rule. Orchestration tests now assert no patch is used.
+- Fixed multi-approval generation in the handoff script (approval groups are
+  joined with a space, not `", "`); added a two-approval execution test.
+- `verify_release_ci` now flattens paginated page objects; added a multi-page
+  fixture test. Exact-SHA verification remains a human-executed Phase 3 step
+  by plan design (documented in the workflow).
+- Release-helper classification now allowlists the exact release test files
+  instead of the `scripts/test-*` wildcard; unrelated test changes classify
+  as full.
+- Handoff-script checksum mismatch test also covers the canonical workflow
+  file; skills document the versioned `--generate-script` command.

--- a/scripts/check-publish-layout.py
+++ b/scripts/check-publish-layout.py
@@ -188,14 +188,86 @@ def check_release_order(
         crate = package["name"]
         if crate not in expected:
             continue
+        # A VERSIONED normal, build, or dev dependency on a publishable crate
+        # that appears later in the canonical order cannot resolve during
+        # `cargo package`, because that crate has not been published yet.
+        # Unversioned (path-only) dev-dependencies are safe: dev-dependencies
+        # are stripped from the published manifest and never carry a registry
+        # version requirement for consumers.
         for dependency in package["dependencies"]:
             dependency_name = dependency["name"]
-            if dependency["kind"] != "dev" and dependency_name in expected:
-                if positions[dependency_name] > positions[crate]:
-                    errors.append(
-                        f"release publish order must place dependency "
-                        f"{dependency_name!r} before {crate!r}"
-                    )
+            if dependency_name not in expected:
+                continue
+            if _is_versioned(dependency) and positions[dependency_name] > positions[crate]:
+                errors.append(
+                    f"release publish order must place dependency "
+                    f"{dependency_name!r} before {crate!r}"
+                )
+
+    cycle = _find_publication_cycle(metadata["packages"], expected)
+    if cycle is not None:
+        chain = " -> ".join(cycle + [cycle[0]])
+        errors.append(f"publication cycle among publishable crates: {chain}")
+
+
+def _is_versioned(dependency: dict) -> bool:
+    """True when the dependency carries a cargo version requirement.
+
+    Path-only manifests (no `version`) report `req == "*"` from cargo
+    metadata. Only versioned edges are published across crates and therefore
+    participate in publish-order and publish-cycle constraints.
+    """
+
+    requirement = dependency.get("req")
+    return isinstance(requirement, str) and requirement != "*"
+
+
+def _find_publication_cycle(
+    packages: list[dict], publishable: set[str]
+) -> list[str] | None:
+    """Return one cycle over publishable crate names, or None when acyclic.
+
+    Only VERSIONED edges participate: an unversioned dev-dependency is
+    stripped from the published manifest and never needs crates.io resolution,
+    so it cannot create a publish-time cycle. Any versioned cycle forces at
+    least one edge to point forward in any linear publication order, so it is
+    reported as a structural publish-cycle before tagging.
+    """
+
+    adjacency = {
+        package["name"]: sorted(
+            dependency["name"]
+            for dependency in package["dependencies"]
+            if dependency["name"] in publishable and _is_versioned(dependency)
+        )
+        for package in packages
+        if package["name"] in publishable
+    }
+
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {crate: WHITE for crate in adjacency}
+    stack: list[str] = []
+
+    def visit(crate: str) -> list[str] | None:
+        color[crate] = GRAY
+        stack.append(crate)
+        for neighbor in adjacency[crate]:
+            if color[neighbor] == GRAY:
+                return stack[stack.index(neighbor) :]
+            if color[neighbor] == WHITE:
+                cycle = visit(neighbor)
+                if cycle is not None:
+                    return cycle
+        stack.pop()
+        color[crate] = BLACK
+        return None
+
+    for crate in sorted(adjacency):
+        if color[crate] == WHITE:
+            cycle = visit(crate)
+            if cycle is not None:
+                return cycle
+    return None
 
 
 def check_workspace_members(metadata: dict, root_text: str, errors: list[str]) -> None:
@@ -371,6 +443,60 @@ def check_crate_metadata(
                 )
 
 
+def _check_internal_dependency_versions(
+    crate: str,
+    manifest_text: str,
+    expected_version: str,
+    errors: list[str],
+    manifest_name: str,
+) -> None:
+    """Require registry versions on internal normal/build path dependencies.
+
+    Normal and build dependencies are kept in the published manifest, so they
+    must carry the exact workspace version for crates.io packaging. Dev
+    dependencies are stripped from the published manifest and never resolve
+    against crates.io for consumers, so they may be path-only (unversioned);
+    when a dev dependency does declare a version it must still match.
+    """
+
+    try:
+        manifest = tomllib.loads(manifest_text)
+    except tomllib.TOMLDecodeError:
+        return
+
+    version_fragment = f'version = "{expected_version}"'
+    # Normal and build dependencies are kept in the published manifest.
+    for table_name in ("dependencies", "build-dependencies"):
+        table = manifest.get(table_name, {})
+        if not isinstance(table, dict):
+            continue
+        for name, spec in table.items():
+            if not isinstance(spec, dict) or "path" not in spec:
+                continue
+            if not spec["path"].startswith("../tenferro-"):
+                continue
+            if spec.get("version") != expected_version:
+                errors.append(
+                    f"{manifest_name} {table_name} tenferro dependency "
+                    f"{name!r} must include {version_fragment} for crates.io packaging"
+                )
+    # Dev dependencies are stripped from the published manifest, so they may
+    # be path-only; any declared version must still match.
+    table = manifest.get("dev-dependencies", {})
+    if isinstance(table, dict):
+        for name, spec in table.items():
+            if not isinstance(spec, dict) or "path" not in spec:
+                continue
+            if not spec["path"].startswith("../tenferro-"):
+                continue
+            declared = spec.get("version")
+            if declared is not None and declared != expected_version:
+                errors.append(
+                    f"{manifest_name} dev-dependencies tenferro dependency "
+                    f"{name!r} must include {version_fragment} for crates.io packaging"
+                )
+
+
 def check_package_metadata(root_text: str, errors: list[str]) -> None:
     expected_version = workspace_version(root_text)
     for crate in TENFERRO_CRATES:
@@ -392,13 +518,9 @@ def check_package_metadata(root_text: str, errors: list[str]) -> None:
                     f"{rel(manifest_path)} package.{key} must inherit workspace metadata"
                 )
         check_crate_metadata(crate, manifest_text, errors, rel(manifest_path))
-        for line_no, line in enumerate(manifest_text.splitlines(), start=1):
-            version_fragment = f'version = "{expected_version}"'
-            if 'path = "../tenferro-' in line and version_fragment not in line:
-                errors.append(
-                    f"{rel(manifest_path)}:{line_no}: tenferro path dependency "
-                    f'must include {version_fragment} for crates.io packaging'
-                )
+        _check_internal_dependency_versions(
+            crate, manifest_text, expected_version, errors, rel(manifest_path)
+        )
 
     tutorial_manifest = ROOT / "docs" / "tutorial-code" / "Cargo.toml"
     if "publish = false" not in section(

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -83,6 +83,7 @@ PROFILE_COMMANDS: dict[str, tuple[str, ...]] = {
     "ci-config": (
         "python3 scripts/test-release-publish.py",
         "python3 scripts/test-check-publish-layout.py",
+        "python3 scripts/test-release-validation-policy.py",
         "python3 scripts/check-publish-layout.py",
         "python3 scripts/test-storage-ownership-contracts-v2.py",
         _STORAGE_OWNERSHIP_CHECKER,

--- a/scripts/release-publish.py
+++ b/scripts/release-publish.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import http.client
 import io
 import json
 import re
 import runpy
+import shlex
 import stat
 import subprocess
 import sys
@@ -609,6 +611,107 @@ def verify_release_checkout(
     return head
 
 
+def verify_release_ci(
+    commit: str,
+    required_checks: set[str],
+    *,
+    runner: Callable = run,
+    owner: str = "tensor4all",
+    repository: str = "tenferro-rs",
+) -> None:
+    """Fail closed unless every required CI check succeeded on exactly this commit.
+
+    Runs the canonical query
+    ``gh api repos/tensor4all/tenferro-rs/commits/<SHA>/check-runs --paginate --slurp``
+    and requires, per required check name, ``head_sha == commit``,
+    ``status == "completed"``, and ``conclusion == "success"``. A required
+    check that is missing, ran on another commit, is still running, or did not
+    conclude successfully raises :class:`ReleaseError`. ``--slurp`` wraps each
+    page (an object carrying ``check_runs``) into one outer array so a
+    single ``json.loads`` sees the whole result.
+    """
+    output = runner(
+        [
+            "gh",
+            "api",
+            f"repos/{owner}/{repository}/commits/{commit}/check-runs",
+            "--paginate",
+            "--slurp",
+        ],
+        cwd=ROOT,
+    ).stdout
+    try:
+        payload = json.loads(output)
+    except (TypeError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReleaseError(
+            "gh check-runs returned invalid JSON for " f"{owner}/{repository}@{commit}"
+        ) from error
+    pages = (
+        payload.get("check_runs")
+        if isinstance(payload, dict) and "check_runs" in payload
+        else payload
+    )
+    # With more check runs than one page, `gh api --paginate --slurp` yields a
+    # list of page objects, each carrying its own `check_runs` array. Every
+    # page must be well-formed; malformed pages fail closed instead of being
+    # silently skipped.
+    if (
+        isinstance(pages, list)
+        and pages
+        and isinstance(pages[0], dict)
+        and "check_runs" in pages[0]
+    ):
+        flattened: list[object] = []
+        for page in pages:
+            if not isinstance(page, dict):
+                raise ReleaseError(
+                    "gh check-runs page is not an object for "
+                    f"{owner}/{repository}@{commit}"
+                )
+            runs = page.get("check_runs")
+            if not isinstance(runs, list):
+                raise ReleaseError(
+                    "gh check-runs page is missing a check_runs list for "
+                    f"{owner}/{repository}@{commit}"
+                )
+            flattened.extend(runs)
+        pages = flattened
+    if not isinstance(pages, list):
+        raise ReleaseError(
+            "gh check-runs response is missing a check_runs list for "
+            f"{owner}/{repository}@{commit}"
+        )
+    by_name: dict[str, dict] = {}
+    for run in pages:
+        if not isinstance(run, dict):
+            continue
+        name = run.get("name")
+        if isinstance(name, str):
+            by_name[name] = run
+    missing = sorted(required_checks - by_name.keys())
+    if missing:
+        raise ReleaseError(
+            f"required CI checks missing for {owner}/{repository}@{commit}: {missing}"
+        )
+    for name in sorted(required_checks):
+        run = by_name[name]
+        if run.get("head_sha") != commit:
+            raise ReleaseError(
+                f"required check {name!r} ran on a different commit for "
+                f"{owner}/{repository}@{commit}"
+            )
+        if run.get("status") != "completed":
+            raise ReleaseError(
+                f"required check {name!r} is not completed for "
+                f"{owner}/{repository}@{commit}"
+            )
+        if run.get("conclusion") != "success":
+            raise ReleaseError(
+                f"required check {name!r} did not succeed for "
+                f"{owner}/{repository}@{commit}"
+            )
+
+
 def cargo_metadata(*, runner: Callable = run, root: Path = ROOT) -> dict:
     try:
         metadata = json.loads(
@@ -930,24 +1033,6 @@ def publish_release(
     validate_new_package_approvals(package_exists, version_exists, approvals)
     source_reader = source_reader_factory(commit, runner=runner, root=root)
 
-    bootstrap_args_by_crate: dict[str, list[str]] = {}
-    if "tenferro-runtime" in packages and "tenferro-cpu" in packages:
-        cpu_path = (root / package_root(packages["tenferro-cpu"], root=root)).resolve()
-        bootstrap_args_by_crate["tenferro-runtime"] = [
-            "--no-verify",
-            "--config",
-            f"patch.crates-io.tenferro-cpu.path={json.dumps(str(cpu_path), ensure_ascii=False)}",
-        ]
-    if "tenferro-xla" in packages and "tenferro-einsum" in packages:
-        einsum_path = (
-            root / package_root(packages["tenferro-einsum"], root=root)
-        ).resolve()
-        bootstrap_args_by_crate["tenferro-xla"] = [
-            "--no-verify",
-            "--config",
-            f"patch.crates-io.tenferro-einsum.path={json.dumps(str(einsum_path), ensure_ascii=False)}",
-        ]
-
     positions = {crate: index for index, crate in enumerate(order)}
     prerequisites_by_crate: dict[str, list[str]] = {}
     for crate in order:
@@ -1011,7 +1096,6 @@ def publish_release(
         package_dir = package_root(package, root=root)
         expected_files = package_files_loader(crate, runner=runner, root=root)
         expected_files_by_crate[crate] = expected_files
-        bootstrap_args = bootstrap_args_by_crate.get(crate, [])
         local_inspection = build_and_inspect_archive(
             metadata,
             crate,
@@ -1020,7 +1104,7 @@ def publish_release(
             package_dir,
             source_reader,
             expected_files,
-            ["cargo", "package", "-p", crate, "--locked", *bootstrap_args],
+            ["cargo", "package", "-p", crate, "--locked"],
             runner=runner,
             root=root,
             archive_inspector=archive_inspector,
@@ -1061,7 +1145,6 @@ def publish_release(
                 "--locked",
                 "--registry",
                 "crates-io",
-                *bootstrap_args,
             ],
             expected_contents=local_inspection.contents,
             runner=runner,
@@ -1077,7 +1160,6 @@ def publish_release(
                 "--locked",
                 "--registry",
                 "crates-io",
-                *bootstrap_args,
             ],
             cwd=root,
             capture=False,
@@ -1102,6 +1184,152 @@ def publish_release(
         print("preflight passed; no packages published (rerun with --execute)")
 
 
+HANDOFF_TEMPLATE = r'''#!/usr/bin/env bash
+# Generated by scripts/release-publish.py --generate-script for tenferro-rs @VERSION@.
+# Run this script from the clean, detached release worktree at tag v@VERSION@.
+# Regenerate instead of editing: manual edits void the checksum pin below and
+# the helper re-validates every invariant before each publication.
+set -euo pipefail
+
+VERSION='@VERSION@'
+APPROVALS=(@APPROVALS@)
+HELPER='@HELPER@'
+PYTHON="${PYTHON:-python3}"
+
+EXPECTED_SHA256='@DIGESTS@'
+
+# 1. Integrity pin: the release helper and canonical workflow must be
+#    byte-identical to the files present when this script was generated.
+#    Any change aborts before anything else runs.
+"$PYTHON" - "$EXPECTED_SHA256" <<'PYEOF'
+import hashlib
+import json
+import sys
+
+expected = json.loads(sys.argv[1])
+for path, want in expected.items():
+    try:
+        data = open(path, "rb").read()
+    except OSError as error:
+        print(f"publish-handoff: cannot read {path}: {error}", file=sys.stderr)
+        sys.exit(1)
+    if hashlib.sha256(data).hexdigest() != want:
+        print(
+            f"publish-handoff: checksum mismatch for {path}; "
+            "regenerate the handoff script with --generate-script",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+PYEOF
+
+# 2. The script must not be accessible to group or other users.
+if [ $(( 0$(stat -c '%a' "$0") & 077 )) -ne 0 ]; then
+    echo "publish-handoff: $0 must be owner-only (mode 0700); refusing to run" >&2
+    exit 1
+fi
+
+# 3. Publication requires a human at a terminal.
+if ! test -t 0; then
+    echo "publish-handoff: stdin is not a terminal; refusing to run" >&2
+    exit 1
+fi
+
+# 4. The release worktree must be clean and detached. The helper re-verifies
+#    the exact pushed remote tag and main lineage authoritatively.
+if [ -n "$(git status --porcelain)" ]; then
+    echo "publish-handoff: release worktree must be clean, including untracked files" >&2
+    exit 1
+fi
+if git symbolic-ref -q HEAD >/dev/null 2>&1; then
+    echo "publish-handoff: release worktree must be detached at the tag" >&2
+    exit 1
+fi
+
+# 5. Fail-closed preflight (no --execute). Aborts on any invariant violation.
+"$PYTHON" "$HELPER" "$VERSION" "${APPROVALS[@]}"
+
+# 6. One exact lowercase confirmation immediately before publication.
+if ! read -r -p "Type exactly 'y' to publish tenferro-rs $VERSION to crates.io: " ANSWER; then
+    echo "publish-handoff: aborted (no confirmation read)" >&2
+    exit 1
+fi
+if [ "$ANSWER" != "y" ]; then
+    echo "publish-handoff: aborted; expected exactly 'y'" >&2
+    exit 1
+fi
+
+# 7. Execute publication with exactly the approvals passed at generation. The
+#    helper re-validates provenance, registry state, and approvals before each
+#    cargo publish, so this cannot bypass the gates.
+"$PYTHON" "$HELPER" "$VERSION" "${APPROVALS[@]}" --execute
+'''
+
+
+def generate_handoff_script(
+    version: str,
+    approvals: set[str],
+    output: Path,
+    *,
+    root: Path = ROOT,
+    runner: Callable = run,
+) -> None:
+    """Write a guarded human publication script for one release.
+
+    The generated script re-runs the fail-closed preflight and requires one
+    exact lowercase ``y`` at a TTY before invoking the helper with
+    ``--execute``. It pins SHA-256 checksums of the helper and canonical
+    workflow computed here with :mod:`hashlib`, so no external ``sha256sum``
+    binary is needed and a later helper change cannot silently alter
+    publication behavior.
+    """
+    if EXACT_VERSION.fullmatch(version) is None:
+        raise ReleaseError(f"release version must be exact, found {version!r}")
+    try:
+        output.resolve().relative_to(root.resolve())
+    except ValueError:
+        pass
+    else:
+        raise ReleaseError(
+            "handoff script must be written outside the release worktree "
+            "(the helper aborts on untracked files)"
+        )
+
+    pinned = (
+        (root / "scripts/release-publish.py", "release helper"),
+        (
+            root / "ai/contribution-workflows/release-publish.md",
+            "canonical release workflow",
+        ),
+    )
+    digests: dict[str, str] = {}
+    for path, label in pinned:
+        try:
+            data = path.read_bytes()
+        except OSError as error:
+            raise ReleaseError(f"could not read {label} {path}: {error}") from error
+        digests[path.relative_to(root).as_posix()] = hashlib.sha256(data).hexdigest()
+
+    approvals_line = " ".join(
+        f"--approve-new-package {shlex.quote(name)}"
+        for name in sorted(approvals)
+    )
+    script = (
+        HANDOFF_TEMPLATE.replace("@VERSION@", version)
+        .replace("@APPROVALS@", approvals_line)
+        .replace("@HELPER@", "scripts/release-publish.py")
+        .replace("@DIGESTS@", json.dumps(digests))
+    )
+    try:
+        output.write_text(script, encoding="utf-8")
+        output.chmod(0o700)
+    except OSError as error:
+        raise ReleaseError(f"could not write handoff script {output}: {error}") from error
+    try:
+        runner(["bash", "-n", str(output)], cwd=root)
+    except ReleaseError as error:
+        raise ReleaseError(f"generated handoff script failed bash -n: {error}") from error
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("version", help="exact release version without the v prefix")
@@ -1118,6 +1346,13 @@ def main(argv: list[str] | None = None) -> int:
         help="perform irreversible cargo publish commands after all preflights",
     )
     parser.add_argument(
+        "--generate-script",
+        type=Path,
+        metavar="PATH",
+        help="write a guarded human publication handoff script to PATH "
+        "(must be outside the release worktree) and exit without publishing",
+    )
+    parser.add_argument(
         "--release-root",
         type=Path,
         default=ROOT,
@@ -1127,6 +1362,15 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
+        if args.generate_script is not None:
+            generate_handoff_script(
+                args.version,
+                set(args.approve_new_package),
+                args.generate_script,
+                root=args.release_root.resolve(),
+            )
+            print(f"generated handoff script: {args.generate_script.resolve()}")
+            return 0
         publish_release(
             args.version,
             set(args.approve_new_package),

--- a/scripts/release-validation-policy.py
+++ b/scripts/release-validation-policy.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Classify the validation lane required for a release-time change set.
+
+Release publication is irreversible, so the maintainer must re-validate the
+tagged tree before publishing. Not every change needs the full workspace and
+CPU/GPU suites: a version-bump-only diff cannot change kernel behavior, and a
+change confined to the release helpers cannot change crate code at all. This
+classifier assigns each changed path to the strongest lane that any change
+demands:
+
+- ``helper-or-workflow-only``: changes confined to the release helper,
+  publish-layout checker, their tests, the CI profile runner, the canonical
+  release workflow, the release skill adapters, or the PR CI workflow
+  definition. Run the focused ``ci-config`` lane (python release-helper tests,
+  publish-layout check, ``bash -n``, non-uploading dry-run reproductions).
+  No full workspace build, no CPU/GPU suites.
+- ``publication-metadata-only``: changes to Cargo metadata fields only
+  (``version``, ``description``, ``homepage``, ``keywords``, ``categories``,
+  ``documentation``, ``readme``, in ``[package]`` or ``[workspace.package]``).
+  Run metadata, publish-layout, and archive/dry-run checks only. No CPU/GPU or
+  full workspace rerun when exact-SHA CI already passed for the commit.
+- ``semantic-manifest``: any other Cargo.toml change (dependency sources,
+  versions, or features, target config, ``build.rs``, native libraries,
+  profiles, added/removed manifests). Run affected tests plus the applicable
+  CI tier.
+- ``full``: Rust source changes and anything unclassifiable. Run the full
+  normal validation; conservative by default.
+
+Mixed change sets select the strongest (most validating) lane.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tomllib
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+
+LANE_HELPER = "helper-or-workflow-only"
+LANE_METADATA = "publication-metadata-only"
+LANE_SEMANTIC = "semantic-manifest"
+LANE_FULL = "full"
+
+LANE_STRENGTH = {LANE_HELPER: 0, LANE_METADATA: 1, LANE_SEMANTIC: 2, LANE_FULL: 3}
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Release machinery whose own tests cover it; changes here never alter crate
+# code, so the focused ci-config lane is sufficient. Only the release-related
+# test files that the ci-config profile actually executes are helper-only;
+# any other scripts/test-*.py change is classified conservatively as full.
+RELEASE_HELPER_PATHS = frozenset(
+    {
+        "scripts/release-publish.py",
+        "scripts/check-publish-layout.py",
+        "scripts/release-validation-policy.py",
+        "scripts/ci/run_profile.py",
+        "scripts/test-release-publish.py",
+        "scripts/test-check-publish-layout.py",
+        "scripts/test-release-validation-policy.py",
+        "ai/contribution-workflows/release-publish.md",
+        ".agents/skills/tenferro-release-publish/SKILL.md",
+        ".claude/skills/tenferro-release-publish/SKILL.md",
+        ".kimi/skills/tenferro-release-publish/SKILL.md",
+        ".opencode/commands/tenferro-release-publish.md",
+        ".github/workflows/ci-pr-workspace-tests.yml",
+    }
+)
+
+# Cargo [package] fields that describe publication metadata only. A change to
+# any of them (in [package] or [workspace.package]) cannot alter crate code,
+# dependency resolution, or build behavior.
+MANIFEST_METADATA_FIELDS = frozenset(
+    {
+        "version",
+        "description",
+        "homepage",
+        "keywords",
+        "categories",
+        "documentation",
+        "readme",
+    }
+)
+
+
+class ManifestFields(NamedTuple):
+    metadata: dict[str, object]
+    structural: dict[str, object]
+
+
+def _manifest_fields(text: bytes) -> ManifestFields:
+    """Split one manifest into publication-metadata and structural fields."""
+
+    parsed = tomllib.loads(text.decode("utf-8"))
+    if not isinstance(parsed, dict):
+        raise ValueError("Cargo.toml root must be a table")
+    metadata: dict[str, object] = {}
+    structural: dict[str, object] = {}
+    package = parsed.get("package")
+    if isinstance(package, dict):
+        for key, value in package.items():
+            if key in MANIFEST_METADATA_FIELDS:
+                metadata[key] = value
+            else:
+                structural[key] = value
+    workspace = parsed.get("workspace")
+    if isinstance(workspace, dict):
+        workspace_package = workspace.get("package")
+        if isinstance(workspace_package, dict):
+            for key, value in workspace_package.items():
+                if key in MANIFEST_METADATA_FIELDS:
+                    metadata[f"workspace.package.{key}"] = value
+                else:
+                    structural[f"workspace.package.{key}"] = value
+        for key, value in workspace.items():
+            if key != "package":
+                structural[f"workspace.{key}"] = value
+    for key, value in parsed.items():
+        if key not in ("package", "workspace"):
+            structural[key] = value
+    return ManifestFields(metadata, structural)
+
+
+def classify_change(path: str, old: bytes | None, new: bytes | None) -> str:
+    """Return the validation lane for one changed path."""
+
+    if path in RELEASE_HELPER_PATHS:
+        return LANE_HELPER
+    if path.endswith("Cargo.toml"):
+        try:
+            old_fields = _manifest_fields(old) if old is not None else None
+            new_fields = _manifest_fields(new) if new is not None else None
+        except (tomllib.TOMLDecodeError, ValueError, UnicodeDecodeError):
+            return LANE_SEMANTIC
+        if old_fields is None or new_fields is None:
+            return LANE_SEMANTIC
+        if old_fields.structural == new_fields.structural:
+            return LANE_METADATA
+        return LANE_SEMANTIC
+    # Rust sources, non-manifest config, docs, and anything unrecognized:
+    # conservative full validation.
+    return LANE_FULL
+
+
+def classify_changes(changes: Sequence[tuple[str, bytes | None, bytes | None]]) -> str:
+    """Return the strongest lane demanded by any change in the set."""
+
+    strongest = LANE_HELPER
+    for path, old, new in changes:
+        lane = classify_change(path, old, new)
+        if LANE_STRENGTH[lane] > LANE_STRENGTH[strongest]:
+            strongest = lane
+    return strongest
+
+
+def _git_show(
+    revision: str, path: str, runner: Callable
+) -> bytes | None:
+    completed = runner(["git", "show", f"{revision}:{path}"], check=False)
+    return completed.stdout if completed.returncode == 0 else None
+
+
+def classify_diff(
+    base: str,
+    head: str,
+    *,
+    runner: Callable = subprocess.run,
+    root: Path = ROOT,
+) -> str:
+    """Classify every path changed between two git revisions."""
+
+    completed = runner(
+        ["git", "diff", "--name-status", base, head],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    changes: list[tuple[str, bytes | None, bytes | None]] = []
+    for line in completed.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) == 2:
+            status, path = parts
+        elif len(parts) == 3:
+            _old_path, status, path = parts  # rename/copy pair
+        else:
+            continue
+        old = None if status.startswith("A") else _git_show(base, path, runner)
+        new = None if status.startswith("D") else _git_show(head, path, runner)
+        changes.append((path, old, new))
+    return classify_changes(changes)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--base",
+        metavar="SHA",
+        help="classify all paths changed between --base and --head in the repo",
+    )
+    source.add_argument(
+        "--change",
+        nargs=3,
+        action="append",
+        metavar=("PATH", "OLD", "NEW"),
+        help="classify one path with old and new content files ('-' when absent); "
+        "repeatable",
+    )
+    parser.add_argument("--head", metavar="SHA", help="head revision for --base")
+    args = parser.parse_args(argv)
+
+    if args.base is not None:
+        if args.head is None:
+            parser.error("--base requires --head")
+        lane = classify_diff(args.base, args.head)
+    else:
+        changes: list[tuple[str, bytes | None, bytes | None]] = []
+        for path, old_name, new_name in args.change:
+            try:
+                old = None if old_name == "-" else Path(old_name).read_bytes()
+                new = None if new_name == "-" else Path(new_name).read_bytes()
+            except OSError as error:
+                parser.error(f"could not read change content for {path}: {error}")
+            changes.append((path, old, new))
+        lane = classify_changes(changes)
+    print(lane)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repository-rules-review.py
+++ b/scripts/repository-rules-review.py
@@ -202,6 +202,7 @@ HUMAN_ONLY_SECTIONS = frozenset(
         "Final Cross-Phase Multi-Agent Audit",
         "External Contribution Intake",
         "CI Cost Discipline",
+        "Publication Order And Publish-Safety",
         "Performance-Gated Experiment Protocol",
     }
 )

--- a/scripts/test-check-publish-layout.py
+++ b/scripts/test-check-publish-layout.py
@@ -37,36 +37,29 @@ VALID_EXPLICIT_FEATURES = VALID_ALL_FEATURES.replace(
 
 
 class ReleaseOrderTests(unittest.TestCase):
-    def metadata(self) -> dict:
+    def metadata(self, *, dependencies: dict[str, list[dict]] | None = None) -> dict:
+        """Acyclic baseline fixture; callers override dependencies per test."""
+
         root = CHECKER.ROOT
-        packages = [
-            {
-                "id": "core-id",
-                "name": "tenferro-core-ops",
-                "manifest_path": str(root / "crates/tenferro-core-ops/Cargo.toml"),
-                "publish": None,
-                "dependencies": [
-                    {"name": "tenferro-runtime", "kind": "dev"},
-                ],
-            },
-            {
-                "id": "runtime-id",
-                "name": "tenferro-runtime",
-                "manifest_path": str(root / "crates/tenferro-runtime/Cargo.toml"),
-                "publish": None,
-                "dependencies": [
-                    {"name": "tenferro-core-ops", "kind": None},
-                    {"name": "tenferro-hidden", "kind": None},
-                ],
-            },
-            {
-                "id": "hidden-id",
-                "name": "tenferro-hidden",
-                "manifest_path": str(root / "crates/tenferro-hidden/Cargo.toml"),
-                "publish": [],
-                "dependencies": [],
-            },
-        ]
+        dependencies = dependencies or {
+            "tenferro-core-ops": [],
+            "tenferro-runtime": [
+                {"name": "tenferro-core-ops", "kind": None, "req": "^0.3.0"},
+                {"name": "tenferro-hidden", "kind": None, "req": "^0.3.0"},
+            ],
+            "tenferro-hidden": [],
+        }
+        packages = []
+        for name, crate_dependencies in dependencies.items():
+            packages.append(
+                {
+                    "id": f"{name}-id",
+                    "name": name,
+                    "manifest_path": str(root / "crates" / name / "Cargo.toml"),
+                    "publish": [] if name == "tenferro-hidden" else None,
+                    "dependencies": crate_dependencies,
+                }
+            )
         return {
             "packages": packages,
             "workspace_members": [package["id"] for package in packages],
@@ -76,12 +69,140 @@ class ReleaseOrderTests(unittest.TestCase):
         crates = "\n".join(order)
         return f"## Phase 3 — Publish From The Tag\n\n```text\n{crates}\n```\n"
 
-    def test_accepts_topological_order_excluding_dev_and_nonpublishable(
+    def dep(
+        self, name: str, *, kind: str = "dev", versioned: bool = True
+    ) -> dict:
+        entry: dict = {"name": name, "kind": kind}
+        if versioned:
+            entry["req"] = "^0.3.0"
+        return entry
+
+    def test_accepts_topological_order_ignoring_nonpublishable_and_backward_edges(
         self,
     ) -> None:
         errors: list[str] = []
         CHECKER.check_release_order(
             self.metadata(),
+            self.release_text(["tenferro-core-ops", "tenferro-runtime"]),
+            errors,
+        )
+        self.assertEqual(errors, [])
+
+    def test_rejects_forward_dev_dependency_on_later_publishable_crate(
+        self,
+    ) -> None:
+        metadata = self.metadata(
+            dependencies={
+                "tenferro-xla": [self.dep("tenferro-einsum")],
+                "tenferro-einsum": [],
+            }
+        )
+        errors: list[str] = []
+        CHECKER.check_release_order(
+            metadata,
+            self.release_text(["tenferro-xla", "tenferro-einsum"]),
+            errors,
+        )
+        self.assertEqual(
+            errors,
+            [
+                "release publish order must place dependency "
+                "'tenferro-einsum' before 'tenferro-xla'"
+            ],
+        )
+
+    def test_accepts_unversioned_forward_dev_dependency(self) -> None:
+        # A path-only (unversioned) forward dev-dependency is safe: dev
+        # dependencies are stripped from the published manifest and never
+        # resolve against crates.io during `cargo package`.
+        metadata = self.metadata(
+            dependencies={
+                "tenferro-xla": [self.dep("tenferro-einsum", versioned=False)],
+                "tenferro-einsum": [],
+            }
+        )
+        errors: list[str] = []
+        CHECKER.check_release_order(
+            metadata,
+            self.release_text(["tenferro-xla", "tenferro-einsum"]),
+            errors,
+        )
+        self.assertEqual(errors, [])
+
+    def test_accepts_backward_dev_dependency_on_earlier_publishable_crate(
+        self,
+    ) -> None:
+        metadata = self.metadata(
+            dependencies={
+                "tenferro-xla": [self.dep("tenferro-einsum")],
+                "tenferro-einsum": [],
+            }
+        )
+        errors: list[str] = []
+        CHECKER.check_release_order(
+            metadata,
+            self.release_text(["tenferro-einsum", "tenferro-xla"]),
+            errors,
+        )
+        self.assertEqual(errors, [])
+
+    def test_rejects_normal_dev_publication_cycle(self) -> None:
+        # tenferro-cpu -> tenferro-runtime (normal) joined with
+        # tenferro-runtime -> tenferro-cpu (dev) forms a publish cycle.
+        metadata = self.metadata(
+            dependencies={
+                "tenferro-cpu": [
+                    {"name": "tenferro-runtime", "kind": None, "req": "^0.3.0"}
+                ],
+                "tenferro-runtime": [self.dep("tenferro-cpu")],
+            }
+        )
+        errors: list[str] = []
+        CHECKER.check_release_order(
+            metadata,
+            self.release_text(["tenferro-runtime", "tenferro-cpu"]),
+            errors,
+        )
+        cycle_errors = [
+            error for error in errors if error.startswith("publication cycle")
+        ]
+        self.assertEqual(len(cycle_errors), 1)
+        self.assertIn("tenferro-cpu", cycle_errors[0])
+        self.assertIn("tenferro-runtime", cycle_errors[0])
+
+    def test_accepts_unversioned_dev_edge_that_would_otherwise_cycle(
+        self,
+    ) -> None:
+        # tenferro-runtime -> (dev, path-only) tenferro-cpu joined with
+        # tenferro-cpu -> (normal, versioned) tenferro-runtime is safe: the
+        # unversioned dev edge needs no registry resolution at package time.
+        metadata = self.metadata(
+            dependencies={
+                "tenferro-cpu": [
+                    {"name": "tenferro-runtime", "kind": None, "req": "^0.3.0"}
+                ],
+                "tenferro-runtime": [self.dep("tenferro-cpu", versioned=False)],
+            }
+        )
+        errors: list[str] = []
+        CHECKER.check_release_order(
+            metadata,
+            self.release_text(["tenferro-runtime", "tenferro-cpu"]),
+            errors,
+        )
+        self.assertEqual(errors, [])
+
+    def test_accepts_dev_dependency_on_nonpublishable_crate(self) -> None:
+        metadata = self.metadata(
+            dependencies={
+                "tenferro-runtime": [{"name": "tenferro-hidden", "kind": "dev"}],
+                "tenferro-core-ops": [],
+                "tenferro-hidden": [],
+            }
+        )
+        errors: list[str] = []
+        CHECKER.check_release_order(
+            metadata,
             self.release_text(["tenferro-core-ops", "tenferro-runtime"]),
             errors,
         )
@@ -104,8 +225,18 @@ class ReleaseOrderTests(unittest.TestCase):
 
     def test_checks_optional_and_build_dependencies(self) -> None:
         cases = (
-            {"name": "tenferro-core-ops", "kind": None, "optional": True},
-            {"name": "tenferro-core-ops", "kind": "build", "optional": False},
+            {
+                "name": "tenferro-core-ops",
+                "kind": None,
+                "optional": True,
+                "req": "^0.3.0",
+            },
+            {
+                "name": "tenferro-core-ops",
+                "kind": "build",
+                "optional": False,
+                "req": "^0.3.0",
+            },
         )
         for dependency in cases:
             with self.subTest(dependency=dependency):

--- a/scripts/test-release-publish.py
+++ b/scripts/test-release-publish.py
@@ -8,10 +8,13 @@ import importlib.util
 import io
 import json
 import re
+import shlex
+import stat
 import subprocess
 import tarfile
 import tempfile
 import unittest
+from collections.abc import Callable
 from pathlib import Path
 from unittest import mock
 
@@ -78,6 +81,423 @@ class ReleaseDocumentationContractTests(unittest.TestCase):
         expected = (self.ROOT / self.SKILL_PATHS[0]).read_bytes()
         for relative in self.SKILL_PATHS[1:]:
             self.assertEqual(expected, (self.ROOT / relative).read_bytes())
+
+    def test_generated_handoff_script_is_documented(self) -> None:
+        text = (self.ROOT / "ai/contribution-workflows/release-publish.md").read_text()
+        normalized = " ".join(text.split())
+        for phrase in (
+            "generate-script",
+            "inside the release worktree",
+            "one exact lowercase `y` at a TTY",
+            "pins SHA-256 checksums",
+            "mismatch aborts before anything runs",
+        ):
+            self.assertIn(phrase, normalized)
+        for relative in (*self.SKILL_PATHS, ".opencode/commands/tenferro-release-publish.md"):
+            adapter = (self.ROOT / relative).read_text()
+            normalized_adapter = " ".join(adapter.split())
+            self.assertIn("generate-script", adapter)
+            self.assertIn("X.Y.Z --generate-script", normalized_adapter)
+            self.assertIn("one exact lowercase `y` at a TTY", normalized_adapter)
+            self.assertIn(
+                "stop after validation; a human maintainer runs Phase 3 publication "
+                "from the tag.",
+                normalized_adapter,
+            )
+
+
+    def test_change_aware_validation_and_exact_sha_are_documented(self) -> None:
+        text = (self.ROOT / "ai/contribution-workflows/release-publish.md").read_text()
+        normalized = " ".join(text.split())
+        for phrase in (
+            "release-validation-policy.py",
+            "helper-or-workflow-only",
+            "publication-metadata-only",
+            "semantic manifest",
+            "check-runs --paginate",
+            "head_sha == <SHA>",
+            "verify_release_ci(commit, required_checks)",
+        ):
+            self.assertIn(phrase, normalized)
+        for relative in (*self.SKILL_PATHS, ".opencode/commands/tenferro-release-publish.md"):
+            adapter = (self.ROOT / relative).read_text()
+            self.assertIn("release-validation-policy.py", adapter)
+            self.assertIn("verify_release_ci", adapter)
+
+
+class HandoffScriptTests(unittest.TestCase):
+    VERSION = "0.3.0"
+    APPROVALS = {"tenferro-internal-cpu-kernels"}
+    STUB = (
+        "#!/usr/bin/env python3\n"
+        "import os, sys\n"
+        "with open(os.environ['STUB_LOG'], 'a') as f:\n"
+        "    f.write(' '.join(sys.argv[1:]) + '\\n')\n"
+    )
+
+    def make_worktree(self, directory: Path) -> Path:
+        """Create a clean detached fake release worktree with a stub helper."""
+        root = directory / "release-worktree"
+        (root / "scripts").mkdir(parents=True)
+        (root / "ai/contribution-workflows").mkdir(parents=True)
+        (root / "Cargo.toml").write_text("fake\n", encoding="utf-8")
+        (root / "ai/contribution-workflows/release-publish.md").write_text(
+            "fake workflow\n", encoding="utf-8"
+        )
+        (root / "scripts/release-publish.py").write_text(self.STUB, encoding="utf-8")
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.invalid"],
+            cwd=root,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "test"], cwd=root, check=True
+        )
+        subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-qm", "init"], cwd=root, check=True)
+        subprocess.run(["git", "checkout", "-q", "--detach", "HEAD"], cwd=root, check=True)
+        return root
+
+    @staticmethod
+    def generate(root: Path, output: Path) -> None:
+        RELEASE.generate_handoff_script(
+            HandoffScriptTests.VERSION,
+            HandoffScriptTests.APPROVALS,
+            output,
+            root=root,
+        )
+
+    @staticmethod
+    def run_handoff(
+        worktree: Path,
+        script_path: Path,
+        stdin: bytes,
+        *,
+        tty: bool,
+    ) -> tuple[int, str]:
+        transcript = worktree.parent / "typescript"
+        env = {
+            "STUB_LOG": str(worktree.parent / "stub.log"),
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        }
+        if tty:
+            command = [
+                "script",
+                "-qec",
+                f"cd {shlex.quote(str(worktree))} && bash {shlex.quote(str(script_path))}",
+                str(transcript),
+            ]
+            completed = subprocess.run(
+                command,
+                input=stdin,
+                capture_output=True,
+                text=False,
+                timeout=120,
+                env=env,
+            )
+            output = (
+                transcript.read_text(encoding="utf-8", errors="replace")
+                if transcript.exists()
+                else ""
+            )
+        else:
+            completed = subprocess.run(
+                ["bash", str(script_path)],
+                input=stdin,
+                capture_output=True,
+                text=False,
+                timeout=120,
+                cwd=worktree,
+                env=env,
+            )
+            output = completed.stderr.decode("utf-8", "replace")
+        return completed.returncode, output
+
+    @staticmethod
+    def log_lines(worktree: Path) -> list[str]:
+        log = worktree.parent / "stub.log"
+        if not log.exists():
+            return []
+        return log.read_text(encoding="utf-8").splitlines()
+
+    def setUp(self) -> None:
+        self._directory = tempfile.TemporaryDirectory(prefix="tenferro-handoff-")
+        self.worktree = self.make_worktree(Path(self._directory.name))
+        self.output = Path(self._directory.name) / "publish.sh"
+        self.generate(self.worktree, self.output)
+
+    def tearDown(self) -> None:
+        self._directory.cleanup()
+
+    def test_generated_script_is_owner_only_and_parses(self) -> None:
+        mode = stat.S_IMODE(self.output.stat().st_mode)
+        self.assertEqual(mode, 0o700)
+        self.assertEqual(
+            subprocess.run(["bash", "-n", str(self.output)]).returncode, 0
+        )
+
+    def test_exact_y_runs_preflight_then_execute_with_approvals(self) -> None:
+        returncode, _stderr = self.run_handoff(
+            self.worktree, self.output, b"y\n", tty=True
+        )
+        self.assertEqual(returncode, 0)
+        self.assertEqual(
+            self.log_lines(self.worktree),
+            [
+                f"{self.VERSION} --approve-new-package "
+                "tenferro-internal-cpu-kernels",
+                f"{self.VERSION} --approve-new-package "
+                "tenferro-internal-cpu-kernels --execute",
+            ],
+        )
+
+    def test_non_y_answers_abort_before_any_execute(self) -> None:
+        for stdin in (b"n\n", b"Y\n", b"yes\n", b""):
+            with self.subTest(stdin=stdin):
+                log = self.worktree.parent / "stub.log"
+                transcript = self.worktree.parent / "typescript"
+                log.unlink(missing_ok=True)
+                transcript.unlink(missing_ok=True)
+                returncode, _output = self.run_handoff(
+                    self.worktree, self.output, stdin, tty=True
+                )
+                self.assertEqual(returncode, 1)
+                lines = self.log_lines(self.worktree)
+                self.assertEqual(len(lines), 1)
+                self.assertNotIn("--execute", lines[0])
+
+    def test_non_tty_stdin_aborts_before_any_helper_invocation(self) -> None:
+        returncode, stderr = self.run_handoff(
+            self.worktree, self.output, b"y\n", tty=False
+        )
+        self.assertEqual(returncode, 1)
+        self.assertIn("not a terminal", stderr)
+        self.assertEqual(self.log_lines(self.worktree), [])
+
+    def test_multiple_approvals_are_forwarded_verbatim(self) -> None:
+        approvals = {"tenferro-internal-cpu-kernels", "t4a-tblis-src"}
+        output = Path(self._directory.name) / "multi.sh"
+        RELEASE.generate_handoff_script(self.VERSION, approvals, output, root=self.worktree)
+        returncode, _output = self.run_handoff(self.worktree, output, b"y\n", tty=True)
+        self.assertEqual(returncode, 0)
+        self.assertEqual(
+            self.log_lines(self.worktree),
+            [
+                f"{self.VERSION} --approve-new-package t4a-tblis-src "
+                "--approve-new-package tenferro-internal-cpu-kernels",
+                f"{self.VERSION} --approve-new-package t4a-tblis-src "
+                "--approve-new-package tenferro-internal-cpu-kernels --execute",
+            ],
+        )
+
+    def test_checksum_mismatch_aborts_before_any_helper_invocation(self) -> None:
+        mutations = (
+            ("scripts/release-publish.py", "print('tampered')\n"),
+            ("ai/contribution-workflows/release-publish.md", "\n# tampered\n"),
+        )
+        for relative, suffix in mutations:
+            with self.subTest(relative=relative):
+                log = self.worktree.parent / "stub.log"
+                transcript = self.worktree.parent / "typescript"
+                log.unlink(missing_ok=True)
+                transcript.unlink(missing_ok=True)
+                target = self.worktree / relative
+                original = target.read_text(encoding="utf-8")
+                target.write_text(original + suffix, encoding="utf-8")
+                returncode, output = self.run_handoff(
+                    self.worktree, self.output, b"y\n", tty=True
+                )
+                self.assertEqual(returncode, 1)
+                self.assertIn("checksum mismatch", output)
+                self.assertEqual(self.log_lines(self.worktree), [])
+                target.write_text(original, encoding="utf-8")
+
+    def test_dirty_or_attached_worktree_aborts_before_any_helper_invocation(
+        self,
+    ) -> None:
+        (self.worktree / "untracked.txt").write_text("dirty\n", encoding="utf-8")
+        returncode, _stderr = self.run_handoff(
+            self.worktree, self.output, b"y\n", tty=True
+        )
+        self.assertEqual(returncode, 1)
+        self.assertEqual(self.log_lines(self.worktree), [])
+        (self.worktree / "untracked.txt").unlink()
+
+        subprocess.run(
+            ["git", "checkout", "-q", "master"], cwd=self.worktree, check=True
+        )
+        returncode, _stderr = self.run_handoff(
+            self.worktree, self.output, b"y\n", tty=True
+        )
+        self.assertEqual(returncode, 1)
+        self.assertEqual(self.log_lines(self.worktree), [])
+
+    def test_generator_rejects_output_inside_worktree_and_bad_versions(self) -> None:
+        with self.assertRaisesRegex(
+            RELEASE.ReleaseError, "outside the release worktree"
+        ):
+            RELEASE.generate_handoff_script(
+                self.VERSION, self.APPROVALS, self.worktree / "publish.sh", root=self.worktree
+            )
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "version must be exact"):
+            RELEASE.generate_handoff_script(
+                "0.3", self.APPROVALS, self.output, root=self.worktree
+            )
+
+    def test_cli_generates_handoff_script(self) -> None:
+        output = Path(self._directory.name) / "cli-publish.sh"
+        self.assertEqual(
+            RELEASE.main(
+                [
+                    self.VERSION,
+                    "--approve-new-package",
+                    "tenferro-internal-cpu-kernels",
+                    "--generate-script",
+                    str(output),
+                ]
+            ),
+            0,
+        )
+        self.assertTrue(output.exists())
+        self.assertEqual(stat.S_IMODE(output.stat().st_mode), 0o700)
+
+
+class VerifyReleaseCiTests(unittest.TestCase):
+    COMMIT = "a" * 40
+
+    def completed_run(self, name: str, **overrides: object) -> dict:
+        run: dict[str, object] = {
+            "name": name,
+            "head_sha": self.COMMIT,
+            "status": "completed",
+            "conclusion": "success",
+        }
+        run.update(overrides)
+        return run
+
+    def runner_for(self, runs: list[dict], *, invalid_json: bool = False) -> Callable:
+        def runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            body = "not json" if invalid_json else json.dumps({"check_runs": runs})
+            return subprocess.CompletedProcess(command, 0, body, "")
+
+        return runner
+
+    def test_accepts_all_required_checks_completed_successfully(self) -> None:
+        runs = [
+            self.completed_run("workspace-tests"),
+            self.completed_run("docs"),
+            self.completed_run("other-job"),
+        ]
+        RELEASE.verify_release_ci(
+            self.COMMIT, {"workspace-tests", "docs"}, runner=self.runner_for(runs)
+        )
+
+    def test_missing_required_check_fails_closed(self) -> None:
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "missing"):
+            RELEASE.verify_release_ci(
+                self.COMMIT, {"workspace-tests", "docs"}, runner=self.runner_for([])
+            )
+
+    def test_wrong_commit_fails_closed(self) -> None:
+        runs = [self.completed_run("workspace-tests", head_sha="b" * 40)]
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "different commit"):
+            RELEASE.verify_release_ci(
+                self.COMMIT, {"workspace-tests"}, runner=self.runner_for(runs)
+            )
+
+    def test_incomplete_status_fails_closed(self) -> None:
+        runs = [self.completed_run("workspace-tests", status="in_progress")]
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "not completed"):
+            RELEASE.verify_release_ci(
+                self.COMMIT, {"workspace-tests"}, runner=self.runner_for(runs)
+            )
+
+    def test_unsuccessful_conclusion_fails_closed(self) -> None:
+        runs = [self.completed_run("workspace-tests", conclusion="failure")]
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "did not succeed"):
+            RELEASE.verify_release_ci(
+                self.COMMIT, {"workspace-tests"}, runner=self.runner_for(runs)
+            )
+
+    def test_invalid_gh_output_fails_closed(self) -> None:
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "invalid JSON"):
+            RELEASE.verify_release_ci(
+                self.COMMIT,
+                {"workspace-tests"},
+                runner=self.runner_for([], invalid_json=True),
+            )
+
+    def test_multiple_paginated_pages_are_flattened(self) -> None:
+        runs = [
+            self.completed_run("workspace-tests"),
+            self.completed_run("docs"),
+        ]
+        payload = json.dumps(
+            [
+                {"check_runs": [runs[0]]},
+                {"check_runs": [runs[1]]},
+            ]
+        )
+
+        def runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(command, 0, payload, "")
+
+        RELEASE.verify_release_ci(
+            self.COMMIT, {"workspace-tests", "docs"}, runner=runner
+        )
+
+    def test_slurped_single_page_is_accepted(self) -> None:
+        # `gh api --paginate --slurp` always wraps pages in an outer array,
+        # even when there is only one page.
+        payload = json.dumps(
+            [{"check_runs": [self.completed_run("workspace-tests")]}]
+        )
+
+        def runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(command, 0, payload, "")
+
+        RELEASE.verify_release_ci(self.COMMIT, {"workspace-tests"}, runner=runner)
+
+    def test_malformed_slurped_page_fails_closed(self) -> None:
+        payloads = (
+            json.dumps([{"check_runs": [self.completed_run("workspace-tests")]}, "junk"]),
+            json.dumps([{"check_runs": [self.completed_run("workspace-tests")]}, {"total_count": 1}]),
+            json.dumps([{"check_runs": "not-a-list"}]),
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                def runner(
+                    command: list[str], **_kwargs: object
+                ) -> subprocess.CompletedProcess[str]:
+                    return subprocess.CompletedProcess(command, 0, payload, "")
+
+                with self.assertRaises(RELEASE.ReleaseError):
+                    RELEASE.verify_release_ci(
+                        self.COMMIT, {"workspace-tests"}, runner=runner
+                    )
+
+    def test_canonical_query_names_repository_and_paginates(self) -> None:
+        commands: list[list[str]] = []
+
+        def runner(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            commands.append(command)
+            return subprocess.CompletedProcess(command, 0, "{}", "")
+
+        with self.assertRaisesRegex(RELEASE.ReleaseError, "missing"):
+            RELEASE.verify_release_ci(self.COMMIT, {"workspace-tests"}, runner=runner)
+        self.assertEqual(
+            commands,
+            [
+                [
+                    "gh",
+                    "api",
+                    f"repos/tensor4all/tenferro-rs/commits/{self.COMMIT}/check-runs",
+                    "--paginate",
+                    "--slurp",
+                ]
+            ],
+        )
 
 
 class GitDependencyTests(unittest.TestCase):
@@ -605,7 +1025,7 @@ class OrchestrationTests(unittest.TestCase):
             ],
         )
 
-    def assert_runtime_bootstrap_commands(
+    def assert_runtime_commands(
         self, runtime_exists: bool, cpu_exists: bool = False
     ) -> None:
         cargo_commands: list[list[str]] = []
@@ -664,15 +1084,10 @@ class OrchestrationTests(unittest.TestCase):
                 delay=0,
             )
 
-        patch = (
-            "patch.crates-io.tenferro-cpu.path="
-            + json.dumps(str((root / "crates/tenferro-cpu").resolve()))
-        )
-        bootstrap = ["--no-verify", "--config", patch]
         self.assertEqual(
             cargo_commands,
             [
-                ["cargo", "package", "-p", "tenferro-runtime", "--locked", *bootstrap],
+                ["cargo", "package", "-p", "tenferro-runtime", "--locked"],
                 *(
                     []
                     if runtime_exists
@@ -686,7 +1101,6 @@ class OrchestrationTests(unittest.TestCase):
                             "--locked",
                             "--registry",
                             "crates-io",
-                            *bootstrap,
                         ],
                         [
                             "cargo",
@@ -696,7 +1110,6 @@ class OrchestrationTests(unittest.TestCase):
                             "--locked",
                             "--registry",
                             "crates-io",
-                            *bootstrap,
                         ],
                     ]
                 ),
@@ -728,17 +1141,20 @@ class OrchestrationTests(unittest.TestCase):
                 ),
             ],
         )
+        for command in cargo_commands:
+            self.assertNotIn("--no-verify", command)
+            self.assertNotIn("--config", command)
 
-    def test_runtime_bootstrap_patches_tag_cpu_while_both_are_missing(self) -> None:
-        self.assert_runtime_bootstrap_commands(runtime_exists=False)
+    def test_runtime_publishes_without_patch_while_both_are_missing(self) -> None:
+        self.assert_runtime_commands(runtime_exists=False)
 
-    def test_runtime_bootstrap_patches_tag_cpu_on_restart_after_runtime_publish(self) -> None:
-        self.assert_runtime_bootstrap_commands(runtime_exists=True)
+    def test_runtime_publishes_without_patch_on_restart_after_runtime_publish(self) -> None:
+        self.assert_runtime_commands(runtime_exists=True)
 
-    def test_runtime_bootstrap_is_stable_after_runtime_and_cpu_publish(self) -> None:
-        self.assert_runtime_bootstrap_commands(runtime_exists=True, cpu_exists=True)
+    def test_runtime_commands_stable_after_runtime_and_cpu_publish(self) -> None:
+        self.assert_runtime_commands(runtime_exists=True, cpu_exists=True)
 
-    def assert_xla_bootstrap_commands(
+    def assert_xla_commands(
         self, xla_exists: bool, einsum_exists: bool = False
     ) -> None:
         cargo_commands: list[list[str]] = []
@@ -800,16 +1216,11 @@ class OrchestrationTests(unittest.TestCase):
                 delay=0,
             )
 
-        patch = (
-            "patch.crates-io.tenferro-einsum.path="
-            + json.dumps(str((root / "crates/tenferro-einsum").resolve()))
-        )
-        bootstrap = ["--no-verify", "--config", patch]
         xla_commands = [command for command in cargo_commands if "tenferro-xla" in command]
         self.assertEqual(
             xla_commands,
             [
-                ["cargo", "package", "-p", "tenferro-xla", "--locked", *bootstrap],
+                ["cargo", "package", "-p", "tenferro-xla", "--locked"],
                 *(
                     []
                     if xla_exists
@@ -823,7 +1234,6 @@ class OrchestrationTests(unittest.TestCase):
                             "--locked",
                             "--registry",
                             "crates-io",
-                            *bootstrap,
                         ],
                         [
                             "cargo",
@@ -833,7 +1243,6 @@ class OrchestrationTests(unittest.TestCase):
                             "--locked",
                             "--registry",
                             "crates-io",
-                            *bootstrap,
                         ],
                     ]
                 ),
@@ -842,18 +1251,17 @@ class OrchestrationTests(unittest.TestCase):
         self.assertTrue(any("tenferro-cpu" in command for command in cargo_commands))
         self.assertTrue(any("tenferro-einsum" in command for command in cargo_commands))
         for command in cargo_commands:
-            if "tenferro-xla" not in command:
-                self.assertNotIn("--no-verify", command)
-                self.assertNotIn(patch, command)
+            self.assertNotIn("--no-verify", command)
+            self.assertNotIn("--config", command)
 
-    def test_xla_bootstrap_patches_tag_einsum_while_both_are_missing(self) -> None:
-        self.assert_xla_bootstrap_commands(xla_exists=False)
+    def test_xla_publishes_without_patch_while_both_are_missing(self) -> None:
+        self.assert_xla_commands(xla_exists=False)
 
-    def test_xla_bootstrap_patches_tag_einsum_on_restart_after_xla_publish(self) -> None:
-        self.assert_xla_bootstrap_commands(xla_exists=True)
+    def test_xla_publishes_without_patch_on_restart_after_xla_publish(self) -> None:
+        self.assert_xla_commands(xla_exists=True)
 
-    def test_xla_bootstrap_is_stable_after_xla_and_einsum_publish(self) -> None:
-        self.assert_xla_bootstrap_commands(xla_exists=True, einsum_exists=True)
+    def test_xla_commands_stable_after_xla_and_einsum_publish(self) -> None:
+        self.assert_xla_commands(xla_exists=True, einsum_exists=True)
 
     def test_rejects_differing_dry_run_staging_archives(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test-release-validation-policy.py
+++ b/scripts/test-release-validation-policy.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Focused tests for the release validation lane classifier."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("release-validation-policy.py")
+SPEC = importlib.util.spec_from_file_location("release_validation_policy", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot import {SCRIPT}")
+POLICY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(POLICY)
+
+
+MANIFEST = b"""\
+[package]
+name = "tenferro-fixture"
+version = "0.3.0"
+description = "Fixture"
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/tenferro-fixture"
+readme = "README.md"
+keywords = ["tensor"]
+categories = ["science"]
+
+[dependencies]
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0" }
+
+[features]
+default = []
+"""
+
+
+class LaneClassificationTests(unittest.TestCase):
+    def test_helper_only_changes_select_focused_lane(self) -> None:
+        cases = (
+            "scripts/release-publish.py",
+            "scripts/check-publish-layout.py",
+            "scripts/release-validation-policy.py",
+            "scripts/test-release-publish.py",
+            "scripts/ci/run_profile.py",
+            "ai/contribution-workflows/release-publish.md",
+            ".agents/skills/tenferro-release-publish/SKILL.md",
+            ".claude/skills/tenferro-release-publish/SKILL.md",
+            ".kimi/skills/tenferro-release-publish/SKILL.md",
+            ".opencode/commands/tenferro-release-publish.md",
+            ".github/workflows/ci-pr-workspace-tests.yml",
+        )
+        for path in cases:
+            with self.subTest(path=path):
+                self.assertEqual(
+                    POLICY.classify_change(path, b"old", b"new"),
+                    POLICY.LANE_HELPER,
+                )
+
+    def test_metadata_only_manifest_change_selects_metadata_lane(self) -> None:
+        new = MANIFEST.replace(
+            b'version = "0.3.0"\ndescription', b'version = "0.4.0"\ndescription'
+        )
+        self.assertEqual(
+            POLICY.classify_change("crates/tenferro-fixture/Cargo.toml", MANIFEST, new),
+            POLICY.LANE_METADATA,
+        )
+        described = MANIFEST.replace(
+            b'description = "Fixture"', b'description = "Renamed fixture"'
+        )
+        self.assertEqual(
+            POLICY.classify_change(
+                "crates/tenferro-fixture/Cargo.toml", MANIFEST, described
+            ),
+            POLICY.LANE_METADATA,
+        )
+
+    def test_root_version_bump_is_metadata_only(self) -> None:
+        old = b'[workspace]\nmembers = ["crates/a"]\n[workspace.package]\nversion = "0.3.0"\n'
+        new = old.replace(b'"0.3.0"', b'"0.4.0"')
+        self.assertEqual(
+            POLICY.classify_change("Cargo.toml", old, new), POLICY.LANE_METADATA
+        )
+
+    def test_semantic_manifest_changes_select_semantic_lane(self) -> None:
+        mutations = (
+            (b'version = "0.3.0"', b'version = "0.3.1"'),  # dependency requirement
+            (b'[features]\ndefault = []', b"[features]\ndefault = [\"cpu-faer\"]"),
+            (b'tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0" }',
+             b'tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }'),
+        )
+        for old_fragment, new_fragment in mutations:
+            with self.subTest(old_fragment=old_fragment):
+                self.assertEqual(
+                    POLICY.classify_change(
+                        "crates/tenferro-fixture/Cargo.toml",
+                        MANIFEST.replace(old_fragment, old_fragment),
+                        MANIFEST.replace(old_fragment, new_fragment),
+                    ),
+                    POLICY.LANE_SEMANTIC,
+                )
+
+    def test_added_or_removed_manifest_is_semantic(self) -> None:
+        self.assertEqual(
+            POLICY.classify_change("crates/tenferro-new/Cargo.toml", None, MANIFEST),
+            POLICY.LANE_SEMANTIC,
+        )
+        self.assertEqual(
+            POLICY.classify_change("crates/tenferro-gone/Cargo.toml", MANIFEST, None),
+            POLICY.LANE_SEMANTIC,
+        )
+
+    def test_malformed_manifest_is_semantic(self) -> None:
+        self.assertEqual(
+            POLICY.classify_change(
+                "crates/tenferro-fixture/Cargo.toml", b"not = [toml", MANIFEST
+            ),
+            POLICY.LANE_SEMANTIC,
+        )
+
+    def test_rust_source_and_ambiguous_paths_select_full_lane(self) -> None:
+        for path, old, new in (
+            ("crates/tenferro-runtime/src/lib.rs", b"old", b"new"),
+            ("crates/tenferro-xla/src/executor.rs", b"old", b"new"),
+            ("docs/design/release.md", b"old", b"new"),
+            ("REPOSITORY_RULES.md", b"old", b"new"),
+            (".github/workflows/CI_gpu.yml", b"old", b"new"),
+            ("scripts/test-unrelated-tooling.py", b"old", b"new"),
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(
+                    POLICY.classify_change(path, old, new), POLICY.LANE_FULL
+                )
+
+    def test_mixed_change_sets_select_strongest_lane(self) -> None:
+        helper = ("scripts/release-publish.py", b"old", b"new")
+        metadata = (
+            "crates/tenferro-fixture/Cargo.toml",
+            MANIFEST,
+            MANIFEST.replace(
+                b'version = "0.3.0"\ndescription', b'version = "0.4.0"\ndescription'
+            ),
+        )
+        semantic = (
+            "crates/tenferro-fixture/Cargo.toml",
+            MANIFEST,
+            MANIFEST + b"\n[target.'cfg(unix)'.dependencies]\nlibc = \"0.2\"\n",
+        )
+        rust = ("crates/tenferro-runtime/src/lib.rs", b"old", b"new")
+        self.assertEqual(
+            POLICY.classify_changes([helper, metadata]), POLICY.LANE_METADATA
+        )
+        self.assertEqual(
+            POLICY.classify_changes([helper, semantic]), POLICY.LANE_SEMANTIC
+        )
+        self.assertEqual(POLICY.classify_changes([helper, rust]), POLICY.LANE_FULL)
+        self.assertEqual(
+            POLICY.classify_changes([metadata, semantic, rust]), POLICY.LANE_FULL
+        )
+
+    def test_diff_classification_uses_injected_runner(self) -> None:
+        files = {
+            "scripts/release-publish.py": b"helper",
+            "crates/tenferro-fixture/Cargo.toml": MANIFEST,
+            "crates/tenferro-runtime/src/lib.rs": b"code",
+        }
+        calls: list[tuple[str, ...]] = []
+
+        def runner(
+            command: list[str], **kwargs: object
+        ) -> subprocess.CompletedProcess:
+            calls.append(tuple(command))
+            if command[:2] == ["git", "diff"]:
+                return subprocess.CompletedProcess(
+                    command, 0, "M\tscripts/release-publish.py\nM\tcrates/tenferro-fixture/Cargo.toml\nM\tcrates/tenferro-runtime/src/lib.rs\n", ""
+                )
+            revision, _, path = command[2].partition(":")
+            content = files.get(path)
+            if content is None:
+                return subprocess.CompletedProcess(command, 1, "", "")
+            return subprocess.CompletedProcess(command, 0, content, "")
+
+        lane = POLICY.classify_diff("BASE", "HEAD", runner=runner)
+        self.assertEqual(lane, POLICY.LANE_FULL)
+        self.assertIn(("git", "diff", "--name-status", "BASE", "HEAD"), calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Release-workflow hardening for #1650: forbid publication cycles and forward versioned dev-dependencies, fix the two manifest violations, add a guarded human publication script, change-aware release validation, and move reusable policy to the shared agent rules.

### Part 1 — publish-safety checks
- `check-publish-layout.py`: forward normal/build/dev dependency check and publication-cycle detection now apply to **versioned** edges only (path-only dev-deps report `req='*'` and are stripped from published manifests); new `_check_internal_dependency_versions` requires normal/build path deps to carry the workspace version.
- Manifests: `tenferro-runtime` (cpu) and `tenferro-xla` (einsum) dev-deps are now **path-only (unversioned)** — the decisive experiment showed versioned forward/cyclic dev-deps fail `cargo package` resolution while path-only succeeds. xla forwards `cpu-faer` through einsum because the linked `tenferro-cpu` cannot compile without a provider feature.
- ⚠️ **Deviation from the issue's preferred approach** (needs maintainer sign-off): moving runtime's cross-layer tests into `publish = false` test crates is infeasible (doctests + private-access `#[cfg(test)]` tests cannot relocate); path-only dev-deps achieve the same publish-safety with a tiny diff. See the worklog.

### Part 2 — guarded human publication script
- `release-publish.py --generate-script PATH`: emits a mode-0700, `bash -n`-clean, non-append, restart-safe handoff script pinned to SHA-256 (Python `hashlib`, no external sha256sum) of the helper + canonical workflow; aborts unless stdin is a TTY and the worktree is clean/detached; re-runs the fail-closed preflight; requires one exact lowercase `y` before invoking the helper with `--execute` and exactly the approvals passed at generation. Generator rejects output paths inside the release worktree.
- Removed the obsolete `[patch.crates-io]` bootstrap (`--no-verify`/`--config`) from `publish_release` — unnecessary after path-only dev-deps and contradicting the packageable-as-is rule. `cargo package -p tenferro-runtime/xla --locked` both fully verify with no patch.

### Part 3 — change-aware release validation
- New `release-validation-policy.py`: classifies the release diff (by old/new manifest content, not just paths) into helper-only / publication-metadata-only / semantic-manifest / full lanes; mixed sets take the strongest lane; wired into the ci-config profile. Tests prove metadata-only and helper-only sets do NOT request full workspace/CPU-GPU.
- `verify_release_ci(commit, required_checks)` in `release-publish.py`: fail-closed exact-SHA CI reuse via `gh api .../commits/<SHA>/check-runs --paginate --slurp`, requiring per check `head_sha == <SHA>`, completed, success. Human-executed at Phase 3 per plan.

### Part 4 — shared rules + docs
- `REPOSITORY_RULES.md` Publication Order And Publish-Safety section; workflow Phase 2/3 (handoff script, change-aware validation, exact-SHA); skill mirrors byte-identical + opencode adapter; worklog `docs/worklogs/2026-08-10-release-publish-safety.md`.
- Shared cross-repo policy added to `tensor4all-agent-rules` (sibling PR #10).

## Verification
- `scripts/test-release-publish.py` 60 tests (incl. executing the generated script against a stub helper under a PTY: exact-y continues, n/Y/EOF/non-TTY/checksum-mismatch abort, approvals forwarded; verify_release_ci fixtures incl. slurped pages and malformed pages)
- `scripts/test-check-publish-layout.py` + `check-publish-layout.py` GREEN
- `scripts/test-release-validation-policy.py`
- `ci-config` profile exit 0 (incl. actionlint)
- `bash scripts/check-pr-fast.sh --coverage-reviewed` + focused tests: passed
- `cargo test -p tenferro-runtime` (937) and `-p tenferro-xla` (76): all pass
- `cargo package -p tenferro-runtime --locked` and `-p tenferro-xla --locked`: full verification, no patches
- Reviewed by reviewer-gpt (gpt-5.6-sol, 3 rounds): final verdict READY

## Notes
- Local `repository-rules-review.py` LLM step failed with HTTP 402 (API quota); the deterministic router dry-run passes and the routing test is green. The external LLM review will run in CI.