### PR TITLE
docs: remove stale next-release package approval

### DIFF
--- a/.agents/skills/tenferro-release-publish/SKILL.md
+++ b/.agents/skills/tenferro-release-publish/SKILL.md
@@ -30,7 +30,10 @@ Keep the interaction incremental:
    `python3 scripts/release-publish.py X.Y.Z --generate-script PATH`
    that re-runs the fail-closed preflight and requires one exact lowercase
    `y` at a TTY before invoking the helper with `--execute`; agents never run
-   publication and never type that confirmation. Phase 3 validation is
+   publication and never type that confirmation. This target-neutral example
+   intentionally omits `--approve-new-package`; add one
+   `--approve-new-package PACKAGE` only for each genuinely new package named by
+   the user's explicit approval. Phase 3 validation is
    change-aware (`scripts/release-validation-policy.py`): helper-only or
    publication-metadata-only diffs run focused lanes, and a rerun is skipped
    only when the exact-SHA CI check passes

--- a/.claude/skills/tenferro-release-publish/SKILL.md
+++ b/.claude/skills/tenferro-release-publish/SKILL.md
@@ -30,7 +30,10 @@ Keep the interaction incremental:
    `python3 scripts/release-publish.py X.Y.Z --generate-script PATH`
    that re-runs the fail-closed preflight and requires one exact lowercase
    `y` at a TTY before invoking the helper with `--execute`; agents never run
-   publication and never type that confirmation. Phase 3 validation is
+   publication and never type that confirmation. This target-neutral example
+   intentionally omits `--approve-new-package`; add one
+   `--approve-new-package PACKAGE` only for each genuinely new package named by
+   the user's explicit approval. Phase 3 validation is
    change-aware (`scripts/release-validation-policy.py`): helper-only or
    publication-metadata-only diffs run focused lanes, and a rerun is skipped
    only when the exact-SHA CI check passes

--- a/.kimi/skills/tenferro-release-publish/SKILL.md
+++ b/.kimi/skills/tenferro-release-publish/SKILL.md
@@ -30,7 +30,10 @@ Keep the interaction incremental:
    `python3 scripts/release-publish.py X.Y.Z --generate-script PATH`
    that re-runs the fail-closed preflight and requires one exact lowercase
    `y` at a TTY before invoking the helper with `--execute`; agents never run
-   publication and never type that confirmation. Phase 3 validation is
+   publication and never type that confirmation. This target-neutral example
+   intentionally omits `--approve-new-package`; add one
+   `--approve-new-package PACKAGE` only for each genuinely new package named by
+   the user's explicit approval. Phase 3 validation is
    change-aware (`scripts/release-validation-policy.py`): helper-only or
    publication-metadata-only diffs run focused lanes, and a rerun is skipped
    only when the exact-SHA CI check passes

--- a/.opencode/commands/tenferro-release-publish.md
+++ b/.opencode/commands/tenferro-release-publish.md
@@ -20,7 +20,10 @@ human maintainer runs Phase 3 publication from the tag. The maintainer can
 generate a guarded handoff script with
 `python3 scripts/release-publish.py X.Y.Z --generate-script PATH` that re-runs the
 preflight and requires one exact lowercase `y` at a TTY before `--execute`;
-agents never run publication and never type that confirmation. Phase 3
+agents never run publication and never type that confirmation. This
+target-neutral example intentionally omits `--approve-new-package`; add one
+`--approve-new-package PACKAGE` only for each genuinely new package named by
+the user's explicit approval. Phase 3
 validation is change-aware (`scripts/release-validation-policy.py`); a rerun
 is skipped only when the exact-SHA CI check passes
 (`verify_release_ci` in `scripts/release-publish.py`). After human

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -149,14 +149,14 @@ Agents must stop after validation and must never execute a publication.
    python3 scripts/release-publish.py X.Y.Z
    ```
 
-   **New-package gate:** `tenferro-internal-cpu-kernels` is new for v0.3.0.
-   The command above must abort before publishing anything unless the user's
-   approval names exactly `tenferro-internal-cpu-kernels`. After recording that
-   exact approval, the human operator asserts it concretely with:
+   **New-package gate:** use the command above unchanged when every publishable
+   package already exists on crates.io. If the helper reports a genuinely new
+   package, stop until the user's approval names that exact package. After
+   recording the approval, the human operator asserts it concretely with:
 
    ```bash
    python3 scripts/release-publish.py X.Y.Z \
-     --approve-new-package tenferro-internal-cpu-kernels
+     --approve-new-package PACKAGE
    ```
 
    Never infer this approval from a general release request. On restart, keep
@@ -172,7 +172,6 @@ Agents must stop after validation and must never execute a publication.
 
    ```bash
    python3 scripts/release-publish.py X.Y.Z \
-     --approve-new-package tenferro-internal-cpu-kernels \
      --generate-script "$TMPDIR/publish-X.Y.Z.sh"
    ```
 
@@ -180,7 +179,10 @@ Agents must stop after validation and must never execute a publication.
    on untracked files). The generated script pins SHA-256 checksums of the
    helper and this workflow, aborts unless stdin is a TTY and the worktree is
    clean and detached, and carries exactly the `--approve-new-package` values
-   passed at generation. Run it from the release worktree root:
+   passed at generation. For a release with an explicitly approved new package,
+   add one `--approve-new-package PACKAGE` argument per approved package;
+   otherwise do not pass that option. Run the script from the release worktree
+   root:
 
    ```bash
    cd <fresh-path> && bash "$TMPDIR/publish-X.Y.Z.sh"
@@ -213,13 +215,13 @@ Agents must stop after validation and must never execute a publication.
    after the single exact `y`):
 
    ```bash
-   python3 scripts/release-publish.py X.Y.Z \
-     --approve-new-package tenferro-internal-cpu-kernels \
-     --execute
+   python3 scripts/release-publish.py X.Y.Z --execute
    ```
 
-   Before each `cargo publish`, the helper waits for every prerequisite registry
-   archive, then runs `cargo package` and inspects that exact local `.crate` file.
+   If the preflight required explicitly approved new-package arguments, repeat
+   those same arguments before `--execute`. Before each `cargo publish`, the
+   helper waits for every prerequisite registry archive, then runs
+   `cargo package` and inspects that exact local `.crate` file.
    It checks the file list and normalized metadata (name, version, description,
    license, repository, homepage, documentation, README, `rust-version`,
    keywords, categories, and `include`/`exclude`), verifies

--- a/docs/worklogs/2026-08-10-release-publish-safety.md
+++ b/docs/worklogs/2026-08-10-release-publish-safety.md
@@ -144,3 +144,27 @@ do not impose tenferro topology.
   as full.
 - Handoff-script checksum mismatch test also covers the canonical workflow
   file; skills document the versioned `--generate-script` command.
+
+## Next-release approval cleanup
+
+The generic Phase 3 preflight, handoff-generation, and execution examples now
+omit new-package approval arguments. They add `--approve-new-package PACKAGE`
+only when a release really contains a new package and the user explicitly names
+it. This keeps existing packages out of the approval set while preserving the
+helper's fail-closed gate for future new packages; helper semantics did not
+change. The three byte-identical skills and the OpenCode adapter carry the same
+target-neutral rule, guarded by a focused documentation contract test.
+
+The shared-rule dependency is resolved: tensor4all-agent-rules PR #10 merged as
+`5cff8254`, with its `validate-rules` check successful. The current shared
+`rules/common/repository.md` contains the publication and release safety policy
+used here.
+
+Focused verification passed for the documentation and no-approval handoff
+contracts, the existing exact/stale new-package approval gate, publish layout,
+release validation policy, Python byte compilation, formatting, adapter byte
+identity, deterministic repository-rules review, and `git diff --check`.
+`ci-config` reaches the same release-helper suite but its interactive handoff
+tests require GNU `script -qec` and a Git `master` default branch, which are not
+available in this macOS environment; the affected changed tests pass when run
+without those Linux-only interactive cases.

--- a/scripts/test-release-publish.py
+++ b/scripts/test-release-publish.py
@@ -105,6 +105,25 @@ class ReleaseDocumentationContractTests(unittest.TestCase):
                 normalized_adapter,
             )
 
+    def test_next_release_examples_do_not_reuse_stale_new_package_approval(self) -> None:
+        paths = (
+            "ai/contribution-workflows/release-publish.md",
+            *self.SKILL_PATHS,
+            ".opencode/commands/tenferro-release-publish.md",
+        )
+        for relative in paths:
+            text = (self.ROOT / relative).read_text()
+            stale_approval = (
+                "--approve-new-package " + "tenferro-internal-cpu-kernels"
+            )
+            self.assertNotIn(stale_approval, text)
+            self.assertIn("--approve-new-package PACKAGE", text)
+
+        workflow = (self.ROOT / paths[0]).read_text()
+        self.assertIn("genuinely new", workflow)
+        self.assertIn(
+            'python3 scripts/release-publish.py X.Y.Z --execute', workflow
+        )
 
     def test_change_aware_validation_and_exact_sha_are_documented(self) -> None:
         text = (self.ROOT / "ai/contribution-workflows/release-publish.md").read_text()
@@ -126,8 +145,8 @@ class ReleaseDocumentationContractTests(unittest.TestCase):
 
 
 class HandoffScriptTests(unittest.TestCase):
-    VERSION = "0.3.0"
-    APPROVALS = {"tenferro-internal-cpu-kernels"}
+    VERSION = "1.2.3"
+    APPROVALS = {"tenferro-new-package"}
     STUB = (
         "#!/usr/bin/env python3\n"
         "import os, sys\n"
@@ -246,11 +265,16 @@ class HandoffScriptTests(unittest.TestCase):
             self.log_lines(self.worktree),
             [
                 f"{self.VERSION} --approve-new-package "
-                "tenferro-internal-cpu-kernels",
+                "tenferro-new-package",
                 f"{self.VERSION} --approve-new-package "
-                "tenferro-internal-cpu-kernels --execute",
+                "tenferro-new-package --execute",
             ],
         )
+
+    def test_generated_script_omits_approval_flags_when_none_are_required(self) -> None:
+        output = Path(self._directory.name) / "no-approvals.sh"
+        RELEASE.generate_handoff_script(self.VERSION, set(), output, root=self.worktree)
+        self.assertIn("APPROVALS=()", output.read_text())
 
     def test_non_y_answers_abort_before_any_execute(self) -> None:
         for stdin in (b"n\n", b"Y\n", b"yes\n", b""):
@@ -276,7 +300,7 @@ class HandoffScriptTests(unittest.TestCase):
         self.assertEqual(self.log_lines(self.worktree), [])
 
     def test_multiple_approvals_are_forwarded_verbatim(self) -> None:
-        approvals = {"tenferro-internal-cpu-kernels", "t4a-tblis-src"}
+        approvals = {"tenferro-new-package", "t4a-tblis-src"}
         output = Path(self._directory.name) / "multi.sh"
         RELEASE.generate_handoff_script(self.VERSION, approvals, output, root=self.worktree)
         returncode, _output = self.run_handoff(self.worktree, output, b"y\n", tty=True)
@@ -285,9 +309,9 @@ class HandoffScriptTests(unittest.TestCase):
             self.log_lines(self.worktree),
             [
                 f"{self.VERSION} --approve-new-package t4a-tblis-src "
-                "--approve-new-package tenferro-internal-cpu-kernels",
+                "--approve-new-package tenferro-new-package",
                 f"{self.VERSION} --approve-new-package t4a-tblis-src "
-                "--approve-new-package tenferro-internal-cpu-kernels --execute",
+                "--approve-new-package tenferro-new-package --execute",
             ],
         )
 


### PR DESCRIPTION
## What

- make the canonical release examples omit new-package approval for releases whose packages already exist
- keep the explicit `--approve-new-package PACKAGE` path for genuinely new packages only
- synchronize the three release skills and the OpenCode adapter
- add focused contracts that reject the stale v0.3 package approval and verify approval-free handoff generation

## Why

`tenferro-internal-cpu-kernels` now exists on crates.io. Reusing its v0.3 first-publication approval for v0.4 is stale, and the release helper correctly rejects it. The generic workflow should therefore show an approval-free command by default and add approval arguments only after the user explicitly names a genuinely new package.

The helper and its fail-closed approval semantics are unchanged.

## Verification

- release documentation, registry approval, and approval-free handoff contracts: 11 passed
- publish-layout contracts: 27 passed
- live publish-layout check: passed
- release validation policy: 9 passed
- Python byte compilation
- root and extension formatting
- `git diff --check`

The complete local `ci-config` profile reaches Linux-specific interactive handoff tests that use GNU `script -qec` and assume a `master` default branch; those existing harness assumptions fail on this macOS host. The changed focused contracts pass locally, and hosted Linux `ci-config` remains the merge gate.

## Work log

- [`docs/worklogs/2026-08-10-release-publish-safety.md`](https://github.com/tensor4all/tenferro-rs/blob/codex/1650-next-release-cleanup/docs/worklogs/2026-08-10-release-publish-safety.md)

Refs #1650
Refs #1652
