### PR TITLE
fix: reject integer/bool linalg decomposition dtypes at trace time and single-pass pooled fills (#1649, #1640)

### DIFF
--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -313,7 +313,7 @@ fn zeroed_tensor_from_pool<T>(
     shape: Vec<usize>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Zero + Clone + PoolScalar + 'static,
+    T: Zero + PoolScalar + 'static,
 {
     filled_tensor_from_pool(buffers, op, shape, T::zero())
 }
@@ -325,12 +325,18 @@ fn filled_tensor_from_pool<T>(
     fill: T,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + PoolScalar + 'static,
+    T: PoolScalar + 'static,
 {
-    let len = checked_shape_product(op, "output shape", &shape)?;
-    let mut data = buffers.acquire_zeroed::<T>(len);
-    data.fill(fill);
-    TypedTensor::from_vec_col_major(shape, data)
+    // Preserve operation-specific shape-product error attribution, then fill
+    // the pooled full-overwrite destination exactly once.
+    checked_shape_product(op, "output shape", &shape)?;
+    let mut out = PooledUninitOutput::<T>::new(buffers, shape)?;
+    // INVARIANT: the pooled destination is fully overwritten by the fill pass
+    // below before the completion handoff, so no uninitialized element is
+    // ever read or dropped.
+    out.as_uninit_slice_mut().fill(MaybeUninit::new(fill));
+    // SAFETY: the fill pass writes every logical destination element.
+    unsafe { out.assume_init() }
 }
 
 fn clone_host_tensor_from_pool<T>(

--- a/crates/tenferro-cpu/tests/integration/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/integration/runtime_error_tests.rs
@@ -123,6 +123,20 @@ fn cpu_zero_fill_pooled_outputs_use_checked_shape_product() {
         !filled_section.contains("let len = shape.iter().product();"),
         "CPU zero/fill pooled output allocation must not use unchecked shape.iter().product()"
     );
+    assert!(
+        filled_section.contains("PooledUninitOutput::<T>::new(buffers, shape)?"),
+        "CPU fill pooled outputs must use the full-overwrite uninit guard"
+    );
+    assert!(
+        filled_section.contains(".fill(MaybeUninit::new(fill))")
+            && filled_section.contains("// INVARIANT:")
+            && filled_section.contains("// SAFETY:"),
+        "CPU fill pooled outputs must fill the entire destination before the completion handoff and record the invariant markers"
+    );
+    assert!(
+        !filled_section.contains("acquire_zeroed"),
+        "CPU fill pooled outputs must not zero-fill a destination that is fully overwritten"
+    );
 }
 
 #[test]

--- a/crates/tenferro-linalg/src/ad/rules/mod.rs
+++ b/crates/tenferro-linalg/src/ad/rules/mod.rs
@@ -720,7 +720,8 @@ pub(crate) fn linearize_svd(
         eps * eps,
         matrix_shape(k.clone(), k.clone(), batch_shape),
         s_dtype,
-    );
+        "linearize_svd",
+    )?;
     let safe_gap = fixed_add(builder, ValueRef::Local(s_gap_sq), ValueRef::Local(eps_sq));
     let f = fixed_div(builder, ValueRef::Local(s_gap), ValueRef::Local(safe_gap));
     let s_dim_linear_dtype =
@@ -738,7 +739,8 @@ pub(crate) fn linearize_svd(
             eps * eps,
             vector_shape(k.clone(), batch_shape),
             s_dtype,
-        );
+            "linearize_svd",
+        )?;
         let safe_s_sq = fixed_add(builder, ValueRef::Local(s_sq), ValueRef::Local(s_eps_sq));
         let s_inv = fixed_div(builder, s.clone(), ValueRef::Local(safe_s_sq));
         let s_inv_mat = embed_diag_fixed(builder, ValueRef::Local(s_inv));
@@ -755,7 +757,8 @@ pub(crate) fn linearize_svd(
             0.5,
             matrix_shape(k.clone(), k.clone(), batch_shape),
             dtype,
-        );
+            "linearize_svd",
+        )?;
 
         let dss = hadamard_fixed_linear(builder, s_dim_linear_dtype.clone(), ds_mat);
         let dss_h = adjoint_matrix_linear(builder, dss, matrix_rank, dtype);
@@ -953,7 +956,8 @@ pub(crate) fn linearize_eigh(
         matrix_rank,
         dtype,
         vector_shape(n.clone(), batch_shape),
-    );
+        "linearize_eigh",
+    )?;
 
     let vh = adjoint_matrix_fixed(builder, v.clone(), matrix_rank, dtype);
     let tmp = matmul_linear(
@@ -1003,7 +1007,8 @@ pub(crate) fn linearize_eigh(
         eps * eps,
         matrix_shape(n.clone(), n.clone(), batch_shape),
         w_dtype,
-    );
+        "linearize_eigh",
+    )?;
     let safe_diff = fixed_add(builder, ValueRef::Local(diff_sq), ValueRef::Local(eps_sq));
     let f = fixed_div(builder, ValueRef::Local(diff), ValueRef::Local(safe_diff));
     let f = convert_fixed_ref_to_dtype(builder, ValueRef::Local(f), w_dtype, dtype);
@@ -1052,7 +1057,8 @@ pub(crate) fn linearize_eigh_values(
         matrix_rank,
         dtype,
         vector_shape(n.clone(), batch_shape),
-    );
+        "linearize_eigh_values",
+    )?;
     let vh = adjoint_matrix_fixed(builder, v.clone(), matrix_rank, dtype);
     let tmp = matmul_linear(
         builder,
@@ -1112,7 +1118,8 @@ pub(crate) fn linearize_cholesky(
         matrix_rank,
         dtype,
         vector_shape(n.clone(), batch_shape),
-    );
+        "linearize_cholesky",
+    )?;
     let l_conj = conjugate_primal_if_dtype_complex(builder, l.clone(), dtype);
 
     let tmp = builder.add_operation(
@@ -1154,7 +1161,8 @@ pub(crate) fn linearize_cholesky(
         0.5,
         vector_shape(n.clone(), batch_shape),
         dtype,
-    );
+        "linearize_cholesky",
+    )?;
     let half_diag_mat = embed_diag_linear(builder, half_diag);
     let phi_s = linear_add(builder, strict_lower, half_diag_mat);
     let dl = matmul_linear(
@@ -1254,7 +1262,8 @@ pub(crate) fn linearize_qr(
             0.5,
             vector_shape(m.clone(), batch_shape),
             dtype,
-        );
+            "linearize_qr",
+        )?;
         let half_sym_diag_mat = embed_diag_linear(builder, half_sym_diag);
         let dr_leading_hat = linear_add(builder, upper, half_sym_diag_mat);
 
@@ -1405,8 +1414,14 @@ pub(crate) fn linearize_qr(
             },
         )[0];
         let sym_diag = extract_diag_linear(builder, sym);
-        let half_sym_diag =
-            linear_scale_with_dtype(builder, sym_diag, 0.5, vector_shape(k, batch_shape), dtype);
+        let half_sym_diag = linear_scale_with_dtype(
+            builder,
+            sym_diag,
+            0.5,
+            vector_shape(k, batch_shape),
+            dtype,
+            "linearize_qr",
+        )?;
         let half_sym_diag_mat = embed_diag_linear(builder, half_sym_diag);
         let dr_leading_hat = linear_add(builder, upper, half_sym_diag_mat);
 
@@ -1508,7 +1523,8 @@ pub(crate) fn linearize_qr(
         0.5,
         vector_shape(n.clone(), batch_shape),
         dtype,
-    );
+        "linearize_qr",
+    )?;
     let half_sym_diag_mat = embed_diag_linear(builder, half_sym_diag);
     let dr_hat = linear_add(builder, upper, half_sym_diag_mat);
 

--- a/crates/tenferro-linalg/src/ad/rules/support.rs
+++ b/crates/tenferro-linalg/src/ad/rules/support.rs
@@ -1,6 +1,8 @@
 use computegraph::types::{LocalValueId, OperationRole, ValueRef};
 use num_complex::{Complex32, Complex64};
-use tenferro_ops::ad::{support as ad_support, PrimitiveRuleBuilder};
+use tenferro_ops::ad::{
+    support as ad_support, ADRuleError, ADRuleKind, ADRuleResult, PrimitiveRuleBuilder,
+};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{DType, DotGeneralConfig, PadConfig};
@@ -168,13 +170,14 @@ pub(super) fn fixed_scale_with_dtype(
     factor: f64,
     shape: Vec<DimExpr>,
     dtype: DType,
-) -> LocalValueId {
-    let constant = broadcast_scalar_constant_with_dtype(builder, factor, shape, dtype);
-    builder.add_operation(
+    op: &'static str,
+) -> ADRuleResult<LocalValueId> {
+    let constant = broadcast_scalar_constant_with_dtype(builder, factor, shape, dtype, op)?;
+    Ok(builder.add_operation(
         StdTensorOp::Mul,
         vec![ValueRef::Local(constant), input],
         OperationRole::Primary,
-    )[0]
+    )[0])
 }
 
 fn broadcast_scalar_constant_with_dtype(
@@ -182,15 +185,22 @@ fn broadcast_scalar_constant_with_dtype(
     factor: f64,
     shape: Vec<DimExpr>,
     dtype: DType,
-) -> LocalValueId {
-    let op = match dtype {
+    op: &'static str,
+) -> ADRuleResult<LocalValueId> {
+    let op_value = match dtype {
         DType::F64 => StdTensorOp::constant(factor),
         DType::F32 => StdTensorOp::constant(factor as f32),
         DType::C64 => StdTensorOp::constant(Complex64::new(factor, 0.0)),
         DType::C32 => StdTensorOp::constant(Complex32::new(factor as f32, 0.0)),
-        DType::I32 | DType::I64 | DType::Bool => StdTensorOp::constant(factor),
+        DType::I32 | DType::I64 | DType::Bool => {
+            return Err(ADRuleError::invalid_input(
+                format!("tenferro-linalg.{op}"),
+                ADRuleKind::Jvp,
+                format!("dtype {dtype:?} is not supported by linalg decomposition derivatives"),
+            ));
+        }
     };
-    broadcast_scalar_constant_with_op(builder, op, shape)
+    Ok(broadcast_scalar_constant_with_op(builder, op_value, shape))
 }
 
 fn broadcast_scalar_constant_with_op(
@@ -269,15 +279,16 @@ pub(super) fn linear_scale_with_dtype(
     factor: f64,
     shape: Vec<DimExpr>,
     dtype: DType,
-) -> LocalValueId {
-    let constant = broadcast_scalar_constant_with_dtype(builder, factor, shape, dtype);
-    builder.add_operation(
+    op: &'static str,
+) -> ADRuleResult<LocalValueId> {
+    let constant = broadcast_scalar_constant_with_dtype(builder, factor, shape, dtype, op)?;
+    Ok(builder.add_operation(
         StdTensorOp::Mul,
         vec![ValueRef::Local(constant), ValueRef::Local(input)],
         OperationRole::Linearized {
             active_mask: vec![false, true],
         },
-    )[0]
+    )[0])
 }
 
 pub(super) fn linear_sub(
@@ -472,7 +483,8 @@ pub(super) fn self_adjoint_from_lower_linear(
     rank: usize,
     dtype: DType,
     diag_shape: Vec<DimExpr>,
-) -> LocalValueId {
+    op: &'static str,
+) -> ADRuleResult<LocalValueId> {
     let strict_lower = builder.add_operation(
         StdTensorOp::Tril { k: -1 },
         vec![ValueRef::Local(input)],
@@ -489,10 +501,10 @@ pub(super) fn self_adjoint_from_lower_linear(
     } else {
         let diag_h = conjugate_linear_if_dtype_complex(builder, diag, dtype);
         let diag_sum = linear_add(builder, diag, diag_h);
-        linear_scale_with_dtype(builder, diag_sum, 0.5, diag_shape, dtype)
+        linear_scale_with_dtype(builder, diag_sum, 0.5, diag_shape, dtype, op)?
     };
     let diag_mat = embed_diag_linear(builder, diag);
-    linear_add(builder, offdiag, diag_mat)
+    Ok(linear_add(builder, offdiag, diag_mat))
 }
 
 pub(super) fn matmul_fixed(
@@ -851,124 +863,4 @@ pub(super) fn take_leading_rows_linear(
 }
 
 #[cfg(test)]
-mod tests {
-    use std::collections::BTreeMap;
-
-    use computegraph::graph::{Graph, GraphBuilder};
-    use computegraph::types::ValueRef;
-    use tenferro_ops::dim_expr::DimExpr;
-    use tenferro_ops::input_key::TensorInputKey;
-    use tenferro_ops::std_tensor_op::StdTensorOp;
-    use tenferro_tensor::DType;
-
-    use super::{identity_matrix_fixed, leading_column_selector_symbolic, one_like_fixed};
-
-    fn op_kind_name(op: &StdTensorOp) -> &'static str {
-        match op {
-            StdTensorOp::Constant { .. } => "Constant",
-            StdTensorOp::BroadcastInDim { .. } => "BroadcastInDim",
-            StdTensorOp::EmbedDiag { .. } => "EmbedDiag",
-            StdTensorOp::Exp => "Exp",
-            StdTensorOp::Log => "Log",
-            StdTensorOp::Sin => "Sin",
-            StdTensorOp::Cos => "Cos",
-            StdTensorOp::Tanh => "Tanh",
-            StdTensorOp::Sqrt => "Sqrt",
-            StdTensorOp::Rsqrt => "Rsqrt",
-            StdTensorOp::Expm1 => "Expm1",
-            StdTensorOp::Log1p => "Log1p",
-            _ => "Other",
-        }
-    }
-
-    fn op_kind_histogram(graph: &Graph<StdTensorOp>) -> BTreeMap<&'static str, usize> {
-        let mut counts = BTreeMap::new();
-        for op in graph.operations() {
-            *counts.entry(op_kind_name(&op.operation)).or_insert(0) += 1;
-        }
-        counts
-    }
-
-    fn assert_no_analytic_constant_shortcuts(graph: &computegraph::graph::Graph<StdTensorOp>) {
-        for op in graph.operations() {
-            assert!(
-                !matches!(
-                    op.operation,
-                    StdTensorOp::Exp
-                        | StdTensorOp::Log
-                        | StdTensorOp::Sin
-                        | StdTensorOp::Cos
-                        | StdTensorOp::Tanh
-                        | StdTensorOp::Sqrt
-                        | StdTensorOp::Rsqrt
-                        | StdTensorOp::Expm1
-                        | StdTensorOp::Log1p
-                ),
-                "constant and identity rule helpers must use semantic constant emission, not analytic shortcuts; saw {:?}",
-                op.operation
-            );
-        }
-    }
-
-    #[test]
-    fn one_like_fixed_uses_semantic_constant_not_analytic_shortcut() {
-        let mut builder = GraphBuilder::<StdTensorOp>::new();
-        let anchor = builder.add_input(TensorInputKey::User { id: 2 });
-
-        let one = one_like_fixed(&mut builder, DType::F64, ValueRef::Local(anchor), 2);
-        let graph = builder.build();
-
-        assert!(graph.values()[one].producer.is_some());
-        assert_no_analytic_constant_shortcuts(&graph);
-        assert_eq!(
-            op_kind_histogram(&graph),
-            BTreeMap::from([("BroadcastInDim", 1), ("Constant", 1)])
-        );
-    }
-
-    #[test]
-    fn identity_matrix_fixed_uses_semantic_constant_not_analytic_shortcut() {
-        let mut builder = GraphBuilder::<StdTensorOp>::new();
-        let anchor = builder.add_input(TensorInputKey::User { id: 1 });
-
-        let identity =
-            identity_matrix_fixed(&mut builder, DType::F64, 2, &[], ValueRef::Local(anchor));
-        let graph = builder.build();
-
-        assert!(graph.values()[identity].producer.is_some());
-        assert_no_analytic_constant_shortcuts(&graph);
-        assert_eq!(
-            op_kind_histogram(&graph),
-            BTreeMap::from([("BroadcastInDim", 1), ("Constant", 1), ("EmbedDiag", 1)])
-        );
-    }
-
-    #[test]
-    fn symbolic_leading_selector_broadcasts_scalar_constants_once() {
-        let mut builder = GraphBuilder::<StdTensorOp>::new();
-        let anchor = builder.add_input(TensorInputKey::User { id: 3 });
-
-        let selector = leading_column_selector_symbolic(
-            &mut builder,
-            DType::F64,
-            DimExpr::InputDim {
-                input_idx: 0,
-                axis: 1,
-            },
-            DimExpr::InputDim {
-                input_idx: 0,
-                axis: 0,
-            },
-            &[],
-            ValueRef::Local(anchor),
-        );
-        let graph = builder.build();
-
-        assert!(graph.values()[selector].producer.is_some());
-        assert_eq!(
-            op_kind_histogram(&graph).get("BroadcastInDim"),
-            Some(&2),
-            "selector constants must remain scalar until their one required broadcast"
-        );
-    }
-}
+mod tests;

--- a/crates/tenferro-linalg/src/ad/rules/support/tests.rs
+++ b/crates/tenferro-linalg/src/ad/rules/support/tests.rs
@@ -1,0 +1,146 @@
+use std::collections::BTreeMap;
+
+use computegraph::graph::{Graph, GraphBuilder};
+use computegraph::types::ValueRef;
+use tenferro_ops::dim_expr::DimExpr;
+use tenferro_ops::input_key::TensorInputKey;
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_tensor::DType;
+
+use super::{
+    broadcast_scalar_constant_with_dtype, identity_matrix_fixed, leading_column_selector_symbolic,
+    one_like_fixed,
+};
+
+fn op_kind_name(op: &StdTensorOp) -> &'static str {
+    match op {
+        StdTensorOp::Constant { .. } => "Constant",
+        StdTensorOp::BroadcastInDim { .. } => "BroadcastInDim",
+        StdTensorOp::EmbedDiag { .. } => "EmbedDiag",
+        StdTensorOp::Exp => "Exp",
+        StdTensorOp::Log => "Log",
+        StdTensorOp::Sin => "Sin",
+        StdTensorOp::Cos => "Cos",
+        StdTensorOp::Tanh => "Tanh",
+        StdTensorOp::Sqrt => "Sqrt",
+        StdTensorOp::Rsqrt => "Rsqrt",
+        StdTensorOp::Expm1 => "Expm1",
+        StdTensorOp::Log1p => "Log1p",
+        _ => "Other",
+    }
+}
+
+fn op_kind_histogram(graph: &Graph<StdTensorOp>) -> BTreeMap<&'static str, usize> {
+    let mut counts = BTreeMap::new();
+    for op in graph.operations() {
+        *counts.entry(op_kind_name(&op.operation)).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn assert_no_analytic_constant_shortcuts(graph: &computegraph::graph::Graph<StdTensorOp>) {
+    for op in graph.operations() {
+        assert!(
+            !matches!(
+                op.operation,
+                StdTensorOp::Exp
+                    | StdTensorOp::Log
+                    | StdTensorOp::Sin
+                    | StdTensorOp::Cos
+                    | StdTensorOp::Tanh
+                    | StdTensorOp::Sqrt
+                    | StdTensorOp::Rsqrt
+                    | StdTensorOp::Expm1
+                    | StdTensorOp::Log1p
+            ),
+            "constant and identity rule helpers must use semantic constant emission, not analytic shortcuts; saw {:?}",
+            op.operation
+        );
+    }
+}
+
+#[test]
+fn one_like_fixed_uses_semantic_constant_not_analytic_shortcut() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let anchor = builder.add_input(TensorInputKey::User { id: 2 });
+
+    let one = one_like_fixed(&mut builder, DType::F64, ValueRef::Local(anchor), 2);
+    let graph = builder.build();
+
+    assert!(graph.values()[one].producer.is_some());
+    assert_no_analytic_constant_shortcuts(&graph);
+    assert_eq!(
+        op_kind_histogram(&graph),
+        BTreeMap::from([("BroadcastInDim", 1), ("Constant", 1)])
+    );
+}
+
+#[test]
+fn identity_matrix_fixed_uses_semantic_constant_not_analytic_shortcut() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let anchor = builder.add_input(TensorInputKey::User { id: 1 });
+
+    let identity = identity_matrix_fixed(&mut builder, DType::F64, 2, &[], ValueRef::Local(anchor));
+    let graph = builder.build();
+
+    assert!(graph.values()[identity].producer.is_some());
+    assert_no_analytic_constant_shortcuts(&graph);
+    assert_eq!(
+        op_kind_histogram(&graph),
+        BTreeMap::from([("BroadcastInDim", 1), ("Constant", 1), ("EmbedDiag", 1)])
+    );
+}
+
+#[test]
+fn symbolic_leading_selector_broadcasts_scalar_constants_once() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let anchor = builder.add_input(TensorInputKey::User { id: 3 });
+
+    let selector = leading_column_selector_symbolic(
+        &mut builder,
+        DType::F64,
+        DimExpr::InputDim {
+            input_idx: 0,
+            axis: 1,
+        },
+        DimExpr::InputDim {
+            input_idx: 0,
+            axis: 0,
+        },
+        &[],
+        ValueRef::Local(anchor),
+    );
+    let graph = builder.build();
+
+    assert!(graph.values()[selector].producer.is_some());
+    assert_eq!(
+        op_kind_histogram(&graph).get("BroadcastInDim"),
+        Some(&2),
+        "selector constants must remain scalar until their one required broadcast"
+    );
+}
+
+#[test]
+fn scale_constant_helpers_reject_integer_and_bool_without_emitting_any_op() {
+    for dtype in [DType::I32, DType::I64, DType::Bool] {
+        let mut builder = GraphBuilder::<StdTensorOp>::new();
+        let err = broadcast_scalar_constant_with_dtype(&mut builder, 0.5, vec![], dtype, "svd")
+            .expect_err("integer/bool scale constants must be rejected");
+        assert!(
+            matches!(
+                err,
+                tenferro_ops::ad::ADRuleError::InvalidInput {
+                    rule: tenferro_ops::ad::ADRuleKind::Jvp,
+                    ..
+                }
+            ),
+            "expected InvalidInput for {dtype:?}, got {err:?}"
+        );
+        let graph = builder.build();
+        assert!(
+            graph.operations().is_empty(),
+            "rejected dtype must not publish any constant op, got {} ops for {dtype:?}",
+            graph.operations().len()
+        );
+    }
+}

--- a/crates/tenferro-linalg/src/eager_composites.rs
+++ b/crates/tenferro-linalg/src/eager_composites.rs
@@ -3,7 +3,7 @@ use tenferro_ad::{CompareDir, DType, DotGeneralConfig, EagerTensor, Error, Resul
 use tenferro_runtime::ErrorPhase;
 
 use crate::eager_ext::{eig, eigh, lu, qr, solve, svd, triangular_solve};
-use crate::validation::validate_lstsq;
+use crate::validation::{ensure_float_or_complex, validate_lstsq};
 
 pub(crate) fn slogdet(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
     let (_p, _l, u, parity) = lu(a)?;
@@ -137,15 +137,6 @@ fn scalar_real(anchor: &EagerTensor, value: f64) -> Result<EagerTensor> {
         DType::C32 => Tensor::from_vec_col_major(vec![], vec![Complex32::new(value as f32, 0.0)])?,
     };
     EagerTensor::from_tensor_in(tensor, anchor.runtime().clone())
-}
-
-fn ensure_float_or_complex(op: &'static str, dtype: DType) -> Result<()> {
-    match dtype {
-        DType::F32 | DType::F64 | DType::C32 | DType::C64 => Ok(()),
-        DType::I32 | DType::I64 | DType::Bool => Err(Error::TensorRuntime(
-            crate::error::unsupported_dtype(op, dtype),
-        )),
-    }
 }
 
 fn can_square_without_abs(dtype: DType, axes_len: usize, ord: Option<f64>) -> bool {

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -9,7 +9,7 @@ use tenferro_runtime::{
 use crate::extension::{
     validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, QrOptions, SvdOptions,
 };
-use crate::validation::validate_lstsq;
+use crate::validation::{ensure_float_or_complex, validate_lstsq};
 
 /// Linear algebra extension methods for [`TracedTensor`].
 pub trait TracedTensorLinalgExt {
@@ -51,7 +51,9 @@ pub trait TracedTensorLinalgExt {
     /// # Errors
     ///
     /// Returns `Error::Validation` when the input is not a batched matrix
-    /// (rank `>= 2`), or `Error::Extension` for graph registration failures.
+    /// (rank `>= 2`), `Error::Extension` with `ErrorKind::Unsupported` for
+    /// integer or boolean dtypes, or `Error::Extension` for graph
+    /// registration failures.
     ///
     /// # Deferred errors
     ///
@@ -521,6 +523,7 @@ pub fn svd_with_options(
     options: SvdOptions,
 ) -> Result<(TracedTensor, TracedTensor, TracedTensor)> {
     validate_derivative_eps("svd_with_options", options.derivative_eps)?;
+    ensure_float_or_complex("svd", a.dtype)?;
     three_outputs(
         apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::Svd {
@@ -557,8 +560,9 @@ pub fn svd_with_options(
 /// # Errors
 ///
 /// Returns `Error::Validation` when the input is not a batched matrix
-/// (rank `>= 2`), or `Error::RuntimeState` when extension registration is
-/// unavailable.
+/// (rank `>= 2`) or `Error::Extension` with `ErrorKind::Unsupported` for
+/// integer or boolean dtypes; `Error::RuntimeState` when extension
+/// registration is unavailable.
 ///
 /// # Deferred errors
 ///
@@ -568,6 +572,7 @@ pub fn svd_with_options(
 /// intentionally unsupported for the full variant (see the linalg AD support
 /// manifest) and surfaces a typed AD error, not a silent thin-SVD fallback.
 pub fn svd_full(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor, TracedTensor)> {
+    ensure_float_or_complex("svd_full", a.dtype)?;
     three_outputs(
         apply(Arc::new(LinalgExtensionOp::new(LinalgOp::SvdFull)), &[a])?,
         "svd_full",
@@ -632,6 +637,7 @@ pub fn qr_with_options(
     a: &TracedTensor,
     options: QrOptions,
 ) -> Result<(TracedTensor, TracedTensor)> {
+    ensure_float_or_complex("qr", a.dtype)?;
     two_outputs(
         apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::Qr {
@@ -710,6 +716,7 @@ pub fn eigh_with_options(
     options: EighOptions,
 ) -> Result<(TracedTensor, TracedTensor)> {
     validate_derivative_eps("eigh_with_options", options.derivative_eps)?;
+    ensure_float_or_complex("eigh", a.dtype)?;
     two_outputs(
         apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::Eigh {
@@ -746,6 +753,7 @@ pub fn eigh_with_options(
 /// Symbolic square-shape constraints can fail later as
 /// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn cholesky(a: &TracedTensor) -> Result<TracedTensor> {
+    ensure_float_or_complex("cholesky", a.dtype)?;
     one_output(
         apply(Arc::new(LinalgExtensionOp::new(LinalgOp::Cholesky)), &[a])?,
         "cholesky",
@@ -1225,6 +1233,7 @@ pub fn inv(a: &TracedTensor) -> Result<TracedTensor> {
 /// Symbolic square-shape constraints can fail later as
 /// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn eigvalsh(a: &TracedTensor) -> Result<TracedTensor> {
+    ensure_float_or_complex("eigvalsh", a.dtype)?;
     eigh_values(a)
 }
 
@@ -1529,15 +1538,6 @@ fn real_values_dtype(dtype: DType) -> DType {
         DType::C64 => DType::F64,
         DType::C32 => DType::F32,
         other => other,
-    }
-}
-
-fn ensure_float_or_complex(op: &'static str, dtype: DType) -> Result<()> {
-    match dtype {
-        DType::F32 | DType::F64 | DType::C32 | DType::C64 => Ok(()),
-        DType::I32 | DType::I64 | DType::Bool => Err(Error::TensorRuntime(
-            crate::error::unsupported_dtype(op, dtype),
-        )),
     }
 }
 

--- a/crates/tenferro-linalg/src/validation.rs
+++ b/crates/tenferro-linalg/src/validation.rs
@@ -21,7 +21,7 @@ pub(crate) fn validate_lstsq(
     Ok(())
 }
 
-fn ensure_float_or_complex(op: &'static str, dtype: DType) -> Result<()> {
+pub(crate) fn ensure_float_or_complex(op: &'static str, dtype: DType) -> Result<()> {
     match dtype {
         DType::F32 | DType::F64 | DType::C32 | DType::C64 => Ok(()),
         DType::I32 | DType::I64 | DType::Bool => Err(Error::TensorRuntime(

--- a/crates/tenferro-linalg/tests/integration/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/integration/traced_extension.rs
@@ -509,3 +509,39 @@ fn traced_pinv_rejects_integer_and_bool_dtypes_before_scalar_rounding() {
         );
     }
 }
+
+fn assert_unsupported_dtype_at_construction(
+    result: tenferro_runtime::Result<()>,
+    op: &'static str,
+    dtype: DType,
+) {
+    let err = match result {
+        Ok(()) => panic!("expected unsupported dtype error for {op} {dtype:?}"),
+        Err(err) => err,
+    };
+    assert!(
+        matches!(
+            err,
+            Error::TensorRuntime(TensorError::Extension {
+                op: found_op,
+                family: tenferro_linalg::LINALG_EXTENSION_FAMILY_ID,
+                kind: tenferro_tensor::ErrorKind::Unsupported,
+                ..
+            }) if found_op == op
+        ),
+        "expected unsupported dtype error for {op} {dtype:?}, got {err:?}"
+    );
+}
+
+#[test]
+fn traced_svd_eigh_qr_cholesky_reject_integer_and_bool_dtypes_at_construction() {
+    for dtype in [DType::I32, DType::I64, DType::Bool] {
+        let tensor = traced_with_dtype(dtype, vec![2, 2]);
+        assert_unsupported_dtype_at_construction(tensor.svd().map(|_| ()), "svd", dtype);
+        assert_unsupported_dtype_at_construction(tensor.svd_full().map(|_| ()), "svd_full", dtype);
+        assert_unsupported_dtype_at_construction(tensor.eigh().map(|_| ()), "eigh", dtype);
+        assert_unsupported_dtype_at_construction(tensor.eigvalsh().map(|_| ()), "eigvalsh", dtype);
+        assert_unsupported_dtype_at_construction(tensor.qr().map(|_| ()), "qr", dtype);
+        assert_unsupported_dtype_at_construction(tensor.cholesky().map(|_| ()), "cholesky", dtype);
+    }
+}

--- a/docs/worklogs/2026-08-10-linalg-ad-dtype-and-pool-fill.md
+++ b/docs/worklogs/2026-08-10-linalg-ad-dtype-and-pool-fill.md
@@ -1,0 +1,86 @@
+# Work log: linalg AD dtype boundary (#1649) and pooled full-overwrite fill (#1640)
+
+Session summary for the combined bug-fix batch. Both findings were filed by
+`tensor4all-ai-bot`; both were verified against current `main`
+(`1458b509efa87f6810dc15b73cc3ec9afcd12b19`) before implementation.
+
+## Context read
+
+- `crates/tenferro-linalg/src/ad/rules/support.rs` — `broadcast_scalar_constant_with_dtype`,
+  `fixed_scale_with_dtype`, `linear_scale_with_dtype`, `self_adjoint_from_lower_linear`.
+- `crates/tenferro-linalg/src/ad/rules/mod.rs` — `linearize_svd`, `linearize_svd_values`,
+  `linearize_eigh`, `linearize_eigh_values`, `linearize_cholesky`, `linearize_qr`, and the
+  existing `invalid_dim_expr` / `LINALG_AD_OP_PREFIX` error conventions.
+- `crates/tenferro-linalg/src/validation.rs` / `src/traced.rs` / `src/eager_composites.rs` —
+  duplicate `ensure_float_or_complex` helpers; traced decomposition constructors and their
+  rustdoc; `eigvalsh -> eigh_values` and `norm -> svd_values` reachability.
+- `crates/tenferro-cpu/src/structural.rs` — `filled_tensor_from_pool`, `zeroed_tensor_from_pool`,
+  `embed_diagonal` Bool path, `typed_embed_diagonal_with_pool`.
+- `crates/tenferro-internal-cpu-kernels/src/pooled_uninit_output.rs` and `buffer_pool.rs` —
+  `PooledUninitOutput` full-overwrite guard contract and drop safety.
+- `crates/tenferro-cpu/src/provider.rs`, `dot_runtime.rs`, `exec_session.rs` — provider
+  requests expose initialized `TensorWrite` only (no uninit destination variant).
+- Issues #1649, #1640, and the accepted repair boundary in the #1649 design-audit comment.
+- REPOSITORY_RULES.md (dtype-aware AD seeds, full-overwrite buffer contract, AD Rule
+  Coverage, invariant markers, module-local test placement).
+
+## Decisions
+
+### #1649 — linalg AD constant dtype
+
+- The reported F64 constant for I32/I64/Bool in `broadcast_scalar_constant_with_dtype` is
+  real but the conversion-based suggestion (round factor) was rejected: rounding `0.5` or
+  `eps^2` would invent integer/bool derivative semantics. Integer/bool SVD/Eigh/QR/Cholesky
+  are unsupported by the primal backends; the correct repair is to reject them.
+- **Boundary validation**: add `ensure_float_or_complex(op, dtype)` to the traced
+  constructors `svd_with_options` (covers `svd`), `svd_full`, `eigh_with_options` (covers
+  `eigh`), `qr_with_options` (covers `qr`), `cholesky`, and `eigvalsh` (its `eigh_values`
+  route bypasses `eigh_with_options`). `svd_values` needs no guard (only reachable via the
+  already-guarded `norm`). `eig`/`lu`/`solve`/`triangular_solve` are intentionally not
+  touched: out of the accepted boundary, `eig` already guards AD, and existing
+  metadata-promotion tests rely on integer `solve`/`triangular_solve` construction.
+- **Defensive AD invariant**: the scale/constant helper chain becomes fallible and rejects
+  I32/I64/Bool with `ADRuleError::invalid_input("tenferro-linalg.{op}", Jvp, ...)` before
+  any constant op is emitted, so an F64 derivative constant is never published. `op` is
+  threaded as `&'static str` using the rule function names (`linearize_svd`, ...) to match
+  the existing `invalid_dim_expr` convention.
+- **DRY**: consolidate the three identical `ensure_float_or_complex` copies
+  (`validation.rs`, `traced.rs`, `eager_composites.rs`) into the shared
+  `crate::validation::ensure_float_or_complex` (made `pub(crate)`).
+- **Coverage policy**: the new integer/bool rejection arm is an intentional defensive arm on
+  a linalg AD file that already carries below-default thresholds (per the AD Rule Coverage
+  section). No threshold changes and no line-padding.
+
+### #1640 — pooled full-overwrite fill
+
+- `filled_tensor_from_pool` is the root finding: it zero-initialized the pooled buffer and
+  then fully overwrote it. Replaced with a single pass through
+  `PooledUninitOutput::<T>::new` + `as_uninit_slice_mut().fill(MaybeUninit::new(fill))` +
+  `assume_init()`, preserving the operation-specific shape-product error attribution. The
+  armed uninit token is safely discarded on error/unwind by `PooledUninitOutput::Drop`.
+  `PoolScalar` already implies `Copy + TensorScalar`, so the bounds simplify.
+- **Deferred (follow-up issue, not this PR)**: `dot_runtime.rs` canonical-operand
+  allocation and `exec_session.rs` dot-output allocation also zero-fill before full
+  overwrite, but converting them requires an uninit destination variant across the
+  `CpuLayoutTransformRequest` / `CpuDotGeneralRequest` provider contracts (all provider
+  implementations plus test providers), and zero-K GEMM with `beta = 0` has distinct
+  overwrite semantics. This is a provider-contract change, deliberately out of bug-fix
+  scope.
+
+## Verification
+
+- Design reviewed by independent gpt-review before implementation; findings incorporated
+  (`eigvalsh` boundary, no-constant-published assertion, source-contract regression for the
+  full-overwrite contract, svd_full rustdoc, module-local test placement, eager helper
+  dedup).
+- Post-implementation: gpt-review of the full diff; `cargo fmt`, focused tests for
+  tenferro-linalg and tenferro-cpu, clippy, and the repository-required
+  `check-pr-fast.sh` gate.
+
+## Residual risks / follow-ups
+
+- Integer/bool dtype rejection at trace time is not yet applied to `eig`/`lu`/
+  `full_piv_lu`/`solve`/`triangular_solve`; those still fail at backend execution. A
+  follow-up could extend the same boundary for consistency (accepted boundary deliberately
+  limited the scope to SVD/Eigh/QR/Cholesky).
+- Provider-contract uninit GEMM/layout-transform outputs remain as a separate issue.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] Refactor / cleanup (dedup + perf, both tied to bug fixes)

## Related issue

Fixes #1649
Fixes #1640

## Summary

Two verified ai-bot bug reports, fixed in two coherent commits:

**#1649 — linalg AD seed constant dtype.** `broadcast_scalar_constant_with_dtype`
(`crates/tenferro-linalg/src/ad/rules/support.rs`) emitted an F64 constant for
I32/I64/Bool inputs, which then multiplied against the integer/bool input and
produced a dtype-mismatch derivative graph. Integer/bool SVD/Eigh/QR/Cholesky
are unsupported by the primal backends, so the conversion-based suggestion
(rounding coefficients) was rejected: it would invent integer/bool derivative
semantics. Repair per the accepted boundary in #1649:

- Validate float/complex dtype at the traced `svd`/`svd_full`/`eigh`/`qr`/
  `cholesky`/`eigvalsh` construction boundary (`ensure_float_or_complex`,
  consolidated from three identical copies in `validation.rs`, `traced.rs`, and
  `eager_composites.rs`).
- Make the AD scale/constant helper chain fallible and reject I32/I64/Bool with
  a typed `ADRuleError::invalid_input` **before** emitting any constant op, so
  an F64 derivative constant is never published; propagated through all 11
  call sites in the svd/eigh/cholesky/qr linearize rules.
- Preserve F32/F64/C32/C64 behavior and coefficient dtype exactly. No new
  public API, no backend change.

**#1640 — pooled full-overwrite double pass.** `filled_tensor_from_pool`
(`crates/tenferro-cpu/src/structural.rs`) acquired a zeroed pooled buffer and
then overwrote every element, wasting a full pass on the structural hot path.
Now fills the pooled full-overwrite destination exactly once through
`PooledUninitOutput`, keeping operation-specific shape-product error
attribution and recording the fill-before-handoff invariant
(`// INVARIANT:` + `// SAFETY:`).

## Same-root-cause search

- #1649: all callers of `broadcast_scalar_constant_with_dtype` /
  `fixed_scale_with_dtype` / `linear_scale_with_dtype` /
  `self_adjoint_from_lower_linear` updated in the same commit; the duplicate
  `ensure_float_or_complex` helpers in `traced.rs` and `eager_composites.rs`
  removed. `eig`/`lu`/`solve`/`triangular_solve` traced constructors were
  intentionally not extended (out of the accepted boundary; `eig` already
  guards its AD rules; existing dtype-promotion tests depend on integer
  `solve`/`triangular_solve` construction). Residual follow-up noted in the
  work log.
- #1640: `dot_runtime.rs` canonical-operand and `exec_session.rs` dot-output
  allocations also zero-fill before full overwrite, but converting them
  requires an uninit destination variant across the provider request contracts
  (`CpuLayoutTransformRequest` / `CpuDotGeneralRequest` take initialized
  `TensorWrite`), plus care for zero-K GEMM `beta*out` semantics. Deferred to a
  follow-up issue rather than stretching this bug-fix PR.

## Tests

- `cargo test -p tenferro-linalg --features autodiff --test integration` (199) and `--lib` (163): pass, including the finite-difference sweep and the AD support manifest.
- `cargo test -p tenferro-cpu --lib` (511) and `--test integration` (46): pass.
- New regression tests: construction-boundary rejection for I32/I64/Bool ×
  svd/svd_full/eigh/eigvalsh/qr/cholesky; no-op-emission defensive unit test;
  strengthened `cpu_zero_fill_pooled_outputs_use_checked_shape_product`
  source-contract test.
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-cpu cpu_zero_fill_pooled_outputs_use_checked_shape_product'`: passed (fmt + clippy + focused test).
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --dry-run --llm-skipped-reason "local deterministic review"`: pass.
- GPU/linalg CUDA paths not run locally (no hardware); the changes do not touch
  GPU code and CPU-only behavior is covered above.

## Work log

[docs/worklogs/2026-08-10-linalg-ad-dtype-and-pool-fill.md](docs/worklogs/2026-08-10-linalg-ad-dtype-and-pool-fill.md)
(design decisions, rejected alternatives, deferred follow-ups).

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules review (deterministic; the external LLM review is permanently disabled) and resolved or documented its findings.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md` (and the remediation workflow for the batch).
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.

Base: `main` @ `1458b509efa87f6810dc15b73cc3ec9afcd12b19` (branch `fix/1649-1640-ai-bot-batch`, 2 coherent commits, non-squash merge).
