### PR TITLE
perf(cpu): skip uncontended arbiter broadcast + document session-open cost (#1667)

### DIFF
--- a/crates/tenferro-ad/benches/eager_dispatch_baseline.rs
+++ b/crates/tenferro-ad/benches/eager_dispatch_baseline.rs
@@ -1,3 +1,10 @@
+//! Eager standard-op dispatch baseline (lazy vs materialized consume).
+//!
+//! The per-op floor includes the CPU session-open cost that issue #1667 tracks:
+//! for a single worker the `enter_managed_session` wrapper (~5-8 us) plus the
+//! eager view-read materialization are currently hard to avoid. See
+//! docs/design/cpu-session-open-cost.md.
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -397,23 +397,24 @@ impl ResourceArbiter {
         expected: usize,
         timeout: std::time::Duration,
     ) -> bool {
-        let Ok(mut state) = self.inner.state.lock() else {
-            return false;
-        };
+        // Poll instead of waiting on the production condvar: the acquire
+        // fast path legitimately skips the broadcast when a waiter is the
+        // only one, so a helper without a waiter-list entry would otherwise
+        // wait the full timeout.
         let deadline = std::time::Instant::now() + timeout;
-        while state.waiters.len() < expected {
-            let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
-                return false;
+        loop {
+            let count = match self.inner.state.lock() {
+                Ok(state) => state.waiters.len(),
+                Err(_) => return false,
             };
-            let Ok((next, wait)) = self.inner.changed.wait_timeout(state, remaining) else {
-                return false;
-            };
-            state = next;
-            if wait.timed_out() && state.waiters.len() < expected {
+            if count >= expected {
+                return true;
+            }
+            if std::time::Instant::now() >= deadline {
                 return false;
             }
+            std::thread::sleep(std::time::Duration::from_millis(5));
         }
-        true
     }
 
     #[cfg(test)]
@@ -461,9 +462,11 @@ impl Drop for ResourcePermit {
         if let Some(position) = state.active.iter().position(|active| active.id == self.id) {
             state.active.swap_remove(position);
         }
-        // Only broadcast when a waiter could be released; with none waiting the
-        // futex wake is pure overhead on the hot drop path.
-        if !state.waiters.is_empty() {
+        // Broadcast when a queued waiter could be released, or when the request
+        // id is exhausted: the exhaustion-recovery loop parks on the condvar
+        // WITHOUT a waiter-list entry until active and waiters are both empty,
+        // so dropping the last active permit must still wake it (issue #1667).
+        if !state.waiters.is_empty() || state.next_request_id == u64::MAX {
             self.inner.changed.notify_all();
         }
     }

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -301,7 +301,12 @@ impl ResourceArbiter {
             .checked_add(1)
             .ok_or(ResourceArbiterError::RequestIdExhausted)?;
         state.waiters.push_back(Waiter { id, request, owner });
-        self.inner.changed.notify_all();
+        // Skip the broadcast when we are the only waiter: no other thread is
+        // blocked on this arbiter's condvar, so the futex wake is pure overhead.
+        // The grant/release paths still notify when there is someone to wake.
+        if state.waiters.len() > 1 {
+            self.inner.changed.notify_all();
+        }
 
         loop {
             let Some(position) = state.waiters.iter().position(|waiter| waiter.id == id) else {
@@ -456,7 +461,11 @@ impl Drop for ResourcePermit {
         if let Some(position) = state.active.iter().position(|active| active.id == self.id) {
             state.active.swap_remove(position);
         }
-        self.inner.changed.notify_all();
+        // Only broadcast when a waiter could be released; with none waiting the
+        // futex wake is pure overhead on the hot drop path.
+        if !state.waiters.is_empty() {
+            self.inner.changed.notify_all();
+        }
     }
 }
 

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -462,13 +462,11 @@ impl Drop for ResourcePermit {
         if let Some(position) = state.active.iter().position(|active| active.id == self.id) {
             state.active.swap_remove(position);
         }
-        // Broadcast when a queued waiter could be released, or when the request
-        // id is exhausted: the exhaustion-recovery loop parks on the condvar
-        // WITHOUT a waiter-list entry until active and waiters are both empty,
-        // so dropping the last active permit must still wake it (issue #1667).
-        if !state.waiters.is_empty() || state.next_request_id == u64::MAX {
-            self.inner.changed.notify_all();
-        }
+        // Always broadcast: the request-id-exhaustion recovery loop parks on
+        // the condvar WITHOUT a waiter-list entry (until active and waiters
+        // are both empty), so the waiter list cannot tell whether a thread is
+        // parked. Skipping here would risk stranding that recovery waiter.
+        self.inner.changed.notify_all();
     }
 }
 

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -200,6 +200,8 @@ struct ArbiterState {
 struct ArbiterInner {
     state: Mutex<ArbiterState>,
     changed: Condvar,
+    #[cfg(test)]
+    recovery_waiters: std::sync::atomic::AtomicUsize,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -267,6 +269,10 @@ impl ResourceArbiter {
                     self.inner.state.clear_poison();
                 }
                 Err(ResourceArbiterError::RequestIdExhausted) => {
+                    #[cfg(test)]
+                    self.inner
+                        .recovery_waiters
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     let mut state = self
                         .inner
                         .state
@@ -279,6 +285,10 @@ impl ResourceArbiter {
                             .wait(state)
                             .unwrap_or_else(std::sync::PoisonError::into_inner);
                     }
+                    #[cfg(test)]
+                    self.inner
+                        .recovery_waiters
+                        .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
                     state.next_request_id = 0;
                 }
             }
@@ -301,9 +311,10 @@ impl ResourceArbiter {
             .checked_add(1)
             .ok_or(ResourceArbiterError::RequestIdExhausted)?;
         state.waiters.push_back(Waiter { id, request, owner });
-        // Skip the broadcast when we are the only waiter: no other thread is
-        // blocked on this arbiter's condvar, so the futex wake is pure overhead.
-        // The grant/release paths still notify when there is someone to wake.
+        // Skip the broadcast when we are the only queued waiter: no other
+        // queued waiter can be blocked on the condvar. (Exhaustion-recovery
+        // waiters are intentionally uncovered here; the unconditional drop
+        // broadcast below wakes them.)
         if state.waiters.len() > 1 {
             self.inner.changed.notify_all();
         }

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -269,26 +269,30 @@ impl ResourceArbiter {
                     self.inner.state.clear_poison();
                 }
                 Err(ResourceArbiterError::RequestIdExhausted) => {
-                    #[cfg(test)]
-                    self.inner
-                        .recovery_waiters
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     let mut state = self
                         .inner
                         .state
                         .lock()
                         .unwrap_or_else(std::sync::PoisonError::into_inner);
                     while !state.active.is_empty() || !state.waiters.is_empty() {
+                        // Mark the park while holding the mutex, immediately
+                        // before wait releases it into the condvar: a drop can
+                        // then only notify after this thread is actually parked
+                        // (the drop cannot acquire the mutex first).
+                        #[cfg(test)]
+                        self.inner
+                            .recovery_waiters
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         state = self
                             .inner
                             .changed
                             .wait(state)
                             .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        #[cfg(test)]
+                        self.inner
+                            .recovery_waiters
+                            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
                     }
-                    #[cfg(test)]
-                    self.inner
-                        .recovery_waiters
-                        .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
                     state.next_request_id = 0;
                 }
             }

--- a/crates/tenferro-cpu/src/arbiter/tests.rs
+++ b/crates/tenferro-cpu/src/arbiter/tests.rs
@@ -127,8 +127,21 @@ fn exhaustion_recovery_waiter_wakes_when_last_active_permit_drops() {
         tx.send(()).unwrap();
         permit
     });
-    // Give the acquire thread time to hit the exhaustion-recovery park.
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    // Wait until the recovery thread has entered the exhaustion-recovery park
+    // (it parks without a waiter-list entry), then drop the last active permit.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while arbiter
+        .inner
+        .recovery_waiters
+        .load(std::sync::atomic::Ordering::Relaxed)
+        == 0
+    {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "recovery thread did not enter the exhaustion-recovery park"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
     drop(active);
     assert!(
         rx.recv_timeout(std::time::Duration::from_secs(2)).is_ok(),

--- a/crates/tenferro-cpu/src/arbiter/tests.rs
+++ b/crates/tenferro-cpu/src/arbiter/tests.rs
@@ -107,6 +107,37 @@ fn older_blocked_node_waiter_does_not_serialize_a_disjoint_node() {
 }
 
 #[test]
+fn exhaustion_recovery_waiter_wakes_when_last_active_permit_drops() {
+    // The request-id-exhaustion recovery loop parks on the condvar WITHOUT a
+    // waiter-list entry until active and waiters are both empty. Dropping the
+    // last active permit must still wake it (issue #1667 drop fast path);
+    // otherwise it sleeps forever.
+    let arbiter = Arc::new(ResourceArbiter::new());
+    let active = arbiter.acquire(cpu_set([0])).unwrap();
+    {
+        let mut state = arbiter.inner.state.lock().unwrap();
+        state.next_request_id = u64::MAX;
+    }
+    let (tx, rx) = std::sync::mpsc::channel();
+    let arbiter2 = Arc::clone(&arbiter);
+    let handle = std::thread::spawn(move || {
+        // Use the recovering path (as the backend does); the plain test
+        // helper returns RequestIdExhausted directly without recovery.
+        let permit = arbiter2.acquire_recovering(cpu_set([1]), request_owner());
+        tx.send(()).unwrap();
+        permit
+    });
+    // Give the acquire thread time to hit the exhaustion-recovery park.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    drop(active);
+    assert!(
+        rx.recv_timeout(std::time::Duration::from_secs(2)).is_ok(),
+        "exhaustion-recovery waiter was not woken by the last active drop"
+    );
+    drop(handle.join().unwrap());
+}
+
+#[test]
 fn poisoned_state_returns_a_typed_error() {
     let arbiter = ResourceArbiter::new();
     arbiter.poison_for_test();

--- a/crates/tenferro-linalg/benches/eager_extension_dispatch.rs
+++ b/crates/tenferro-linalg/benches/eager_extension_dispatch.rs
@@ -3,6 +3,14 @@
 //! This benchmark isolates the per-call eager extension execution cost that
 //! issue #1664 root-caused (SemanticProgram build + compile + run_compiled per
 //! call, or per-call module install). It is the pre/post gate for issue #1665.
+//!
+//! Remaining hard-to-avoid per-op costs (issue #1667): with a single worker
+//! (`CpuBackend::with_threads(1)`), the CPU session-open still pays the
+//! `enter_managed_session` wrapper (~5-8 us: owner/reentrancy guards + scoped-job
+//! indirection, with no Rayon pool to enter) and the eager view-read
+//! materialization inside `exec_body` (eager reads are `TensorRead::View`, so
+//! the #1662 compact-read fast path does not apply). See
+//! docs/design/cpu-session-open-cost.md for the measured breakdown.
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/docs/design/cpu-session-open-cost.md
+++ b/docs/design/cpu-session-open-cost.md
@@ -52,11 +52,13 @@ above.
 
 ## Measurement method
 
-`TENFERRO_PROFILE_CPU_SESSION=1` +
-`TENFERRO_PROFILE_CPU_SESSION_PRINT_EVERY=N` enables per-section recording in
-`run_backend_session_cached` (`setup.pre_entry`, `entry.managed_session`,
-`run.resources_lock`, `session_construct`, `exec_body`). The bench target is
-`crates/tenferro-linalg/benches/eager_extension_dispatch.rs`.
+Temporary instrumentation added sections around `run_backend_session_cached`
+(`setup.pre_entry`, `entry.managed_session`, `run.resources_lock`) alongside
+the sections the source still records (`session_construct`, `exec_body`),
+printed via `TENFERRO_PROFILE_CPU_SESSION` +
+`TENFERRO_PROFILE_CPU_SESSION_PRINT_EVERY=N`. The bench target is
+`crates/tenferro-linalg/benches/eager_extension_dispatch.rs`. Re-measure with
+the same instrumentation if the session-open cost is revisited.
 
 ## Remaining work (not in this PR)
 

--- a/docs/design/cpu-session-open-cost.md
+++ b/docs/design/cpu-session-open-cost.md
@@ -41,10 +41,12 @@ above.
    native entry. This is part of `exec_body` for linalg ops.
 
 3. **The `ResourceArbiter` is cheap (~0.5 µs) but does a futex broadcast per
-   acquire and per drop even when uncontended.** Skipping the broadcast when
-   there is no waiter is a safe micro-optimization (implemented in #1667):
-   `acquire_request` notifies only when another waiter exists, and
-   `ResourcePermit::drop` notifies only when the waiter list is non-empty.
+   acquire even when uncontended.** Skipping the broadcast on `acquire_request`
+   when the new waiter is the only one (no other thread can be blocked) is a
+   safe micro-optimization (implemented in #1667). The permit-drop broadcast is
+   kept unconditional: the request-id-exhaustion recovery loop parks without a
+   waiter-list entry, so the waiter list cannot reveal whether a thread is
+   parked, and skipping the drop broadcast would risk stranding it.
 
 4. **`exec_body` for linalg ops is the largest remaining cost** (~12 µs for a
    2x2 solve) and is dominated by the eager view-read materialization plus the

--- a/docs/design/cpu-session-open-cost.md
+++ b/docs/design/cpu-session-open-cost.md
@@ -42,11 +42,12 @@ above.
 
 3. **The `ResourceArbiter` is cheap (~0.5 µs) but does a futex broadcast per
    acquire even when uncontended.** Skipping the broadcast on `acquire_request`
-   when the new waiter is the only one (no other thread can be blocked) is a
-   safe micro-optimization (implemented in #1667). The permit-drop broadcast is
-   kept unconditional: the request-id-exhaustion recovery loop parks without a
-   waiter-list entry, so the waiter list cannot reveal whether a thread is
-   parked, and skipping the drop broadcast would risk stranding it.
+   when the new waiter is the only *queued* waiter (no other queued waiter can
+   be blocked on the condvar) is a safe micro-optimization (implemented in
+   #1667). The permit-drop broadcast is kept unconditional: the
+   request-id-exhaustion recovery loop parks without a waiter-list entry, so
+   the waiter list cannot reveal whether a thread is parked, and skipping the
+   drop broadcast would risk stranding it.
 
 4. **`exec_body` for linalg ops is the largest remaining cost** (~12 µs for a
    2x2 solve) and is dominated by the eager view-read materialization plus the

--- a/docs/design/cpu-session-open-cost.md
+++ b/docs/design/cpu-session-open-cost.md
@@ -1,0 +1,70 @@
+# CPU Session-Open Cost Structure (eager single-op dispatch)
+
+Status: measured 2026-08-13 on Linux x86-64, `CpuBackend::with_threads(1)`
+(single worker, faer), via `TENFERRO_PROFILE_CPU_SESSION` instrumentation on
+`CpuBackend::run_backend_session_cached`. Issue #1667.
+
+This note records the per-call cost of opening a CPU backend session for one
+eager op. The numbers are approximate (±30% machine noise); the *shape* of the
+cost structure is the durable finding.
+
+## Per-call breakdown (2x2 f64 solve, `no_ad`)
+
+| Component | Cost | What it is |
+|---|---:|---|
+| `setup.pre_entry` | ~0.5 µs | provider-bundle clone + execution-owner fresh + `ResourceArbiter` permit + `CpuOperationEntry` construction |
+| `entry.managed_session` | ~5–8 µs (wrapper only) | `enter_managed_session` machinery for a **single-worker** domain: double `with_execution_owner` guard, `install_scoped`/scoped-job indirection, `CpuExecutionContext::entered`. For `num_threads == 1` there is no Rayon pool, so the install itself is a no-op — only the wrapper runs |
+| `run.resources_lock` | ~0.06 µs | engine `resources` mutex |
+| `session_construct` | ~0.03 µs | `CpuExecSession` struct |
+| `exec_body` | ~11–14 µs (solve) | the actual op: `with_cpu_exec_session` downcast + `to_contiguous_read` per input + faer solve |
+
+The eager `no_ad` total for a 2x2 solve is ~40–46 µs; the eager wrapper
+(validation, reads, `finish_eager_extension_outputs`, `to_tensor()`
+materialization) accounts for the remainder beyond the session-open table
+above.
+
+## Key findings
+
+1. **The `entry.managed_session` wrapper is the single biggest reducible
+   component for single-worker backends.** With no Rayon pool to enter, its
+   `install_scoped` indirection is pure overhead. Removing it is NOT safe in
+   general: the `with_execution_owner` guards and the executor's
+   `execution_scope.enter` are load-bearing for reentrancy detection and owner
+   tracking (see `docs/design/cpu-backend-execution.md`), and a naive skip
+   showed both an allocation-profile change and inconsistent op-level
+   measurements. A safe reduction must preserve the owner/reentrancy contract
+   while dropping only the pool-entry indirection.
+
+2. **The #1662 compact-`to_contiguous_read` fast path does not apply to the
+   eager path.** Eager tensor reads are borrowed views (`TensorRead::View`),
+   so `to_contiguous_read` still materializes them through the session's
+   native entry. This is part of `exec_body` for linalg ops.
+
+3. **The `ResourceArbiter` is cheap (~0.5 µs) but does a futex broadcast per
+   acquire and per drop even when uncontended.** Skipping the broadcast when
+   there is no waiter is a safe micro-optimization (implemented in #1667):
+   `acquire_request` notifies only when another waiter exists, and
+   `ResourcePermit::drop` notifies only when the waiter list is non-empty.
+
+4. **`exec_body` for linalg ops is the largest remaining cost** (~12 µs for a
+   2x2 solve) and is dominated by the eager view-read materialization plus the
+   linalg extension dispatch, not by the faer arithmetic itself.
+
+## Measurement method
+
+`TENFERRO_PROFILE_CPU_SESSION=1` +
+`TENFERRO_PROFILE_CPU_SESSION_PRINT_EVERY=N` enables per-section recording in
+`run_backend_session_cached` (`setup.pre_entry`, `entry.managed_session`,
+`run.resources_lock`, `session_construct`, `exec_body`). The bench target is
+`crates/tenferro-linalg/benches/eager_extension_dispatch.rs`.
+
+## Remaining work (not in this PR)
+
+- A reentrancy-preserving fast path for the single-worker
+  `entry.managed_session` wrapper.
+- Applying the compact-read fast path to eager view reads (or returning
+  `TensorRead::Tensor` for already-compact eager values).
+- Reducing the linalg extension `exec_body` overhead.
+
+Related: #1667 (this issue), #1662 (compact `to_contiguous_read` fast path),
+#1628 (Mac CPU performance), #1665 (eager extension path unification).


### PR DESCRIPTION
## Summary

Reduces the eager single-op CPU session-open overhead and records the cost
structure (issue #1667).

The per-call breakdown of `CpuBackend::run_backend_session_cached` (measured
on Linux, 1 thread) is: `setup` ~0.5µs, the `enter_managed_session` wrapper
~5-8µs (single-worker domains have no Rayon pool to enter, yet still pay the
owner/reentrancy guards + scoped-job indirection), `resources`+`session`
~0.1µs, and `exec_body` ~11-14µs for a 2x2 solve (eager view-read
materialization + linalg dispatch). The eager view reads (`TensorRead::View`)
mean the #1662 compact-read fast path does not apply to the eager path.

## Changes

### `crates/tenferro-cpu/src/arbiter.rs`
- `acquire_request` broadcasts the condvar only when another *queued* waiter
  exists (`waiters.len() > 1`); the sole new waiter proceeds without waiting,
  so the futex wake is pure overhead. Exhaustion-recovery waiters (which park
  without a waiter-list entry) are intentionally not covered here.
- `ResourcePermit::drop` keeps the broadcast **unconditional**: the
  request-id-exhaustion recovery loop parks without a waiter-list entry, so
  the list cannot reveal whether a thread is parked; skipping the drop
  broadcast would risk stranding it.
- Adds a `#[cfg(test)]` recovery-waiter counter (incremented under the mutex
  immediately before the condvar wait) so the regression test deterministically
  exercises the wakeup.

### `crates/tenferro-cpu/src/arbiter/tests.rs`
- Regression test `exhaustion_recovery_waiter_wakes_when_last_active_permit_drops`
  (forces request-id exhaustion, waits for the park signal, drops the last
  active permit, verifies the recovery completes).
- The waiter-count test helper now polls instead of relying on production
  condvar notifications (which the acquire fast path legitimately skips).

### `docs/design/cpu-session-open-cost.md` (new)
- Measured cost structure of the eager session open, the single-worker wrapper
  nuance, the eager view-read gap vs #1662, and the remaining work.

### Benchmarks
- `eager_extension_dispatch` / `eager_dispatch_baseline`: document the
  hard-to-avoid per-op costs (session-open wrapper, view-read materialization).

## Verification

- `cargo test -p tenferro-cpu -p tenferro-ad -p tenferro-linalg -p tenferro-runtime` — all green (incl. arbiter + allocation-boundary tests).
- CI-parity clippy, `check-pr-fast.sh`, `repository-rules-review.py` — pass.
- reviewer-gpt (frontier gate) — PASS (production sync correct; test made deterministic).

## Remaining (documented, not in this PR)

- Reentrancy-preserving fast path for the single-worker `enter_managed_session`
  wrapper (~5-8µs).
- Applying the compact-read fast path to eager view reads (or returning
  `TensorRead::Tensor` for already-compact eager values).
- Reducing the linalg extension `exec_body` overhead (~12µs for a 2x2 solve).

Closes #1667. Related: #1662, #1628, #1665.
