### PR TITLE
feat(runtime): session-explicit concrete ops (_in surface) (#1673)

### DIFF
--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -53,6 +53,10 @@ tenferro-cpu = { path = "../tenferro-cpu", default-features = false }
 name = "elementwise_fusion"
 harness = false
 
+[[bench]]
+name = "session_chain"
+harness = false
+
 [[test]]
 name = "integration"
 path = "tests/integration.rs"

--- a/crates/tenferro-runtime/benches/session_chain.rs
+++ b/crates/tenferro-runtime/benches/session_chain.rs
@@ -1,0 +1,98 @@
+//! Session-entry cost benchmark for the `_in` concrete-ops surface.
+//!
+//! Exact 10-op chain: three repetitions of `add -> exp -> mul` (9 ops)
+//! followed by a final `reduce_sum([0])` (10th). Two shape arms (no-broadcast
+//! 1x8 duplicate path vs 1x1/1x8 real reshape+broadcast) and two execution
+//! arms (one-shot `TensorOpsExt`, one session entry per op = 10 entries, vs
+//! `TensorSessionOpsExt` inside one `with_backend_session` = 1 entry).
+//!
+//! Constants are chosen so the chain does not overflow (`exp` of large
+//! values); the result is validated outside the timed region.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{Tensor, TensorOpsExt, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
+
+/// `a` is a 1x8 constant row in the no-broadcast arm and a 1x1 row (the
+/// singleton broadcast source) in the broadcast arm.
+fn operand_a(broadcast: bool) -> Tensor {
+    let value = vec![0.5_f64];
+    if broadcast {
+        Tensor::from_vec_col_major(vec![1], value).expect("benchmark tensor")
+    } else {
+        Tensor::from_vec_col_major(vec![8], vec![0.5_f64; 8]).expect("benchmark tensor")
+    }
+}
+
+fn operand_b() -> Tensor {
+    Tensor::from_vec_col_major(vec![8], vec![1.0_f64; 8]).expect("benchmark tensor")
+}
+
+/// 10 ops, each entering its own backend session.
+fn run_chain_one_shot(a: &Tensor, b: &Tensor, backend: &mut CpuBackend) -> Tensor {
+    let x = a.add(b, backend).expect("add 1");
+    let x = x.exp(backend).expect("exp 1");
+    let x = x.mul(a, backend).expect("mul 1");
+    let x = x.add(b, backend).expect("add 2");
+    let x = x.exp(backend).expect("exp 2");
+    let x = x.mul(a, backend).expect("mul 2");
+    let x = x.add(b, backend).expect("add 3");
+    let x = x.exp(backend).expect("exp 3");
+    let x = x.mul(a, backend).expect("mul 3");
+    x.reduce_sum(&[0], backend).expect("reduce_sum")
+}
+
+/// The same 10 ops inside one backend session (1 entry).
+fn run_chain_one_session(a: &Tensor, b: &Tensor, backend: &mut CpuBackend) -> Tensor {
+    backend.with_backend_session(|session| {
+        let x = a.add_in(b, session).expect("add 1");
+        let x = x.exp_in(session).expect("exp 1");
+        let x = x.mul_in(a, session).expect("mul 1");
+        let x = x.add_in(b, session).expect("add 2");
+        let x = x.exp_in(session).expect("exp 2");
+        let x = x.mul_in(a, session).expect("mul 2");
+        let x = x.add_in(b, session).expect("add 3");
+        let x = x.exp_in(session).expect("exp 3");
+        let x = x.mul_in(a, session).expect("mul 3");
+        x.reduce_sum_in(&[0], session).expect("reduce_sum")
+    })
+}
+
+fn bench_session_chain(c: &mut Criterion) {
+    for (arm, broadcast) in [("no_broadcast", false), ("broadcast", true)] {
+        let mut group = c.benchmark_group(format!("session_chain/{arm}"));
+        let a = operand_a(broadcast);
+        let b = operand_b();
+        let mut backend = CpuBackend::new();
+
+        // Validation outside the timed region: finite scalar result, and the
+        // two execution arms agree.
+        let one_shot = run_chain_one_shot(&a, &b, &mut backend);
+        assert!(one_shot.shape().is_empty(), "chain must reduce to a scalar");
+        assert!(one_shot.as_slice::<f64>().unwrap()[0].is_finite());
+        let one_session = run_chain_one_session(&a, &b, &mut backend);
+        assert!(one_session.as_slice::<f64>().unwrap()[0].is_finite());
+        assert_eq!(
+            one_shot.as_slice::<f64>().unwrap(),
+            one_session.as_slice::<f64>().unwrap()
+        );
+
+        group.bench_function("one_shot", |bench| {
+            bench.iter(|| {
+                let out = run_chain_one_shot(black_box(&a), black_box(&b), &mut backend);
+                black_box(out);
+            });
+        });
+        group.bench_function("one_session", |bench| {
+            bench.iter(|| {
+                let out = run_chain_one_session(black_box(&a), black_box(&b), &mut backend);
+                black_box(out);
+            });
+        });
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_session_chain);
+criterion_main!(benches);

--- a/crates/tenferro-runtime/src/lib.rs
+++ b/crates/tenferro-runtime/src/lib.rs
@@ -111,9 +111,9 @@ pub use shape_packing::TracedSliceBuilder;
 pub use sym_dim::SymDim;
 pub use tenferro_ops::ShapeRelation;
 pub use tenferro_tensor::{
-    BackendSessionHost, CacheStats, CompareDir, DType, DotGeneralConfig, GatherConfig, MemoryKind,
-    PadConfig, ScatterConfig, SliceConfig, Tensor, TensorBackend, TensorRead, TensorScalar,
-    TensorValue, TensorView, TypedTensor, TypedTensorView,
+    BackendSession, BackendSessionHost, CacheStats, CompareDir, DType, DotGeneralConfig,
+    GatherConfig, MemoryKind, PadConfig, ScatterConfig, SliceConfig, Tensor, TensorBackend,
+    TensorRead, TensorScalar, TensorValue, TensorView, TypedTensor, TypedTensorView,
 };
 pub use trace::{TraceContext, TraceValue, TracedGraph};
 
@@ -466,6 +466,141 @@ pub trait TensorOpsExt {
     ) -> tenferro_tensor::Result<Tensor>;
 }
 
+/// Backend-explicit session operations for concrete [`Tensor`] values.
+///
+/// These operations run inside a caller-provided [`BackendSession`], so a
+/// chain of `_in` operations executes in a single backend session entry and
+/// never enters a session of its own. Each one-shot [`TensorOpsExt`]
+/// counterpart performs its broadcast and execution inside a single session
+/// entry of its own.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+/// use tenferro_tensor::BackendSessionHost;
+///
+/// let mut backend = CpuBackend::new();
+/// let a = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
+/// let b = Tensor::from_vec_col_major(vec![8], vec![2.0_f64; 8]).unwrap();
+/// let total = backend.with_backend_session(|session| {
+///     let sum = a.add_in(&b, session).unwrap();
+///     let grown = sum.exp_in(session).unwrap();
+///     grown.mul_in(&a, session).unwrap().reduce_sum_in(&[0], session).unwrap()
+/// });
+/// assert!(total.as_slice::<f64>().unwrap()[0].is_finite());
+/// ```
+pub trait TensorSessionOpsExt {
+    /// Elementwise addition with NumPy-style broadcasting inside a session.
+    ///
+    /// The broadcast (reshape + `broadcast_in_dim`, or a copy when shapes
+    /// already match) and the add itself all run in the caller's `session`;
+    /// this op never enters a session of its own.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    /// let b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
+    /// let sum = backend.with_backend_session(|session| a.add_in(&b, session)).unwrap();
+    /// assert_eq!(sum.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with a
+    /// [`ShapeMismatch`](tenferro_tensor::ValidationError::ShapeMismatch) or
+    /// `DTypeMismatch` payload when operands are incompatible, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn add_in(
+        &self,
+        rhs: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise multiplication with NumPy-style broadcasting inside a session.
+    ///
+    /// Like [`Self::add_in`], broadcast and multiply run in the one `session`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
+    /// let b = Tensor::from_vec_col_major(vec![4], vec![3.0_f64; 4]).unwrap();
+    /// let product = backend.with_backend_session(|session| a.mul_in(&b, session)).unwrap();
+    /// assert_eq!(product.as_slice::<f64>().unwrap(), &[6.0; 4]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` for incompatible operands, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn mul_in(
+        &self,
+        rhs: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise exponential inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.exp_in(session)).unwrap();
+    /// let y = y.as_slice::<f64>().unwrap();
+    /// assert!((y[0] - 1.0).abs() < 1.0e-12);
+    /// assert!((y[1] - std::f64::consts::E).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn exp_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Sum over one or more axes inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    /// let sums = backend.with_backend_session(|session| x.reduce_sum_in(&[1], session)).unwrap();
+    /// assert_eq!(sums.as_slice::<f64>().unwrap(), &[3.0, 3.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds`
+    /// or `DuplicateAxis` for invalid reductions, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn reduce_sum_in(
+        &self,
+        axes: &[usize],
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+}
+
 /// Backend-explicit operations for dynamic-rank typed tensors.
 ///
 /// `TypedTensor` is owned by `tenferro-tensor`, so `tenferro-runtime` exposes
@@ -792,6 +927,133 @@ pub trait TypedTensorOpsExt<T: TensorScalar> {
         shape: &[usize],
         dims: &[usize],
         backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+}
+
+/// Backend-explicit session operations for dynamic-rank typed tensors.
+///
+/// Like [`TensorSessionOpsExt`] but for [`TypedTensor`] with a statically
+/// known scalar type `T`. The typed surface keeps inputs borrowed (read-based
+/// session ops) and validates the output dtype through
+/// `into_typed_result`-style conversion before returning.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+/// use tenferro_tensor::BackendSessionHost;
+///
+/// let mut backend = CpuBackend::new();
+/// let a = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![1.0]).unwrap();
+/// let b = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![2.0; 4]).unwrap();
+/// let total = backend.with_backend_session(|session| {
+///     let sum = a.add_in(&b, session).unwrap();
+///     sum.exp_in(session).unwrap().reduce_sum_in(&[0], session).unwrap()
+/// });
+/// assert!(total.host_data().unwrap()[0].is_finite());
+/// ```
+pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
+    /// Elementwise addition with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
+    /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap();
+    /// let sum = backend.with_backend_session(|session| a.add_in(&b, session)).unwrap();
+    /// assert_eq!(sum.host_data().unwrap(), &[4.0, 6.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
+    /// a typed backend failure.
+    fn add_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise multiplication with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![2.0]).unwrap();
+    /// let b = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![3.0; 4]).unwrap();
+    /// let product = backend.with_backend_session(|session| a.mul_in(&b, session)).unwrap();
+    /// assert_eq!(product.host_data().unwrap(), &[6.0; 4]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
+    /// a typed backend failure.
+    fn mul_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise exponential inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, 1.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.exp_in(session)).unwrap();
+    /// let y = y.host_data().unwrap();
+    /// assert!((y[0] - 1.0).abs() < 1.0e-12);
+    /// assert!((y[1] - std::f64::consts::E).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn exp_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Sum over one or more axes inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
+    /// let sums = backend.with_backend_session(|session| x.reduce_sum_in(&[1], session)).unwrap();
+    /// assert_eq!(sums.host_data().unwrap(), &[3.0, 3.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds`
+    /// for an axis outside the input rank or `DuplicateAxis` when `axes`
+    /// repeats an axis, or [`tenferro_tensor::Error::BackendSource`] for a
+    /// typed backend failure.
+    fn reduce_sum_in(
+        &self,
+        axes: &[usize],
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
 }
 

--- a/crates/tenferro-runtime/src/prelude.rs
+++ b/crates/tenferro-runtime/src/prelude.rs
@@ -2,6 +2,6 @@
 
 pub use crate::{
     CompareDir, DType, GraphCompiler, Runtime, Tensor, TensorBackend, TensorOpsExt, TensorScalar,
-    TraceContext, TraceValue, TracedGraph, TracedTensor, TypedTensor, TypedTensorMaskOpsExt,
-    TypedTensorOpsExt,
+    TensorSessionOpsExt, TraceContext, TraceValue, TracedGraph, TracedTensor, TypedTensor,
+    TypedTensorMaskOpsExt, TypedTensorOpsExt, TypedTensorSessionOpsExt,
 };

--- a/crates/tenferro-runtime/src/tensor.rs
+++ b/crates/tenferro-runtime/src/tensor.rs
@@ -7,9 +7,9 @@ use tenferro_ops::broadcast::{
     broadcast_error_to_validation, broadcast_input_plan, broadcast_shape, broadcast_shapes,
 };
 use tenferro_tensor::validate::matmul_config_for_shapes;
-use tenferro_tensor::{CompareDir, DType, Error, Result, TensorBackend};
+use tenferro_tensor::{BackendSession, CompareDir, DType, Error, Result, TensorBackend};
 
-use crate::TensorOpsExt;
+use crate::{TensorOpsExt, TensorSessionOpsExt};
 use tenferro_tensor::Tensor;
 
 impl TensorOpsExt for Tensor {
@@ -149,6 +149,26 @@ impl TensorOpsExt for Tensor {
     }
 }
 
+impl TensorSessionOpsExt for Tensor {
+    fn add_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+        let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
+        session.add(&lhs, &rhs)
+    }
+
+    fn mul_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+        let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
+        session.mul(&lhs, &rhs)
+    }
+
+    fn exp_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.exp(self)
+    }
+
+    fn reduce_sum_in(&self, axes: &[usize], session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.reduce_sum(self, axes)
+    }
+}
+
 /// Convert a tensor to a different dtype using the checked conversion lattice.
 ///
 /// Use [`cast`] for explicit lossy dtype projection.
@@ -211,8 +231,7 @@ fn cast(input: &Tensor, to: DType, backend: &mut impl TensorBackend) -> Result<T
 /// let z = x.add(&y, &mut backend).unwrap();
 /// ```
 fn add(lhs: &Tensor, rhs: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
-    let (lhs, rhs) = broadcast_binary(lhs, rhs, backend)?;
-    backend.with_backend_session(|exec| exec.add(&lhs, &rhs))
+    backend.with_backend_session(|session| lhs.add_in(rhs, session))
 }
 
 macro_rules! unary_fn {
@@ -256,11 +275,6 @@ macro_rules! binary_fn {
 }
 
 binary_fn!(
-    mul,
-    mul,
-    "Elementwise multiplication with NumPy-style broadcasting."
-);
-binary_fn!(
     div,
     div,
     "Elementwise division with NumPy-style broadcasting."
@@ -286,7 +300,6 @@ unary_fn!(neg, neg, "Elementwise negation.");
 unary_fn!(abs, abs, "Elementwise absolute value.");
 unary_fn!(sign, sign, "Elementwise sign.");
 unary_fn!(conj, conj, "Elementwise complex conjugate.");
-unary_fn!(exp, exp, "Elementwise exponential.");
 unary_fn!(log, log, "Elementwise natural logarithm.");
 unary_fn!(sin, sin, "Elementwise sine.");
 unary_fn!(cos, cos, "Elementwise cosine.");
@@ -295,6 +308,37 @@ unary_fn!(sqrt, sqrt, "Elementwise square root.");
 unary_fn!(rsqrt, rsqrt, "Elementwise reciprocal square root.");
 unary_fn!(expm1, expm1, "Elementwise `exp(x) - 1`.");
 unary_fn!(log1p, log1p, "Elementwise `log(1 + x)`.");
+
+/// Elementwise multiplication with NumPy-style broadcasting.
+///
+/// # Examples
+///
+/// ```rust
+/// # use tenferro_cpu::CpuBackend;
+/// use tenferro_runtime::{Tensor, TensorOpsExt};
+/// # let mut backend = CpuBackend::new();
+/// # let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
+/// # let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
+/// let z = x.mul(&y, &mut backend).unwrap();
+/// ```
+fn mul(lhs: &Tensor, rhs: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
+    backend.with_backend_session(|session| lhs.mul_in(rhs, session))
+}
+
+/// Elementwise exponential.
+///
+/// # Examples
+///
+/// ```rust
+/// # use tenferro_cpu::CpuBackend;
+/// use tenferro_runtime::{Tensor, TensorOpsExt};
+/// # let mut backend = CpuBackend::new();
+/// # let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap();
+/// let y = x.exp(&mut backend).unwrap();
+/// ```
+fn exp(input: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
+    backend.with_backend_session(|session| input.exp_in(session))
+}
 
 /// Elementwise subtraction with NumPy-style broadcasting.
 ///
@@ -450,7 +494,38 @@ fn transpose(input: &Tensor, perm: &[usize], backend: &mut impl TensorBackend) -
 /// assert_eq!(y.shape(), &[2]);
 /// ```
 fn reduce_sum(input: &Tensor, axes: &[usize], backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|exec| exec.reduce_sum(input, axes))
+    backend.with_backend_session(|session| input.reduce_sum_in(axes, session))
+}
+
+fn broadcast_to_in(
+    input: &Tensor,
+    target_shape: &[usize],
+    session: &mut dyn BackendSession,
+) -> Result<Tensor> {
+    let input_shape = input.shape();
+    if input_shape == target_shape {
+        return input.duplicate();
+    }
+
+    let plan = broadcast_input_plan(input_shape, target_shape).map_err(broadcast_error)?;
+    let source = if plan.source_shape == input_shape {
+        input.duplicate()?
+    } else {
+        session.reshape(input, &plan.source_shape)?
+    };
+    session.broadcast_in_dim(&source, target_shape, &plan.dims)
+}
+
+fn broadcast_binary_in(
+    lhs: &Tensor,
+    rhs: &Tensor,
+    session: &mut dyn BackendSession,
+) -> Result<(Tensor, Tensor)> {
+    let shape = broadcast_shape(lhs.shape(), rhs.shape()).map_err(broadcast_error)?;
+    Ok((
+        broadcast_to_in(lhs, &shape, session)?,
+        broadcast_to_in(rhs, &shape, session)?,
+    ))
 }
 
 fn broadcast_binary(

--- a/crates/tenferro-runtime/src/typed_tensor.rs
+++ b/crates/tenferro-runtime/src/typed_tensor.rs
@@ -8,11 +8,11 @@ use tenferro_ops::broadcast::{
 };
 use tenferro_tensor::validate::matmul_config_for_shapes;
 use tenferro_tensor::{
-    CompareDir, DType, Error, Result, Tensor, TensorBackend, TensorRead, TensorScalar,
-    ValidationError,
+    BackendSession, CompareDir, DType, Error, Result, Tensor, TensorBackend, TensorRead,
+    TensorScalar, ValidationError,
 };
 
-use crate::{TypedTensorMaskOpsExt, TypedTensorOpsExt};
+use crate::{TypedTensorMaskOpsExt, TypedTensorOpsExt, TypedTensorSessionOpsExt};
 use tenferro_tensor::TypedTensor;
 
 impl<T: TensorScalar> TypedTensorOpsExt<T> for TypedTensor<T> {
@@ -192,6 +192,42 @@ impl<T: TensorScalar> TypedTensorOpsExt<T> for TypedTensor<T> {
     }
 }
 
+impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
+    fn add_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let (lhs, rhs) = broadcast_binary_in_read(self, rhs, session)?;
+        let out = session.add_read(lhs.tensor_read(), rhs.tensor_read())?;
+        into_typed_result("add", out)
+    }
+
+    fn mul_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let (lhs, rhs) = broadcast_binary_in_read(self, rhs, session)?;
+        let out = session.mul_read(lhs.tensor_read(), rhs.tensor_read())?;
+        into_typed_result("mul", out)
+    }
+
+    fn exp_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.exp_read(T::tensor_read(self))?;
+        into_typed_result("exp", out)
+    }
+
+    fn reduce_sum_in(
+        &self,
+        axes: &[usize],
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let out = session.reduce_sum_read(T::tensor_read(self), axes)?;
+        into_typed_result("reduce_sum", out)
+    }
+}
+
 impl TypedTensorMaskOpsExt for TypedTensor<bool> {
     fn where_select<T: TensorScalar, B: TensorBackend>(
         &self,
@@ -220,10 +256,7 @@ fn add<T: TensorScalar>(
     rhs: &TypedTensor<T>,
     backend: &mut impl TensorBackend,
 ) -> Result<TypedTensor<T>> {
-    let (lhs, rhs) = broadcast_binary_read(lhs, rhs, backend)?;
-    let out =
-        backend.with_backend_session(|exec| exec.add_read(lhs.tensor_read(), rhs.tensor_read()))?;
-    into_typed_result("add", out)
+    backend.with_backend_session(|session| lhs.add_in(rhs, session))
 }
 
 macro_rules! unary_fn {
@@ -277,11 +310,6 @@ macro_rules! binary_fn {
 }
 
 binary_fn!(
-    mul,
-    mul_read,
-    "Elementwise multiplication with NumPy-style broadcasting."
-);
-binary_fn!(
     div,
     div_read,
     "Elementwise division with NumPy-style broadcasting."
@@ -311,7 +339,6 @@ unary_fn!(neg, neg_read, "Elementwise negation.");
 unary_fn!(abs, abs_read, "Elementwise absolute value.");
 unary_fn!(sign, sign_read, "Elementwise sign.");
 unary_fn!(conj, conj_read, "Elementwise complex conjugate.");
-unary_fn!(exp, exp_read, "Elementwise exponential.");
 unary_fn!(log, log_read, "Elementwise natural logarithm.");
 unary_fn!(sin, sin_read, "Elementwise sine.");
 unary_fn!(cos, cos_read, "Elementwise cosine.");
@@ -320,6 +347,44 @@ unary_fn!(sqrt, sqrt_read, "Elementwise square root.");
 unary_fn!(rsqrt, rsqrt_read, "Elementwise reciprocal square root.");
 unary_fn!(expm1, expm1_read, "Elementwise `exp(x) - 1`.");
 unary_fn!(log1p, log1p_read, "Elementwise `log(1 + x)`.");
+
+/// Elementwise multiplication with NumPy-style broadcasting.
+///
+/// # Examples
+///
+/// ```rust
+/// # use tenferro_cpu::CpuBackend;
+/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+/// # let mut backend = CpuBackend::new();
+/// # let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
+/// # let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
+/// let z = x.mul(&y, &mut backend).unwrap();
+/// ```
+fn mul<T: TensorScalar>(
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+    backend: &mut impl TensorBackend,
+) -> Result<TypedTensor<T>> {
+    backend.with_backend_session(|session| lhs.mul_in(rhs, session))
+}
+
+/// Elementwise exponential.
+///
+/// # Examples
+///
+/// ```rust
+/// # use tenferro_cpu::CpuBackend;
+/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+/// # let mut backend = CpuBackend::new();
+/// # let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 4.0]).unwrap();
+/// let y = x.exp(&mut backend).unwrap();
+/// ```
+fn exp<T: TensorScalar>(
+    input: &TypedTensor<T>,
+    backend: &mut impl TensorBackend,
+) -> Result<TypedTensor<T>> {
+    backend.with_backend_session(|session| input.exp_in(session))
+}
 
 /// Elementwise subtraction with NumPy-style broadcasting.
 ///
@@ -482,9 +547,7 @@ fn reduce_sum<T: TensorScalar>(
     axes: &[usize],
     backend: &mut impl TensorBackend,
 ) -> Result<TypedTensor<T>> {
-    let out =
-        backend.with_backend_session(|exec| exec.reduce_sum_read(T::tensor_read(input), axes))?;
-    into_typed_result("reduce_sum", out)
+    backend.with_backend_session(|session| input.reduce_sum_in(axes, session))
 }
 
 /// Reshape a typed tensor through the backend structural operation.
@@ -573,6 +636,38 @@ impl ReadInput<'_> {
             Self::Owned(tensor) => TensorRead::from_tensor(tensor),
         }
     }
+}
+
+fn broadcast_to_in_read<'a, T: TensorScalar>(
+    input: &'a TypedTensor<T>,
+    target_shape: &[usize],
+    session: &mut dyn BackendSession,
+) -> Result<ReadInput<'a>> {
+    if input.shape() == target_shape {
+        return Ok(ReadInput::Borrowed(T::tensor_read(input)));
+    }
+
+    let plan = broadcast_input_plan(input.shape(), target_shape).map_err(broadcast_error)?;
+    let source = if plan.source_shape == input.shape() {
+        ReadInput::Borrowed(T::tensor_read(input))
+    } else {
+        let reshaped = session.reshape_read(T::tensor_read(input), &plan.source_shape)?;
+        ReadInput::Owned(reshaped)
+    };
+    let out = session.broadcast_in_dim_read(source.tensor_read(), target_shape, &plan.dims)?;
+    Ok(ReadInput::Owned(out))
+}
+
+fn broadcast_binary_in_read<'a, T: TensorScalar>(
+    lhs: &'a TypedTensor<T>,
+    rhs: &'a TypedTensor<T>,
+    session: &mut dyn BackendSession,
+) -> Result<(ReadInput<'a>, ReadInput<'a>)> {
+    let shape = broadcast_shape(lhs.shape(), rhs.shape()).map_err(broadcast_error)?;
+    Ok((
+        broadcast_to_in_read(lhs, &shape, session)?,
+        broadcast_to_in_read(rhs, &shape, session)?,
+    ))
 }
 
 fn broadcast_binary_read<'a, T: TensorScalar>(

--- a/crates/tenferro-runtime/tests/integration.rs
+++ b/crates/tenferro-runtime/tests/integration.rs
@@ -16,6 +16,8 @@ mod runtime_foundations;
 mod runtime_preparation_api;
 #[path = "integration/runtime_public_api.rs"]
 mod runtime_public_api;
+#[path = "integration/session_in_ops.rs"]
+mod session_in_ops;
 #[path = "integration/trace_context.rs"]
 mod trace_context;
 #[path = "integration/typed_tensor_contract.rs"]

--- a/crates/tenferro-runtime/tests/integration/session_in_ops.rs
+++ b/crates/tenferro-runtime/tests/integration/session_in_ops.rs
@@ -1,0 +1,659 @@
+//! Parity and single-session-entry tests for the `_in` session surfaces.
+//!
+//! Covers, per surface (dynamic [`Tensor`] and typed [`TypedTensor`]):
+//! equal-shape ops, real broadcast, invalid-broadcast structured-error parity
+//! with the one-shot path, dtype parity, typed output dtype validation
+//! (`into_typed_result`), and a deterministic proof that an `_in` chain
+//! executes inside exactly one backend session entry while the one-shot
+//! counterpart enters one session per op.
+
+use std::cell::Cell;
+
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{
+    Tensor, TensorOpsExt, TensorSessionOpsExt, TypedTensor, TypedTensorOpsExt,
+    TypedTensorSessionOpsExt,
+};
+use tenferro_tensor::backend::{
+    BackendCachedDot, TensorAnalytic, TensorBuffer, TensorDeviceTransfer, TensorDot,
+    TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
+};
+use tenferro_tensor::{
+    BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir, DType, DotGeneralConfig,
+    Error, GatherConfig, PadConfig, ScatterConfig, ShapeMismatch, SliceConfig, TensorBackend,
+    TensorRead, TensorWrite, ValidationError,
+};
+
+type TensorResult = tenferro_tensor::Result<Tensor>;
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        let error = (actual - expected).abs();
+        assert!(
+            error < 1.0e-12,
+            "value {index}: actual={actual}, expected={expected}, error={error}"
+        );
+    }
+}
+
+fn assert_incompatible_shapes_error(error: Error) {
+    match error {
+        Error::Validation {
+            op: "broadcast",
+            source: ValidationError::ShapeMismatch(shape),
+        } => assert!(
+            matches!(
+                shape.as_ref(),
+                ShapeMismatch::IncompatibleShapes { lhs, rhs }
+                    if lhs.as_slice() == [2] && rhs.as_slice() == [3]
+            ),
+            "unexpected shape payload: {shape:?}"
+        ),
+        other => panic!("expected broadcast ShapeMismatch, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic surface (TensorSessionOpsExt)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn session_in_dynamic_equal_shape_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let a_values = vec![1.5_f64; 8];
+    let b_values = vec![2.25_f64; 8];
+    let a = Tensor::from_vec_col_major(vec![8], a_values.clone()).unwrap();
+    let b = Tensor::from_vec_col_major(vec![8], b_values.clone()).unwrap();
+
+    let one_shot = a
+        .add(&b, &mut backend)
+        .unwrap()
+        .exp(&mut backend)
+        .unwrap()
+        .mul(&b, &mut backend)
+        .unwrap()
+        .reduce_sum(&[0], &mut backend)
+        .unwrap();
+
+    let session = backend.with_backend_session(|s| {
+        let x = a.add_in(&b, s).unwrap();
+        let x = x.exp_in(s).unwrap();
+        let x = x.mul_in(&b, s).unwrap();
+        x.reduce_sum_in(&[0], s).unwrap()
+    });
+
+    // Independent value check in plain scalar math: the chain computes
+    // sum_i exp(a_i + b_i) * b_i without any tenferro op, so a shared
+    // one-shot regression cannot satisfy it.
+    let expected: f64 = a_values
+        .iter()
+        .zip(&b_values)
+        .map(|(&x, &y)| (x + y).exp() * y)
+        .sum();
+    assert_close(session.as_slice::<f64>().unwrap(), &[expected]);
+
+    assert_eq!(session.shape(), one_shot.shape());
+    assert_close(
+        session.as_slice::<f64>().unwrap(),
+        one_shot.as_slice::<f64>().unwrap(),
+    );
+}
+
+#[test]
+fn session_in_dynamic_broadcast_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let a_values = vec![1.0_f64];
+    let b_values = vec![2.0_f64; 8];
+    let a = Tensor::from_vec_col_major(vec![1], a_values.clone()).unwrap();
+    let b = Tensor::from_vec_col_major(vec![8], b_values.clone()).unwrap();
+
+    let one_shot = a
+        .add(&b, &mut backend)
+        .unwrap()
+        .exp(&mut backend)
+        .unwrap()
+        .mul(&a, &mut backend)
+        .unwrap()
+        .reduce_sum(&[0], &mut backend)
+        .unwrap();
+
+    let session = backend.with_backend_session(|s| {
+        let x = a.add_in(&b, s).unwrap();
+        let x = x.exp_in(s).unwrap();
+        let x = x.mul_in(&a, s).unwrap();
+        x.reduce_sum_in(&[0], s).unwrap()
+    });
+
+    // Independent value check: the broadcast chain computes
+    // sum_i exp(a_0 + b_i) * a_0 in plain scalar math.
+    let expected: f64 = b_values
+        .iter()
+        .map(|&y| (a_values[0] + y).exp() * a_values[0])
+        .sum();
+    assert_close(session.as_slice::<f64>().unwrap(), &[expected]);
+
+    assert_eq!(session.shape(), one_shot.shape());
+    assert_close(
+        session.as_slice::<f64>().unwrap(),
+        one_shot.as_slice::<f64>().unwrap(),
+    );
+}
+
+#[test]
+fn session_in_dynamic_invalid_broadcast_matches_one_shot_error() {
+    let mut backend = CpuBackend::new();
+    let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
+
+    let one_shot_error = a.add(&b, &mut backend).unwrap_err();
+    let session_error = backend
+        .with_backend_session(|s| a.add_in(&b, s))
+        .unwrap_err();
+
+    assert_incompatible_shapes_error(one_shot_error);
+    assert_incompatible_shapes_error(session_error);
+}
+
+#[test]
+fn session_in_dynamic_dtype_error_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2], vec![1_i32; 2]).unwrap();
+
+    let one_shot_error = a.add(&b, &mut backend).unwrap_err();
+    let session_error = backend
+        .with_backend_session(|s| a.add_in(&b, s))
+        .unwrap_err();
+
+    // Assert the full payload (op name, source lhs dtype as expected, rhs
+    // dtype as actual) for both paths, not just the error kind.
+    for error in [one_shot_error, session_error] {
+        let Error::Validation {
+            op: "add",
+            source: ValidationError::DTypeMismatch { expected, actual },
+        } = &error
+        else {
+            panic!("expected add DTypeMismatch, got {error:?}");
+        };
+        assert_eq!(*expected, tenferro_tensor::core::DType::F64);
+        assert_eq!(*actual, tenferro_tensor::core::DType::I32);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Typed surface (TypedTensorSessionOpsExt)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn session_in_typed_equal_shape_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let a_values = vec![1.5_f64; 8];
+    let b_values = vec![2.25_f64; 8];
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![8], a_values.clone()).unwrap();
+    let b = TypedTensor::<f64>::from_vec_col_major(vec![8], b_values.clone()).unwrap();
+
+    let one_shot = a
+        .add(&b, &mut backend)
+        .unwrap()
+        .exp(&mut backend)
+        .unwrap()
+        .mul(&b, &mut backend)
+        .unwrap()
+        .reduce_sum(&[0], &mut backend)
+        .unwrap();
+
+    let session = backend.with_backend_session(|s| {
+        let x = a.add_in(&b, s).unwrap();
+        let x = x.exp_in(s).unwrap();
+        let x = x.mul_in(&b, s).unwrap();
+        x.reduce_sum_in(&[0], s).unwrap()
+    });
+
+    // Independent value check in plain scalar math (see the dynamic twin).
+    let expected: f64 = a_values
+        .iter()
+        .zip(&b_values)
+        .map(|(&x, &y)| (x + y).exp() * y)
+        .sum();
+    assert_close(session.host_data().unwrap(), &[expected]);
+
+    assert_eq!(session.shape(), one_shot.shape());
+    assert_close(session.host_data().unwrap(), one_shot.host_data().unwrap());
+}
+
+#[test]
+fn session_in_typed_broadcast_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let a_values = vec![1.0_f64];
+    let b_values = vec![2.0_f64; 8];
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![1], a_values.clone()).unwrap();
+    let b = TypedTensor::<f64>::from_vec_col_major(vec![8], b_values.clone()).unwrap();
+
+    let one_shot = a
+        .add(&b, &mut backend)
+        .unwrap()
+        .exp(&mut backend)
+        .unwrap()
+        .mul(&a, &mut backend)
+        .unwrap()
+        .reduce_sum(&[0], &mut backend)
+        .unwrap();
+
+    let session = backend.with_backend_session(|s| {
+        let x = a.add_in(&b, s).unwrap();
+        let x = x.exp_in(s).unwrap();
+        let x = x.mul_in(&a, s).unwrap();
+        x.reduce_sum_in(&[0], s).unwrap()
+    });
+
+    // Independent value check: sum_i exp(a_0 + b_i) * a_0 in plain scalar math.
+    let expected: f64 = b_values
+        .iter()
+        .map(|&y| (a_values[0] + y).exp() * a_values[0])
+        .sum();
+    assert_close(session.host_data().unwrap(), &[expected]);
+
+    assert_eq!(session.shape(), one_shot.shape());
+    assert_close(session.host_data().unwrap(), one_shot.host_data().unwrap());
+}
+
+#[test]
+fn session_in_typed_invalid_broadcast_matches_one_shot_error() {
+    let mut backend = CpuBackend::new();
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0; 2]).unwrap();
+    let b = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0; 3]).unwrap();
+
+    let one_shot_error = a.add(&b, &mut backend).unwrap_err();
+    let session_error = backend
+        .with_backend_session(|s| a.add_in(&b, s))
+        .unwrap_err();
+
+    assert_incompatible_shapes_error(one_shot_error);
+    assert_incompatible_shapes_error(session_error);
+}
+
+#[test]
+fn session_in_typed_validates_output_dtype() {
+    let mut backend = WrongDTypeSessionBackend;
+    let a = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]).unwrap();
+
+    let add_error = backend
+        .with_backend_session(|s| a.add_in(&a, s))
+        .unwrap_err();
+    let mul_error = backend
+        .with_backend_session(|s| a.mul_in(&a, s))
+        .unwrap_err();
+    let exp_error = backend.with_backend_session(|s| a.exp_in(s)).unwrap_err();
+    let reduce_error = backend
+        .with_backend_session(|s| a.reduce_sum_in(&[0], s))
+        .unwrap_err();
+    for (op, error) in [
+        ("add", add_error),
+        ("mul", mul_error),
+        ("exp", exp_error),
+        ("reduce_sum", reduce_error),
+    ] {
+        let Error::Validation {
+            op: error_op,
+            source: ValidationError::DTypeMismatch { expected, actual },
+        } = &error
+        else {
+            panic!("expected {op} DTypeMismatch, got {error:?}");
+        };
+        assert_eq!(*error_op, op);
+        assert_eq!(*expected, tenferro_tensor::core::DType::I32);
+        assert_eq!(*actual, tenferro_tensor::core::DType::F64);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Single-session-entry proof
+// ---------------------------------------------------------------------------
+
+#[test]
+fn session_in_chain_enters_one_session_one_shot_enters_ten() {
+    let mut backend = SessionCountingBackend::new();
+    let a = Tensor::from_vec_col_major(vec![1], vec![0.5_f64]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![8], vec![1.0_f64; 8]).unwrap();
+
+    // 10 one-shot ops (3x add->exp->mul + final reduce_sum): one session entry
+    // per op.
+    let one_shot = a
+        .add(&b, &mut backend)
+        .unwrap()
+        .exp(&mut backend)
+        .unwrap()
+        .mul(&a, &mut backend)
+        .unwrap()
+        .add(&b, &mut backend)
+        .unwrap()
+        .exp(&mut backend)
+        .unwrap()
+        .mul(&a, &mut backend)
+        .unwrap()
+        .add(&b, &mut backend)
+        .unwrap()
+        .exp(&mut backend)
+        .unwrap()
+        .mul(&a, &mut backend)
+        .unwrap()
+        .reduce_sum(&[0], &mut backend)
+        .unwrap();
+    assert_eq!(
+        backend.entries.get(),
+        10,
+        "one-shot chain must enter one session per op"
+    );
+
+    backend.entries.set(0);
+    let session = backend.with_backend_session(|s| {
+        let x = a.add_in(&b, s).unwrap();
+        let x = x.exp_in(s).unwrap();
+        let x = x.mul_in(&a, s).unwrap();
+        let x = x.add_in(&b, s).unwrap();
+        let x = x.exp_in(s).unwrap();
+        let x = x.mul_in(&a, s).unwrap();
+        let x = x.add_in(&b, s).unwrap();
+        let x = x.exp_in(s).unwrap();
+        let x = x.mul_in(&a, s).unwrap();
+        x.reduce_sum_in(&[0], s).unwrap()
+    });
+    assert_eq!(
+        backend.entries.get(),
+        1,
+        "session chain must enter exactly one session"
+    );
+
+    assert_close(
+        session.as_slice::<f64>().unwrap(),
+        one_shot.as_slice::<f64>().unwrap(),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test backends
+// ---------------------------------------------------------------------------
+
+/// Test backend counting `with_backend_session` entries while delegating real
+/// execution to an inner [`CpuBackend`]. All direct op methods are unreachable
+/// in these tests and panic.
+struct SessionCountingBackend {
+    inner: CpuBackend,
+    entries: Cell<usize>,
+}
+
+impl SessionCountingBackend {
+    fn new() -> Self {
+        Self {
+            inner: CpuBackend::new(),
+            entries: Cell::new(0),
+        }
+    }
+}
+
+/// Test backend whose session ops return an `F64` tensor regardless of the
+/// requested dtype, so the typed `_in` surface must reject the output through
+/// `into_typed_result`.
+struct WrongDTypeSessionBackend;
+
+macro_rules! panic_backend_methods {
+    ($($name:ident($($arg:ident : $argty:ty),*) -> $ret:ty;)+) => {
+        $(
+            fn $name(&mut self, $($arg: $argty),*) -> $ret {
+                let _ = ($($arg),*);
+                panic!(concat!(stringify!($name), " should not be called in this test"))
+            }
+        )+
+    };
+}
+
+/// Panic-only implementations of every op trait except the elementwise,
+/// analytic, and reduction families (which some test backends override with
+/// real ops). Also excludes `BackendSessionHost`, which each backend
+/// implements explicitly.
+macro_rules! test_backend_impls {
+    ($ty:ident, $marker:ident) => {
+        struct $marker;
+
+        impl BackendRuntimeCache for $ty {
+            type RuntimeCache = <CpuBackend as BackendRuntimeCache>::RuntimeCache;
+        }
+
+        impl TensorStructural for $ty {
+            fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> TensorResult {
+                CpuBackend::new().to_contiguous_read(input)
+            }
+
+            fn copy_read_into(
+                &mut self,
+                src: TensorRead<'_>,
+                dst: TensorWrite<'_>,
+            ) -> tenferro_tensor::Result<()> {
+                CpuBackend::new().copy_read_into(src, dst)
+            }
+
+            panic_backend_methods! {
+                transpose(input: &Tensor, perm: &[usize]) -> TensorResult;
+                reshape(input: &Tensor, shape: &[usize]) -> TensorResult;
+                broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> TensorResult;
+                cast(input: &Tensor, to: DType) -> TensorResult;
+                convert(input: &Tensor, to: DType) -> TensorResult;
+                extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> TensorResult;
+                embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> TensorResult;
+                tril(input: &Tensor, k: i64) -> TensorResult;
+                triu(input: &Tensor, k: i64) -> TensorResult;
+            }
+        }
+
+        impl TensorIndexing for $ty {
+            panic_backend_methods! {
+                gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> TensorResult;
+                scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> TensorResult;
+                slice(input: &Tensor, config: &SliceConfig) -> TensorResult;
+                dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> TensorResult;
+                dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) -> TensorResult;
+                pad(input: &Tensor, config: &PadConfig) -> TensorResult;
+                concatenate(inputs: &[&Tensor], axis: usize) -> TensorResult;
+                reverse(input: &Tensor, axes: &[usize]) -> TensorResult;
+            }
+        }
+
+        impl TensorDot for $ty {
+            fn dot_general(
+                &mut self,
+                _lhs: &Tensor,
+                _rhs: &Tensor,
+                _config: &DotGeneralConfig,
+            ) -> TensorResult {
+                panic!("dot_general should not be called in this test")
+            }
+        }
+
+        impl TensorFusion for $ty {}
+        impl TensorBuffer for $ty {}
+
+        impl TensorDeviceTransfer for $ty {
+            fn download_to_host(&mut self, _tensor: TensorRead<'_>) -> TensorResult {
+                Err(Error::unsupported(
+                    concat!(stringify!($ty), "::download_to_host"),
+                    "test backend does not transfer tensors",
+                ))
+            }
+
+            fn upload_host_tensor(&mut self, _tensor: TensorRead<'_>) -> TensorResult {
+                Err(Error::unsupported(
+                    concat!(stringify!($ty), "::upload_host_tensor"),
+                    "test backend does not transfer tensors",
+                ))
+            }
+        }
+
+        impl BackendCachedDot for $ty {}
+
+        impl BackendSession for $ty {
+            fn session_type_id(&self) -> std::any::TypeId {
+                std::any::TypeId::of::<$marker>()
+            }
+
+            unsafe fn session_data_mut(&mut self) -> *mut () {
+                self as *mut Self as *mut ()
+            }
+        }
+
+        impl TensorBackend for $ty {}
+    };
+}
+
+macro_rules! panic_elementwise {
+    ($ty:ident) => {
+        impl TensorElementwise for $ty {
+            panic_backend_methods! {
+                add(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                sub(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                mul(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                neg(input: &Tensor) -> TensorResult;
+                div(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                abs(input: &Tensor) -> TensorResult;
+                sign(input: &Tensor) -> TensorResult;
+                maximum(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                minimum(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> TensorResult;
+                select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> TensorResult;
+                clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> TensorResult;
+            }
+
+            fn conj(&mut self, input: &Tensor) -> TensorResult {
+                CpuBackend::new().conj(input)
+            }
+        }
+    };
+}
+
+macro_rules! panic_analytic {
+    ($ty:ident) => {
+        impl TensorAnalytic for $ty {
+            panic_backend_methods! {
+                exp(input: &Tensor) -> TensorResult;
+                log(input: &Tensor) -> TensorResult;
+                sin(input: &Tensor) -> TensorResult;
+                cos(input: &Tensor) -> TensorResult;
+                tanh(input: &Tensor) -> TensorResult;
+                sqrt(input: &Tensor) -> TensorResult;
+                rsqrt(input: &Tensor) -> TensorResult;
+                pow(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                expm1(input: &Tensor) -> TensorResult;
+                log1p(input: &Tensor) -> TensorResult;
+            }
+        }
+    };
+}
+
+macro_rules! panic_reduction {
+    ($ty:ident) => {
+        impl TensorReduction for $ty {
+            panic_backend_methods! {
+                reduce_sum(input: &Tensor, axes: &[usize]) -> TensorResult;
+                reduce_prod(input: &Tensor, axes: &[usize]) -> TensorResult;
+                reduce_max(input: &Tensor, axes: &[usize]) -> TensorResult;
+                reduce_min(input: &Tensor, axes: &[usize]) -> TensorResult;
+            }
+        }
+    };
+}
+
+test_backend_impls!(SessionCountingBackend, SessionCountingBackendMarker);
+panic_elementwise!(SessionCountingBackend);
+panic_analytic!(SessionCountingBackend);
+panic_reduction!(SessionCountingBackend);
+
+impl BackendSessionHost for SessionCountingBackend {
+    fn with_backend_session<R: Send>(
+        &mut self,
+        f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
+    ) -> R {
+        self.entries.set(self.entries.get() + 1);
+        self.inner.with_backend_session(f)
+    }
+}
+
+test_backend_impls!(WrongDTypeSessionBackend, WrongDTypeSessionBackendMarker);
+
+impl TensorElementwise for WrongDTypeSessionBackend {
+    panic_backend_methods! {
+        sub(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+        neg(input: &Tensor) -> TensorResult;
+        div(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+        abs(input: &Tensor) -> TensorResult;
+        sign(input: &Tensor) -> TensorResult;
+        maximum(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+        minimum(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+        compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> TensorResult;
+        select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> TensorResult;
+        clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> TensorResult;
+    }
+
+    fn add(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn add_read(&mut self, _lhs: TensorRead<'_>, _rhs: TensorRead<'_>) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn mul(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn mul_read(&mut self, _lhs: TensorRead<'_>, _rhs: TensorRead<'_>) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn conj(&mut self, input: &Tensor) -> TensorResult {
+        CpuBackend::new().conj(input)
+    }
+}
+
+impl TensorAnalytic for WrongDTypeSessionBackend {
+    panic_backend_methods! {
+        log(input: &Tensor) -> TensorResult;
+        sin(input: &Tensor) -> TensorResult;
+        cos(input: &Tensor) -> TensorResult;
+        tanh(input: &Tensor) -> TensorResult;
+        sqrt(input: &Tensor) -> TensorResult;
+        rsqrt(input: &Tensor) -> TensorResult;
+        pow(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+        expm1(input: &Tensor) -> TensorResult;
+        log1p(input: &Tensor) -> TensorResult;
+    }
+
+    fn exp(&mut self, _input: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn exp_read(&mut self, _input: TensorRead<'_>) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+}
+
+impl TensorReduction for WrongDTypeSessionBackend {
+    panic_backend_methods! {
+        reduce_prod(input: &Tensor, axes: &[usize]) -> TensorResult;
+        reduce_max(input: &Tensor, axes: &[usize]) -> TensorResult;
+        reduce_min(input: &Tensor, axes: &[usize]) -> TensorResult;
+    }
+
+    fn reduce_sum(&mut self, _input: &Tensor, _axes: &[usize]) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn reduce_sum_read(&mut self, _input: TensorRead<'_>, _axes: &[usize]) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+}
+
+impl BackendSessionHost for WrongDTypeSessionBackend {}
+
+fn wrong_dtype_tensor() -> Tensor {
+    Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![1.0]).unwrap())
+}

--- a/docs/design/session-oriented-concrete-apis.md
+++ b/docs/design/session-oriented-concrete-apis.md
@@ -147,3 +147,130 @@ session API:  &mut dyn BackendSession ──────────────
 - `Send` bounds preserved and documented as a soundness requirement.
 - The 10-op trivial-chain gate passes (≥2x, predicted ~6x).
 - No material regression for large operations.
+
+## Prototype specification (PR B: the `_in` surface)
+
+Scope decision for the first implementation PR. The design-review gate rules
+apply: this section is the pre-implementation design document; the
+implementation must not start until it has a reviewer-gpt verdict.
+
+### Measured current state of the one-shot path
+
+A binary op already pays more than one session entry today
+(`crates/tenferro-runtime/src/tensor.rs`):
+
+- `add` → `broadcast_binary` → `broadcast_to` per operand (each
+  `broadcast_to` can enter 0-2 sessions: `reshape` + `broadcast_in_dim`, or
+  zero when shapes already match via `duplicate`) → then
+  `with_backend_session(|exec| exec.add(...))` for the op itself.
+  Worst case: **5 sessions per binary op** (both operands need
+  reshape+broadcast = 2 each + 1 final add, e.g. `[1,2] + [2,1]` → `[2,2]`);
+  the common one-sided reshape+broadcast case is 3; equal-shape case is 1.
+- `unary_fn` (exp etc.) and `reduce_sum`: 1 session each.
+
+So the session-explicit surface must own the broadcast step too, or a binary
+op still pays 2 entries inside one session.
+
+### Surface (prototype op set)
+
+`crates/tenferro-runtime/src/lib.rs`, next to `TensorOpsExt`:
+
+```rust
+pub trait TensorSessionOpsExt {
+    fn add_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor>;
+    fn mul_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor>;
+    fn exp_in(&self, session: &mut dyn BackendSession) -> Result<Tensor>;
+    fn reduce_sum_in(&self, axes: &[usize], session: &mut dyn BackendSession) -> Result<Tensor>;
+}
+```
+
+and `TypedTensorSessionOpsExt<T: TensorScalar>` with the same four methods
+returning `TypedTensor<T>`. Exact op set is deliberately small:
+`add_in`/`mul_in` (binary + broadcast, the multi-session flagship),
+`exp_in` (unary), `reduce_sum_in` (reduction).
+
+**Naming is transitional**: the `_in` suffix exists only because the
+session-explicit form coexists with the one-shot `TensorOpsExt` during the
+migration — same receiver type (`Tensor`) + same method name on two in-scope
+traits is an ambiguous-method-resolution error in Rust (and a prelude glob
+would break every call site). The **final** canonical names drop the suffix:
+once the one-shot API is migrated away (a release-boundary breaking change),
+the session-explicit methods become the plain `add`/`exp`/`reduce_sum`. The
+`_in` names must not be treated as the permanent public spelling.
+
+### Validation and broadcast sharing
+
+- Broadcast plan computation (`broadcast_shapes`, `broadcast_input_plan`) is
+  pure and shared. The error mapping (`broadcast_error`) is **not** shared:
+  the dynamic surface uses `broadcast_error_to_validation`
+  (`crates/tenferro-runtime/src/tensor.rs`) and the typed surface has its own
+  manual mapping (`typed_tensor.rs`). Each `_in` surface reuses its existing
+  local mapping; no third mapping is added.
+- **Dynamic `Tensor` helper (owned)**: session-level
+  `broadcast_to_in(input, target_shape, session)` using
+  `session.reshape` + `session.broadcast_in_dim` with the same plan logic as
+  the existing `broadcast_to`, **preserving the `duplicate()` path** for
+  equal shapes and broadcast sources (owned copy semantics unchanged).
+  `add_in`/`mul_in` = `broadcast_to_in` both operands + `session.add`/
+  `session.mul`, all inside the one borrowed session.
+- **Typed `TypedTensor<T>` helper (borrowed, read-based)**: the typed one-shot
+  path keeps inputs borrowed and dispatches to the `*_read` methods
+  (`typed_tensor.rs`); the typed `_in` surface mirrors that with
+  `reshape_read`/`broadcast_in_dim_read`/`add_read`/`mul_read` on the session
+  and `into_typed_result` for the output (dtype fixed by `T`, no promotion
+  logic). Do NOT funnel the typed path through the owned dynamic helper —
+  that would introduce copies or change allocation semantics.
+- No second validation vocabulary; no new error kinds. One-shot/session
+  parity tests cover values and structured errors for both surfaces.
+
+### One-shot delegation
+
+One-shot `add`/`mul`/`exp`/`reduce_sum` become
+`backend.with_backend_session(|s| ..._in(...))` where practical. This drops
+the worst-case binary-op session count from 5 to 1 — a side benefit that must
+be measured as a no-regression check, not assumed. `dot_general`/`matmul`
+are excluded from this PR (cache-ownership decision pending) and keep their
+current path.
+
+### Explicitly out of scope for PR B
+
+- `dot_general`/`matmul` (deferred until cache ownership/parity with
+  `with_backend_session_cached` / `SessionCachedDot` is decided; the current
+  one-shot matmul already uses the plain entry, so this is purely a
+  cache-ownership decision).
+- `convert`/`cast` and the rest of the op vocabulary (follow-up PRs).
+- `EinsumPlan::execute_in_session` and all extension-crate tiers (PR C).
+- GPU session surfaces; CUDA/WebGPU nested-entry enforcement.
+- Removing `Send` bounds (soundness requirement, see above).
+
+### Public API and tests (explicit before merge)
+
+Both public traits (`TensorSessionOpsExt`, `TypedTensorSessionOpsExt`) get
+runnable doc examples (AGENTS.md requirement — compile and run, no `ignore`).
+Integration tests cover, per surface: equal-shape op, real broadcast, invalid
+broadcast (structured error parity with the one-shot path), dtype/error
+parity, typed output dtype validation (`into_typed_result`), and a test that
+an `_in` chain executes inside exactly one session entry.
+
+### Performance gate (measured, not assumed)
+
+New criterion bench in `crates/tenferro-runtime/benches/` (criterion is
+already a workspace dependency), with an explicit `[[bench]]` target and
+`harness = false` in `Cargo.toml` (mirroring `elementwise_fusion.rs`):
+
+- **Exact chain (10 ops)**: three repetitions of `add → exp → mul` (9 ops)
+  followed by a final `reduce_sum([0])` (10th). `reduce_sum` is final so no
+  intermediate op changes shape.
+- **No-broadcast arm**: 1×8 f64 constant-filled operands (broadcast is the
+  `duplicate` path).
+- **Broadcast arm**: 1×1 f64 operands against 1×8 (real reshape+broadcast).
+- **One-shot arm**: the chain via `TensorOpsExt` (each op enters its own
+  session — 10 entries). **Session arm**: the same chain via
+  `TensorSessionOpsExt` inside one `with_backend_session` (1 entry).
+- Validate one result outside the timed region (finite, correct shape);
+  `black_box` inputs and outputs inside the iter.
+- **Protocol**: record base-commit (pre-delegation) and post-change medians;
+  gate `T_one_shot / T_one_session >= 2` (predicted ~6); also a
+  representative large-op one-shot before/after pair for the no-regression
+  criterion. Report pinned (idle core), matching the session floor
+  methodology; the gate is evaluated on the pinned numbers.

--- a/docs/worklogs/2026-08-14-session-in-surface.md
+++ b/docs/worklogs/2026-08-14-session-in-surface.md
@@ -1,0 +1,85 @@
+# 2026-08-14 — session-explicit concrete ops: `_in` prototype (issue #1673, PR B)
+
+## Session summary
+
+First implementation slice of the session-oriented concrete API (issue
+#1673): `TensorSessionOpsExt` / `TypedTensorSessionOpsExt` with
+`add_in`/`mul_in`/`exp_in`/`reduce_sum_in` (the `_in` suffix is a documented
+transitional name — final canonical names drop it at the migration break).
+One-shot `add`/`mul`/`exp`/`reduce_sum` now delegate to the `_in`
+implementations, so a one-shot binary op goes from up to 5 session entries
+(two broadcast + one op, `[1,2]+[2,1]` worst case) to exactly 1.
+
+## Gate record (frontier review)
+
+- **Pre-implementation design gate** (reviewer-gpt on
+  `docs/design/session-oriented-concrete-apis.md` §"Prototype specification
+  (PR B)"): 3 rounds. Round 1: 4 blocking (session count 3→5; `broadcast_error`
+  not shared — dynamic uses `broadcast_error_to_validation`, typed has its own
+  mapping; typed borrowed/read-based path must be separate from the owned
+  dynamic helper; bench target + exact 10-op chain) + 2 non-blocking (dot
+  exclusion rationale; doctest/test plan). Rounds 2-3: one-line name fix
+  (`broadcast_shapes`) + stale 3-to-1 count → **approved for implementation**.
+- **Post-implementation diff gate** (reviewer-gpt on the full diff): 1
+  blocking (worklog + recorded performance evidence missing — this file) + 2
+  non-blocking (rustdoc session-entry claims; parity tests could share a
+  shared-wrong-result) + 1 nit (exp doctest exact equality). All fixed:
+  rustdoc wording, independent value/dtype/`mul_in` test strengthening,
+  exp tolerance.
+
+## Design decisions
+
+- **Owned dynamic surface**: `broadcast_to_in` preserves the `duplicate()`
+  path for equal shapes / broadcast sources; add/mul = broadcast both + the
+  session op, one borrowed session. Error mapping reuses
+  `broadcast_error_to_validation`.
+- **Borrowed typed surface**: read-based (`reshape_read` /
+  `broadcast_in_dim_read` / `add_read` / `mul_read` / `exp_read` /
+  `reduce_sum_read` + `into_typed_result`), reusing the existing `ReadInput`
+  and the typed manual broadcast-error mapping. Not funneled through the
+  owned helper (avoids copies/allocation-semantics drift).
+- **Transitional naming**: `_in` exists only because the session form
+  coexists with the one-shot `TensorOpsExt` (same receiver type + same method
+  name on two in-scope traits = Rust ambiguous-method-resolution, and a
+  prelude glob would break every call site). Final canonical names drop the
+  suffix at a release-boundary migration break.
+- Out of scope for this PR: dot/matmul (cache-ownership decision pending),
+  convert/cast, einsum plans (PR C), GPU session changes, Send bounds.
+
+## Measurements (release, pinned to idle core 40, criterion medians)
+
+| arm | one_shot (10 entries) | one_session (1 entry) | ratio |
+|---|---|---|---|
+| no_broadcast (1×8) | 106.7 µs | 34.8 µs | 3.06× |
+| broadcast (1×1 vs 1×8) | 122.1 µs | 44.9 µs | 2.72× |
+
+- Gate `T_one_shot / T_one_session >= 2` passes (measured 3.06× / 2.72×;
+  the ~6× prediction assumed managed-pinned entries; this bench uses default
+  `CpuBackend::new()` with cheaper entries).
+- **Pre-delegation one-shot baseline** (delegation reverted, bench + `_in`
+  kept): no_broadcast 136.9 µs, broadcast 211.9 µs → delegation improves the
+  one-shot arms by 19% / 43% (no regression; a side benefit of folding
+  broadcast into the op session).
+- **Large-op no-regression** (1024×1024 one-shot add, 50 iters, pinned):
+  15017 µs current vs 14982 µs origin/main (+0.2%, noise).
+
+## Verification
+
+- `cargo build -p tenferro-runtime` — pass
+- `cargo test -p tenferro-runtime` — 402 unit + 131 integration + 1 prelude + 425 doc, 0 failed
+- `cargo test -p tenferro-runtime --doc` — 425 doctests (incl. 10 new `_in` examples), 0 failed
+- `cargo test -p tenferro-runtime --test integration session_in` — 9/9 pass
+- `cargo build --workspace` — pass; `cargo test -p tenferro-ad` — 571 pass (runtime is a dependency)
+- `cargo fmt --all --check` — clean; `cargo clippy -p tenferro-runtime --all-targets` — 0 warnings
+- Bench: `cargo bench -p tenferro-runtime --bench session_chain` (pinned core 40, release) — see Measurements
+- PR gates: `check-pr-fast.sh` and `repository-rules-review.py` run at PR time (recorded in the PR body)
+
+## Residual risks
+
+- Predicted-vs-measured gate ratio differs (≈3 vs ≈6): the design's ~3 µs/
+  entry figure was measured for managed-pinned CPU; default-entry benches are
+  cheaper. The gate still passes; report the measured entry cost, not the
+  predicted one, in follow-up work.
+- The `_in` public names are transitional; renaming at the migration break is
+  a breaking change to plan for (release boundary).
+- GPU/CUDA/WebGPU nested-entry enforcement still open (PR A tracked it).


### PR DESCRIPTION
## Summary

First implementation of the session-explicit concrete API for issue #1673:
`TensorSessionOpsExt` / `TypedTensorSessionOpsExt` with
`add_in`/`mul_in`/`exp_in`/`reduce_sum_in` operating on a borrowed
`&mut dyn BackendSession`. One-shot `add`/`mul`/`exp`/`reduce_sum` delegate to
the `_in` implementations.

## What this proves

A one-shot binary op currently pays **up to 5 session entries** (broadcast +
op; e.g. `[1,2]+[2,1]` worst case). With the session-explicit form it is **1
entry**. The `_in` suffix is a documented **transitional name** — the final
canonical names drop it at the migration break (same receiver type + same
method name on two in-scope traits is an ambiguous-method-resolution error in
Rust, so the suffix is required during coexistence; see design doc).

## Measurements (release, pinned to idle core 40, criterion medians)

| arm | one_shot (10 entries) | one_session (1 entry) | ratio |
|---|---|---|---|
| no_broadcast (1×8) | 106.7 µs | 34.8 µs | **3.06×** |
| broadcast (1×1 vs 1×8) | 122.1 µs | 44.9 µs | **2.72×** |

- Gate `T_one_shot / T_one_session >= 2` **passes**.
- Pre-delegation one-shot baseline (delegation reverted): 136.9 / 211.9 µs →
  delegation improves the one-shot arms 19% / 43% (side benefit, no
  regression).
- Large-op no-regression: 1024×1024 one-shot add = 15017 µs current vs
  14982 µs origin/main (+0.2%, noise).

## Design (reviewer-gpt-gated)

- **Dynamic surface (owned)**: `broadcast_to_in` preserves the `duplicate()`
  path; add/mul = broadcast both + session op, one borrowed session; error
  mapping reuses `broadcast_error_to_validation`.
- **Typed surface (borrowed, read-based)**: `reshape_read` /
  `broadcast_in_dim_read` / `add_read` / `mul_read` / `exp_read` /
  `reduce_sum_read` + `into_typed_result`, reusing `ReadInput`; not funneled
  through the owned helper (avoids copies).
- Out of scope: dot/matmul (cache-ownership decision pending), convert/cast,
  einsum plans (PR C), GPU session changes, Send bounds.

## Gate record (frontier review, per AGENTS.md)

- **Pre-implementation design gate** (reviewer-gpt on
  `docs/design/session-oriented-concrete-apis.md` §"Prototype specification
  (PR B)"): 3 rounds → **approved for implementation** (findings: session
  count 3→5, error-mapping sharing, typed-vs-owned helper separation, bench
  protocol, dot rationale, helper name).
- **Post-implementation diff gate** (reviewer-gpt on the full diff): 2
  rounds → **Correct-to-merge** (findings: worklog + performance record,
  rustdoc session-entry claims, independent-value test strengthening, exp
  doctest tolerance).

## Verification

`check-pr-fast.sh` green (402 unit + 131 integration + 425 doctests in
tenferro-runtime), repository-rules review pass, fmt/clippy clean, workspace
builds, `cargo test -p tenferro-ad` pass.

Worklog: `docs/worklogs/2026-08-14-session-in-surface.md`.
