### PR TITLE
perf(cpu): skip Rayon pool entry for compact to_contiguous_read

### DIFF
--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -330,6 +330,13 @@ impl TensorAnalytic for CpuExecSession<'_> {
 impl TensorStructural for CpuExecSession<'_> {
     // Structural
     fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
+        // INVARIANT: compact tensors need no kernel and no engine entry; the
+        // Arc clone is the only work, so it must not pay the multi-thread pool
+        // entry cost (O(us) on a 4-thread pool). Views still go through the
+        // entry path because they may materialize via strided kernels.
+        if matches!(input, TensorRead::Tensor(_)) {
+            return materialize_tensor_read(self.buffers, "CpuBackend::to_contiguous_read", input);
+        }
         self.run_native_fresh(|buffers| {
             materialize_tensor_read(buffers, "CpuBackend::to_contiguous_read", input)
         })


### PR DESCRIPTION
## Summary

`CpuExecSession::to_contiguous_read` routed every call through the native execution entry (Rayon pool install on the BLAS provider) even when the input is already a compact tensor whose only work is an `Arc` clone. On a 4-thread pool the entry costs O(us), which dominates small eager linalg dispatch. This is the root cause of the remaining eager linalg gap reported in #1628.

Compact `TensorRead::Tensor` inputs now clone directly without entering the pool; views still go through the entry path because they may materialize via strided kernels.

## Measured effect

macOS (M5 Max, `system-accelerate`, 4 threads, eager 2x2):

| op | before | after | PyTorch |
|---|---:|---:|---:|
| svd | 14.2 us | **3.3 us** | 3.7 us |
| solve | 42.2 us | **5.5 us** | 5.3 us |
| eigh | 8.4 us | **2.1 us** | 2.7 us |

`solve` improved most because `LuSolvePrepared` calls `to_contiguous_read` once per input (4 inputs), each paying the pool entry.

## Verification

- `cargo test -p tenferro-cpu --lib`: 502 passed
- `cargo test -p tenferro-linalg --lib`: 156 passed
- `cargo test -p tenferro-einsum --lib`: 123 passed
- `cargo test -p tenferro-ad --lib`: 80 passed
- `cargo test -p tenferro-runtime --lib`: 400 passed
- `cargo fmt --all --check`: clean

Refs #1628
