### PR TITLE
perf(linalg): single-call eager solve via partial-pivot LinalgOp::Solve (#1674)

### DIFF
--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -88,6 +88,9 @@ impl LinalgAdRule {
                 transpose_a,
                 ctx,
             ),
+            LinalgOp::Solve => {
+                rules::linearize_solve(builder, primal_in, primal_out, tangent_in, false, ctx)
+            }
             LinalgOp::TriangularSolve {
                 left_side,
                 lower,
@@ -198,6 +201,17 @@ impl LinalgAdRule {
                     &value_inputs,
                     &mode,
                     transpose_a,
+                    ctx,
+                )
+            }
+            LinalgOp::Solve => {
+                let value_inputs = linear_solve_transpose_inputs("solve", inputs, active_mask)?;
+                rules::transpose_solve(
+                    &mut builder,
+                    cotangent_out,
+                    &value_inputs,
+                    &mode,
+                    false,
                     ctx,
                 )
             }

--- a/crates/tenferro-linalg/src/ad/rules/mod.rs
+++ b/crates/tenferro-linalg/src/ad/rules/mod.rs
@@ -36,9 +36,9 @@ mod solve;
 mod support;
 
 pub(crate) use solve::{
-    linearize_full_piv_lu_solve, linearize_lu_solve_prepared, linearize_triangular_solve,
-    transpose_full_piv_lu_solve, transpose_lu_solve_prepared, transpose_triangular_solve,
-    TriangularSolveFlags,
+    linearize_full_piv_lu_solve, linearize_lu_solve_prepared, linearize_solve,
+    linearize_triangular_solve, transpose_full_piv_lu_solve, transpose_lu_solve_prepared,
+    transpose_solve, transpose_triangular_solve, TriangularSolveFlags,
 };
 use support::*;
 

--- a/crates/tenferro-linalg/src/ad/rules/solve.rs
+++ b/crates/tenferro-linalg/src/ad/rules/solve.rs
@@ -96,11 +96,16 @@ pub(crate) fn linearize_triangular_solve(
 #[derive(Clone, Copy)]
 enum LinearSolveOp {
     FullPivLuSolve,
+    Solve,
 }
 
 fn linear_solve_op(kind: LinearSolveOp, transpose_a: bool) -> StdTensorOp {
     match kind {
         LinearSolveOp::FullPivLuSolve => linalg_std_op(LinalgOp::FullPivLuSolve { transpose_a }),
+        // The plain partial-pivot solve has no transpose flag; the adjoint
+        // solve transposes the matrix before the plain solve (see
+        // `transpose_linear_solve`), so `transpose_a` is always false here.
+        LinearSolveOp::Solve => linalg_std_op(LinalgOp::Solve),
     }
 }
 
@@ -232,6 +237,25 @@ pub(crate) fn linearize_full_piv_lu_solve(
     )
 }
 
+pub(crate) fn linearize_solve(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+    transpose_a: bool,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    linearize_linear_solve(
+        builder,
+        primal_in,
+        primal_out,
+        tangent_in,
+        transpose_a,
+        ctx,
+        LinearSolveOp::Solve,
+    )
+}
+
 fn invalid_input(op: &'static str, rule: ADRuleKind, message: impl Into<String>) -> ADRuleError {
     ADRuleError::invalid_input(format!("{LINALG_AD_OP_PREFIX}{op}"), rule, message)
 }
@@ -242,6 +266,7 @@ impl LinearSolveOp {
     fn op_name(self) -> &'static str {
         match self {
             LinearSolveOp::FullPivLuSolve => "full_piv_lu_solve",
+            LinearSolveOp::Solve => "solve",
         }
     }
 }
@@ -437,9 +462,20 @@ fn transpose_linear_solve(
         validate_square_matrix_input(kind.op_name(), ADRuleKind::Transpose, &inputs[0], ctx)?;
         let dtype = ctx.dtype_of(&inputs[0])?;
         let conjugated_a = conjugate_primal_if_dtype_complex(builder, inputs[0].clone(), dtype);
+        // `LinalgOp::Solve` carries no transpose flag (partial-pivot plain
+        // solve), so the adjoint solve op(A)^T y = ct is expressed as a plain
+        // solve of the transposed (and, for complex dtypes, conjugated)
+        // matrix instead of a transposed-solve op.
+        let (adjoint_a, adjoint_transpose_a) = match kind {
+            LinearSolveOp::Solve => {
+                let transposed = transpose_matrix_fixed(builder, conjugated_a, rank);
+                (ValueRef::Local(transposed), false)
+            }
+            LinearSolveOp::FullPivLuSolve => (conjugated_a, !transpose_a),
+        };
         let out = builder.add_operation(
-            linear_solve_op(kind, !transpose_a),
-            vec![conjugated_a, ValueRef::Local(ct)],
+            linear_solve_op(kind, adjoint_transpose_a),
+            vec![adjoint_a, ValueRef::Local(ct)],
             OperationRole::Linearized {
                 active_mask: vec![false, true],
             },
@@ -587,6 +623,25 @@ pub(crate) fn transpose_full_piv_lu_solve(
         transpose_a,
         ctx,
         LinearSolveOp::FullPivLuSolve,
+    )
+}
+
+pub(crate) fn transpose_solve(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+    transpose_a: bool,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    transpose_linear_solve(
+        builder,
+        cotangent_out,
+        inputs,
+        mode,
+        transpose_a,
+        ctx,
+        LinearSolveOp::Solve,
     )
 }
 

--- a/crates/tenferro-linalg/src/ad/semantic.rs
+++ b/crates/tenferro-linalg/src/ad/semantic.rs
@@ -187,6 +187,15 @@ impl SemanticLinearTransposeRule for LinalgAdRule {
                 builder,
                 SemanticAdRuleRole::LinearTranspose,
             ),
+            LinalgOp::Solve => semantic_custom_transpose(
+                request.op(),
+                request.primal_inputs(),
+                request.primal_outputs(),
+                request.cotangent_outputs(),
+                request.active_inputs(),
+                builder,
+                SemanticAdRuleRole::LinearTranspose,
+            ),
             LinalgOp::LuFactor | LinalgOp::SvdFull => Err(SemanticAdError::Unsupported {
                 family_id: LINALG_EXTENSION_FAMILY_ID,
                 role: SemanticAdRuleRole::LinearTranspose,
@@ -1719,6 +1728,7 @@ fn transpose_linalg_extension(
         LinalgOp::TriangularSolve { .. }
             | LinalgOp::LuSolvePrepared { .. }
             | LinalgOp::FullPivLuSolve { .. }
+            | LinalgOp::Solve
     ) {
         return Err(semantic_internal(
             role,

--- a/crates/tenferro-linalg/src/ad/support.rs
+++ b/crates/tenferro-linalg/src/ad/support.rs
@@ -143,6 +143,10 @@ impl LinalgAdOpKind {
             LinalgOp::LuSolvePrepared { .. } => Self::LuSolvePrepared,
             LinalgOp::FullPivLu => Self::FullPivLu,
             LinalgOp::FullPivLuSolve { .. } => Self::FullPivLuSolve,
+            // The partial-pivot single-op solve shares the solve-family AD
+            // route (linearize + custom linear transpose) with FullPivLuSolve
+            // and is not separately exposed in the public manifest.
+            LinalgOp::Solve => Self::FullPivLuSolve,
             LinalgOp::Svd { .. } => Self::Svd,
             LinalgOp::SvdFull => Self::SvdFull,
             LinalgOp::SvdVals { .. } => Self::SvdVals,

--- a/crates/tenferro-linalg/src/ad/support/tests.rs
+++ b/crates/tenferro-linalg/src/ad/support/tests.rs
@@ -22,6 +22,8 @@ fn manifest_internal_mapping_covers_linalg_op_variants() {
             LinalgOp::FullPivLuSolve { transpose_a: false },
             LinalgAdOpKind::FullPivLuSolve,
         ),
+        // Single-op partial-pivot solve shares the solve-family manifest kind.
+        (LinalgOp::Solve, LinalgAdOpKind::FullPivLuSolve),
         (
             LinalgOp::Svd {
                 derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -1124,30 +1124,7 @@ pub fn full_piv_lu_solve(a: &EagerTensor, b: &EagerTensor) -> Result<EagerTensor
 /// metadata, `Error::Extension` for an unsupported dtype or singular system,
 /// and `Error::RuntimeState` when the backend is unavailable.
 pub fn solve(a: &EagerTensor, b: &EagerTensor) -> Result<EagerTensor> {
-    let mut factor_outputs = apply_linalg_eager(LinalgOp::LuFactor, &[a])?.into_iter();
-    let (packed_lu, pivots) = match (
-        factor_outputs.next(),
-        factor_outputs.next(),
-        factor_outputs.next(),
-        factor_outputs.next(),
-    ) {
-        (Some(packed_lu), Some(pivots), Some(_parity), None) => (packed_lu, pivots),
-        _ => {
-            return Err(Error::Internal(
-                "lu_factor eager op returned an unexpected number of outputs".to_string(),
-            ));
-        }
-    };
-    one_output(
-        apply_linalg_eager(
-            LinalgOp::LuSolvePrepared {
-                transpose_a: false,
-                conjugate_a: false,
-            },
-            &[a, &packed_lu, &pivots, b],
-        )?,
-        "solve",
-    )
+    one_output(apply_linalg_eager(LinalgOp::Solve, &[a, b])?, "solve")
 }
 
 /// Cholesky factorization for eager tensors.

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -285,6 +285,12 @@ pub(crate) enum LinalgOp {
     FullPivLuSolve {
         transpose_a: bool,
     },
+    /// Solve `a @ x = b` with partial-pivot LU (same kernel as
+    /// `LinalgBackend::solve`). Two inputs (matrix, rhs) to one output.
+    /// Only the eager surface (autodiff feature) constructs this variant;
+    /// the traced `solve` composite stays LuFactor + LuSolvePrepared.
+    #[cfg_attr(not(feature = "autodiff"), allow(dead_code))]
+    Solve,
     Svd {
         derivative_eps: f64,
         gauge: SvdGauge,
@@ -330,6 +336,7 @@ impl LinalgOp {
             | Self::LogAbsDetFromLuFactor
             | Self::LuSolvePrepared { .. }
             | Self::SignDetFromLuFactor
+            | Self::Solve
             | Self::SvdVals { .. }
             | Self::TriangularSolve { .. } => 1,
             Self::Svd { .. } | Self::SvdFull => 3,
@@ -342,7 +349,7 @@ impl LinalgOp {
 
     fn input_count(self) -> usize {
         match self {
-            Self::FullPivLuSolve { .. } | Self::TriangularSolve { .. } => 2,
+            Self::FullPivLuSolve { .. } | Self::Solve | Self::TriangularSolve { .. } => 2,
             Self::LogAbsDetFromLuFactor => 2,
             Self::SignDetFromLuFactor => 3,
             Self::LuSolvePrepared { .. } => 4,
@@ -369,6 +376,7 @@ impl LinalgOp {
             Self::SvdFull => 15,
             Self::LogAbsDetFromLuFactor => 16,
             Self::SignDetFromLuFactor => 17,
+            Self::Solve => 18,
         }
     }
 }
@@ -447,7 +455,8 @@ impl ExtensionOp for LinalgExtensionOp {
             | LinalgOp::LogAbsDetFromLuFactor
             | LinalgOp::SignDetFromLuFactor
             | LinalgOp::FullPivLu
-            | LinalgOp::SvdFull => {}
+            | LinalgOp::SvdFull
+            | LinalgOp::Solve => {}
         }
     }
 
@@ -515,6 +524,11 @@ impl ExtensionOp for LinalgExtensionOp {
             LinalgOp::FullPivLuSolve { .. } => {
                 require_matrix_meta("tenferro-linalg.full_piv_lu_solve", input_shapes[0])?;
                 require_matrix_meta("tenferro-linalg.full_piv_lu_solve", input_shapes[1])?;
+                vec![(promote_dtypes(&input_dtypes), input_shapes[1].to_vec())]
+            }
+            LinalgOp::Solve => {
+                require_matrix_meta("tenferro-linalg.solve", input_shapes[0])?;
+                require_matrix_meta("tenferro-linalg.solve", input_shapes[1])?;
                 vec![(promote_dtypes(&input_dtypes), input_shapes[1].to_vec())]
             }
             LinalgOp::TriangularSolve { .. } => {
@@ -669,6 +683,11 @@ fn linalg_session_supported<B: BackendSession + 'static>(op: &LinalgExtensionOp)
                 // Complete-pivoting LU and general eig have no CUDA kernels.
                 LinalgOp::FullPivLu | LinalgOp::FullPivLuSolve { .. } => false,
                 LinalgOp::Eig { .. } | LinalgOp::EigVals { .. } => false,
+                // Plain partial-pivot solve runs in-session via cuSOLVER
+                // getrf plus prepared pivot/triangular solves
+                // (`gpu/linalg.rs::solve` = lu_factor + lu_solve_prepared, no
+                // Unsupported path for F32/F64/C32/C64), so it is admitted.
+                LinalgOp::Solve => true,
                 // Full-matrices SVD falls back to the default `svd_full`
                 // impl, which reports `Unsupported`.
                 LinalgOp::SvdFull => false,
@@ -740,6 +759,7 @@ fn execute_linalg<B: LinalgBackend>(
             inputs[1],
             transpose_a,
         )?]),
+        LinalgOp::Solve => Ok(vec![backend.solve(inputs[0], inputs[1])?]),
         LinalgOp::Svd {
             derivative_eps,
             gauge,

--- a/crates/tenferro-linalg/src/extension/tests.rs
+++ b/crates/tenferro-linalg/src/extension/tests.rs
@@ -41,6 +41,7 @@ fn session_support_admits_every_cpu_linear_algebra_op() {
         LinalgOp::FullPivLu,
         LinalgOp::FullPivLuSolve { transpose_a: false },
         LinalgOp::FullPivLuSolve { transpose_a: true },
+        LinalgOp::Solve,
         LinalgOp::Svd {
             derivative_eps: 0.0,
             gauge: SvdGauge::Raw,

--- a/crates/tenferro-linalg/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-linalg/tests/integration/eager_tensor.rs
@@ -9,7 +9,8 @@ use tenferro_gpu::{
     cuda::download_tensor, cuda::gpu_available, cuda::upload_tensor, cuda::CudaBackend,
 };
 use tenferro_linalg::{
-    EagerTensorLinalgExt, EighGauge, EighOptions, QrGauge, QrOptions, SvdGauge, SvdOptions,
+    EagerTensorLinalgExt, EighGauge, EighOptions, LinalgBackend, QrGauge, QrOptions, SvdGauge,
+    SvdOptions,
 };
 
 fn test_ctx() -> Arc<EagerRuntime> {
@@ -31,6 +32,10 @@ fn f64_data(tensor: &Tensor) -> &[f64] {
     tensor.as_slice::<f64>().unwrap()
 }
 
+fn f32_data(tensor: &Tensor) -> &[f32] {
+    tensor.as_slice::<f32>().unwrap()
+}
+
 fn c64_data(tensor: &Tensor) -> &[Complex64] {
     tensor.as_slice::<Complex64>().unwrap()
 }
@@ -39,6 +44,17 @@ fn assert_close_slice(actual: &[f64], expected: &[f64], tol: f64) {
     assert_eq!(actual.len(), expected.len());
     for (idx, (&actual, &expected)) in actual.iter().zip(expected.iter()).enumerate() {
         let diff = (actual - expected).abs();
+        assert!(
+            diff <= tol,
+            "idx {idx}: expected {expected}, got {actual}, diff {diff}"
+        );
+    }
+}
+
+fn assert_close_c64_slice(actual: &[Complex64], expected: &[Complex64], tol: f64) {
+    assert_eq!(actual.len(), expected.len());
+    for (idx, (&actual, &expected)) in actual.iter().zip(expected.iter()).enumerate() {
+        let diff = (actual - expected).norm();
         assert!(
             diff <= tol,
             "idx {idx}: expected {expected}, got {actual}, diff {diff}"
@@ -97,6 +113,231 @@ fn well_conditioned_4x4() -> Vec<f64> {
         data[j + n * j] += 1.0 + j as f64 / n as f64;
     }
     data
+}
+
+// ---------------------------------------------------------------------------
+// solve AD verification helpers: analytic 2x2 solves and finite differences
+// ---------------------------------------------------------------------------
+
+// Nonsymmetric, well-conditioned A = [[2, 1], [3, 4]] in column-major order
+// (cond ~ 5.8). A diagonal matrix cannot detect an omitted transpose in the
+// A^-H adjoint, so the VJP tests use this matrix instead.
+const SOLVE_A_CM: [f64; 4] = [2.0, 3.0, 1.0, 4.0];
+const SOLVE_B: [f64; 2] = [1.0, 2.0];
+
+// Nonsymmetric complex A with distinct real and imaginary parts (so
+// A^T != A^H): A = [[1+2i, 0.5-1i], [3, 4+2i]] in column-major order.
+const SOLVE_C64_A: [Complex64; 4] = [
+    Complex64::new(1.0, 2.0),
+    Complex64::new(3.0, 0.0),
+    Complex64::new(0.5, -1.0),
+    Complex64::new(4.0, 2.0),
+];
+const SOLVE_C64_B: [Complex64; 2] = [Complex64::new(1.0, 0.0), Complex64::new(0.0, 1.0)];
+
+/// Solve a column-major 2x2 real system via the explicit inverse (analytic
+/// helper; finite-difference checks below evaluate the real eager `solve`).
+fn solve2_f64(a: [f64; 4], b: [f64; 2]) -> [f64; 2] {
+    let det = a[0] * a[3] - a[1] * a[2];
+    let inv = [a[3] / det, -a[1] / det, -a[2] / det, a[0] / det];
+    [inv[0] * b[0] + inv[2] * b[1], inv[1] * b[0] + inv[3] * b[1]]
+}
+
+/// Column-major 2x2 real matrix-vector product.
+fn matvec2_f64(a: [f64; 4], x: [f64; 2]) -> [f64; 2] {
+    [a[0] * x[0] + a[2] * x[1], a[1] * x[0] + a[3] * x[1]]
+}
+
+/// Solve a column-major 2x2 complex system via the explicit inverse.
+fn solve2_c64(a: [Complex64; 4], b: [Complex64; 2]) -> [Complex64; 2] {
+    let det = a[0] * a[3] - a[1] * a[2];
+    let inv = [a[3] / det, -a[1] / det, -a[2] / det, a[0] / det];
+    [inv[0] * b[0] + inv[2] * b[1], inv[1] * b[0] + inv[3] * b[1]]
+}
+
+/// Column-major 2x2 complex matrix-vector product.
+fn matvec2_c64(a: [Complex64; 4], x: [Complex64; 2]) -> [Complex64; 2] {
+    [a[0] * x[0] + a[2] * x[1], a[1] * x[0] + a[3] * x[1]]
+}
+
+fn transpose2_c64(a: [Complex64; 4]) -> [Complex64; 4] {
+    [a[0], a[2], a[1], a[3]]
+}
+
+fn conj2_c64(a: [Complex64; 4]) -> [Complex64; 4] {
+    [a[0].conj(), a[1].conj(), a[2].conj(), a[3].conj()]
+}
+
+/// Central-difference directional derivative of a 2-vector solve function at
+/// `(a, b)` along the direction `(da, db)`.
+fn fd_directional_vec2(
+    f: impl Fn(&[f64], &[f64]) -> [f64; 2],
+    a: &[f64],
+    b: &[f64],
+    da: &[f64],
+    db: &[f64],
+    step: f64,
+) -> [f64; 2] {
+    let mut a_plus = a.to_vec();
+    let mut a_minus = a.to_vec();
+    let mut b_plus = b.to_vec();
+    let mut b_minus = b.to_vec();
+    for (idx, &d) in da.iter().enumerate() {
+        a_plus[idx] += step * d;
+        a_minus[idx] -= step * d;
+    }
+    for (idx, &d) in db.iter().enumerate() {
+        b_plus[idx] += step * d;
+        b_minus[idx] -= step * d;
+    }
+    let plus = f(&a_plus, &b_plus);
+    let minus = f(&a_minus, &b_minus);
+    [
+        (plus[0] - minus[0]) / (2.0 * step),
+        (plus[1] - minus[1]) / (2.0 * step),
+    ]
+}
+
+/// Central-difference gradient of a scalar loss over the entries of `a` then
+/// `b`.
+fn fd_loss_grad_f64(
+    loss: impl Fn(&[f64], &[f64]) -> f64,
+    a: &[f64],
+    b: &[f64],
+    step: f64,
+) -> (Vec<f64>, Vec<f64>) {
+    let mut g_a = vec![0.0; a.len()];
+    let mut g_b = vec![0.0; b.len()];
+    for idx in 0..a.len() {
+        let mut plus = a.to_vec();
+        let mut minus = a.to_vec();
+        plus[idx] += step;
+        minus[idx] -= step;
+        g_a[idx] = (loss(&plus, b) - loss(&minus, b)) / (2.0 * step);
+    }
+    for idx in 0..b.len() {
+        let mut plus = b.to_vec();
+        let mut minus = b.to_vec();
+        plus[idx] += step;
+        minus[idx] -= step;
+        g_b[idx] = (loss(a, &plus) - loss(a, &minus)) / (2.0 * step);
+    }
+    (g_a, g_b)
+}
+
+/// Central-difference directional derivative of a complex 2-vector solve
+/// function. The direction is complex, so `solve`'s complex-linearity is
+/// exercised with a single complex perturbation.
+fn fd_directional_c64(
+    f: impl Fn(&[Complex64], &[Complex64]) -> [Complex64; 2],
+    a: &[Complex64],
+    b: &[Complex64],
+    da: &[Complex64],
+    db: &[Complex64],
+    step: f64,
+) -> [Complex64; 2] {
+    let mut a_plus = a.to_vec();
+    let mut a_minus = a.to_vec();
+    let mut b_plus = b.to_vec();
+    let mut b_minus = b.to_vec();
+    for (idx, &d) in da.iter().enumerate() {
+        a_plus[idx] += Complex64::new(step * d.re, step * d.im);
+        a_minus[idx] -= Complex64::new(step * d.re, step * d.im);
+    }
+    for (idx, &d) in db.iter().enumerate() {
+        b_plus[idx] += Complex64::new(step * d.re, step * d.im);
+        b_minus[idx] -= Complex64::new(step * d.re, step * d.im);
+    }
+    let plus = f(&a_plus, &b_plus);
+    let minus = f(&a_minus, &b_minus);
+    [
+        (plus[0] - minus[0]) / Complex64::new(2.0 * step, 0.0),
+        (plus[1] - minus[1]) / Complex64::new(2.0 * step, 0.0),
+    ]
+}
+
+/// Central-difference gradient of a real loss over complex entries: entry `i`
+/// is `dL/dRe(x_i) + i * dL/dIm(x_i)`.
+fn fd_loss_grad_c64(
+    loss: impl Fn(&[Complex64], &[Complex64]) -> f64,
+    a: &[Complex64],
+    b: &[Complex64],
+    step: f64,
+) -> (Vec<Complex64>, Vec<Complex64>) {
+    let mut g_a = vec![Complex64::new(0.0, 0.0); a.len()];
+    let mut g_b = vec![Complex64::new(0.0, 0.0); b.len()];
+    for idx in 0..a.len() {
+        let mut plus = a.to_vec();
+        let mut minus = a.to_vec();
+        plus[idx] += Complex64::new(step, 0.0);
+        minus[idx] -= Complex64::new(step, 0.0);
+        g_a[idx].re = (loss(&plus, b) - loss(&minus, b)) / (2.0 * step);
+        plus[idx] = a[idx] + Complex64::new(0.0, step);
+        minus[idx] = a[idx] - Complex64::new(0.0, step);
+        g_a[idx].im = (loss(&plus, b) - loss(&minus, b)) / (2.0 * step);
+    }
+    for idx in 0..b.len() {
+        let mut plus = b.to_vec();
+        let mut minus = b.to_vec();
+        plus[idx] += Complex64::new(step, 0.0);
+        minus[idx] -= Complex64::new(step, 0.0);
+        g_b[idx].re = (loss(a, &plus) - loss(a, &minus)) / (2.0 * step);
+        plus[idx] = b[idx] + Complex64::new(0.0, step);
+        minus[idx] = b[idx] - Complex64::new(0.0, step);
+        g_b[idx].im = (loss(a, &plus) - loss(a, &minus)) / (2.0 * step);
+    }
+    (g_a, g_b)
+}
+
+/// Eager `solve` on an f64 2x2 system.
+fn eager_solve_f64(ctx: &Arc<EagerRuntime>, a: &[f64], b: &[f64]) -> [f64; 2] {
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 2], a.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let b = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 1], b.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let solved = a.solve(&b).unwrap().to_tensor().unwrap();
+    let values = f64_data(&solved);
+    [values[0], values[1]]
+}
+
+/// Eager `solve` on an f32 2x2 system, returned as f64 for differencing.
+fn eager_solve_f32(ctx: &Arc<EagerRuntime>, a: &[f64], b: &[f64]) -> [f64; 2] {
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 2], a.iter().map(|v| *v as f32).collect()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let b = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 1], b.iter().map(|v| *v as f32).collect()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let solved = a.solve(&b).unwrap().to_tensor().unwrap();
+    let values = f32_data(&solved);
+    [values[0] as f64, values[1] as f64]
+}
+
+/// Eager `solve` on a Complex64 2x2 system.
+fn eager_solve_c64(ctx: &Arc<EagerRuntime>, a: &[Complex64], b: &[Complex64]) -> [Complex64; 2] {
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 2], a.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let b = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 1], b.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let solved = a.solve(&b).unwrap().to_tensor().unwrap();
+    let values = c64_data(&solved);
+    [values[0], values[1]]
 }
 
 #[test]
@@ -319,6 +560,452 @@ fn batched_solve_sum_backward_wrt_matrix_uses_native_batch_layout() {
         f64_data(&grad.to_tensor().unwrap()),
         &[-1.0, -0.5, -1.0, -0.5, -2.0 / 3.0, -0.4, -2.0 / 3.0, -0.4],
         1.0e-12,
+    );
+}
+
+#[test]
+fn solve_matches_concrete_partial_pivot_backend() {
+    // The eager single-op solve must run the same partial-pivot kernel as the
+    // concrete `LinalgBackend::solve` on well- and ill-conditioned square
+    // systems, for f64 and f32.
+    let mut backend = CpuBackend::new();
+    for (case, matrix, rhs) in [
+        ("f64 well-conditioned", [2.0, 0.0, 0.0, 4.0], [4.0, 8.0]),
+        (
+            "f64 ill-conditioned",
+            [1.0, 1.0, 1.0, 1.0 + 1.0e-8],
+            [1.0, 2.0],
+        ),
+    ] {
+        let a = Tensor::from_vec_col_major(vec![2, 2], matrix.to_vec()).unwrap();
+        let b = Tensor::from_vec_col_major(vec![2, 1], rhs.to_vec()).unwrap();
+        let concrete =
+            crate::support::with_cpu_linalg(&mut backend, |session| session.solve(&a, &b)).unwrap();
+        let eager = EagerTensor::from_tensor_in(a, test_ctx())
+            .unwrap()
+            .solve(&EagerTensor::from_tensor_in(b, test_ctx()).unwrap())
+            .unwrap()
+            .to_tensor()
+            .unwrap();
+        let actual = f64_data(&eager);
+        let expected = f64_data(&concrete);
+        for (idx, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+            let diff = (actual - expected).abs();
+            assert!(
+                diff <= 1.0e-13,
+                "{case} idx {idx}: expected {expected}, got {actual}, diff {diff}"
+            );
+        }
+        let x = expected;
+        let residual = [
+            matrix[0] * x[0] + matrix[2] * x[1] - rhs[0],
+            matrix[1] * x[0] + matrix[3] * x[1] - rhs[1],
+        ];
+        assert!(
+            residual.iter().all(|value| value.abs() <= 1.0e-10),
+            "{case}: partial-pivot solve left residual {residual:?}"
+        );
+    }
+    for (case, matrix, rhs) in [
+        (
+            "f32 well-conditioned",
+            [2.0_f32, 0.0, 0.0, 4.0],
+            [4.0_f32, 8.0],
+        ),
+        (
+            "f32 ill-conditioned",
+            [1.0_f32, 1.0, 1.0, 1.001],
+            [1.0_f32, 2.0],
+        ),
+    ] {
+        let a = Tensor::from_vec_col_major(vec![2, 2], matrix.to_vec()).unwrap();
+        let b = Tensor::from_vec_col_major(vec![2, 1], rhs.to_vec()).unwrap();
+        let concrete =
+            crate::support::with_cpu_linalg(&mut backend, |session| session.solve(&a, &b)).unwrap();
+        let eager = EagerTensor::from_tensor_in(a, test_ctx())
+            .unwrap()
+            .solve(&EagerTensor::from_tensor_in(b, test_ctx()).unwrap())
+            .unwrap()
+            .to_tensor()
+            .unwrap();
+        let actual = eager.as_slice::<f32>().unwrap();
+        let expected = concrete.as_slice::<f32>().unwrap();
+        for (idx, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+            let diff = (actual - expected).abs();
+            assert!(
+                diff <= 1.0e-6,
+                "{case} idx {idx}: expected {expected}, got {actual}, diff {diff}"
+            );
+        }
+        let x = expected;
+        let residual = [
+            matrix[0] * x[0] + matrix[2] * x[1] - rhs[0],
+            matrix[1] * x[0] + matrix[3] * x[1] - rhs[1],
+        ];
+        assert!(
+            residual.iter().all(|value| value.abs() <= 1.0e-4),
+            "{case}: partial-pivot solve left residual {residual:?}"
+        );
+    }
+}
+
+#[test]
+fn solve_forward_jvp_wrt_matrix_and_rhs_matches_analytic_and_finite_difference() {
+    let ctx = ad_test_ctx();
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 2], SOLVE_A_CM.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let b = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 1], SOLVE_B.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let x = a.solve(&b).unwrap();
+    let da = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let db = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 1.0]).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+
+    // JVP wrt A: dx = solve(A, -dA x). x = [0.4, 0.2], dA = I ->
+    // dx = -A^-1 x = [-0.28, 0.16].
+    let dx_a = ctx.jvp(&x, &a, &da).unwrap();
+    let x_expected = solve2_f64(SOLVE_A_CM, SOLVE_B);
+    let dax = matvec2_f64([1.0, 0.0, 0.0, 1.0], x_expected);
+    let dx_a_expected = solve2_f64(SOLVE_A_CM, [-dax[0], -dax[1]]);
+    assert_close_slice(
+        f64_data(&dx_a.to_tensor().unwrap()),
+        &dx_a_expected,
+        1.0e-12,
+    );
+    let dx_a_fd = fd_directional_vec2(
+        |a, b| eager_solve_f64(&ctx, a, b),
+        &SOLVE_A_CM,
+        &SOLVE_B,
+        &[1.0, 0.0, 0.0, 1.0],
+        &[0.0, 0.0],
+        1.0e-5,
+    );
+    assert_close_slice(f64_data(&dx_a.to_tensor().unwrap()), &dx_a_fd, 1.0e-6);
+
+    // JVP wrt b: dx = solve(A, db). db = [1, 1] -> dx = A^-1 [1, 1] =
+    // [0.6, -0.2].
+    let dx_b = ctx.jvp(&x, &b, &db).unwrap();
+    let dx_b_expected = solve2_f64(SOLVE_A_CM, [1.0, 1.0]);
+    assert_close_slice(
+        f64_data(&dx_b.to_tensor().unwrap()),
+        &dx_b_expected,
+        1.0e-12,
+    );
+    let dx_b_fd = fd_directional_vec2(
+        |a, b| eager_solve_f64(&ctx, a, b),
+        &SOLVE_A_CM,
+        &SOLVE_B,
+        &[0.0, 0.0, 0.0, 0.0],
+        &[1.0, 1.0],
+        1.0e-5,
+    );
+    assert_close_slice(f64_data(&dx_b.to_tensor().unwrap()), &dx_b_fd, 1.0e-6);
+}
+
+#[test]
+fn solve_backward_wrt_matrix_and_rhs_matches_analytic_and_finite_difference() {
+    let ctx = ad_test_ctx();
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 2], SOLVE_A_CM.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let b = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 1], SOLVE_B.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let x = a.solve(&b).unwrap();
+    let loss = x.reduce_sum(Some(&[0, 1])).unwrap();
+    let _ = loss.backward().unwrap();
+
+    // For L = sum(x), x = A^-1 b: g_b = A^-T 1, g_A = -g_b x^T. With the
+    // nonsymmetric A above, g_b = A^-T [1, 1] = [0.2, 0.2] and
+    // g_A = -[[0.08, 0.04], [0.08, 0.04]] in column-major order. An omitted
+    // transpose in the adjoint solve would give g_b = A^-1 [1, 1] =
+    // [0.6, -0.2] instead and fail this check.
+    let x_expected = solve2_f64(SOLVE_A_CM, SOLVE_B);
+    let g_b_expected = solve2_f64(transpose2(&SOLVE_A_CM), [1.0, 1.0]);
+    let mut g_a_expected = [0.0; 4];
+    for i in 0..2 {
+        for j in 0..2 {
+            g_a_expected[i + 2 * j] = -g_b_expected[i] * x_expected[j];
+        }
+    }
+    assert_close_slice(
+        f64_data(&b.grad().unwrap().unwrap().to_tensor().unwrap()),
+        &g_b_expected,
+        1.0e-12,
+    );
+    assert_close_slice(
+        f64_data(&a.grad().unwrap().unwrap().to_tensor().unwrap()),
+        &g_a_expected,
+        1.0e-12,
+    );
+
+    // Independent finite-difference gradient over both inputs.
+    let (fd_g_a, fd_g_b) = fd_loss_grad_f64(
+        |a, b| {
+            let x = eager_solve_f64(&ctx, a, b);
+            x[0] + x[1]
+        },
+        &SOLVE_A_CM,
+        &SOLVE_B,
+        1.0e-5,
+    );
+    assert_close_slice(
+        f64_data(&a.grad().unwrap().unwrap().to_tensor().unwrap()),
+        &fd_g_a,
+        1.0e-6,
+    );
+    assert_close_slice(
+        f64_data(&b.grad().unwrap().unwrap().to_tensor().unwrap()),
+        &fd_g_b,
+        1.0e-6,
+    );
+}
+
+#[test]
+fn solve_forward_and_backward_match_finite_difference_in_f32() {
+    let ctx = ad_test_ctx();
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 2], SOLVE_A_CM.iter().map(|v| *v as f32).collect())
+            .unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let b = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 1], SOLVE_B.iter().map(|v| *v as f32).collect())
+            .unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let x = a.solve(&b).unwrap();
+    let da = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f32, 0.0, 0.0, 1.0]).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let db = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f32, 1.0]).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+
+    // f32 JVP wrt A and b against finite differences (step 1e-2, the f32
+    // analogue of the 1e-5 f64 step scaled by sqrt(f32 epsilon)).
+    let dx_a = ctx.jvp(&x, &a, &da).unwrap();
+    let dx_a_values: Vec<f64> = f32_data(&dx_a.to_tensor().unwrap())
+        .iter()
+        .map(|v| *v as f64)
+        .collect();
+    let dx_a_fd = fd_directional_vec2(
+        |a, b| eager_solve_f32(&ctx, a, b),
+        &SOLVE_A_CM,
+        &SOLVE_B,
+        &[1.0, 0.0, 0.0, 1.0],
+        &[0.0, 0.0],
+        1.0e-2,
+    );
+    assert_close_slice(&dx_a_values, &dx_a_fd, 1.0e-3);
+    let dx_b = ctx.jvp(&x, &b, &db).unwrap();
+    let dx_b_values: Vec<f64> = f32_data(&dx_b.to_tensor().unwrap())
+        .iter()
+        .map(|v| *v as f64)
+        .collect();
+    let dx_b_fd = fd_directional_vec2(
+        |a, b| eager_solve_f32(&ctx, a, b),
+        &SOLVE_A_CM,
+        &SOLVE_B,
+        &[0.0, 0.0, 0.0, 0.0],
+        &[1.0, 1.0],
+        1.0e-2,
+    );
+    assert_close_slice(&dx_b_values, &dx_b_fd, 1.0e-3);
+
+    // f32 VJP wrt A and b against finite differences.
+    let loss = x.reduce_sum(Some(&[0, 1])).unwrap();
+    let _ = loss.backward().unwrap();
+    let (fd_g_a, fd_g_b) = fd_loss_grad_f64(
+        |a, b| {
+            let x = eager_solve_f32(&ctx, a, b);
+            x[0] + x[1]
+        },
+        &SOLVE_A_CM,
+        &SOLVE_B,
+        1.0e-2,
+    );
+    let g_a_values: Vec<f64> = f32_data(&a.grad().unwrap().unwrap().to_tensor().unwrap())
+        .iter()
+        .map(|v| *v as f64)
+        .collect();
+    let g_b_values: Vec<f64> = f32_data(&b.grad().unwrap().unwrap().to_tensor().unwrap())
+        .iter()
+        .map(|v| *v as f64)
+        .collect();
+    assert_close_slice(&g_a_values, &fd_g_a, 1.0e-3);
+    assert_close_slice(&g_b_values, &fd_g_b, 1.0e-3);
+}
+
+#[test]
+fn solve_forward_jvp_complex_matches_analytic_and_finite_difference() {
+    let ctx = ad_test_ctx();
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 2], SOLVE_C64_A.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let b = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 1], SOLVE_C64_B.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let x = a.solve(&b).unwrap();
+    let da_data = [
+        Complex64::new(1.0, 1.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(1.0, -1.0),
+    ];
+    let db_data = [Complex64::new(1.0, 0.5), Complex64::new(-0.5, 1.0)];
+    let da = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 2], da_data.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let db = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 1], db_data.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+
+    // JVP wrt A: dx = solve(A, -dA x); JVP wrt b: dx = solve(A, db). The JVP
+    // is transpose-free; the VJP test below pins down the A^H adjoint.
+    let x_expected = solve2_c64(SOLVE_C64_A, SOLVE_C64_B);
+    let dx_a_expected = {
+        let dax = matvec2_c64(da_data, x_expected);
+        solve2_c64(SOLVE_C64_A, [-dax[0], -dax[1]])
+    };
+    let dx_b_expected = solve2_c64(SOLVE_C64_A, db_data);
+    let dx_a = ctx.jvp(&x, &a, &da).unwrap();
+    let dx_b = ctx.jvp(&x, &b, &db).unwrap();
+    assert_close_c64_slice(
+        c64_data(&dx_a.to_tensor().unwrap()),
+        &dx_a_expected,
+        1.0e-12,
+    );
+    assert_close_c64_slice(
+        c64_data(&dx_b.to_tensor().unwrap()),
+        &dx_b_expected,
+        1.0e-12,
+    );
+
+    // Finite differences along the complex directions.
+    let dx_a_fd = fd_directional_c64(
+        |a, b| eager_solve_c64(&ctx, a, b),
+        &SOLVE_C64_A,
+        &SOLVE_C64_B,
+        &da_data,
+        &[Complex64::new(0.0, 0.0); 2],
+        1.0e-5,
+    );
+    assert_close_c64_slice(c64_data(&dx_a.to_tensor().unwrap()), &dx_a_fd, 1.0e-6);
+    let dx_b_fd = fd_directional_c64(
+        |a, b| eager_solve_c64(&ctx, a, b),
+        &SOLVE_C64_A,
+        &SOLVE_C64_B,
+        &[Complex64::new(0.0, 0.0); 4],
+        &db_data,
+        1.0e-5,
+    );
+    assert_close_c64_slice(c64_data(&dx_b.to_tensor().unwrap()), &dx_b_fd, 1.0e-6);
+}
+
+#[test]
+fn solve_backward_complex_uses_adjoint_and_matches_finite_difference() {
+    let ctx = ad_test_ctx();
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 2], SOLVE_C64_A.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let b = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 1], SOLVE_C64_B.to_vec()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let x = a.solve(&b).unwrap();
+    // Real loss L = sum(|x|^2); tenferro's Hermitian convention gives the
+    // cotangent into x as 2x (grad(sum(|z|^2)) = 2z).
+    let x_sq = x.mul(&x.conj().unwrap()).unwrap();
+    let loss = x_sq.reduce_sum(Some(&[0, 1])).unwrap();
+    let _ = loss.backward().unwrap();
+
+    // Analytic: g_b = A^-H ct, g_A = -g_b X^H with ct = 2x. A^T != A^H for
+    // this matrix, so using the plain transpose would give a different g_b.
+    let x_expected = solve2_c64(SOLVE_C64_A, SOLVE_C64_B);
+    let ct = [2.0 * x_expected[0], 2.0 * x_expected[1]];
+    let a_h = conj2_c64(transpose2_c64(SOLVE_C64_A));
+    let g_b_expected = solve2_c64(a_h, ct);
+    let mut g_a_expected = [Complex64::new(0.0, 0.0); 4];
+    for i in 0..2 {
+        for j in 0..2 {
+            g_a_expected[i + 2 * j] = -g_b_expected[i] * x_expected[j].conj();
+        }
+    }
+    assert_close_c64_slice(
+        c64_data(&b.grad().unwrap().unwrap().to_tensor().unwrap()),
+        &g_b_expected,
+        1.0e-12,
+    );
+    assert_close_c64_slice(
+        c64_data(&a.grad().unwrap().unwrap().to_tensor().unwrap()),
+        &g_a_expected,
+        1.0e-12,
+    );
+
+    // The chosen matrix genuinely distinguishes A^H from A^T: an adjoint
+    // built with the plain transpose would give a measurably different g_b.
+    let g_b_if_transpose = solve2_c64(transpose2_c64(SOLVE_C64_A), ct);
+    assert!(
+        (g_b_expected[0] - g_b_if_transpose[0]).norm() > 1.0e-6
+            || (g_b_expected[1] - g_b_if_transpose[1]).norm() > 1.0e-6,
+        "test matrix must distinguish A^H from A^T"
+    );
+
+    // Independent finite differences of the real loss over the Re and Im
+    // parts of both inputs.
+    let (fd_g_a, fd_g_b) = fd_loss_grad_c64(
+        |a, b| {
+            let x = eager_solve_c64(&ctx, a, b);
+            x[0].norm_sqr() + x[1].norm_sqr()
+        },
+        &SOLVE_C64_A,
+        &SOLVE_C64_B,
+        1.0e-5,
+    );
+    assert_close_c64_slice(
+        c64_data(&a.grad().unwrap().unwrap().to_tensor().unwrap()),
+        &fd_g_a,
+        1.0e-6,
+    );
+    assert_close_c64_slice(
+        c64_data(&b.grad().unwrap().unwrap().to_tensor().unwrap()),
+        &fd_g_b,
+        1.0e-6,
     );
 }
 

--- a/docs/worklogs/2026-08-13-single-call-eager-solve.md
+++ b/docs/worklogs/2026-08-13-single-call-eager-solve.md
@@ -1,0 +1,54 @@
+# 2026-08-13 — single-call eager solve (`LinalgOp::Solve`)
+
+## Session summary
+
+Issue #1674: the eager `solve` ran two `apply_eager` calls (`LuFactor` +
+`LuSolvePrepared`), paying the fixed per-call extension machinery twice
+(~64 µs for a 2×2, measured pinned/release in issue #1672). Added a
+partial-pivot `LinalgOp::Solve` (2 in → 1 out) and switched `eager_ext.rs::solve`
+to a single `apply_linalg_eager` call. Result: **~64 → ~27.7 µs (−57%)**, no
+regression in matmul/eigh/svd, eager AD forward/backward intact (JVP/VJP
+verified against finite differences incl. complex adjoint).
+
+## Context read
+
+- `crates/tenferro-linalg/src/eager_ext.rs::solve` (composite),
+  `extension.rs` (`LinalgOp` vocabulary + `execute_linalg` dispatch +
+  `linalg_session_supported`), `ad/rules/solve.rs` (shared `LinearSolveOp`
+  machinery), `ad.rs` / `ad/semantic.rs` (traced + eager AD registration).
+- Cost structure from #1672: single apply_eager floor ~25-29 µs (session open
+  ~3 µs + machinery + materialization + wrap); `execute_linalg` itself only
+  ~10 µs of the 64 µs.
+
+## Chosen design
+
+- **New `LinalgOp::Solve` (partial pivoting)** instead of reusing the
+  existing single-op `FullPivLuSolve`: full pivoting is slower and
+  parallelizes poorly, and would silently change the documented partial-pivot
+  numerics of `solve`, diverging from the concrete `LinalgBackend::solve`.
+- Dispatch to the existing `backend.solve` (faer partial-pivot LU on CPU,
+  cuSOLVER getrf + prepared pivot/triangular solves on CUDA in-session).
+- AD: `LinearSolveOp::Solve` reuses `linearize_linear_solve` /
+  `transpose_linear_solve`; the transpose forms `A^H` explicitly
+  (`StdTensorOp::Transpose` on the conjugated matrix) since `Solve` has no
+  transpose flag, then a plain partial-pivot solve. Registered in traced
+  `ad.rs` and eager `semantic.rs` (`semantic_custom_transpose`).
+- Traced `solve_in_graph` composite intentionally unchanged (no per-call
+  overhead in the graph path).
+
+## Rejected alternatives
+
+- Reusing `FullPivLuSolve`: full pivoting (see above).
+- Keeping the composite: pays the second session + machinery round for every
+  eager solve.
+
+## Residual risks
+
+- CUDA eager `solve` now runs in-session via `LinalgOp::Solve` (was the
+  LuFactor/LuSolvePrepared composite, also in-session); verified admitted and
+  never returns `Unsupported` for F32/F64/C32/C64. GPU runtime validation of
+  the new path is covered by the existing `cargo check --features cuda` and
+  the gated GPU tests; actual GPU run requires a CUDA host.
+- The eager AD solve tests were initially diag-only (could not detect an
+  omitted transpose); strengthened with nonsymmetric + finite-difference +
+  C64 adjoint coverage per review.


### PR DESCRIPTION
## Summary

Make the eager `solve` a **single `apply_eager` call** by adding a
partial-pivoting `LinalgOp::Solve` (2 in → 1 out), instead of the current
`LuFactor` + `LuSolvePrepared` composite (2 `apply_eager` calls).

Closes #1674. Measured in #1672: the single apply_eager floor is ~25-29 µs
(session open ~3 µs + extension machinery + materialization + wrap), and the
eager `solve` paid it twice (~64 µs for a 2×2).

## Measurements (pinned to an idle core, release)

| bench | before | after |
|---|---|---|
| `no_ad/solve_2x2` | ~64 µs | **~27.7 µs (−57%)** |
| `eager_ad_forward/solve_2x2` | runs (composite AD) | **~39.4 µs**, AD intact |
| `no_ad/matmul_2x2` / `eigh_2x2` / `svd_2x2` | — | unchanged (no regression) |

## Design

- **New `LinalgOp::Solve` (partial pivoting)** — deliberately *not* reusing
  the existing single-op `FullPivLuSolve`: full pivoting is slower and
  parallelizes poorly, and would silently change the documented partial-pivot
  numerics of `solve` (diverging from the concrete `LinalgBackend::solve`).
- Dispatches to the existing `backend.solve` kernel: faer partial-pivot LU on
  CPU; cuSOLVER getrf + prepared pivot/triangular solves in-session on CUDA
  (admitted per-op, verified never `Unsupported` for F32/F64/C32/C64).
- AD reuses the shared `LinearSolveOp` machinery
  (`linearize_linear_solve` / `transpose_linear_solve`); since `Solve` has no
  transpose flag, the transpose path forms `A^H` explicitly and then solves.
  Registered in both the traced `ad.rs` and eager `semantic.rs` rules.
- Traced `solve_in_graph` composite intentionally unchanged (no per-call
  overhead in the graph path).

## Tests

- `solve_matches_concrete_partial_pivot_backend`: eager == concrete `solve`
  on well- and ill-conditioned f64/f32 systems.
- JVP/VJP vs analytic **and finite differences** for both inputs, f64/f32,
  plus C64 adjoint coverage with a nonsymmetric complex matrix that
  distinguishes `A^H` from `A^T` (addressed reviewer feedback: the first
  version only used a diagonal matrix).

Verification: `check-pr-fast.sh` green (165 unit + 205 integration + 174 doc
tests in tenferro-linalg), repository-rules review pass, clippy clean on
default and autodiff feature sets, `cargo check --features cuda,autodiff` pass.

Worklog: `docs/worklogs/2026-08-13-single-call-eager-solve.md`.
