### PR TITLE
perf(cpu): skip engine entry for compact reshape

### DIFF
--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -2992,19 +2992,21 @@ impl TensorStructural for CpuBackend {
     }
 
     fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
-        self.try_install(|| structural::reshape(input, shape))
+        // INVARIANT: typed_reshape performs a serial host copy (to_vec); no
+        // parallel kernel runs, so the engine entry is pure overhead on
+        // multi-thread pools.
+        structural::reshape(input, shape)
     }
 
     fn reshape_read(&mut self, input: TensorRead<'_>, shape: &[usize]) -> crate::Result<Tensor> {
-        let materializes = matches!(&input, TensorRead::View(_));
-        if materializes {
-            self.install_with_pool(|buffers| {
+        match &input {
+            // INVARIANT: compact inputs take the serial host-copy path, so
+            // they must not pay the engine entry; views may materialize via
+            // strided kernels and keep the entry.
+            TensorRead::Tensor(tensor) => structural::reshape(tensor, shape),
+            TensorRead::View(_) => self.install_with_pool(|buffers| {
                 structural::reshape_read_with_pool(buffers, input, shape)
-            })
-        } else {
-            self.install_with_pool_unmarked(|buffers| {
-                structural::reshape_read_with_pool(buffers, input, shape)
-            })
+            }),
         }
     }
 

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -330,6 +330,13 @@ impl TensorAnalytic for CpuExecSession<'_> {
 impl TensorStructural for CpuExecSession<'_> {
     // Structural
     fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
+        // INVARIANT: compact tensors need no kernel and no engine entry; the
+        // Arc clone is the only work, so it must not pay the multi-thread pool
+        // entry cost (O(us) on a 4-thread pool). Views still go through the
+        // entry path because they may materialize via strided kernels.
+        if matches!(input, TensorRead::Tensor(_)) {
+            return materialize_tensor_read(self.buffers, "CpuBackend::to_contiguous_read", input);
+        }
         self.run_native_fresh(|buffers| {
             materialize_tensor_read(buffers, "CpuBackend::to_contiguous_read", input)
         })

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -352,17 +352,21 @@ impl TensorStructural for CpuExecSession<'_> {
     }
 
     fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
-        self.run_native(|_| structural::reshape(input, shape))
+        // INVARIANT: typed_reshape performs a serial host copy (to_vec); no
+        // parallel kernel runs, so the engine entry is pure overhead on
+        // multi-thread pools.
+        structural::reshape(input, shape)
     }
 
     fn reshape_read(&mut self, input: TensorRead<'_>, shape: &[usize]) -> crate::Result<Tensor> {
-        let materializes = matches!(&input, TensorRead::View(_));
-        if materializes {
-            self.run_native_fresh(|buffers| {
+        match &input {
+            // INVARIANT: compact inputs take the serial host-copy path, so
+            // they must not pay the engine entry; views may materialize via
+            // strided kernels and keep the entry.
+            TensorRead::Tensor(tensor) => structural::reshape(tensor, shape),
+            TensorRead::View(_) => self.run_native_fresh(|buffers| {
                 structural::reshape_read_with_pool(buffers, input, shape)
-            })
-        } else {
-            self.run_native(|buffers| structural::reshape_read_with_pool(buffers, input, shape))
+            }),
         }
     }
 

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -789,6 +789,10 @@ pub fn typed_reshape<T: Clone + TensorScalar + 'static>(
     // INVARIANT: `typed_reshape` returns an independently owned tensor while
     // the borrowed input remains live; sharing its move-only root would violate
     // the single-owner contract, so this explicit host duplicate is required.
+    // TODO(perf): for large tensors, consider a parallel host copy (strided
+    // kernel / Rayon par-chunks) instead of the serial to_vec(); if a parallel
+    // path lands, revisit whether the entry-skip fast paths in backend.rs /
+    // exec_session.rs should pay the engine entry for large inputs.
     let mut output = TypedTensor::from_vec_col_major(shape.to_vec(), tensor.host_data()?.to_vec())?;
     output.set_placement(tensor.placement().clone());
     Ok(output)


### PR DESCRIPTION
## Summary

Follow-up to #1662 (`to_contiguous_read`). `CpuBackend::reshape` / `CpuExecSession::reshape` routed compact `Tensor` inputs through the engine entry (Rayon pool install on the BLAS provider) even though `typed_reshape` only performs a serial host copy (`to_vec`) with no parallel kernel. On a 4-thread pool the entry costs ~9 us, dominating small reshapes used inside eager einsum/AD dispatch.

Compact `TensorRead::Tensor` inputs now call `structural::reshape` directly; views keep the entry path because they may materialize via strided kernels.

`typed_reshape` also gains a TODO for a future parallel host copy for large tensors (strided kernel / Rayon par-chunks).

## Measured effect

macOS (M5 Max, system-accelerate, 4 threads, v0.2.0-parity probe since the benchmark repo does not yet track v0.3.0):

| op | before | after |
|---|---:|---:|
| `CpuBackend::reshape` 2x2 | 8.8 us | **0.1 us** |

## Verification

- `cargo test -p tenferro-cpu --lib`: 502 passed
- `cargo test -p tenferro-linalg --lib`: 156 passed
- `cargo test -p tenferro-einsum --lib`: 123 passed
- `cargo fmt --all --check`: clean

Refs #1628