### PR TITLE
docs+test: session-API design + portable nested-entry guard (#1673)

### DIFF
--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -4043,6 +4043,10 @@ pub trait BackendCachedDot: BackendRuntimeCache + TensorDot {
 
 /// Backend execution-session entry points.
 ///
+/// `with_backend_session` is the canonical user entry; one-shot concrete ops
+/// delegate to the session form. `with_backend_session_cached` is the
+/// runtime-cache-aware entry used by the runtime layer.
+///
 /// # Examples
 ///
 /// ```rust
@@ -4163,6 +4167,36 @@ pub trait TensorBackend:
 
 impl<T> SessionCachedDot for T where T: TensorBackend + ?Sized {}
 
+thread_local! {
+    /// Tracks whether a [`default_backend_session`] closure is currently
+    /// running on this thread, so nested session entry is caught in debug
+    /// builds even for backends that do not override
+    /// [`BackendSessionHost::with_backend_session`].
+    static IN_SESSION: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Sets the in-session flag for the duration of a session closure and restores
+/// it on exit, including on panic.
+struct InSessionGuard;
+
+impl InSessionGuard {
+    fn enter() -> Self {
+        debug_assert!(
+            !IN_SESSION.get(),
+            "nested backend session entry: a session closure called \
+             with_backend_session / default_backend_session again on this thread"
+        );
+        IN_SESSION.set(true);
+        InSessionGuard
+    }
+}
+
+impl Drop for InSessionGuard {
+    fn drop(&mut self) {
+        IN_SESSION.set(false);
+    }
+}
+
 /// Run a closure using the backend itself as a default execution session.
 ///
 /// This is suitable for backends whose individual ops already manage their own
@@ -4181,5 +4215,6 @@ pub fn default_backend_session<B: TensorBackend, R: Send>(
     backend: &mut B,
     f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
 ) -> R {
+    let _guard = InSessionGuard::enter();
     f(backend)
 }

--- a/crates/tenferro-tensor/src/backend/tests.rs
+++ b/crates/tenferro-tensor/src/backend/tests.rs
@@ -68,3 +68,55 @@ fn contraction_scalar_identity_errors_name_the_public_constructor() {
         }
     ));
 }
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "nested backend session entry")]
+fn nested_default_backend_session_is_rejected_in_debug_builds() {
+    use crate::tests::backend_default_read_tests::DefaultReadBackend;
+
+    let mut backend = DefaultReadBackend::default();
+    default_backend_session(&mut backend, |outer| {
+        // Recover the concrete backend from the session through the
+        // documented capability bridge so the nested call re-enters
+        // `default_backend_session` on the same backend, same thread.
+        let concrete: &mut DefaultReadBackend =
+            unsafe { &mut *outer.session_data_mut().cast::<DefaultReadBackend>() };
+        default_backend_session(concrete, |_inner| ())
+    });
+}
+
+#[test]
+fn default_backend_session_runs_and_clears_the_in_session_flag() {
+    let mut backend = crate::tests::backend_default_read_tests::DefaultReadBackend::default();
+
+    let first = default_backend_session(&mut backend, |_| 1usize);
+    assert_eq!(first, 1);
+    assert!(!IN_SESSION.get());
+
+    // A second sequential session proves the first guard restored the flag.
+    let second = default_backend_session(&mut backend, |_| 2usize);
+    assert_eq!(second, 2);
+    assert!(!IN_SESSION.get());
+}
+
+#[test]
+fn default_backend_session_clears_the_in_session_flag_after_panic() {
+    // Panicking inside `f` must still restore the thread-local flag (the
+    // guard is Drop-based), so a later session on the same thread succeeds.
+    let mut backend = crate::tests::backend_default_read_tests::DefaultReadBackend::default();
+
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        default_backend_session(&mut backend, |_| {
+            assert!(IN_SESSION.get());
+            panic!("boom");
+        })
+    }));
+    assert!(outcome.is_err());
+    assert!(!IN_SESSION.get());
+
+    // The flag is usable again on the same thread.
+    let again = default_backend_session(&mut backend, |_| 3usize);
+    assert_eq!(again, 3);
+    assert!(!IN_SESSION.get());
+}

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -111,4 +111,4 @@ pub(crate) fn core_dtype(dtype: DType) -> tenferro_tensor_core::DType {
 }
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -14,7 +14,7 @@ use num_complex::{Complex32, Complex64};
 #[doc(hidden)]
 struct DefaultReadBackendSessionMarker;
 
-struct DefaultReadBackend {
+pub(crate) struct DefaultReadBackend {
     calls: Vec<&'static str>,
     dot_result: Option<Tensor>,
     gather_indices: Option<Tensor>,

--- a/crates/tenferro-tensor/src/tests/mod.rs
+++ b/crates/tenferro-tensor/src/tests/mod.rs
@@ -1,4 +1,4 @@
-mod backend_default_read_tests;
+pub(crate) mod backend_default_read_tests;
 mod capability_tests;
 mod config_tests;
 mod dispatch_tests;

--- a/docs/design/exec-session.md
+++ b/docs/design/exec-session.md
@@ -52,9 +52,15 @@ backend segment instead of one per instruction.
 `CpuContext` stores the requested CPU thread count and owns the Rayon pool used
 by tenferro-owned multi-threaded CPU work. `CpuContext::install` runs the
 closure on that owned pool for multi-thread contexts and inline for one-thread
-contexts. faer-backed kernels use `Par::Seq` for one thread and
-explicit `Par::rayon(n)` otherwise, so policy construction cannot inherit an
-unrelated ambient Rayon degree before joining the `CpuContext` pool.
+contexts — **with one exception**: `CpuContext::with_pinned_cpus` (used by the
+managed engine, `CpuEngine::new_managed`) constructs a real Rayon pool even
+for a single worker, so a pinned one-worker context also hands the closure off
+to a Rayon worker thread rather than running it inline. Consequently the
+closure given to `with_backend_session` may execute on a worker thread, and
+`Send` is a soundness requirement, not a convenience bound. faer-backed
+kernels use `Par::Seq` for one thread and explicit `Par::rayon(n)` otherwise,
+so policy construction cannot inherit an unrelated ambient Rayon degree before
+joining the `CpuContext` pool.
 
 ```rust
 impl TensorBackend for CpuBackend {
@@ -83,11 +89,13 @@ re-enter the pool.
 `CudaBackend` is the current CUDA GPU backend. It uses CubeCL/CubeCL-CUDA and
 runtime-loaded CUDA libraries from `crates/tenferro-gpu/src/cubecl/`.
 
-Today `CudaBackend` does not define a separate exec-session struct. It uses
-the default `TensorBackend::with_backend_session` adapter, so each `BackendSession`
-call forwards to the backend method. The backend method launches CubeCL kernels
-or calls the relevant cuTENSOR/cuSOLVER/cuBLAS wrapper against the backend's
-`CudaRuntime`.
+`CudaBackend` defines a dedicated exec-session struct, `CudaExecSession`, and
+overrides `BackendSessionHost::with_backend_session` to wrap the session and
+call `f` directly on the calling thread
+(`crates/tenferro-gpu/src/cubecl/exec_session.rs`). WebGPU similarly overrides
+with its own exec session (`crates/tenferro-gpu/src/webgpu/exec_session.rs`).
+The backend session methods launch CubeCL kernels or call the relevant
+cuTENSOR/cuSOLVER/cuBLAS wrapper against the backend's `CudaRuntime`.
 
 | CPU concept | CubeCL/CUDA concept |
 |---|---|
@@ -97,10 +105,10 @@ or calls the relevant cuTENSOR/cuSOLVER/cuBLAS wrapper against the backend's
 | faer/rayon CPU work | kernel launch on stream |
 | per-step session setup overhead | per-kernel launch/runtime dispatch overhead |
 
-Future CubeCL work may introduce a dedicated GPU exec session if there is a
-measurable benefit from binding temporary workspace, stream state, or device
-buffer pooling across an entire compiled program. That should extend
-`CudaBackend`; it should not add a separate `CudaBackend` type.
+GPU exec sessions run the closure on the calling thread, so `Send` is not
+needed for GPU; the trait still requires it because the CPU managed path does.
+Nested-entry detection for the GPU overrides is not yet wired to the portable
+debug guard (see `session-oriented-concrete-apis.md`).
 
 ### Default (no-op)
 

--- a/docs/design/session-oriented-concrete-apis.md
+++ b/docs/design/session-oriented-concrete-apis.md
@@ -1,0 +1,149 @@
+# Session-Oriented Concrete APIs (issue #1673)
+
+Status: design (pre-implementation review target).
+
+## Overview
+
+Add a session-explicit execution surface for concrete `Tensor`/`TypedTensor`
+operations (including extension-crate operations) so a caller can reuse one
+borrowed `BackendSession` across a sequence of operations instead of paying a
+session entry per operation. The tensor value types remain context-free and
+are never owned by or lifetime-bound to a session.
+
+The one-shot API (`a.add(&b, &mut backend)`) stays available and becomes a
+thin wrapper around the session implementation where practical.
+
+## Motivation (measured)
+
+Session entry for managed CPU execution is ~3 µs/op (release, pinned, 1
+worker; issue #1673 data comment). For trivial unary/binary ops (~3 µs total)
+it is ~100% of the cost; for a 10-op trivial chain the current API pays 10
+session entries (~30 µs) where one entry (~3 µs + 10 op bodies) suffices.
+For compute-heavy ops (solve, ~28 µs after #1675) the session share is ~10%,
+so the surface targets short chains of cheap ops; it is not a GPU
+small-op-launch fix.
+
+**Gate (from the issue):** with `T_one_shot` = 10-op trivial chain via the
+current one-shot API (10 session entries) and `T_one_session` = the same
+chain via one session entry, require `T_one_shot / T_one_session >= 2`
+(predicted ~6). The baseline is explicit: current one-shot API, 10 session
+entries.
+
+## Verified execution model (corrects the 2026-08-14 design review)
+
+The design review assumed `with_backend_session` runs the closure
+synchronously on the calling thread and therefore proposed dropping the
+`Send` bounds. That is **false for CPU**:
+
+- `CpuBackend::with_backend_session` → `run_backend_session_cached` →
+  `enter_managed_session`/`enter` → `install_scoped`
+  (`crates/tenferro-cpu/src/provider.rs`) → `CpuContext::install`
+  (`docs/design/exec-session.md`, "Backend Mapping / CPU") →
+  `rayon::ThreadPool::install` — a **real thread handoff to a Rayon worker**,
+  even for 1-thread pools (verified empirically: caller thread id differs
+  from the closure thread id).
+- The default (non-overriding) backend path (`default_backend_session`,
+  `crates/tenferro-tensor/src/backend.rs`) runs the closure on the calling
+  thread.
+
+**Decision: keep the `Send` bounds** (`R: Send`, `f: ... + Send`) on
+`with_backend_session` / `with_backend_session_cached`. They are a soundness
+requirement for the CPU managed session (a non-`Send` closure would execute
+on another thread). This is an inherent property of the current CPU managed
+session, not a migration accident: downstream users of the session-explicit
+surface must capture only `Send` state, which the one-shot API already
+requires of every closure it takes.
+
+Dropping `Send` would require redesigning CPU session execution to run
+closures on the calling thread with per-op pool entry — a performance/
+semantics change to the hottest segmented-execution path. That redesign is
+out of scope and tracked separately if ever desired; it must NOT be assumed
+as a prerequisite.
+
+## Nested-entry prohibition: mechanism, not convention
+
+Operations receiving a `BackendSession` must never call `with_backend_session`
+internally. Enforcement by backend family:
+
+- **CPU (release)**: `inherited_or_new_execution_owner()`
+  (`crates/tenferro-cpu/src/arbiter.rs`) already panics with
+  `BACKEND_REENTRY_PANIC` when a CPU session is entered while
+  `EXECUTION_OWNER` is set on the thread (or an owned Rayon scope has an
+  active owner). Covers the one-shot-inside-session case, including the
+  pinned one-worker managed pool handoff.
+- **Default adapter (debug)**: `default_backend_session` sets a thread-local
+  in-session flag (Drop-guard restored, so panics in `f` still restore) and
+  `debug_assert!`s it was unset at entry (implemented in PR A). Covers
+  non-overriding backends.
+- **CUDA / WebGPU (not yet wired)**: both override `with_backend_session` and
+  call `f` directly, so neither the portable guard nor the CPU panic applies.
+  Dedicated enforcement for those overrides is tracked as follow-up; the
+  acceptance criterion below is scoped to CPU + default-adapter backends
+  until then.
+
+## Generic spelling
+
+Already settled by the current signatures: entries hand out
+`&mut dyn BackendSession` (no `S: BackendSession + ?Sized` generic on the
+trait methods). The `_in`-surface methods take `session: &mut dyn
+BackendSession` directly.
+
+## Cache access parity
+
+`with_backend_session_cached` is the runtime-cache-aware entry (used by the
+scheduler/eager paths); `with_backend_session` is the canonical user entry
+and the one-shot concrete helpers delegate to it. The session-explicit
+surface uses the plain entry; extension plans (`EinsumPlan` etc.) own their
+long-lived caches. The canonical user entry must not silently become the slow
+entry: `with_backend_session` may forward to the cached path when a cache is
+available, but the public contract is the plain entry.
+
+## Surface design (prototype plan)
+
+Layering (same vocabulary, no duplicate validation):
+
+```
+one-shot API: &mut TensorBackend ──enter one session──▶ session implementation
+session API:  &mut dyn BackendSession ─────────────────▶ session implementation
+```
+
+1. `TensorSessionOpsExt` / `TypedTensorSessionOpsExt` with `*_in` methods
+   (naming: `_in` preferred; exact names decided in the prototype).
+   Implemented by calling the session's own op traits directly; broadcasting,
+   dtype promotion, validation, and typed errors identical to the one-shot
+   path (shared helpers — no second vocabulary).
+2. One-shot methods delegate to the `_in` implementations where practical.
+3. Concrete-only extensions (einsum plans first: `EinsumPlan::prepare` +
+   `execute_in_session`) compose standard session ops; no
+   `ExtensionOp`/`SemanticProgram`/runtime registration required at that
+   tier.
+4. Runtime-integrated extensions keep the semantic `ExtensionOp` + AD rules;
+   runtime preparation produces an executor that runs on the borrowed
+   `BackendSession` like the concrete path.
+
+## Non-goals
+
+- No session/runtime handle inside `Tensor`/`TypedTensor`.
+- No change to the `EagerTensor` ownership/AD model.
+- No unbounded or globally owned sessions; closure-scoped borrowing stays the
+  default.
+- No second operation vocabulary or duplicated validation.
+- GPU small-op launch overhead is a separate concern (fusion/static
+  execution), not addressed by session reuse.
+- The one-shot API is not broken for aesthetic consistency.
+
+## Acceptance criteria
+
+- One session entry covers a mixed sequence of standard and extension
+  concrete operations.
+- Standard broadcasting, dtype promotion, validation, placement, and typed
+  errors identical to the one-shot path.
+- One-shot methods delegate to the same implementation where practical.
+- `Tensor`/`TypedTensor` remain context-free.
+- Concrete-only extension authors need no runtime/graph/AD machinery.
+- Nested-entry prohibition enforced per backend family (CPU release panic +
+  default-adapter debug assert; CUDA/WebGPU enforcement tracked as
+  follow-up).
+- `Send` bounds preserved and documented as a soundness requirement.
+- The 10-op trivial-chain gate passes (≥2x, predicted ~6x).
+- No material regression for large operations.


### PR DESCRIPTION
## Summary

First step of issue #1673 (session-oriented concrete APIs): write the design
doc and add the portable nested-entry debug guard. The design review's Send
assumption was verified false — CPU managed sessions hand the closure off to
a Rayon worker (even pinned one-worker pools), so `Send` is a soundness
requirement and stays.

## What's in this PR

1. **`docs/design/session-oriented-concrete-apis.md`** — the design for the
   session-explicit concrete API surface: motivation (session entry ~3 µs/op,
   gate `T_one_shot / T_one_session >= 2`, predicted ~6), the corrected
   execution model (CPU Rayon handoff → `Send` stays; default adapter runs on
   the calling thread), nested-entry enforcement per backend family, cache
   parity, surface layering, non-goals, acceptance criteria.
2. **`docs/design/exec-session.md`** — fixes two stale sections: CPU pinned
   one-worker managed pools hand off to a real Rayon pool (not inline), and
   CUDA/WebGPU have dedicated exec-session overrides (not the default
   adapter).
3. **`crates/tenferro-tensor/src/backend.rs`** — thread-local in-session flag
   + Drop-restored debug guard in `default_backend_session`: nested session
   entry is rejected in debug builds with a clear assert; panics in the
   closure still restore the flag. Doc note: `with_backend_session` is the
   canonical user entry, `_cached` is the runtime-cache-aware entry.
4. **Tests** — nested-entry debug rejection, flag cleared after a panicking
   closure, sequential sessions succeed.

## Verified facts (from this PR's investigation)

- `CpuBackend::with_backend_session` → `run_backend_session_cached` →
  `enter_managed_session`/`install_scoped` → `CpuContext::install` →
  `rayon::ThreadPool::install`: real thread handoff. `with_pinned_cpus`
  (used by `CpuEngine::new_managed`) builds a Rayon pool even for 1 worker
  (empirically verified: closure thread id ≠ caller thread id).
- `default_backend_session` runs `f(backend)` on the calling thread.
- CUDA/WebGPU overrides call `f` directly on the calling thread (their
  nested-entry enforcement is tracked as follow-up; the design doc scopes the
  acceptance criterion to CPU + default adapter accordingly).

Reviewed via the frontier gate (reviewer-gpt): design doc + diff, 5 findings
(3 blocking: stale exec-session.md CPU/CUDA sections, overclaimed portable
guard scope; 2 non-blocking: gate formula, panic-restoration test) — all
fixed and confirmed Correct-to-merge.

Verification: `check-pr-fast.sh` green, repository-rules review pass, fmt
clean, clippy clean (tensor/cpu/runtime).
