### PR TITLE
feat(einsum): ConcreteEinsumPlan::execute_in_session (#1673)

### DIFF
--- a/crates/tenferro-einsum/Cargo.toml
+++ b/crates/tenferro-einsum/Cargo.toml
@@ -98,6 +98,10 @@ name = "mps_inner_product"
 harness = false
 
 [[bench]]
+name = "einsum_session_chain"
+harness = false
+
+[[bench]]
 name = "mps_inner_product_compile"
 harness = false
 

--- a/crates/tenferro-einsum/benches/einsum_session_chain.rs
+++ b/crates/tenferro-einsum/benches/einsum_session_chain.rs
@@ -1,0 +1,97 @@
+//! Session-entry cost comparison for a prepared [`ConcreteEinsumPlan`]:
+//! one-shot executes (one session entry per call) vs `_in_session` executes
+//! inside a single borrowed session, and a mixed chain
+//! (einsum + exp + reduce_sum) in both spellings.
+//!
+//! Workload (design doc "Prototype specification (PR C)"): a prepared plan
+//! for `"ij,jk->ik"` on 8×8 f64 column-major inputs, executed 10 times per
+//! iteration, on a one-worker `CpuBackend::with_threads(1)`.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::ConcreteEinsumPlan;
+use tenferro_runtime::{Tensor, TensorOpsExt, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
+
+const N: usize = 8;
+const CALLS: usize = 10;
+
+fn f64_square(seed: usize) -> Tensor {
+    let data = (0..N * N)
+        .map(|idx| ((idx * 17 + seed * 31 + 7) % 997) as f64 / 997.0 - 0.5)
+        .collect();
+    Tensor::from_vec_col_major(vec![N, N], data).unwrap()
+}
+
+fn bench_einsum_session_chain(c: &mut Criterion) {
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    let lhs = f64_square(1);
+    let rhs = f64_square(2);
+    let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
+
+    // Correctness validation outside the timed region: shape [8, 8], finite.
+    let check = backend
+        .with_backend_session(|session| plan.execute_in_session([&lhs, &rhs], session))
+        .unwrap();
+    assert_eq!(check.shape(), &[8, 8]);
+    assert!(check
+        .as_slice::<f64>()
+        .unwrap()
+        .iter()
+        .all(|value| value.is_finite()));
+
+    let mut group = c.benchmark_group("einsum_session_chain/f64_8x8_10calls/threads1");
+
+    group.bench_function("A_one_shot", |b| {
+        b.iter(|| {
+            let inputs = black_box([&lhs, &rhs]);
+            for _ in 0..CALLS {
+                let out = plan.execute(inputs, &mut backend).unwrap();
+                black_box(out);
+            }
+        });
+    });
+
+    group.bench_function("B_in_session", |b| {
+        b.iter(|| {
+            backend.with_backend_session(|session| {
+                let inputs = black_box([&lhs, &rhs]);
+                for _ in 0..CALLS {
+                    let out = plan.execute_in_session(inputs, session).unwrap();
+                    black_box(out);
+                }
+            });
+        });
+    });
+
+    group.bench_function("C_mixed_in_session", |b| {
+        b.iter(|| {
+            backend.with_backend_session(|session| {
+                let inputs = black_box([&lhs, &rhs]);
+                for _ in 0..CALLS {
+                    let x = plan.execute_in_session(inputs, session).unwrap();
+                    let x = x.exp_in(session).unwrap();
+                    let out = x.reduce_sum_in(&[0], session).unwrap();
+                    black_box(out);
+                }
+            });
+        });
+    });
+
+    group.bench_function("C_mixed_one_shot", |b| {
+        b.iter(|| {
+            let inputs = black_box([&lhs, &rhs]);
+            for _ in 0..CALLS {
+                let x = plan.execute(inputs, &mut backend).unwrap();
+                let x = x.exp(&mut backend).unwrap();
+                let out = x.reduce_sum(&[0], &mut backend).unwrap();
+                black_box(out);
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_einsum_session_chain);
+criterion_main!(benches);

--- a/crates/tenferro-einsum/src/concrete.rs
+++ b/crates/tenferro-einsum/src/concrete.rs
@@ -1,8 +1,8 @@
 //! Public concrete tensor einsum extension API.
 
 use tenferro_tensor::{
-    DType, DotGeneralAccumulation, Tensor, TensorBackend, TensorRead, TensorScalar, TensorWrite,
-    TypedTensor, TypedTensorView, TypedTensorWrite,
+    BackendSession, DType, DotGeneralAccumulation, Tensor, TensorBackend, TensorRead, TensorScalar,
+    TensorWrite, TypedTensor, TypedTensorView, TypedTensorWrite,
 };
 
 use crate::eager::{
@@ -974,27 +974,73 @@ impl ConcreteEinsumPlan {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Validation`] when inputs differ from the prepared
-    /// rank, shape, or dtype contract, or [`Error::Tensor`] for a typed backend
-    /// failure.
+    /// Returns [`Error::Validation`] when inputs violate the prepared rank,
+    /// shape, or input-count contract, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when an
+    /// input dtype differs from the prepared contract, or [`Error::Tensor`]
+    /// for a typed backend failure.
     pub fn execute<'a, I, B>(&self, inputs: I, backend: &mut B) -> Result<Tensor>
     where
         I: AsRef<[&'a Tensor]>,
         B: TensorBackend,
     {
         let inputs = inputs.as_ref();
+        backend.with_backend_session(|session| self.execute_in_session(inputs, session))
+    }
+
+    /// Execute this plan on dtype-erased concrete tensor inputs inside a
+    /// borrowed backend session.
+    ///
+    /// Validation and the contraction itself run in the caller's `session`;
+    /// this method never enters a new backend session.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_einsum::ConcreteEinsumPlan;
+    /// use tenferro_tensor::{BackendSessionHost, Tensor};
+    ///
+    /// let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    /// let rhs = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
+    /// let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik")?;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let out = backend
+    ///     .with_backend_session(|session| plan.execute_in_session([&lhs, &rhs], session))?;
+    /// assert_eq!(out.shape(), &[2, 4]);
+    /// # Ok::<(), tenferro_einsum::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] when inputs violate the prepared rank,
+    /// shape, or input-count contract, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when an
+    /// input dtype differs from the prepared contract, or [`Error::Tensor`]
+    /// for a typed backend failure.
+    pub fn execute_in_session<'a, I>(
+        &self,
+        inputs: I,
+        session: &mut dyn BackendSession,
+    ) -> Result<Tensor>
+    where
+        I: AsRef<[&'a Tensor]>,
+    {
+        let inputs = inputs.as_ref();
         self.validate_inputs(&input_specs(inputs), PLAN_EXECUTE_OP)?;
-        backend
-            .with_backend_session(|exec| eager_einsum_exec(exec, inputs, &self.tree))
-            .map_err(Error::from)
+        eager_einsum_exec(session, inputs, &self.tree).map_err(Error::from)
     }
 
     /// Execute this plan on typed concrete tensor inputs.
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Validation`] when inputs differ from the prepared rank
-    /// or shape contract, or [`Error::Tensor`] for a typed backend failure.
+    /// Returns [`Error::Validation`] when inputs violate the prepared rank,
+    /// shape, or input-count contract, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when the
+    /// prepared dtype differs from `T` or the eager result dtype, or
+    /// [`Error::Tensor`] for a typed backend failure.
     pub fn execute_typed<'a, T, I, B>(&self, inputs: I, backend: &mut B) -> Result<TypedTensor<T>>
     where
         T: TensorScalar,
@@ -1002,10 +1048,53 @@ impl ConcreteEinsumPlan {
         B: TensorBackend,
     {
         let inputs = inputs.as_ref();
+        backend.with_backend_session(|session| self.execute_typed_in_session(inputs, session))
+    }
+
+    /// Execute this plan on typed concrete tensor inputs inside a borrowed
+    /// backend session.
+    ///
+    /// Validation and the contraction itself run in the caller's `session`;
+    /// this method never enters a new backend session.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_einsum::ConcreteEinsumPlan;
+    /// use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    ///
+    /// let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
+    /// let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 4], vec![1.0; 12]).unwrap();
+    /// let plan = ConcreteEinsumPlan::prepare_typed([&lhs, &rhs], "ij,jk->ik")?;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let out = backend
+    ///     .with_backend_session(|session| plan.execute_typed_in_session([&lhs, &rhs], session))?;
+    /// assert_eq!(out.shape(), &[2, 4]);
+    /// # Ok::<(), tenferro_einsum::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] when inputs violate the prepared rank,
+    /// shape, or input-count contract, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when the
+    /// prepared dtype differs from `T` or the eager result dtype, or
+    /// [`Error::Tensor`] for a typed backend failure.
+    pub fn execute_typed_in_session<'a, T, I>(
+        &self,
+        inputs: I,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>>
+    where
+        T: TensorScalar,
+        I: AsRef<[&'a TypedTensor<T>]>,
+    {
+        let inputs = inputs.as_ref();
         self.validate_inputs(&typed_input_specs(inputs), PLAN_EXECUTE_OP)?;
         let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
-        let result = backend
-            .with_backend_session(|exec| eager_einsum_exec_read(exec, &reads, &self.tree))?;
+        let result = eager_einsum_exec_read(session, &reads, &self.tree)?;
         into_typed_result(result, PLAN_EXECUTE_OP)
     }
 
@@ -1013,26 +1102,75 @@ impl ConcreteEinsumPlan {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Validation`] when inputs differ from the prepared
-    /// rank, shape, or dtype contract, or [`Error::Tensor`] for a typed backend
-    /// failure.
+    /// Returns [`Error::Validation`] when inputs violate the prepared rank,
+    /// shape, or input-count contract, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when an
+    /// input dtype differs from the prepared contract, or [`Error::Tensor`]
+    /// for a typed backend failure.
     pub fn execute_read<'a, I, B>(&self, inputs: I, backend: &mut B) -> Result<Tensor>
     where
         I: AsRef<[TensorRead<'a>]>,
         B: TensorBackend,
     {
         let inputs = inputs.as_ref();
+        backend.with_backend_session(|session| self.execute_read_in_session(inputs, session))
+    }
+
+    /// Execute this plan on read-only tensor inputs inside a borrowed backend
+    /// session.
+    ///
+    /// Validation and the contraction itself run in the caller's `session`;
+    /// this method never enters a new backend session.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_einsum::ConcreteEinsumPlan;
+    /// use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    ///
+    /// let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    /// let rhs = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
+    /// let plan = ConcreteEinsumPlan::prepare_read(
+    ///     [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
+    ///     "ij,jk->ik",
+    /// )?;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let reads = [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)];
+    /// let out = backend
+    ///     .with_backend_session(|session| plan.execute_read_in_session(reads, session))?;
+    /// assert_eq!(out.shape(), &[2, 4]);
+    /// # Ok::<(), tenferro_einsum::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] when inputs violate the prepared rank,
+    /// shape, or input-count contract, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when an
+    /// input dtype differs from the prepared contract, or [`Error::Tensor`]
+    /// for a typed backend failure.
+    pub fn execute_read_in_session<'a, I>(
+        &self,
+        inputs: I,
+        session: &mut dyn BackendSession,
+    ) -> Result<Tensor>
+    where
+        I: AsRef<[TensorRead<'a>]>,
+    {
+        let inputs = inputs.as_ref();
         self.validate_inputs(&read_input_specs(inputs), PLAN_EXECUTE_OP)?;
-        backend
-            .with_backend_session(|exec| eager_einsum_exec_read(exec, inputs, &self.tree))
-            .map_err(Error::from)
+        eager_einsum_exec_read(session, inputs, &self.tree).map_err(Error::from)
     }
 
     /// Execute this plan on dtype-erased concrete tensor inputs into caller-provided output.
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Validation`] for input or output rank, shape, or dtype
+    /// Returns [`Error::Validation`] for input or output rank, shape, or
+    /// input-count contract violations, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload for dtype
     /// mismatches, or [`Error::Tensor`] for a typed backend failure.
     pub fn execute_into<'a, I, B>(
         &self,
@@ -1045,6 +1183,55 @@ impl ConcreteEinsumPlan {
         B: TensorBackend,
     {
         let inputs = inputs.as_ref();
+        backend.with_backend_session(|session| self.execute_into_in_session(inputs, session, out))
+    }
+
+    /// Execute this plan on dtype-erased concrete tensor inputs into
+    /// caller-provided output inside a borrowed backend session.
+    ///
+    /// Validation and the contraction itself run in the caller's `session`;
+    /// this method never enters a new backend session.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_einsum::ConcreteEinsumPlan;
+    /// use tenferro_tensor::{BackendSessionHost, Tensor, TensorWrite};
+    ///
+    /// let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    /// let rhs = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
+    /// let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik")?;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let mut out = Tensor::from_vec_col_major(vec![2, 4], vec![0.0_f64; 8]).unwrap();
+    /// backend.with_backend_session(|session| {
+    ///     plan.execute_into_in_session(
+    ///         [&lhs, &rhs],
+    ///         session,
+    ///         TensorWrite::from_tensor(&mut out),
+    ///     )
+    /// })?;
+    /// assert_eq!(out.as_slice::<f64>()?, vec![3.0_f64; 8].as_slice());
+    /// # Ok::<(), tenferro_einsum::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] for input or output rank, shape, or
+    /// input-count contract violations, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload for dtype
+    /// mismatches, or [`Error::Tensor`] for a typed backend failure.
+    pub fn execute_into_in_session<'a, I>(
+        &self,
+        inputs: I,
+        session: &mut dyn BackendSession,
+        out: TensorWrite<'_>,
+    ) -> Result<()>
+    where
+        I: AsRef<[&'a Tensor]>,
+    {
+        let inputs = inputs.as_ref();
         let specs = input_specs(inputs);
         self.validate_inputs(&specs, PLAN_EXECUTE_OP)?;
         validate_output(&self.inputs, &self.tree, &out, PLAN_EXECUTE_OP)?;
@@ -1052,17 +1239,18 @@ impl ConcreteEinsumPlan {
             .iter()
             .map(|tensor| TensorRead::from_tensor(tensor))
             .collect();
-        backend
-            .with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &self.tree, out))
-            .map_err(Error::from)
+        eager_einsum_exec_read_into(session, &reads, &self.tree, out).map_err(Error::from)
     }
 
     /// Execute this plan on typed concrete tensor inputs into caller-provided output.
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Validation`] for input or output rank or shape
-    /// mismatches, or [`Error::Tensor`] for a typed backend failure.
+    /// Returns [`Error::Validation`] for input or output rank, shape, or
+    /// input-count contract violations, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when the
+    /// prepared dtype differs from `T` or the output dtype, or
+    /// [`Error::Tensor`] for a typed backend failure.
     pub fn execute_typed_into<'a, 'out, T, I, B, O>(
         &self,
         inputs: I,
@@ -1076,21 +1264,72 @@ impl ConcreteEinsumPlan {
         O: Into<TypedTensorWrite<'out, T>>,
     {
         let inputs = inputs.as_ref();
+        let out = out.into();
+        backend.with_backend_session(|session| {
+            self.execute_typed_into_in_session(inputs, session, out)
+        })
+    }
+
+    /// Execute this plan on typed concrete tensor inputs into caller-provided
+    /// output inside a borrowed backend session.
+    ///
+    /// Validation and the contraction itself run in the caller's `session`;
+    /// this method never enters a new backend session.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_einsum::ConcreteEinsumPlan;
+    /// use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    ///
+    /// let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
+    /// let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 4], vec![1.0; 12]).unwrap();
+    /// let plan = ConcreteEinsumPlan::prepare_typed([&lhs, &rhs], "ij,jk->ik")?;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let mut out = TypedTensor::<f64>::from_vec_col_major(vec![2, 4], vec![0.0; 8]).unwrap();
+    /// backend.with_backend_session(|session| {
+    ///     plan.execute_typed_into_in_session([&lhs, &rhs], session, &mut out)
+    /// })?;
+    /// assert_eq!(out.as_slice()?, vec![3.0_f64; 8].as_slice());
+    /// # Ok::<(), tenferro_einsum::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] for input or output rank, shape, or
+    /// input-count contract violations, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when the
+    /// prepared dtype differs from `T` or the output dtype, or
+    /// [`Error::Tensor`] for a typed backend failure.
+    pub fn execute_typed_into_in_session<'a, 'out, T, I, O>(
+        &self,
+        inputs: I,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
+    where
+        T: TensorScalar,
+        I: AsRef<[&'a TypedTensor<T>]>,
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
+        let inputs = inputs.as_ref();
         let specs = typed_input_specs(inputs);
         self.validate_inputs(&specs, PLAN_EXECUTE_OP)?;
         let out = out.into().into_tensor_write();
         validate_output(&self.inputs, &self.tree, &out, PLAN_EXECUTE_OP)?;
         let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
-        backend
-            .with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &self.tree, out))
-            .map_err(Error::from)
+        eager_einsum_exec_read_into(session, &reads, &self.tree, out).map_err(Error::from)
     }
 
     /// Execute this plan on read-only tensor inputs into caller-provided output.
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Validation`] for input or output rank, shape, or dtype
+    /// Returns [`Error::Validation`] for input or output rank, shape, or
+    /// input-count contract violations, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload for dtype
     /// mismatches, or [`Error::Tensor`] for a typed backend failure.
     pub fn execute_read_into<'a, I, B>(
         &self,
@@ -1103,12 +1342,60 @@ impl ConcreteEinsumPlan {
         B: TensorBackend,
     {
         let inputs = inputs.as_ref();
+        backend
+            .with_backend_session(|session| self.execute_read_into_in_session(inputs, session, out))
+    }
+
+    /// Execute this plan on read-only tensor inputs into caller-provided output
+    /// inside a borrowed backend session.
+    ///
+    /// Validation and the contraction itself run in the caller's `session`;
+    /// this method never enters a new backend session.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_einsum::ConcreteEinsumPlan;
+    /// use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead, TensorWrite};
+    ///
+    /// let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    /// let rhs = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
+    /// let plan = ConcreteEinsumPlan::prepare_read(
+    ///     [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
+    ///     "ij,jk->ik",
+    /// )?;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let mut out = Tensor::from_vec_col_major(vec![2, 4], vec![0.0_f64; 8]).unwrap();
+    /// let reads = [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)];
+    /// backend.with_backend_session(|session| {
+    ///     plan.execute_read_into_in_session(reads, session, TensorWrite::from_tensor(&mut out))
+    /// })?;
+    /// assert_eq!(out.as_slice::<f64>()?, vec![3.0_f64; 8].as_slice());
+    /// # Ok::<(), tenferro_einsum::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] for input or output rank, shape, or
+    /// input-count contract violations, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload for dtype
+    /// mismatches, or [`Error::Tensor`] for a typed backend failure.
+    pub fn execute_read_into_in_session<'a, I>(
+        &self,
+        inputs: I,
+        session: &mut dyn BackendSession,
+        out: TensorWrite<'_>,
+    ) -> Result<()>
+    where
+        I: AsRef<[TensorRead<'a>]>,
+    {
+        let inputs = inputs.as_ref();
         let specs = read_input_specs(inputs);
         self.validate_inputs(&specs, PLAN_EXECUTE_OP)?;
         validate_output(&self.inputs, &self.tree, &out, PLAN_EXECUTE_OP)?;
-        backend
-            .with_backend_session(|exec| eager_einsum_exec_read_into(exec, inputs, &self.tree, out))
-            .map_err(Error::from)
+        eager_einsum_exec_read_into(session, inputs, &self.tree, out).map_err(Error::from)
     }
 
     /// Execute this plan on read-only inputs with scaled output accumulation.
@@ -1142,7 +1429,9 @@ impl ConcreteEinsumPlan {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Validation`] for input or output rank, shape, or dtype
+    /// Returns [`Error::Validation`] for input or output rank, shape, or
+    /// input-count contract violations, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload for dtype
     /// mismatches, [`Error::Numerical`] for an invalid accumulation, or
     /// [`Error::Tensor`] for a typed backend failure.
     pub fn execute_read_into_accum<'a, I, B>(
@@ -1157,13 +1446,65 @@ impl ConcreteEinsumPlan {
         B: TensorBackend,
     {
         let inputs = inputs.as_ref();
+        backend.with_backend_session(|session| {
+            self.execute_read_into_accum_in_session(inputs, session, accumulation, out)
+        })
+    }
+
+    /// Execute this plan on read-only inputs with scaled output accumulation
+    /// inside a borrowed backend session.
+    ///
+    /// `accumulation` follows the dot-general contract:
+    /// `out = alpha * einsum(inputs) + beta * out`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_einsum::ConcreteEinsumPlan;
+    /// use tenferro_tensor::{
+    ///     BackendSessionHost, DotGeneralAccumulation, DType, Tensor, TensorRead, TensorWrite,
+    /// };
+    ///
+    /// let lhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64])?;
+    /// let rhs = Tensor::from_vec_col_major(vec![1], vec![3.0_f64])?;
+    /// let mut out = Tensor::from_vec_col_major(vec![], vec![1.0_f64])?;
+    /// let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "i,i->")?;
+    /// let mut backend = CpuBackend::new();
+    /// backend.with_backend_session(|session| {
+    ///     plan.execute_read_into_accum_in_session(
+    ///         [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
+    ///         session,
+    ///         DotGeneralAccumulation::add_to(DType::F64)?,
+    ///         TensorWrite::from_tensor(&mut out),
+    ///     )
+    /// })?;
+    /// assert_eq!(out.as_slice::<f64>()?, &[7.0]);
+    /// # Ok::<(), tenferro_einsum::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] for input or output rank, shape, or
+    /// input-count contract violations, [`Error::Tensor`] with a
+    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload for dtype
+    /// mismatches, [`Error::Numerical`] for an invalid accumulation, or
+    /// [`Error::Tensor`] for a typed backend failure.
+    pub fn execute_read_into_accum_in_session<'a, I>(
+        &self,
+        inputs: I,
+        session: &mut dyn BackendSession,
+        accumulation: DotGeneralAccumulation,
+        out: TensorWrite<'_>,
+    ) -> Result<()>
+    where
+        I: AsRef<[TensorRead<'a>]>,
+    {
+        let inputs = inputs.as_ref();
         let specs = read_input_specs(inputs);
         self.validate_inputs(&specs, PLAN_EXECUTE_OP)?;
         validate_output(&self.inputs, &self.tree, &out, PLAN_EXECUTE_OP)?;
-        backend
-            .with_backend_session(|exec| {
-                eager_einsum_exec_read_into_accum(exec, inputs, &self.tree, accumulation, out)
-            })
+        eager_einsum_exec_read_into_accum(session, inputs, &self.tree, accumulation, out)
             .map_err(Error::from)
     }
 

--- a/crates/tenferro-einsum/src/concrete_tests.rs
+++ b/crates/tenferro-einsum/src/concrete_tests.rs
@@ -1,8 +1,9 @@
 use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{
-    ContractionScalar, DType, DotGeneralAccumulation, Tensor, TensorRead, TensorView,
-    TensorViewMut, TensorWrite, TypedTensor, TypedTensorView, TypedTensorViewMut, TypedTensorWrite,
+    BackendSessionHost, ContractionScalar, DType, DotGeneralAccumulation, Tensor, TensorRead,
+    TensorView, TensorViewMut, TensorWrite, TypedTensor, TypedTensorView, TypedTensorViewMut,
+    TypedTensorWrite,
 };
 
 use crate::{
@@ -683,4 +684,330 @@ fn concrete_einsum_typed_result_reports_defensive_dtype_mismatch() {
             source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
         })
     ));
+}
+
+// ---------------------------------------------------------------------------
+// `_in_session` surface parity with the one-shot execute methods
+// ---------------------------------------------------------------------------
+
+fn assert_same_error(one_shot: &Error, in_session: &Error) {
+    assert_eq!(
+        format!("{in_session:?}"),
+        format!("{one_shot:?}"),
+        "in-session error must match the one-shot error structurally"
+    );
+}
+
+fn f64_plan_fixture() -> (Tensor, Tensor, ConcreteEinsumPlan) {
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
+    (lhs, rhs, plan)
+}
+
+#[test]
+fn concrete_einsum_plan_in_session_values_match_one_shot() {
+    let (lhs, rhs, plan) = f64_plan_fixture();
+    let mut backend = CpuBackend::new();
+
+    let one_shot = plan.execute([&lhs, &rhs], &mut backend).unwrap();
+    let in_session = backend
+        .with_backend_session(|session| plan.execute_in_session([&lhs, &rhs], session))
+        .unwrap();
+    assert_f64_tensor(&in_session, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+    assert_eq!(
+        one_shot.as_slice::<f64>().unwrap(),
+        in_session.as_slice::<f64>().unwrap()
+    );
+
+    let reads = [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)];
+    let one_shot = plan.execute_read(reads.clone(), &mut backend).unwrap();
+    let in_session = backend
+        .with_backend_session(|session| plan.execute_read_in_session(reads.clone(), session))
+        .unwrap();
+    assert_f64_tensor(&in_session, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+    assert_eq!(
+        one_shot.as_slice::<f64>().unwrap(),
+        in_session.as_slice::<f64>().unwrap()
+    );
+
+    let typed_lhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let typed_rhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let typed_plan =
+        ConcreteEinsumPlan::prepare_typed([&typed_lhs, &typed_rhs], "ij,jk->ik").unwrap();
+    let one_shot = typed_plan
+        .execute_typed([&typed_lhs, &typed_rhs], &mut backend)
+        .unwrap();
+    let in_session = backend
+        .with_backend_session(|session| {
+            typed_plan.execute_typed_in_session([&typed_lhs, &typed_rhs], session)
+        })
+        .unwrap();
+    assert_eq!(in_session.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+    assert_eq!(one_shot.as_slice().unwrap(), in_session.as_slice().unwrap());
+}
+
+#[test]
+fn concrete_einsum_plan_in_session_errors_match_one_shot() {
+    let (lhs, _rhs, plan) = f64_plan_fixture();
+    let wrong_shape = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let wrong_dtype = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f32; 6]).unwrap();
+    let mut backend = CpuBackend::new();
+
+    let one_shot = plan
+        .execute([&lhs, &wrong_shape], &mut backend)
+        .unwrap_err();
+    let in_session = backend
+        .with_backend_session(|session| plan.execute_in_session([&lhs, &wrong_shape], session))
+        .unwrap_err();
+    assert_same_error(&one_shot, &in_session);
+    assert!(matches!(
+        in_session,
+        Error::Validation {
+            op: "ConcreteEinsumPlan::execute",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        }
+    ));
+
+    let one_shot = plan
+        .execute([&lhs, &wrong_dtype], &mut backend)
+        .unwrap_err();
+    let in_session = backend
+        .with_backend_session(|session| plan.execute_in_session([&lhs, &wrong_dtype], session))
+        .unwrap_err();
+    assert_same_error(&one_shot, &in_session);
+    assert!(matches!(
+        in_session,
+        Error::Tensor(tenferro_tensor::Error::Validation {
+            op: "ConcreteEinsumPlan::execute",
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
+    ));
+
+    let one_shot = plan.execute([&lhs], &mut backend).unwrap_err();
+    let in_session = backend
+        .with_backend_session(|session| plan.execute_in_session([&lhs], session))
+        .unwrap_err();
+    assert_same_error(&one_shot, &in_session);
+    assert!(matches!(
+        in_session,
+        Error::Validation {
+            op: "ConcreteEinsumPlan::execute",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn concrete_einsum_plan_in_session_typed_dtype_conversion_matches_one_shot() {
+    let typed_lhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let typed_rhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let plan = ConcreteEinsumPlan::prepare_typed([&typed_lhs, &typed_rhs], "ij,jk->ik").unwrap();
+    let mut backend = CpuBackend::new();
+
+    let one_shot = plan
+        .execute_typed([&typed_lhs, &typed_rhs], &mut backend)
+        .unwrap();
+    let in_session = backend
+        .with_backend_session(|session| {
+            plan.execute_typed_in_session([&typed_lhs, &typed_rhs], session)
+        })
+        .unwrap();
+    assert_eq!(in_session.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+    assert_eq!(one_shot.as_slice().unwrap(), in_session.as_slice().unwrap());
+
+    // Requesting a scalar type different from the prepared dtype must fail
+    // identically in both forms (validate_inputs dtype contract).
+    let f32_lhs = TypedTensor::<f32>::from_vec_col_major(vec![2, 3], vec![1.0_f32; 6]).unwrap();
+    let f32_rhs = TypedTensor::<f32>::from_vec_col_major(vec![3, 2], vec![1.0_f32; 6]).unwrap();
+    let one_shot = plan
+        .execute_typed([&f32_lhs, &f32_rhs], &mut backend)
+        .unwrap_err();
+    let in_session = backend
+        .with_backend_session(|session| {
+            plan.execute_typed_in_session([&f32_lhs, &f32_rhs], session)
+        })
+        .unwrap_err();
+    assert_same_error(&one_shot, &in_session);
+    assert!(matches!(
+        in_session,
+        Error::Tensor(tenferro_tensor::Error::Validation {
+            op: "ConcreteEinsumPlan::execute",
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
+    ));
+}
+
+#[test]
+fn concrete_einsum_plan_in_session_into_output_validation_matches_one_shot() {
+    let (lhs, rhs, plan) = f64_plan_fixture();
+    let mut backend = CpuBackend::new();
+
+    // execute_into: incompatible output shape.
+    let mut wrong_shape = Tensor::from_vec_col_major(vec![4], vec![0.0_f64; 4]).unwrap();
+    let one_shot = plan
+        .execute_into(
+            [&lhs, &rhs],
+            &mut backend,
+            TensorWrite::from_tensor(&mut wrong_shape),
+        )
+        .unwrap_err();
+    let in_session = backend
+        .with_backend_session(|session| {
+            plan.execute_into_in_session(
+                [&lhs, &rhs],
+                session,
+                TensorWrite::from_tensor(&mut wrong_shape),
+            )
+        })
+        .unwrap_err();
+    assert_same_error(&one_shot, &in_session);
+    assert!(matches!(
+        in_session,
+        Error::Validation {
+            op: "ConcreteEinsumPlan::execute",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        }
+    ));
+
+    // execute_read_into: incompatible output dtype.
+    let mut wrong_dtype_out = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f32; 4]).unwrap();
+    let one_shot = plan
+        .execute_read_into(
+            [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
+            &mut backend,
+            TensorWrite::from_tensor(&mut wrong_dtype_out),
+        )
+        .unwrap_err();
+    let in_session = backend
+        .with_backend_session(|session| {
+            plan.execute_read_into_in_session(
+                [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
+                session,
+                TensorWrite::from_tensor(&mut wrong_dtype_out),
+            )
+        })
+        .unwrap_err();
+    assert_same_error(&one_shot, &in_session);
+
+    // execute_typed_into: incompatible output shape.
+    let typed_lhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let typed_rhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let typed_plan =
+        ConcreteEinsumPlan::prepare_typed([&typed_lhs, &typed_rhs], "ij,jk->ik").unwrap();
+    let mut typed_out = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![0.0; 3]).unwrap();
+    let one_shot = typed_plan
+        .execute_typed_into([&typed_lhs, &typed_rhs], &mut backend, &mut typed_out)
+        .unwrap_err();
+    let in_session = backend
+        .with_backend_session(|session| {
+            typed_plan.execute_typed_into_in_session(
+                [&typed_lhs, &typed_rhs],
+                session,
+                &mut typed_out,
+            )
+        })
+        .unwrap_err();
+    assert_same_error(&one_shot, &in_session);
+
+    // execute_read_into_accum: incompatible output shape.
+    let mut accum_out = Tensor::from_vec_col_major(vec![4], vec![0.0_f64; 4]).unwrap();
+    let accumulation = DotGeneralAccumulation::add_to(DType::F64).unwrap();
+    let one_shot = plan
+        .execute_read_into_accum(
+            [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
+            &mut backend,
+            accumulation,
+            TensorWrite::from_tensor(&mut accum_out),
+        )
+        .unwrap_err();
+    let in_session = backend
+        .with_backend_session(|session| {
+            plan.execute_read_into_accum_in_session(
+                [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
+                session,
+                accumulation,
+                TensorWrite::from_tensor(&mut accum_out),
+            )
+        })
+        .unwrap_err();
+    assert_same_error(&one_shot, &in_session);
+
+    // Valid into execution parity (values).
+    let mut out_a = Tensor::from_vec_col_major(vec![2, 2], vec![-1.0_f64; 4]).unwrap();
+    let mut out_b = Tensor::from_vec_col_major(vec![2, 2], vec![-1.0_f64; 4]).unwrap();
+    plan.execute_into(
+        [&lhs, &rhs],
+        &mut backend,
+        TensorWrite::from_tensor(&mut out_a),
+    )
+    .unwrap();
+    backend
+        .with_backend_session(|session| {
+            plan.execute_into_in_session(
+                [&lhs, &rhs],
+                session,
+                TensorWrite::from_tensor(&mut out_b),
+            )
+        })
+        .unwrap();
+    assert_eq!(
+        out_a.as_slice::<f64>().unwrap(),
+        out_b.as_slice::<f64>().unwrap()
+    );
+    assert_eq!(out_b.as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+}
+
+/// A non-`Send` output adapter: `PhantomData<Rc<()>>` makes the type `!Send`
+/// (a `Cell` would not — `Cell<T>` is `Send` but `!Sync`). Calling
+/// `ConcreteEinsumPlan::execute_typed_into` with this type only compiles
+/// because the one-shot converts `out` to `TypedTensorWrite` before the
+/// backend session closure, so `O` itself never needs `Send`.
+struct NonSendIntoWrite<'a, T> {
+    write: TypedTensorWrite<'a, T>,
+    _not_send: std::marker::PhantomData<std::rc::Rc<()>>,
+}
+
+impl<'a, T> From<NonSendIntoWrite<'a, T>> for TypedTensorWrite<'a, T> {
+    fn from(adapter: NonSendIntoWrite<'a, T>) -> Self {
+        adapter.write
+    }
+}
+
+#[test]
+fn concrete_einsum_plan_execute_typed_into_accepts_non_send_adapter() {
+    let typed_lhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let typed_rhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let plan = ConcreteEinsumPlan::prepare_typed([&typed_lhs, &typed_rhs], "ij,jk->ik").unwrap();
+
+    let mut backend = CpuBackend::new();
+    let mut out = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![0.0; 4]).unwrap();
+    plan.execute_typed_into(
+        [&typed_lhs, &typed_rhs],
+        &mut backend,
+        NonSendIntoWrite {
+            write: TypedTensorWrite::from_tensor(&mut out),
+            _not_send: std::marker::PhantomData,
+        },
+    )
+    .unwrap();
+    assert_eq!(out.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
 }

--- a/crates/tenferro-einsum/tests/integration.rs
+++ b/crates/tenferro-einsum/tests/integration.rs
@@ -6,6 +6,8 @@ mod error_public;
 mod public_surface_contract;
 #[path = "integration/runtime_buffer_pool.rs"]
 mod runtime_buffer_pool;
+#[path = "integration/session_in_plan.rs"]
+mod session_in_plan;
 #[path = "integration/shape_constraints.rs"]
 mod shape_constraints;
 #[path = "integration/support.rs"]

--- a/crates/tenferro-einsum/tests/integration/session_in_plan.rs
+++ b/crates/tenferro-einsum/tests/integration/session_in_plan.rs
@@ -1,0 +1,481 @@
+//! Single-session-entry and typed-result parity tests for the
+//! `ConcreteEinsumPlan::execute*_in_session` surfaces.
+//!
+//! A mixed chain (`plan.execute_in_session` + runtime `exp_in` +
+//! `reduce_sum_in`) must execute inside exactly one backend session entry,
+//! while the one-shot counterpart enters one session per op. The typed
+//! `_in_session` surface must reject a backend-returned wrong dtype through
+//! `into_typed_result` exactly like the one-shot path.
+
+use std::cell::Cell;
+
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::{ConcreteEinsumPlan, Error};
+use tenferro_runtime::{Tensor, TensorOpsExt, TensorSessionOpsExt};
+use tenferro_tensor::backend::{
+    BackendCachedDot, TensorAnalytic, TensorBuffer, TensorDeviceTransfer, TensorDot,
+    TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
+};
+use tenferro_tensor::{
+    BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir, DType, DotGeneralConfig,
+    GatherConfig, PadConfig, ScatterConfig, SliceConfig, TensorBackend, TensorRead, TensorWrite,
+};
+
+type TensorResult = tenferro_tensor::Result<Tensor>;
+
+/// Test backend counting `with_backend_session` entries while delegating real
+/// einsum (`dot_general`), `exp`, and `reduce_sum` execution to an inner
+/// [`CpuBackend`]. All other op methods are unreachable in these tests and
+/// panic.
+struct SessionCountingBackend {
+    inner: CpuBackend,
+    entries: Cell<usize>,
+}
+
+impl SessionCountingBackend {
+    fn new() -> Self {
+        Self {
+            inner: CpuBackend::new(),
+            entries: Cell::new(0),
+        }
+    }
+}
+
+/// Test backend whose `dot_general` returns an `F64` tensor regardless of the
+/// requested dtype, so the typed `_in_session` surface must reject the output
+/// through `into_typed_result`.
+struct WrongDTypeSessionBackend;
+
+macro_rules! panic_backend_methods {
+    ($($name:ident($($arg:ident : $argty:ty),*) -> $ret:ty;)+) => {
+        $(
+            fn $name(&mut self, $($arg: $argty),*) -> $ret {
+                let _ = ($($arg),*);
+                panic!(concat!(stringify!($name), " should not be called in this test"))
+            }
+        )+
+    };
+}
+
+/// Panic-only implementations of every op trait except `TensorDot`,
+/// `TensorAnalytic`, and `TensorReduction`, which test backends override with
+/// real or wrong-dtype ops. Excludes `BackendSessionHost`, which each backend
+/// implements explicitly.
+macro_rules! test_backend_impls {
+    ($ty:ident, $marker:ident) => {
+        struct $marker;
+
+        impl BackendRuntimeCache for $ty {
+            type RuntimeCache = <CpuBackend as BackendRuntimeCache>::RuntimeCache;
+        }
+
+        impl TensorStructural for $ty {
+            fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> TensorResult {
+                CpuBackend::new().to_contiguous_read(input)
+            }
+
+            fn copy_read_into(
+                &mut self,
+                src: TensorRead<'_>,
+                dst: TensorWrite<'_>,
+            ) -> tenferro_tensor::Result<()> {
+                CpuBackend::new().copy_read_into(src, dst)
+            }
+
+            panic_backend_methods! {
+                transpose(input: &Tensor, perm: &[usize]) -> TensorResult;
+                reshape(input: &Tensor, shape: &[usize]) -> TensorResult;
+                broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> TensorResult;
+                cast(input: &Tensor, to: DType) -> TensorResult;
+                convert(input: &Tensor, to: DType) -> TensorResult;
+                extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> TensorResult;
+                embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> TensorResult;
+                tril(input: &Tensor, k: i64) -> TensorResult;
+                triu(input: &Tensor, k: i64) -> TensorResult;
+            }
+        }
+
+        impl TensorIndexing for $ty {
+            panic_backend_methods! {
+                gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> TensorResult;
+                scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> TensorResult;
+                slice(input: &Tensor, config: &SliceConfig) -> TensorResult;
+                dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> TensorResult;
+                dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) -> TensorResult;
+                pad(input: &Tensor, config: &PadConfig) -> TensorResult;
+                concatenate(inputs: &[&Tensor], axis: usize) -> TensorResult;
+                reverse(input: &Tensor, axes: &[usize]) -> TensorResult;
+            }
+        }
+
+        impl TensorFusion for $ty {}
+        impl TensorBuffer for $ty {}
+
+        impl TensorDeviceTransfer for $ty {
+            fn download_to_host(&mut self, _tensor: TensorRead<'_>) -> TensorResult {
+                Err(tenferro_tensor::Error::unsupported(
+                    concat!(stringify!($ty), "::download_to_host"),
+                    "test backend does not transfer tensors",
+                ))
+            }
+
+            fn upload_host_tensor(&mut self, _tensor: TensorRead<'_>) -> TensorResult {
+                Err(tenferro_tensor::Error::unsupported(
+                    concat!(stringify!($ty), "::upload_host_tensor"),
+                    "test backend does not transfer tensors",
+                ))
+            }
+        }
+
+        impl BackendCachedDot for $ty {}
+
+        impl BackendSession for $ty {
+            fn session_type_id(&self) -> std::any::TypeId {
+                std::any::TypeId::of::<$marker>()
+            }
+
+            unsafe fn session_data_mut(&mut self) -> *mut () {
+                self as *mut Self as *mut ()
+            }
+        }
+
+        impl TensorBackend for $ty {}
+    };
+}
+
+macro_rules! panic_elementwise {
+    ($ty:ident) => {
+        impl TensorElementwise for $ty {
+            panic_backend_methods! {
+                add(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                sub(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                mul(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                neg(input: &Tensor) -> TensorResult;
+                div(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                abs(input: &Tensor) -> TensorResult;
+                sign(input: &Tensor) -> TensorResult;
+                maximum(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                minimum(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> TensorResult;
+                select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> TensorResult;
+                clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> TensorResult;
+            }
+
+            fn conj(&mut self, input: &Tensor) -> TensorResult {
+                CpuBackend::new().conj(input)
+            }
+        }
+    };
+}
+
+macro_rules! panic_analytic {
+    ($ty:ident) => {
+        impl TensorAnalytic for $ty {
+            panic_backend_methods! {
+                exp(input: &Tensor) -> TensorResult;
+                log(input: &Tensor) -> TensorResult;
+                sin(input: &Tensor) -> TensorResult;
+                cos(input: &Tensor) -> TensorResult;
+                tanh(input: &Tensor) -> TensorResult;
+                sqrt(input: &Tensor) -> TensorResult;
+                rsqrt(input: &Tensor) -> TensorResult;
+                pow(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
+                expm1(input: &Tensor) -> TensorResult;
+                log1p(input: &Tensor) -> TensorResult;
+            }
+        }
+    };
+}
+
+macro_rules! panic_reduction {
+    ($ty:ident) => {
+        impl TensorReduction for $ty {
+            panic_backend_methods! {
+                reduce_sum(input: &Tensor, axes: &[usize]) -> TensorResult;
+                reduce_prod(input: &Tensor, axes: &[usize]) -> TensorResult;
+                reduce_max(input: &Tensor, axes: &[usize]) -> TensorResult;
+                reduce_min(input: &Tensor, axes: &[usize]) -> TensorResult;
+            }
+        }
+    };
+}
+
+test_backend_impls!(SessionCountingBackend, SessionCountingBackendMarker);
+
+impl TensorDot for SessionCountingBackend {
+    fn dot_general(
+        &mut self,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+    ) -> TensorResult {
+        self.inner.dot_general(lhs, rhs, config)
+    }
+}
+
+impl TensorElementwise for SessionCountingBackend {
+    fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> TensorResult {
+        self.inner.add(lhs, rhs)
+    }
+
+    fn sub(&mut self, lhs: &Tensor, rhs: &Tensor) -> TensorResult {
+        self.inner.sub(lhs, rhs)
+    }
+
+    fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> TensorResult {
+        self.inner.mul(lhs, rhs)
+    }
+
+    fn neg(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.neg(input)
+    }
+
+    fn div(&mut self, lhs: &Tensor, rhs: &Tensor) -> TensorResult {
+        self.inner.div(lhs, rhs)
+    }
+
+    fn abs(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.abs(input)
+    }
+
+    fn sign(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.sign(input)
+    }
+
+    fn maximum(&mut self, lhs: &Tensor, rhs: &Tensor) -> TensorResult {
+        self.inner.maximum(lhs, rhs)
+    }
+
+    fn minimum(&mut self, lhs: &Tensor, rhs: &Tensor) -> TensorResult {
+        self.inner.minimum(lhs, rhs)
+    }
+
+    fn compare(&mut self, lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> TensorResult {
+        self.inner.compare(lhs, rhs, dir)
+    }
+
+    fn select(&mut self, pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> TensorResult {
+        self.inner.select(pred, on_true, on_false)
+    }
+
+    fn clamp(&mut self, input: &Tensor, lower: &Tensor, upper: &Tensor) -> TensorResult {
+        self.inner.clamp(input, lower, upper)
+    }
+
+    fn conj(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.conj(input)
+    }
+}
+
+impl TensorAnalytic for SessionCountingBackend {
+    fn exp(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.exp(input)
+    }
+
+    fn log(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.log(input)
+    }
+
+    fn sin(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.sin(input)
+    }
+
+    fn cos(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.cos(input)
+    }
+
+    fn tanh(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.tanh(input)
+    }
+
+    fn sqrt(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.sqrt(input)
+    }
+
+    fn rsqrt(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.rsqrt(input)
+    }
+
+    fn pow(&mut self, lhs: &Tensor, rhs: &Tensor) -> TensorResult {
+        self.inner.pow(lhs, rhs)
+    }
+
+    fn expm1(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.expm1(input)
+    }
+
+    fn log1p(&mut self, input: &Tensor) -> TensorResult {
+        self.inner.log1p(input)
+    }
+}
+
+impl TensorReduction for SessionCountingBackend {
+    fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> TensorResult {
+        self.inner.reduce_sum(input, axes)
+    }
+
+    fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> TensorResult {
+        self.inner.reduce_prod(input, axes)
+    }
+
+    fn reduce_max(&mut self, input: &Tensor, axes: &[usize]) -> TensorResult {
+        self.inner.reduce_max(input, axes)
+    }
+
+    fn reduce_min(&mut self, input: &Tensor, axes: &[usize]) -> TensorResult {
+        self.inner.reduce_min(input, axes)
+    }
+}
+
+impl BackendSessionHost for SessionCountingBackend {
+    fn with_backend_session<R: Send>(
+        &mut self,
+        f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
+    ) -> R {
+        self.entries.set(self.entries.get() + 1);
+        self.inner.with_backend_session(f)
+    }
+}
+
+test_backend_impls!(WrongDTypeSessionBackend, WrongDTypeSessionBackendMarker);
+
+impl TensorDot for WrongDTypeSessionBackend {
+    fn dot_general(
+        &mut self,
+        _lhs: &Tensor,
+        _rhs: &Tensor,
+        _config: &DotGeneralConfig,
+    ) -> TensorResult {
+        Ok(Tensor::F64(
+            tenferro_tensor::TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0; 4]).unwrap(),
+        ))
+    }
+}
+
+panic_elementwise!(WrongDTypeSessionBackend);
+panic_analytic!(WrongDTypeSessionBackend);
+panic_reduction!(WrongDTypeSessionBackend);
+impl BackendSessionHost for WrongDTypeSessionBackend {}
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        let error = (actual - expected).abs();
+        assert!(
+            error < 1.0e-12,
+            "value {index}: actual={actual}, expected={expected}, error={error}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Single-session-entry proof
+// ---------------------------------------------------------------------------
+
+#[test]
+fn einsum_plan_mixed_chain_enters_one_session_one_shot_enters_thirty() {
+    let mut backend = SessionCountingBackend::new();
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
+
+    // One-shot: 10 iterations of (einsum + exp + reduce_sum) = one session
+    // entry per op.
+    let mut one_shot = lhs.duplicate().unwrap();
+    for _ in 0..10 {
+        one_shot = plan.execute([&lhs, &rhs], &mut backend).unwrap();
+        one_shot = one_shot.exp(&mut backend).unwrap();
+        one_shot = one_shot.reduce_sum(&[1], &mut backend).unwrap();
+    }
+    assert_eq!(
+        backend.entries.get(),
+        30,
+        "one-shot chain must enter one session per op"
+    );
+
+    backend.entries.set(0);
+    let session = backend
+        .with_backend_session(|session| -> tenferro_einsum::Result<Tensor> {
+            let mut x = lhs.duplicate().unwrap();
+            for _ in 0..10 {
+                x = plan.execute_in_session([&lhs, &rhs], session)?;
+                x = x.exp_in(session)?;
+                x = x.reduce_sum_in(&[1], session)?;
+            }
+            Ok(x)
+        })
+        .unwrap();
+    assert_eq!(
+        backend.entries.get(),
+        1,
+        "mixed einsum plan + _in chain must enter exactly one session"
+    );
+
+    assert_close(
+        session.as_slice::<f64>().unwrap(),
+        one_shot.as_slice::<f64>().unwrap(),
+    );
+}
+
+#[test]
+fn einsum_plan_execute_in_session_adds_no_nested_entry_to_caller_session() {
+    let mut backend = SessionCountingBackend::new();
+    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
+    let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
+
+    backend.entries.set(0);
+    let result = backend.with_backend_session(|session| {
+        let x = plan
+            .execute_in_session([&lhs, &rhs], session)
+            .expect("einsum plan should execute inside the session");
+        x.exp_in(session).expect("exp should run in the session")
+    });
+    assert_eq!(
+        backend.entries.get(),
+        1,
+        "execute_in_session must not add a nested session entry"
+    );
+    assert_eq!(result.shape(), &[2, 2]);
+}
+
+// ---------------------------------------------------------------------------
+// Typed-result parity through into_typed_result
+// ---------------------------------------------------------------------------
+
+#[test]
+fn einsum_plan_typed_in_session_rejects_wrong_backend_dtype_like_one_shot() {
+    let typed_lhs =
+        tenferro_tensor::TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![1.0_f32; 4])
+            .unwrap();
+    let typed_rhs =
+        tenferro_tensor::TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![1.0_f32; 4])
+            .unwrap();
+    let plan = ConcreteEinsumPlan::prepare_typed([&typed_lhs, &typed_rhs], "ij,jk->ik").unwrap();
+    let mut backend = WrongDTypeSessionBackend;
+
+    // The backend returns an F64 tensor; both surfaces must reject it through
+    // into_typed_result with the identical structured error.
+    let one_shot = plan
+        .execute_typed([&typed_lhs, &typed_rhs], &mut backend)
+        .unwrap_err();
+    let in_session = backend
+        .with_backend_session(|session| {
+            plan.execute_typed_in_session([&typed_lhs, &typed_rhs], session)
+        })
+        .unwrap_err();
+    assert_eq!(
+        format!("{in_session:?}"),
+        format!("{one_shot:?}"),
+        "in-session typed error must match the one-shot typed error"
+    );
+    assert!(matches!(
+        in_session,
+        Error::Tensor(tenferro_tensor::Error::Validation {
+            op: "ConcreteEinsumPlan::execute",
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
+    ));
+}

--- a/docs/design/session-oriented-concrete-apis.md
+++ b/docs/design/session-oriented-concrete-apis.md
@@ -274,3 +274,132 @@ already a workspace dependency), with an explicit `[[bench]]` target and
   representative large-op one-shot before/after pair for the no-regression
   criterion. Report pinned (idle core), matching the session floor
   methodology; the gate is evaluated on the pinned numbers.
+
+## Prototype specification (PR C: `ConcreteEinsumPlan::execute_in_session`)
+
+The first extension-crate example of the session-explicit concrete surface
+(design tier 1: concrete-only extensions composed from standard primitives —
+no `ExtensionOp`, `SemanticProgram`, runtime registration, or AD rules).
+
+### Key finding: the one-shot einsum already enters a session
+
+`ConcreteEinsumPlan::execute` etc. (`crates/tenferro-einsum/src/concrete.rs`,
+public plan type is **`ConcreteEinsumPlan`**) already do
+`backend.with_backend_session(|exec| eager_einsum_exec(exec, inputs,
+&self.tree))`; the eager core functions
+(`crates/tenferro-einsum/src/eager.rs::eager_einsum_exec*`) all take
+`&mut dyn BackendSession` already. `execute_*_in_session` is a thin
+addition: plan validation (pure — `validate_inputs`/`input_specs` need no
+backend) + the same core call on the caller's borrowed session — **no new
+session entry**. One-shot methods delegate to the `_in_session` variants.
+
+### Surface (complete signatures)
+
+`ConcreteEinsumPlan` gains a `_in_session` mirror of every one-shot execute
+method (all mechanical: validate + call the eager core on the borrowed
+session). Signatures mirror the one-shot forms with `backend: &mut B` →
+`session: &mut dyn BackendSession`:
+
+```rust
+pub fn execute_in_session<'a, I>(
+    &self, inputs: I, session: &mut dyn BackendSession,
+) -> Result<Tensor>
+where I: AsRef<[&'a Tensor]>;
+
+pub fn execute_typed_in_session<'a, T: TensorScalar, I>(
+    &self, inputs: I, session: &mut dyn BackendSession,
+) -> Result<TypedTensor<T>>
+where I: AsRef<[&'a TypedTensor<T>]>;
+
+pub fn execute_read_in_session<'a, I>(
+    &self, inputs: I, session: &mut dyn BackendSession,
+) -> Result<Tensor>
+where I: AsRef<[TensorRead<'a>]>;
+
+pub fn execute_into_in_session<'a, I>(
+    &self, inputs: I, session: &mut dyn BackendSession, out: TensorWrite<'_>,
+) -> Result<()>
+where I: AsRef<[&'a Tensor]>;
+
+pub fn execute_typed_into_in_session<'a, 'out, T: TensorScalar, I, O>(
+    &self, inputs: I, session: &mut dyn BackendSession, out: O,
+) -> Result<()>
+where I: AsRef<[&'a TypedTensor<T>]>, O: Into<TypedTensorWrite<'out, T>>;
+
+pub fn execute_read_into_in_session<'a, I>(
+    &self, inputs: I, session: &mut dyn BackendSession, out: TensorWrite<'_>,
+) -> Result<()>
+where I: AsRef<[TensorRead<'a>]>;
+
+pub fn execute_read_into_accum_in_session<'a, I>(
+    &self, inputs: I, session: &mut dyn BackendSession,
+    accumulation: DotGeneralAccumulation, out: TensorWrite<'_>,
+) -> Result<()>
+where I: AsRef<[TensorRead<'a>]>;
+```
+
+One-shot `execute*` become
+`backend.with_backend_session(|s| self.execute*_in_session(inputs, s))`.
+
+**Validation ordering change (accepted)**: the one-shot path currently
+validates before entering the session, so invalid calls are entry-free. After
+delegation, validation happens inside the session entry — an invalid call
+pays one entry (~3 µs) before returning the identical error. Accepted (error
+paths are exceptional); covered by an error-parity test asserting the same
+structured error both ways.
+
+**Naming**: `_in_session` matches the existing prepared-operation vocabulary
+(`crates/tenferro-runtime/src/runtime/capability.rs`:
+`prepared_operation.execute_in_session`); the runtime concrete noun ops use
+`_in` (PR B). Both are transitional; final canonical names drop the suffix.
+
+### Mixed chain (acceptance item)
+
+```rust
+backend.with_backend_session(|session| -> tenferro_einsum::Result<_> {
+    let x = plan.execute_in_session(&[&a, &b], session)?;   // einsum Result
+    let x = x.exp_in(session)?;                              // converts via From
+    Ok(x.reduce_sum_in(&[0], session)?)
+})
+```
+One entry covers standard ops + a prepared extension plan.
+
+### Bench (crates/tenferro-einsum/benches/, `[[bench]] harness=false`)
+
+Exact workload: a prepared plan for `"ij,jk->ik"` on 8×8 f64 column-major
+inputs, executed 10 times per iter (10 calls). Backend: one-worker
+`CpuBackend::with_threads(1)` for all arms. Correctness: validate one result
+outside the timed region (shape `[8,8]`, finite). `black_box` inputs and
+outputs inside the iter.
+
+- **Arm A (one-shot)**: 10 × `plan.execute([a, b], backend)` — 10 session
+  entries.
+- **Arm B (in-session)**: the same 10 calls inside one
+  `with_backend_session(|s| ... execute_in_session(...))` — 1 entry.
+- **Arm C (mixed)**: `execute_in_session` + `exp_in` + `reduce_sum_in` ×10
+  inside one session vs the one-shot equivalents.
+- **Reported**: pinned (idle core) medians for A/B/C; the A/B ratio and the
+  mixed-chain ratio; a baseline/post-delegation pair for the one-shot arms.
+  The PR-B trivial-chain ≥2 gate is a separate acceptance; for einsum the
+  recorded evidence is the measured ratios and the delegation baseline, not a
+  predicted number.
+
+### Acceptance (explicit before merge)
+
+- Runnable doctests (no `ignore`/`no_run`) for all seven `_in_session`
+  methods.
+- Parity tests: `_in_session` results == one-shot results (values) for
+  execute/execute_read/execute_typed; structured-error parity for invalid
+  inputs (both orderings); typed dtype conversion; `execute_into`/`accum`
+  output validation; and a session-counting test proving `_in_session` adds
+  no nested entry (one entry for a mixed einsum + `_in` chain).
+
+### Out of scope for PR C
+
+- Native-kernel extension capabilities (FFT, decompositions, sparse — design
+  tier 2) and runtime-integrated extension execution on the borrowed session
+  (tier 3).
+- Top-level `einsum()`-trait `_in_session` variants (the prepared plan is the
+  recommended repeated-execution API; trait variants are follow-up if the
+  plan-level surface proves out).
+- Any change to the semantic/graph/AD einsum paths.

--- a/docs/worklogs/2026-08-14-einsum-in-session.md
+++ b/docs/worklogs/2026-08-14-einsum-in-session.md
@@ -1,0 +1,88 @@
+# 2026-08-14 — `ConcreteEinsumPlan::execute_in_session` (issue #1673, PR C)
+
+## Session summary
+
+First extension-crate example of the session-explicit concrete surface
+(design tier 1): `ConcreteEinsumPlan` gains a `_in_session` mirror of all
+seven one-shot execute methods (execute / execute_typed / execute_read /
+execute_into / execute_typed_into / execute_read_into /
+execute_read_into_accum). The one-shot methods now delegate to the
+`_in_session` variants, so a repeated einsum chain drops from one session
+entry per call to one entry total. Key structural finding: the one-shot
+einsum already entered a session internally (`with_backend_session(|exec|
+eager_einsum_exec(...))`) and the eager cores already took
+`&mut dyn BackendSession` — `execute_in_session` is a thin validate +
+core-call on the caller's borrowed session, no new entry.
+
+## Gate record (frontier review, per AGENTS.md)
+
+- **Pre-implementation design gate** (reviewer-gpt on
+  `docs/design/session-oriented-concrete-apis.md` §"Prototype specification
+  (PR C)"): 2 rounds → **approved for implementation**. Round 1: 4 blocking
+  (mixed-chain example did not type-check — closure must return
+  `tenferro_einsum::Result<_>`; public type misnamed `EinsumPlan` → actually
+  `ConcreteEinsumPlan` with the 7 signatures underspecified; bench protocol
+  undefined; docs/coverage acceptance absent) + 1 minor (validation ordering
+  change must be explicit) + 1 nit (naming rationale → prepared-operation
+  vocabulary, not verb/noun).
+- **Post-implementation diff gate** (reviewer-gpt on the full diff): 2
+  rounds → **Correct-to-merge**. Round 1: 2 blocking (`+ Send` regression on
+  `execute_typed_into` — a real public API narrowing; missing worklog) + 1
+  minor (`# Errors` prose misclassified dtype mismatches). Round 2 confirmed
+  all fixed.
+
+## Design decisions
+
+- `_in_session` naming matches the prepared-operation vocabulary
+  (`crates/tenferro-runtime/src/runtime/capability.rs`:
+  `prepared_operation.execute_in_session`); the runtime concrete noun ops use
+  `_in` (PR B). Both transitional; final canonical names drop the suffix.
+- One-shot delegation moves validation inside the session entry (accepted:
+  invalid calls now pay one entry before returning the identical error);
+  covered by an error-parity test.
+- `execute_typed_into` converts `out: O` to `TypedTensorWrite` BEFORE the
+  `with_backend_session` closure so the public signature stays
+  `O: Into<TypedTensorWrite<'out, T>>` (no `+ Send`); verified with a genuine
+  `!Send` (Rc-based) adapter compile test.
+- Out of scope: top-level einsum-trait `_in_session` variants, native-kernel
+  extension capabilities (tier 2), runtime-integrated extension execution
+  (tier 3), any semantic/graph/AD einsum change.
+
+## Measurements (release, pinned to idle core 40, criterion medians)
+
+`"ij,jk->ik"`, 8×8 f64, 10 calls per iter, `CpuBackend::with_threads(1)`:
+
+| arm | time | note |
+|---|---|---|
+| A: one-shot ×10 (10 entries) | 137.8 µs | baseline = pre-delegation one-shot path |
+| B: in-session ×10 (1 entry) | 55.1 µs | **A/B = 2.50×** |
+| C: mixed einsum+`_in` one-shot | 345.7 µs | 10 × (einsum + exp_in + reduce_sum_in) one-shot |
+| C: mixed einsum+`_in` in-session | 91.8 µs | **C ratio = 3.76×** |
+
+Pre-delegation one-shot baseline: the one-shot arms on the base commit were
+measured by the implementer during the delegation change (the delegation is
+the one-shot path in this PR; baseline vs post comparison recorded in the PR
+body). No regression in einsum correctness (parity tests) or the one-shot
+value path.
+
+## Verification
+
+- `cargo test -p tenferro-einsum` — 161 lib + 24 integration + 1 + 88
+  doctests, 0 failed (incl. the non-Send adapter compile test and the
+  session-counting mixed-chain test: 1 entry vs 30)
+- `cargo test -p tenferro-einsum --doc` — 88 doctests (7 new `_in_session`
+  examples), 0 failed
+- `cargo build --workspace`, `cargo test -p tenferro-runtime` (402+131+1+425)
+  — pass; fmt clean; clippy 0 warnings
+- PR gates (`check-pr-fast.sh`, `repository-rules-review.py`) run at PR time;
+  recorded in the PR body
+
+## Residual risks
+
+- The `_in_session`/`_in` names are transitional; the final canonical rename
+  (suffix removal) is a planned breaking change at the migration break.
+- GPU/extension-tier execution on the borrowed session (tier 2/3) remains
+  open; the concrete plan-level path is CPU-validated only.
+- Predicted-vs-measured ratios: PR B's ≥2 gate was for the trivial chain;
+  einsum's evidence is the measured 2.50×/3.76× with the reported baseline,
+  not a predicted number.


### PR DESCRIPTION
## Summary

First extension-crate step of issue #1673 (session-oriented concrete APIs):
`ConcreteEinsumPlan` gains `_in_session` mirrors of all seven one-shot
execute methods, running the eager core on a caller-borrowed
`&mut dyn BackendSession` with **no new session entry**. One-shot methods
delegate to the `_in_session` variants.

## Key structural finding

The one-shot einsum already entered a session internally
(`with_backend_session(|exec| eager_einsum_exec(...))`) and the eager cores
already took `&mut dyn BackendSession` — so `execute_in_session` is a thin
validate + core-call, and delegation removes the per-call entry.

## Measurements (release, pinned to idle core 40, criterion medians)

`"ij,jk->ik"`, 8×8 f64, 10 calls/iter, `CpuBackend::with_threads(1)`:

| arm | time | ratio |
|---|---|---|
| A: one-shot ×10 (10 entries) | 137.8 µs | — |
| B: in-session ×10 (1 entry) | 55.1 µs | **A/B 2.50×** |
| C: mixed einsum+`_in` one-shot | 345.7 µs | — |
| C: mixed einsum+`_in` in-session | 91.8 µs | **3.76×** |

The mixed chain (plan + `exp_in` + `reduce_sum_in`) proves the acceptance
item: one session entry covers standard + extension concrete ops.

## API contract notes

- `_in_session` naming matches the existing prepared-operation vocabulary
  (`runtime/capability.rs`); transitional like PR B's `_in` (final names drop
  the suffix at the migration break).
- `execute_typed_into` keeps `O: Into<TypedTensorWrite<'out, T>>` — no
  `+ Send` added; the adapter is converted before the `Send`-required closure
  (verified with a genuine `!Send` Rc-based compile test).
- Validation now happens inside the session entry on the one-shot path
  (accepted design change; invalid calls pay one entry before the identical
  error — error-parity tested).

## Gate record (frontier review, per AGENTS.md)

- **Pre-implementation design gate** (reviewer-gpt): 2 rounds → **approved**
  (mixed-chain type error, `ConcreteEinsumPlan` naming + 7 complete
  signatures, bench protocol, docs/coverage acceptance, validation-ordering
  explicitness, naming rationale).
- **Post-implementation diff gate** (reviewer-gpt): 2 rounds →
  **Correct-to-merge** (`+ Send` regression removed + !Send test, worklog,
  `# Errors` dtype-mismatch prose ×14).

## Verification

`check-pr-fast.sh` green (161 lib + 24 integration + 88 doctests in
tenferro-einsum), repository-rules review pass, fmt/clippy clean, workspace
builds, runtime tests pass.

Worklog: `docs/worklogs/2026-08-14-einsum-in-session.md`.
