### PR TITLE
feat(runtime): complete the _in session-explicit surface (#1680 Phase 1)

### DIFF
--- a/crates/tenferro-runtime/benches/session_chain.rs
+++ b/crates/tenferro-runtime/benches/session_chain.rs
@@ -94,5 +94,127 @@ fn bench_session_chain(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_session_chain);
+/// Phase-1 (issue #1680) chain operands.
+///
+/// Exact 10-op chain: `[2,2]` f64 through
+/// sub -> log -> pow -> maximum -> neg (elementwise, operands stay positive
+/// through `log`), reshape to `[4,1]`, transpose to `[1,4]`, scalar-broadcast
+/// clamp, matmul by a `[4,1]` rhs to `[1,1]`, then cast F64 -> F32.
+///
+/// After `neg` the elements are `[-1, -1, -ln(3)^2, -ln(4)^2]`, all of which
+/// lie above the clamp upper bound `-2`, so the clamp pulls every element to
+/// `-2` and the matmul sums them to the known scalar result `-8.0`.
+fn phase1_operand_a() -> Tensor {
+    Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 3.0, 4.0, 5.0]).expect("benchmark tensor")
+}
+
+fn phase1_operand_b() -> Tensor {
+    Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).expect("benchmark tensor")
+}
+
+fn phase1_operand_power() -> Tensor {
+    Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64; 4]).expect("benchmark tensor")
+}
+
+fn phase1_operand_max() -> Tensor {
+    Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).expect("benchmark tensor")
+}
+
+fn phase1_operand_clamp_bounds() -> (Tensor, Tensor) {
+    (
+        Tensor::from_vec_col_major(vec![], vec![-100.0_f64]).expect("benchmark tensor"),
+        Tensor::from_vec_col_major(vec![], vec![-2.0_f64]).expect("benchmark tensor"),
+    )
+}
+
+fn phase1_operand_rhs() -> Tensor {
+    Tensor::from_vec_col_major(vec![4, 1], vec![1.0_f64; 4]).expect("benchmark tensor")
+}
+
+/// Pre-built phase-1 chain operands, shared by both execution arms.
+struct Phase1Operands {
+    a: Tensor,
+    b: Tensor,
+    power: Tensor,
+    max: Tensor,
+    rhs: Tensor,
+    lower: Tensor,
+    upper: Tensor,
+}
+
+impl Phase1Operands {
+    fn new() -> Self {
+        let (lower, upper) = phase1_operand_clamp_bounds();
+        Self {
+            a: phase1_operand_a(),
+            b: phase1_operand_b(),
+            power: phase1_operand_power(),
+            max: phase1_operand_max(),
+            rhs: phase1_operand_rhs(),
+            lower,
+            upper,
+        }
+    }
+}
+
+/// 10 ops, each entering its own backend session.
+fn run_phase1_chain_one_shot(ops: &Phase1Operands, backend: &mut CpuBackend) -> Tensor {
+    let x = ops.a.sub(&ops.b, backend).expect("sub");
+    let x = x.log(backend).expect("log");
+    let x = x.pow(&ops.power, backend).expect("pow");
+    let x = x.maximum(&ops.max, backend).expect("maximum");
+    let x = x.neg(backend).expect("neg");
+    let x = x.reshape(&[4, 1], backend).expect("reshape");
+    let x = x.transpose(&[1, 0], backend).expect("transpose");
+    let x = x.clamp(&ops.lower, &ops.upper, backend).expect("clamp");
+    let x = x.matmul(&ops.rhs, backend).expect("matmul");
+    x.cast(tenferro_runtime::DType::F32, backend).expect("cast")
+}
+
+/// The same 10 ops inside one backend session (1 entry).
+fn run_phase1_chain_one_session(ops: &Phase1Operands, backend: &mut CpuBackend) -> Tensor {
+    backend.with_backend_session(|session| {
+        let x = ops.a.sub_in(&ops.b, session).expect("sub");
+        let x = x.log_in(session).expect("log");
+        let x = x.pow_in(&ops.power, session).expect("pow");
+        let x = x.maximum_in(&ops.max, session).expect("maximum");
+        let x = x.neg_in(session).expect("neg");
+        let x = x.reshape_in(&[4, 1], session).expect("reshape");
+        let x = x.transpose_in(&[1, 0], session).expect("transpose");
+        let x = x.clamp_in(&ops.lower, &ops.upper, session).expect("clamp");
+        let x = x.matmul_in(&ops.rhs, session).expect("matmul");
+        x.cast_in(tenferro_runtime::DType::F32, session)
+            .expect("cast")
+    })
+}
+
+fn bench_session_chain_phase1(c: &mut Criterion) {
+    let mut group = c.benchmark_group("session_chain/phase1");
+    let ops = Phase1Operands::new();
+    let mut backend = CpuBackend::new();
+
+    // Validation outside the timed region: the known scalar result -8.0
+    // (see the chain comment above), and the two execution arms agree.
+    let one_shot = run_phase1_chain_one_shot(&ops, &mut backend);
+    assert_eq!(one_shot.shape(), &[1, 1], "chain must reduce to [1,1]");
+    assert_eq!(one_shot.as_slice::<f32>().unwrap(), &[-8.0]);
+    let one_session = run_phase1_chain_one_session(&ops, &mut backend);
+    assert_eq!(one_session.as_slice::<f32>().unwrap(), &[-8.0]);
+
+    group.bench_function("one_shot", |bench| {
+        bench.iter(|| {
+            let out = run_phase1_chain_one_shot(black_box(&ops), &mut backend);
+            black_box(out);
+        });
+    });
+    group.bench_function("one_session", |bench| {
+        bench.iter(|| {
+            let out = run_phase1_chain_one_session(black_box(&ops), &mut backend);
+            black_box(out);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_session_chain, bench_session_chain_phase1);
 criterion_main!(benches);

--- a/crates/tenferro-runtime/src/lib.rs
+++ b/crates/tenferro-runtime/src/lib.rs
@@ -599,6 +599,656 @@ pub trait TensorSessionOpsExt {
         axes: &[usize],
         session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
+    /// Convert to a different dtype using the checked conversion lattice inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{DType, Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.convert_in(DType::C64, session)).unwrap();
+    /// assert_eq!(y.dtype(), DType::C64);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::UnsupportedDTypeConversion`] when the
+    /// conversion is outside the checked lattice,
+    /// [`tenferro_tensor::Error::Validation`] with `DTypeMismatch` or
+    /// `InvalidArgument` for invalid tensor metadata, or
+    /// [`tenferro_tensor::Error::BackendSource`] when the backend reports a
+    /// typed failure.
+    fn convert_in(
+        &self,
+        to: DType,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Cast to a different dtype using explicit lossy projection inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{DType, Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![1.2_f64, -2.8]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.cast_in(DType::I32, session)).unwrap();
+    /// assert_eq!(y.as_slice::<i32>().unwrap(), &[1, -2]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::UnsupportedDTypeConversion`] when the
+    /// requested cast is unsupported, [`tenferro_tensor::Error::Validation`]
+    /// with `DTypeMismatch` or `InvalidArgument` for invalid tensor metadata,
+    /// or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn cast_in(
+        &self,
+        to: DType,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise subtraction with NumPy-style broadcasting inside a session.
+    ///
+    /// Like [`Self::add_in`], the broadcast and the subtraction run in the one
+    /// `session`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
+    /// let b = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.sub_in(&b, session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, -4.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` for incompatible operands, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn sub_in(
+        &self,
+        rhs: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise division with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = Tensor::from_vec_col_major(vec![2], vec![4.0_f64, 8.0]).unwrap();
+    /// let b = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.div_in(&b, session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[2.0, 2.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` for shape/dtype incompatibility,
+    /// [`tenferro_tensor::Error::Extension`] with a numerical classification
+    /// for a detected zero divisor, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn div_in(
+        &self,
+        rhs: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise remainder with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = Tensor::from_vec_col_major(vec![2], vec![5.0_f64, 7.0]).unwrap();
+    /// let b = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.rem_in(&b, session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, 3.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` for shape/dtype incompatibility, a numerical
+    /// [`tenferro_tensor::Error::Extension`] for a detected zero divisor, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn rem_in(
+        &self,
+        rhs: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise power with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap();
+    /// let b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 2.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.pow_in(&b, session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[8.0, 9.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` for incompatible metadata, a numerical
+    /// [`tenferro_tensor::Error::Extension`] for a detected negative integer
+    /// exponent, or [`tenferro_tensor::Error::BackendSource`] for a typed
+    /// backend failure.
+    fn pow_in(
+        &self,
+        rhs: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise maximum with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
+    /// let b = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.maximum_in(&b, session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[2.0, 8.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` for incompatible operands, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn maximum_in(
+        &self,
+        rhs: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise minimum with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
+    /// let b = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.minimum_in(&b, session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, 4.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` for incompatible operands, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn minimum_in(
+        &self,
+        rhs: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise negation inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, -2.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.neg_in(session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[-1.0, 2.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] when the dtype is not
+    /// supported by the operation, or [`tenferro_tensor::Error::BackendSource`]
+    /// for a typed backend failure.
+    fn neg_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise absolute value inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![-1.0_f64, 2.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.abs_in(session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn abs_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise sign inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, -2.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.sign_in(session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, -1.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn sign_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise complex conjugate inside a session.
+    ///
+    /// For real dtypes the conjugate is the identity.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, -2.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.conj_in(session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, -2.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn conj_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise natural logarithm inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, std::f64::consts::E]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.log_in(session)).unwrap();
+    /// let y = y.as_slice::<f64>().unwrap();
+    /// assert!(y[0].abs() < 1.0e-12);
+    /// assert!((y[1] - 1.0).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn log_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise `exp(x) - 1` inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.expm1_in(session)).unwrap();
+    /// let y = y.as_slice::<f64>().unwrap();
+    /// assert!(y[0].abs() < 1.0e-12);
+    /// assert!((y[1] - (std::f64::consts::E - 1.0)).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn expm1_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise `log(1 + x)` inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, std::f64::consts::E - 1.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.log1p_in(session)).unwrap();
+    /// let y = y.as_slice::<f64>().unwrap();
+    /// assert!(y[0].abs() < 1.0e-12);
+    /// assert!((y[1] - 1.0).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn log1p_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise sine inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, std::f64::consts::FRAC_PI_2]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.sin_in(session)).unwrap();
+    /// let y = y.as_slice::<f64>().unwrap();
+    /// assert!(y[0].abs() < 1.0e-12);
+    /// assert!((y[1] - 1.0).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn sin_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise cosine inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, std::f64::consts::PI]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.cos_in(session)).unwrap();
+    /// let y = y.as_slice::<f64>().unwrap();
+    /// assert!((y[0] - 1.0).abs() < 1.0e-12);
+    /// assert!((y[1] + 1.0).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn cos_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise hyperbolic tangent inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.tanh_in(session)).unwrap();
+    /// let y = y.as_slice::<f64>().unwrap();
+    /// assert!(y[0].abs() < 1.0e-12);
+    /// assert!((y[1] - 0.7615941559557649).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn tanh_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise square root inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![4.0_f64, 9.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.sqrt_in(session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn sqrt_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise reciprocal square root inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![4.0_f64, 1.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.rsqrt_in(session)).unwrap();
+    /// let y = y.as_slice::<f64>().unwrap();
+    /// assert!((y[0] - 0.5).abs() < 1.0e-12);
+    /// assert!((y[1] - 1.0).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn rsqrt_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    /// Elementwise comparison with NumPy-style broadcasting inside a session.
+    ///
+    /// The result is a bool tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{CompareDir, Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
+    /// let b = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.compare_in(&b, CompareDir::Gt, session)).unwrap();
+    /// assert_eq!(y.as_slice::<bool>().unwrap(), &[true, false]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` for incompatible shape/dtype metadata, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn compare_in(
+        &self,
+        rhs: &Tensor,
+        dir: CompareDir,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Select values from `on_true` or `on_false` using this tensor as condition inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let condition = Tensor::from_vec_col_major(vec![2], vec![true, false]).unwrap();
+    /// let on_true = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    /// let on_false = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| condition.where_select_in(&on_true, &on_false, session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, 4.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` when the condition and branches are incompatible, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn where_select_in(
+        &self,
+        on_true: &Tensor,
+        on_false: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Clamp values elementwise between lower and upper bounds inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2], vec![-2.0_f64, 4.0]).unwrap();
+    /// let lower = Tensor::from_vec_col_major(vec![], vec![0.0_f64]).unwrap();
+    /// let upper = Tensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.clamp_in(&lower, &upper, session)).unwrap();
+    /// assert_eq!(y.as_slice::<f64>().unwrap(), &[0.0, 3.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` when bounds are incompatible with the input, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn clamp_in(
+        &self,
+        lower: &Tensor,
+        upper: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Rank-2 matrix multiplication inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    /// let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
+    /// let c = backend.with_backend_session(|session| a.matmul_in(&b, session)).unwrap();
+    /// assert_eq!(c.shape(), &[2, 2]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch`,
+    /// `ShapeMismatch`, or `DTypeMismatch` for incompatible matrices, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn matmul_in(
+        &self,
+        rhs: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Reshape without changing element order inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.reshape_in(&[4], session)).unwrap();
+    /// assert_eq!(y.shape(), &[4]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch`, `RankMismatch`, or `InvalidArgument` when element
+    /// counts or ranks are invalid, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn reshape_in(
+        &self,
+        shape: &[usize],
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
+    /// Permute axes inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.transpose_in(&[1, 0], session)).unwrap();
+    /// assert_eq!(y.shape(), &[3, 2]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `InvalidPermutationLength`, `AxisOutOfBounds`, or `DuplicateAxis` for
+    /// an invalid permutation, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn transpose_in(
+        &self,
+        perm: &[usize],
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor>;
 }
 
 /// Backend-explicit operations for dynamic-rank typed tensors.
@@ -1053,6 +1703,604 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     fn reduce_sum_in(
         &self,
         axes: &[usize],
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise subtraction with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
+    /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.sub_in(&b, session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[1.0, -4.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
+    /// a typed backend failure.
+    fn sub_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise division with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![4.0, 8.0]).unwrap();
+    /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.div_in(&b, session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[2.0, 2.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible shapes, a numerical [`tenferro_tensor::Error::Extension`]
+    /// for a detected zero divisor, or [`tenferro_tensor::Error::BackendSource`]
+    /// for a typed backend failure.
+    fn div_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise remainder with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![5.0, 7.0]).unwrap();
+    /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.rem_in(&b, session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[1.0, 3.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible shapes, a numerical [`tenferro_tensor::Error::Extension`]
+    /// for a detected zero divisor, or [`tenferro_tensor::Error::BackendSource`]
+    /// for a typed backend failure.
+    fn rem_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise power with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 3.0]).unwrap();
+    /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 2.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.pow_in(&b, session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[8.0, 9.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible shapes, a numerical [`tenferro_tensor::Error::Extension`]
+    /// for a detected negative integer exponent, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn pow_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise maximum with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
+    /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.maximum_in(&b, session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[2.0, 8.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
+    /// a typed backend failure.
+    fn maximum_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise minimum with NumPy-style broadcasting inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
+    /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.minimum_in(&b, session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[1.0, 4.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
+    /// a typed backend failure.
+    fn minimum_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise negation inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, -2.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.neg_in(session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[-1.0, 2.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn neg_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise absolute value inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![-1.0, 2.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.abs_in(session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[1.0, 2.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn abs_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise sign inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, -2.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.sign_in(session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[1.0, -1.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn sign_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise complex conjugate inside a session.
+    ///
+    /// For real dtypes the conjugate is the identity.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, -2.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.conj_in(session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[1.0, -2.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn conj_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise natural logarithm inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, std::f64::consts::E]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.log_in(session)).unwrap();
+    /// let y = y.host_data().unwrap();
+    /// assert!(y[0].abs() < 1.0e-12);
+    /// assert!((y[1] - 1.0).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn log_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise `exp(x) - 1` inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, 1.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.expm1_in(session)).unwrap();
+    /// let y = y.host_data().unwrap();
+    /// assert!(y[0].abs() < 1.0e-12);
+    /// assert!((y[1] - (std::f64::consts::E - 1.0)).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn expm1_in(&self, session: &mut dyn BackendSession)
+        -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise `log(1 + x)` inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, std::f64::consts::E - 1.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.log1p_in(session)).unwrap();
+    /// let y = y.host_data().unwrap();
+    /// assert!(y[0].abs() < 1.0e-12);
+    /// assert!((y[1] - 1.0).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn log1p_in(&self, session: &mut dyn BackendSession)
+        -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise sine inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, std::f64::consts::FRAC_PI_2]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.sin_in(session)).unwrap();
+    /// let y = y.host_data().unwrap();
+    /// assert!(y[0].abs() < 1.0e-12);
+    /// assert!((y[1] - 1.0).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn sin_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise cosine inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, std::f64::consts::PI]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.cos_in(session)).unwrap();
+    /// let y = y.host_data().unwrap();
+    /// assert!((y[0] - 1.0).abs() < 1.0e-12);
+    /// assert!((y[1] + 1.0).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn cos_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise hyperbolic tangent inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, 1.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.tanh_in(session)).unwrap();
+    /// let y = y.host_data().unwrap();
+    /// assert!(y[0].abs() < 1.0e-12);
+    /// assert!((y[1] - 0.7615941559557649).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn tanh_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise square root inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![4.0, 9.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.sqrt_in(session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[2.0, 3.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn sqrt_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise reciprocal square root inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![4.0, 1.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.rsqrt_in(session)).unwrap();
+    /// let y = y.host_data().unwrap();
+    /// assert!((y[0] - 0.5).abs() < 1.0e-12);
+    /// assert!((y[1] - 1.0).abs() < 1.0e-12);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
+    fn rsqrt_in(&self, session: &mut dyn BackendSession)
+        -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Elementwise comparison with NumPy-style broadcasting inside a session.
+    ///
+    /// The result is a bool typed tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{CompareDir, TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
+    /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| a.compare_in(&b, CompareDir::Gt, session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[true, false]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch::IncompatibleShapes` when broadcasting the operands is
+    /// impossible, or [`tenferro_tensor::Error::BackendSource`] for a typed
+    /// backend failure.
+    fn compare_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        dir: CompareDir,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<bool>>;
+    /// Clamp values elementwise between lower and upper bounds inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![-2.0, 4.0]).unwrap();
+    /// let lower = TypedTensor::<f64>::from_vec_col_major(vec![], vec![0.0]).unwrap();
+    /// let upper = TypedTensor::<f64>::from_vec_col_major(vec![], vec![3.0]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.clamp_in(&lower, &upper, session)).unwrap();
+    /// assert_eq!(y.host_data().unwrap(), &[0.0, 3.0]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch::IncompatibleShapes` when a bound cannot broadcast to
+    /// the input, or [`tenferro_tensor::Error::BackendSource`] for a typed
+    /// backend failure.
+    fn clamp_in(
+        &self,
+        lower: &TypedTensor<T>,
+        upper: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Rank-2 matrix multiplication inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
+    /// let b = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0; 6]).unwrap();
+    /// let c = backend.with_backend_session(|session| a.matmul_in(&b, session)).unwrap();
+    /// assert_eq!(c.shape(), &[2, 2]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch` when
+    /// either operand is not rank two or `ShapeMismatch::ContractedDimensions`
+    /// when the inner dimensions differ, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn matmul_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Reshape through the backend structural operation inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.reshape_in(&[3, 2], session)).unwrap();
+    /// assert_eq!(y.shape(), &[3, 2]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch::ReshapeElementCount` when the element counts differ,
+    /// `IntegerOverflow` when shape arithmetic overflows, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
+    fn reshape_in(
+        &self,
+        shape: &[usize],
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Permute axes through the backend structural operation inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
+    /// let y = backend.with_backend_session(|session| x.transpose_in(&[1, 0], session)).unwrap();
+    /// assert_eq!(y.shape(), &[3, 2]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `InvalidPermutationLength` when `perm` has the wrong length,
+    /// `AxisOutOfBounds` for an invalid axis, or `DuplicateAxis` for a
+    /// repeated axis, or [`tenferro_tensor::Error::BackendSource`] for a typed
+    /// backend failure.
+    fn transpose_in(
+        &self,
+        perm: &[usize],
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// Broadcast into a larger shape inside a session.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+    /// use tenferro_tensor::BackendSessionHost;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let row = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap();
+    /// let matrix = backend.with_backend_session(|session| row.broadcast_in_dim_in(&[2, 3], &[1], session)).unwrap();
+    /// assert_eq!(matrix.shape(), &[2, 3]);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch` when
+    /// `dims` does not match the input rank, `AxisOutOfBounds` or
+    /// `DuplicateAxis` for an invalid mapping, or
+    /// `ShapeMismatch::IncompatibleShapes` when known dimensions cannot
+    /// broadcast. [`tenferro_tensor::Error::BackendSource`] reports a typed
+    /// backend failure.
+    fn broadcast_in_dim_in(
+        &self,
+        shape: &[usize],
+        dims: &[usize],
         session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
 }

--- a/crates/tenferro-runtime/src/tensor.rs
+++ b/crates/tenferro-runtime/src/tensor.rs
@@ -167,6 +167,136 @@ impl TensorSessionOpsExt for Tensor {
     fn reduce_sum_in(&self, axes: &[usize], session: &mut dyn BackendSession) -> Result<Tensor> {
         session.reduce_sum(self, axes)
     }
+
+    fn convert_in(&self, to: DType, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.convert(self, to)
+    }
+
+    fn cast_in(&self, to: DType, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.cast(self, to)
+    }
+
+    fn sub_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+        let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
+        session.sub(&lhs, &rhs)
+    }
+
+    fn div_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+        let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
+        session.div(&lhs, &rhs)
+    }
+
+    fn rem_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+        let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
+        session.rem(&lhs, &rhs)
+    }
+
+    fn pow_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+        let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
+        session.pow(&lhs, &rhs)
+    }
+
+    fn maximum_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+        let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
+        session.maximum(&lhs, &rhs)
+    }
+
+    fn minimum_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+        let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
+        session.minimum(&lhs, &rhs)
+    }
+
+    fn neg_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.neg(self)
+    }
+
+    fn abs_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.abs(self)
+    }
+
+    fn sign_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.sign(self)
+    }
+
+    fn conj_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.conj(self)
+    }
+
+    fn log_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.log(self)
+    }
+
+    fn expm1_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.expm1(self)
+    }
+
+    fn log1p_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.log1p(self)
+    }
+
+    fn sin_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.sin(self)
+    }
+
+    fn cos_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.cos(self)
+    }
+
+    fn tanh_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.tanh(self)
+    }
+
+    fn sqrt_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.sqrt(self)
+    }
+
+    fn rsqrt_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.rsqrt(self)
+    }
+
+    fn compare_in(
+        &self,
+        rhs: &Tensor,
+        dir: CompareDir,
+        session: &mut dyn BackendSession,
+    ) -> Result<Tensor> {
+        let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
+        session.compare(&lhs, &rhs, &dir)
+    }
+
+    fn where_select_in(
+        &self,
+        on_true: &Tensor,
+        on_false: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> Result<Tensor> {
+        let (condition, on_true, on_false) =
+            broadcast_ternary_in(self, on_true, on_false, session)?;
+        session.select(&condition, &on_true, &on_false)
+    }
+
+    fn clamp_in(
+        &self,
+        lower: &Tensor,
+        upper: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> Result<Tensor> {
+        let (input, lower, upper) = broadcast_ternary_in(self, lower, upper, session)?;
+        session.clamp(&input, &lower, &upper)
+    }
+
+    fn matmul_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+        let config = matmul_config_for_shapes("matmul", self.shape(), rhs.shape())?;
+        session.dot_general(self, rhs, &config)
+    }
+
+    fn reshape_in(&self, shape: &[usize], session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.reshape(self, shape)
+    }
+
+    fn transpose_in(&self, perm: &[usize], session: &mut dyn BackendSession) -> Result<Tensor> {
+        session.transpose(self, perm)
+    }
 }
 
 /// Convert a tensor to a different dtype using the checked conversion lattice.
@@ -190,7 +320,7 @@ impl TensorSessionOpsExt for Tensor {
 /// dtype-promotion lattice, or when the backend does not support the requested
 /// conversion.
 fn convert(input: &Tensor, to: DType, backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|exec| exec.convert(input, to))
+    backend.with_backend_session(|session| input.convert_in(to, session))
 }
 
 /// Cast a tensor to a different dtype using explicit dtype projection.
@@ -215,7 +345,7 @@ fn convert(input: &Tensor, to: DType, backend: &mut impl TensorBackend) -> Resul
 /// Returns an error when the backend does not support the requested explicit
 /// dtype projection.
 fn cast(input: &Tensor, to: DType, backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|exec| exec.cast(input, to))
+    backend.with_backend_session(|session| input.cast_in(to, session))
 }
 
 /// Elementwise addition with NumPy-style broadcasting.
@@ -248,7 +378,7 @@ macro_rules! unary_fn {
         #[doc = concat!("let y = x.", stringify!($name), "(&mut backend).unwrap();")]
         /// ```
         fn $name(input: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
-            backend.with_backend_session(|exec| exec.$method(input))
+            backend.with_backend_session(|session| input.$method(session))
         }
     };
 }
@@ -268,46 +398,49 @@ macro_rules! binary_fn {
         #[doc = concat!("let z = x.", stringify!($name), "(&y, &mut backend).unwrap();")]
         /// ```
         fn $name(lhs: &Tensor, rhs: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
-            let (lhs, rhs) = broadcast_binary(lhs, rhs, backend)?;
-            backend.with_backend_session(|exec| exec.$method(&lhs, &rhs))
+            backend.with_backend_session(|session| lhs.$method(rhs, session))
         }
     };
 }
 
 binary_fn!(
     div,
-    div,
+    div_in,
     "Elementwise division with NumPy-style broadcasting."
 );
 binary_fn!(
     rem,
-    rem,
+    rem_in,
     "Elementwise remainder with NumPy-style broadcasting."
 );
-binary_fn!(pow, pow, "Elementwise power with NumPy-style broadcasting.");
+binary_fn!(
+    pow,
+    pow_in,
+    "Elementwise power with NumPy-style broadcasting."
+);
 binary_fn!(
     maximum,
-    maximum,
+    maximum_in,
     "Elementwise maximum with NumPy-style broadcasting."
 );
 binary_fn!(
     minimum,
-    minimum,
+    minimum_in,
     "Elementwise minimum with NumPy-style broadcasting."
 );
 
-unary_fn!(neg, neg, "Elementwise negation.");
-unary_fn!(abs, abs, "Elementwise absolute value.");
-unary_fn!(sign, sign, "Elementwise sign.");
-unary_fn!(conj, conj, "Elementwise complex conjugate.");
-unary_fn!(log, log, "Elementwise natural logarithm.");
-unary_fn!(sin, sin, "Elementwise sine.");
-unary_fn!(cos, cos, "Elementwise cosine.");
-unary_fn!(tanh, tanh, "Elementwise hyperbolic tangent.");
-unary_fn!(sqrt, sqrt, "Elementwise square root.");
-unary_fn!(rsqrt, rsqrt, "Elementwise reciprocal square root.");
-unary_fn!(expm1, expm1, "Elementwise `exp(x) - 1`.");
-unary_fn!(log1p, log1p, "Elementwise `log(1 + x)`.");
+unary_fn!(neg, neg_in, "Elementwise negation.");
+unary_fn!(abs, abs_in, "Elementwise absolute value.");
+unary_fn!(sign, sign_in, "Elementwise sign.");
+unary_fn!(conj, conj_in, "Elementwise complex conjugate.");
+unary_fn!(log, log_in, "Elementwise natural logarithm.");
+unary_fn!(sin, sin_in, "Elementwise sine.");
+unary_fn!(cos, cos_in, "Elementwise cosine.");
+unary_fn!(tanh, tanh_in, "Elementwise hyperbolic tangent.");
+unary_fn!(sqrt, sqrt_in, "Elementwise square root.");
+unary_fn!(rsqrt, rsqrt_in, "Elementwise reciprocal square root.");
+unary_fn!(expm1, expm1_in, "Elementwise `exp(x) - 1`.");
+unary_fn!(log1p, log1p_in, "Elementwise `log(1 + x)`.");
 
 /// Elementwise multiplication with NumPy-style broadcasting.
 ///
@@ -353,8 +486,7 @@ fn exp(input: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
 /// let z = x.sub(&y, &mut backend).unwrap();
 /// ```
 fn sub(lhs: &Tensor, rhs: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
-    let (lhs, rhs) = broadcast_binary(lhs, rhs, backend)?;
-    backend.with_backend_session(|exec| exec.sub(&lhs, &rhs))
+    backend.with_backend_session(|session| lhs.sub_in(rhs, session))
 }
 
 /// Elementwise comparison with NumPy-style broadcasting.
@@ -378,8 +510,7 @@ fn compare(
     dir: CompareDir,
     backend: &mut impl TensorBackend,
 ) -> Result<Tensor> {
-    let (lhs, rhs) = broadcast_binary(lhs, rhs, backend)?;
-    backend.with_backend_session(|exec| exec.compare(&lhs, &rhs, &dir))
+    backend.with_backend_session(|session| lhs.compare_in(rhs, dir, session))
 }
 
 /// Select values from `on_true` or `on_false` using a condition tensor.
@@ -403,8 +534,7 @@ fn where_select(
     on_false: &Tensor,
     backend: &mut impl TensorBackend,
 ) -> Result<Tensor> {
-    let (condition, on_true, on_false) = broadcast_ternary(condition, on_true, on_false, backend)?;
-    backend.with_backend_session(|exec| exec.select(&condition, &on_true, &on_false))
+    backend.with_backend_session(|session| condition.where_select_in(on_true, on_false, session))
 }
 
 /// Clamp values elementwise between lower and upper bounds.
@@ -426,8 +556,7 @@ fn clamp(
     upper: &Tensor,
     backend: &mut impl TensorBackend,
 ) -> Result<Tensor> {
-    let (input, lower, upper) = broadcast_ternary(input, lower, upper, backend)?;
-    backend.with_backend_session(|exec| exec.clamp(&input, &lower, &upper))
+    backend.with_backend_session(|session| input.clamp_in(lower, upper, session))
 }
 
 /// Matrix multiplication helper for rank-2 tensors.
@@ -445,8 +574,7 @@ fn clamp(
 /// let c = a.matmul(&b, &mut backend).unwrap();
 /// ```
 fn matmul(a: &Tensor, b: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
-    let config = matmul_config_for_shapes("matmul", a.shape(), b.shape())?;
-    backend.with_backend_session(|exec| exec.dot_general(a, b, &config))
+    backend.with_backend_session(|session| a.matmul_in(b, session))
 }
 
 /// Reshape a tensor without changing element order.
@@ -462,7 +590,7 @@ fn matmul(a: &Tensor, b: &Tensor, backend: &mut impl TensorBackend) -> Result<Te
 /// assert_eq!(y.shape(), &[4]);
 /// ```
 fn reshape(input: &Tensor, shape: &[usize], backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|exec| exec.reshape(input, shape))
+    backend.with_backend_session(|session| input.reshape_in(shape, session))
 }
 
 /// Permute tensor axes.
@@ -478,7 +606,7 @@ fn reshape(input: &Tensor, shape: &[usize], backend: &mut impl TensorBackend) ->
 /// assert_eq!(y.shape(), &[3, 2]);
 /// ```
 fn transpose(input: &Tensor, perm: &[usize], backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|exec| exec.transpose(input, perm))
+    backend.with_backend_session(|session| input.transpose_in(perm, session))
 }
 
 /// Sum a tensor over one or more axes.
@@ -528,50 +656,19 @@ fn broadcast_binary_in(
     ))
 }
 
-fn broadcast_binary(
-    lhs: &Tensor,
-    rhs: &Tensor,
-    backend: &mut impl TensorBackend,
-) -> Result<(Tensor, Tensor)> {
-    let shape = broadcast_shape(lhs.shape(), rhs.shape()).map_err(broadcast_error)?;
-    Ok((
-        broadcast_to(lhs, &shape, backend)?,
-        broadcast_to(rhs, &shape, backend)?,
-    ))
-}
-
-fn broadcast_ternary(
+fn broadcast_ternary_in(
     first: &Tensor,
     second: &Tensor,
     third: &Tensor,
-    backend: &mut impl TensorBackend,
+    session: &mut dyn BackendSession,
 ) -> Result<(Tensor, Tensor, Tensor)> {
     let shape = broadcast_shapes([first.shape(), second.shape(), third.shape()])
         .map_err(broadcast_error)?;
     Ok((
-        broadcast_to(first, &shape, backend)?,
-        broadcast_to(second, &shape, backend)?,
-        broadcast_to(third, &shape, backend)?,
+        broadcast_to_in(first, &shape, session)?,
+        broadcast_to_in(second, &shape, session)?,
+        broadcast_to_in(third, &shape, session)?,
     ))
-}
-
-fn broadcast_to(
-    input: &Tensor,
-    target_shape: &[usize],
-    backend: &mut impl TensorBackend,
-) -> Result<Tensor> {
-    let input_shape = input.shape();
-    if input_shape == target_shape {
-        return input.duplicate();
-    }
-
-    let plan = broadcast_input_plan(input_shape, target_shape).map_err(broadcast_error)?;
-    let source = if plan.source_shape == input_shape {
-        input.duplicate()?
-    } else {
-        backend.with_backend_session(|exec| exec.reshape(input, &plan.source_shape))?
-    };
-    backend.with_backend_session(|exec| exec.broadcast_in_dim(&source, target_shape, &plan.dims))
 }
 
 fn broadcast_error(err: tenferro_ops::broadcast::BroadcastError) -> Error {

--- a/crates/tenferro-runtime/src/typed_tensor.rs
+++ b/crates/tenferro-runtime/src/typed_tensor.rs
@@ -226,6 +226,190 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         let out = session.reduce_sum_read(T::tensor_read(self), axes)?;
         into_typed_result("reduce_sum", out)
     }
+
+    fn sub_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let (lhs, rhs) = broadcast_binary_in_read(self, rhs, session)?;
+        let out = session.sub_read(lhs.tensor_read(), rhs.tensor_read())?;
+        into_typed_result("sub", out)
+    }
+
+    fn div_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let (lhs, rhs) = broadcast_binary_in_read(self, rhs, session)?;
+        let out = session.div_read(lhs.tensor_read(), rhs.tensor_read())?;
+        into_typed_result("div", out)
+    }
+
+    fn rem_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let (lhs, rhs) = broadcast_binary_in_read(self, rhs, session)?;
+        let out = session.rem_read(lhs.tensor_read(), rhs.tensor_read())?;
+        into_typed_result("rem", out)
+    }
+
+    fn pow_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let (lhs, rhs) = broadcast_binary_in_read(self, rhs, session)?;
+        let out = session.pow_read(lhs.tensor_read(), rhs.tensor_read())?;
+        into_typed_result("pow", out)
+    }
+
+    fn maximum_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let (lhs, rhs) = broadcast_binary_in_read(self, rhs, session)?;
+        let out = session.maximum_read(lhs.tensor_read(), rhs.tensor_read())?;
+        into_typed_result("maximum", out)
+    }
+
+    fn minimum_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let (lhs, rhs) = broadcast_binary_in_read(self, rhs, session)?;
+        let out = session.minimum_read(lhs.tensor_read(), rhs.tensor_read())?;
+        into_typed_result("minimum", out)
+    }
+
+    fn neg_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.neg_read(T::tensor_read(self))?;
+        into_typed_result("neg", out)
+    }
+
+    fn abs_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.abs_read(T::tensor_read(self))?;
+        into_typed_result("abs", out)
+    }
+
+    fn sign_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.sign_read(T::tensor_read(self))?;
+        into_typed_result("sign", out)
+    }
+
+    fn conj_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.conj_read(T::tensor_read(self))?;
+        into_typed_result("conj", out)
+    }
+
+    fn log_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.log_read(T::tensor_read(self))?;
+        into_typed_result("log", out)
+    }
+
+    fn expm1_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.expm1_read(T::tensor_read(self))?;
+        into_typed_result("expm1", out)
+    }
+
+    fn log1p_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.log1p_read(T::tensor_read(self))?;
+        into_typed_result("log1p", out)
+    }
+
+    fn sin_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.sin_read(T::tensor_read(self))?;
+        into_typed_result("sin", out)
+    }
+
+    fn cos_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.cos_read(T::tensor_read(self))?;
+        into_typed_result("cos", out)
+    }
+
+    fn tanh_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.tanh_read(T::tensor_read(self))?;
+        into_typed_result("tanh", out)
+    }
+
+    fn sqrt_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.sqrt_read(T::tensor_read(self))?;
+        into_typed_result("sqrt", out)
+    }
+
+    fn rsqrt_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        let out = session.rsqrt_read(T::tensor_read(self))?;
+        into_typed_result("rsqrt", out)
+    }
+
+    fn compare_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        dir: CompareDir,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<bool>> {
+        let (lhs, rhs) = broadcast_binary_in_read(self, rhs, session)?;
+        let out = session.compare_read(lhs.tensor_read(), rhs.tensor_read(), &dir)?;
+        into_typed_result("compare", out)
+    }
+
+    fn clamp_in(
+        &self,
+        lower: &TypedTensor<T>,
+        upper: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let (input, lower, upper) = broadcast_ternary_in_read(self, lower, upper, session)?;
+        let out = session.clamp_read(
+            input.tensor_read(),
+            lower.tensor_read(),
+            upper.tensor_read(),
+        )?;
+        into_typed_result("clamp", out)
+    }
+
+    fn matmul_in(
+        &self,
+        rhs: &TypedTensor<T>,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let config = matmul_config_for_shapes("matmul", self.shape(), rhs.shape())?;
+        let out = session.dot_general_read(T::tensor_read(self), T::tensor_read(rhs), &config)?;
+        into_typed_result("matmul", out)
+    }
+
+    fn reshape_in(
+        &self,
+        shape: &[usize],
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let out = session.reshape_read(T::tensor_read(self), shape)?;
+        into_typed_result("reshape", out)
+    }
+
+    fn transpose_in(
+        &self,
+        perm: &[usize],
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let out = session.transpose_read(T::tensor_read(self), perm)?;
+        into_typed_result("transpose", out)
+    }
+
+    fn broadcast_in_dim_in(
+        &self,
+        shape: &[usize],
+        dims: &[usize],
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let out = session.broadcast_in_dim_read(T::tensor_read(self), shape, dims)?;
+        into_typed_result("broadcast_in_dim", out)
+    }
 }
 
 impl TypedTensorMaskOpsExt for TypedTensor<bool> {
@@ -276,8 +460,7 @@ macro_rules! unary_fn {
             input: &TypedTensor<T>,
             backend: &mut impl TensorBackend,
         ) -> Result<TypedTensor<T>> {
-            let out = backend.with_backend_session(|exec| exec.$method(T::tensor_read(input)))?;
-            into_typed_result(stringify!($name), out)
+            backend.with_backend_session(|session| input.$method(session))
         }
     };
 }
@@ -301,52 +484,49 @@ macro_rules! binary_fn {
             rhs: &TypedTensor<T>,
             backend: &mut impl TensorBackend,
         ) -> Result<TypedTensor<T>> {
-            let (lhs, rhs) = broadcast_binary_read(lhs, rhs, backend)?;
-            let out = backend
-                .with_backend_session(|exec| exec.$method(lhs.tensor_read(), rhs.tensor_read()))?;
-            into_typed_result(stringify!($name), out)
+            backend.with_backend_session(|session| lhs.$method(rhs, session))
         }
     };
 }
 
 binary_fn!(
     div,
-    div_read,
+    div_in,
     "Elementwise division with NumPy-style broadcasting."
 );
 binary_fn!(
     rem,
-    rem_read,
+    rem_in,
     "Elementwise remainder with NumPy-style broadcasting."
 );
 binary_fn!(
     pow,
-    pow_read,
+    pow_in,
     "Elementwise power with NumPy-style broadcasting."
 );
 binary_fn!(
     maximum,
-    maximum_read,
+    maximum_in,
     "Elementwise maximum with NumPy-style broadcasting."
 );
 binary_fn!(
     minimum,
-    minimum_read,
+    minimum_in,
     "Elementwise minimum with NumPy-style broadcasting."
 );
 
-unary_fn!(neg, neg_read, "Elementwise negation.");
-unary_fn!(abs, abs_read, "Elementwise absolute value.");
-unary_fn!(sign, sign_read, "Elementwise sign.");
-unary_fn!(conj, conj_read, "Elementwise complex conjugate.");
-unary_fn!(log, log_read, "Elementwise natural logarithm.");
-unary_fn!(sin, sin_read, "Elementwise sine.");
-unary_fn!(cos, cos_read, "Elementwise cosine.");
-unary_fn!(tanh, tanh_read, "Elementwise hyperbolic tangent.");
-unary_fn!(sqrt, sqrt_read, "Elementwise square root.");
-unary_fn!(rsqrt, rsqrt_read, "Elementwise reciprocal square root.");
-unary_fn!(expm1, expm1_read, "Elementwise `exp(x) - 1`.");
-unary_fn!(log1p, log1p_read, "Elementwise `log(1 + x)`.");
+unary_fn!(neg, neg_in, "Elementwise negation.");
+unary_fn!(abs, abs_in, "Elementwise absolute value.");
+unary_fn!(sign, sign_in, "Elementwise sign.");
+unary_fn!(conj, conj_in, "Elementwise complex conjugate.");
+unary_fn!(log, log_in, "Elementwise natural logarithm.");
+unary_fn!(sin, sin_in, "Elementwise sine.");
+unary_fn!(cos, cos_in, "Elementwise cosine.");
+unary_fn!(tanh, tanh_in, "Elementwise hyperbolic tangent.");
+unary_fn!(sqrt, sqrt_in, "Elementwise square root.");
+unary_fn!(rsqrt, rsqrt_in, "Elementwise reciprocal square root.");
+unary_fn!(expm1, expm1_in, "Elementwise `exp(x) - 1`.");
+unary_fn!(log1p, log1p_in, "Elementwise `log(1 + x)`.");
 
 /// Elementwise multiplication with NumPy-style broadcasting.
 ///
@@ -403,10 +583,7 @@ fn sub<T: TensorScalar>(
     rhs: &TypedTensor<T>,
     backend: &mut impl TensorBackend,
 ) -> Result<TypedTensor<T>> {
-    let (lhs, rhs) = broadcast_binary_read(lhs, rhs, backend)?;
-    let out =
-        backend.with_backend_session(|exec| exec.sub_read(lhs.tensor_read(), rhs.tensor_read()))?;
-    into_typed_result("sub", out)
+    backend.with_backend_session(|session| lhs.sub_in(rhs, session))
 }
 
 /// Elementwise comparison with NumPy-style broadcasting.
@@ -430,11 +607,7 @@ fn compare<T: TensorScalar>(
     dir: CompareDir,
     backend: &mut impl TensorBackend,
 ) -> Result<TypedTensor<bool>> {
-    let (lhs, rhs) = broadcast_binary_read(lhs, rhs, backend)?;
-    let out = backend.with_backend_session(|exec| {
-        exec.compare_read(lhs.tensor_read(), rhs.tensor_read(), &dir)
-    })?;
-    into_typed_result("compare", out)
+    backend.with_backend_session(|session| lhs.compare_in(rhs, dir, session))
 }
 
 /// Select values from `on_true` or `on_false` using a condition tensor.
@@ -489,15 +662,7 @@ fn clamp<T: TensorScalar>(
     upper: &TypedTensor<T>,
     backend: &mut impl TensorBackend,
 ) -> Result<TypedTensor<T>> {
-    let (input, lower, upper) = broadcast_ternary_read(input, lower, upper, backend)?;
-    let out = backend.with_backend_session(|exec| {
-        exec.clamp_read(
-            input.tensor_read(),
-            lower.tensor_read(),
-            upper.tensor_read(),
-        )
-    })?;
-    into_typed_result("clamp", out)
+    backend.with_backend_session(|session| input.clamp_in(lower, upper, session))
 }
 
 /// Matrix multiplication helper for rank-2 typed tensors.
@@ -519,11 +684,7 @@ fn matmul<T: TensorScalar>(
     b: &TypedTensor<T>,
     backend: &mut impl TensorBackend,
 ) -> Result<TypedTensor<T>> {
-    let config = matmul_config_for_shapes("matmul", a.shape(), b.shape())?;
-    let out = backend.with_backend_session(|exec| {
-        exec.dot_general_read(T::tensor_read(a), T::tensor_read(b), &config)
-    })?;
-    into_typed_result("matmul", out)
+    backend.with_backend_session(|session| a.matmul_in(b, session))
 }
 
 /// Sum elements across one or more axes.
@@ -567,9 +728,7 @@ fn reshape<T: TensorScalar>(
     shape: &[usize],
     backend: &mut impl TensorBackend,
 ) -> Result<TypedTensor<T>> {
-    let out =
-        backend.with_backend_session(|exec| exec.reshape_read(T::tensor_read(input), shape))?;
-    into_typed_result("reshape", out)
+    backend.with_backend_session(|session| input.reshape_in(shape, session))
 }
 
 /// Permute typed tensor axes through the backend structural operation.
@@ -589,9 +748,7 @@ fn transpose<T: TensorScalar>(
     perm: &[usize],
     backend: &mut impl TensorBackend,
 ) -> Result<TypedTensor<T>> {
-    let out =
-        backend.with_backend_session(|exec| exec.transpose_read(T::tensor_read(input), perm))?;
-    into_typed_result("transpose", out)
+    backend.with_backend_session(|session| input.transpose_in(perm, session))
 }
 
 /// Broadcast a typed tensor into a larger shape.
@@ -615,10 +772,7 @@ fn broadcast_in_dim<T: TensorScalar>(
     dims: &[usize],
     backend: &mut impl TensorBackend,
 ) -> Result<TypedTensor<T>> {
-    let out = backend.with_backend_session(|exec| {
-        exec.broadcast_in_dim_read(T::tensor_read(input), shape, dims)
-    })?;
-    into_typed_result("broadcast_in_dim", out)
+    backend.with_backend_session(|session| input.broadcast_in_dim_in(shape, dims, session))
 }
 
 // INVARIANT: this private adapter keeps borrowed reads borrowed and owns only
@@ -670,15 +824,18 @@ fn broadcast_binary_in_read<'a, T: TensorScalar>(
     ))
 }
 
-fn broadcast_binary_read<'a, T: TensorScalar>(
-    lhs: &'a TypedTensor<T>,
-    rhs: &'a TypedTensor<T>,
-    backend: &mut impl TensorBackend,
-) -> Result<(ReadInput<'a>, ReadInput<'a>)> {
-    let shape = broadcast_shape(lhs.shape(), rhs.shape()).map_err(broadcast_error)?;
+fn broadcast_ternary_in_read<'a, C: TensorScalar, T: TensorScalar>(
+    first: &'a TypedTensor<C>,
+    second: &'a TypedTensor<T>,
+    third: &'a TypedTensor<T>,
+    session: &mut dyn BackendSession,
+) -> Result<(ReadInput<'a>, ReadInput<'a>, ReadInput<'a>)> {
+    let shape = broadcast_shapes([first.shape(), second.shape(), third.shape()])
+        .map_err(broadcast_error)?;
     Ok((
-        broadcast_to_read(lhs, &shape, backend)?,
-        broadcast_to_read(rhs, &shape, backend)?,
+        broadcast_to_in_read(first, &shape, session)?,
+        broadcast_to_in_read(second, &shape, session)?,
+        broadcast_to_in_read(third, &shape, session)?,
     ))
 }
 

--- a/crates/tenferro-runtime/tests/integration/session_in_ops.rs
+++ b/crates/tenferro-runtime/tests/integration/session_in_ops.rs
@@ -37,6 +37,18 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
     }
 }
 
+/// Permute a rank-2 col-major layout with `perm = [1, 0]`, in plain math.
+fn transpose_col_major(values: &[f64], shape: &[usize]) -> Vec<f64> {
+    let (rows, cols) = (shape[0], shape[1]);
+    let mut out = vec![0.0; values.len()];
+    for row in 0..rows {
+        for col in 0..cols {
+            out[row * cols + col] = values[col * rows + row];
+        }
+    }
+    out
+}
+
 fn assert_incompatible_shapes_error(error: Error) {
     match error {
         Error::Validation {
@@ -51,6 +63,19 @@ fn assert_incompatible_shapes_error(error: Error) {
             "unexpected shape payload: {shape:?}"
         ),
         other => panic!("expected broadcast ShapeMismatch, got {other:?}"),
+    }
+}
+
+fn assert_rank_mismatch_error(error: Error) {
+    match error {
+        Error::Validation {
+            op: "matmul",
+            source: ValidationError::RankMismatch { expected, actual },
+        } => {
+            assert_eq!(expected, 2);
+            assert_eq!(actual, 1);
+        }
+        other => panic!("expected matmul RankMismatch, got {other:?}"),
     }
 }
 
@@ -277,23 +302,111 @@ fn session_in_typed_invalid_broadcast_matches_one_shot_error() {
 fn session_in_typed_validates_output_dtype() {
     let mut backend = WrongDTypeSessionBackend;
     let a = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]).unwrap();
+    let lower = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![0, 0]).unwrap();
+    let upper = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![3, 3]).unwrap();
+    let matrix = TypedTensor::<i32>::from_vec_col_major(vec![2, 2], vec![1, 2, 3, 4]).unwrap();
 
-    let add_error = backend
-        .with_backend_session(|s| a.add_in(&a, s))
-        .unwrap_err();
-    let mul_error = backend
-        .with_backend_session(|s| a.mul_in(&a, s))
-        .unwrap_err();
-    let exp_error = backend.with_backend_session(|s| a.exp_in(s)).unwrap_err();
-    let reduce_error = backend
-        .with_backend_session(|s| a.reduce_sum_in(&[0], s))
-        .unwrap_err();
-    for (op, error) in [
-        ("add", add_error),
-        ("mul", mul_error),
-        ("exp", exp_error),
-        ("reduce_sum", reduce_error),
-    ] {
+    let errors = [
+        (
+            "add",
+            backend
+                .with_backend_session(|s| a.add_in(&a, s))
+                .unwrap_err(),
+        ),
+        (
+            "mul",
+            backend
+                .with_backend_session(|s| a.mul_in(&a, s))
+                .unwrap_err(),
+        ),
+        (
+            "exp",
+            backend.with_backend_session(|s| a.exp_in(s)).unwrap_err(),
+        ),
+        (
+            "reduce_sum",
+            backend
+                .with_backend_session(|s| a.reduce_sum_in(&[0], s))
+                .unwrap_err(),
+        ),
+        (
+            "sub",
+            backend
+                .with_backend_session(|s| a.sub_in(&a, s))
+                .unwrap_err(),
+        ),
+        (
+            "div",
+            backend
+                .with_backend_session(|s| a.div_in(&a, s))
+                .unwrap_err(),
+        ),
+        (
+            "pow",
+            backend
+                .with_backend_session(|s| a.pow_in(&a, s))
+                .unwrap_err(),
+        ),
+        (
+            "maximum",
+            backend
+                .with_backend_session(|s| a.maximum_in(&a, s))
+                .unwrap_err(),
+        ),
+        (
+            "neg",
+            backend.with_backend_session(|s| a.neg_in(s)).unwrap_err(),
+        ),
+        (
+            "abs",
+            backend.with_backend_session(|s| a.abs_in(s)).unwrap_err(),
+        ),
+        (
+            "log",
+            backend.with_backend_session(|s| a.log_in(s)).unwrap_err(),
+        ),
+        (
+            "sqrt",
+            backend.with_backend_session(|s| a.sqrt_in(s)).unwrap_err(),
+        ),
+        (
+            "clamp",
+            backend
+                .with_backend_session(|s| a.clamp_in(&lower, &upper, s))
+                .unwrap_err(),
+        ),
+        (
+            "matmul",
+            backend
+                .with_backend_session(|s| matrix.matmul_in(&matrix, s))
+                .unwrap_err(),
+        ),
+        (
+            "reshape",
+            backend
+                .with_backend_session(|s| matrix.reshape_in(&[4], s))
+                .unwrap_err(),
+        ),
+        (
+            "transpose",
+            backend
+                .with_backend_session(|s| matrix.transpose_in(&[1, 0], s))
+                .unwrap_err(),
+        ),
+        (
+            "broadcast_in_dim",
+            backend
+                .with_backend_session(|s| matrix.broadcast_in_dim_in(&[2, 2], &[0, 1], s))
+                .unwrap_err(),
+        ),
+        (
+            "compare",
+            backend
+                .with_backend_session(|s| a.compare_in(&a, CompareDir::Gt, s))
+                .unwrap_err(),
+        ),
+    ];
+    for (op, error) in errors {
         let Error::Validation {
             op: error_op,
             source: ValidationError::DTypeMismatch { expected, actual },
@@ -302,7 +415,14 @@ fn session_in_typed_validates_output_dtype() {
             panic!("expected {op} DTypeMismatch, got {error:?}");
         };
         assert_eq!(*error_op, op);
-        assert_eq!(*expected, tenferro_tensor::core::DType::I32);
+        // `compare` produces a bool tensor; every other op produces the input
+        // scalar type.
+        let expected_dtype = if op == "compare" {
+            tenferro_tensor::core::DType::Bool
+        } else {
+            tenferro_tensor::core::DType::I32
+        };
+        assert_eq!(*expected, expected_dtype);
         assert_eq!(*actual, tenferro_tensor::core::DType::F64);
     }
 }
@@ -372,6 +492,718 @@ fn session_in_chain_enters_one_session_one_shot_enters_ten() {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 1 (issue #1680): full `_in` surface parity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn session_in_dynamic_binary_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+
+    // Equal-shape arm: sub -> div -> pow -> maximum -> minimum.
+    let a_values = vec![4.0_f64, 9.0, 6.0, 12.0];
+    let b_values = vec![2.0_f64, 3.0, 2.0, 4.0];
+    let a = Tensor::from_vec_col_major(vec![2, 2], a_values.clone()).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2, 2], b_values.clone()).unwrap();
+
+    let one_shot = a
+        .sub(&b, &mut backend)
+        .unwrap()
+        .div(&b, &mut backend)
+        .unwrap()
+        .pow(&b, &mut backend)
+        .unwrap()
+        .maximum(&b, &mut backend)
+        .unwrap()
+        .minimum(&b, &mut backend)
+        .unwrap();
+
+    let session = backend.with_backend_session(|s| {
+        a.sub_in(&b, s)
+            .unwrap()
+            .div_in(&b, s)
+            .unwrap()
+            .pow_in(&b, s)
+            .unwrap()
+            .maximum_in(&b, s)
+            .unwrap()
+            .minimum_in(&b, s)
+            .unwrap()
+    });
+
+    // Independent value check in plain scalar math.
+    let expected: Vec<f64> = a_values
+        .iter()
+        .zip(&b_values)
+        .map(|(&x, &y)| {
+            let v = (x - y) / y;
+            let v = v.powf(y);
+            let v = v.max(y);
+            v.min(y)
+        })
+        .collect();
+    assert_close(session.as_slice::<f64>().unwrap(), &expected);
+    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
+    assert_eq!(session.shape(), one_shot.shape());
+
+    // Real broadcast arm: [1] vs [4].
+    let a = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![4], vec![2.0_f64; 4]).unwrap();
+    let one_shot = a
+        .sub(&b, &mut backend)
+        .unwrap()
+        .div(&b, &mut backend)
+        .unwrap()
+        .pow(&b, &mut backend)
+        .unwrap()
+        .maximum(&b, &mut backend)
+        .unwrap()
+        .minimum(&b, &mut backend)
+        .unwrap();
+    let session = backend.with_backend_session(|s| {
+        a.sub_in(&b, s)
+            .unwrap()
+            .div_in(&b, s)
+            .unwrap()
+            .pow_in(&b, s)
+            .unwrap()
+            .maximum_in(&b, s)
+            .unwrap()
+            .minimum_in(&b, s)
+            .unwrap()
+    });
+    let expected = [2.0_f64; 4];
+    assert_close(session.as_slice::<f64>().unwrap(), &expected);
+    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
+}
+
+#[test]
+fn session_in_dynamic_unary_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let x_values = vec![2.0_f64, 3.0, 4.0, 5.0];
+    let x = Tensor::from_vec_col_major(vec![4], x_values.clone()).unwrap();
+
+    let one_shot = x
+        .neg(&mut backend)
+        .unwrap()
+        .abs(&mut backend)
+        .unwrap()
+        .sqrt(&mut backend)
+        .unwrap()
+        .rsqrt(&mut backend)
+        .unwrap()
+        .sign(&mut backend)
+        .unwrap()
+        .conj(&mut backend)
+        .unwrap()
+        .log(&mut backend)
+        .unwrap()
+        .expm1(&mut backend)
+        .unwrap()
+        .log1p(&mut backend)
+        .unwrap()
+        .sin(&mut backend)
+        .unwrap()
+        .cos(&mut backend)
+        .unwrap()
+        .tanh(&mut backend)
+        .unwrap();
+
+    let session = backend.with_backend_session(|s| {
+        x.neg_in(s)
+            .unwrap()
+            .abs_in(s)
+            .unwrap()
+            .sqrt_in(s)
+            .unwrap()
+            .rsqrt_in(s)
+            .unwrap()
+            .sign_in(s)
+            .unwrap()
+            .conj_in(s)
+            .unwrap()
+            .log_in(s)
+            .unwrap()
+            .expm1_in(s)
+            .unwrap()
+            .log1p_in(s)
+            .unwrap()
+            .sin_in(s)
+            .unwrap()
+            .cos_in(s)
+            .unwrap()
+            .tanh_in(s)
+            .unwrap()
+    });
+
+    // Independent value check in plain scalar math; `conj` is the identity
+    // for real values.
+    let mut expected: Vec<f64> = x_values.iter().map(|&v| -v).collect();
+    expected = expected.iter().map(|&v| v.abs()).collect();
+    expected = expected.iter().map(|&v| v.sqrt()).collect();
+    expected = expected.iter().map(|&v| 1.0 / v).collect();
+    expected = expected.iter().map(|&v| v.signum()).collect();
+    expected = expected.iter().map(|&v| v.ln()).collect();
+    expected = expected.iter().map(|&v| v.exp_m1()).collect();
+    expected = expected.iter().map(|&v| (1.0 + v).ln()).collect();
+    expected = expected.iter().map(|&v| v.sin()).collect();
+    expected = expected.iter().map(|&v| v.cos()).collect();
+    expected = expected.iter().map(|&v| v.tanh()).collect();
+    assert_close(session.as_slice::<f64>().unwrap(), &expected);
+    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
+}
+
+#[test]
+fn session_in_dynamic_ternary_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let on_true = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let on_false = Tensor::from_vec_col_major(vec![4], vec![5.0_f64, 6.0, 7.0, 8.0]).unwrap();
+
+    // Equal-shape arm: where_select -> clamp.
+    let condition = Tensor::from_vec_col_major(vec![4], vec![true, false, true, false]).unwrap();
+    let lower = Tensor::from_vec_col_major(vec![], vec![0.0_f64]).unwrap();
+    let upper = Tensor::from_vec_col_major(vec![], vec![5.0_f64]).unwrap();
+
+    let one_shot = condition
+        .where_select(&on_true, &on_false, &mut backend)
+        .unwrap()
+        .clamp(&lower, &upper, &mut backend)
+        .unwrap();
+    let session = backend.with_backend_session(|s| {
+        condition
+            .where_select_in(&on_true, &on_false, s)
+            .unwrap()
+            .clamp_in(&lower, &upper, s)
+            .unwrap()
+    });
+    // select -> [1, 6, 3, 8], then clamp(0, 5).
+    let expected = [1.0_f64, 5.0, 3.0, 5.0];
+    assert_close(session.as_slice::<f64>().unwrap(), &expected);
+    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
+
+    // Broadcast arm: singleton condition and bounds.
+    let condition = Tensor::from_vec_col_major(vec![1], vec![true]).unwrap();
+    let lower = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
+    let upper = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
+
+    let one_shot = condition
+        .where_select(&on_true, &on_false, &mut backend)
+        .unwrap()
+        .clamp(&lower, &upper, &mut backend)
+        .unwrap();
+    let session = backend.with_backend_session(|s| {
+        condition
+            .where_select_in(&on_true, &on_false, s)
+            .unwrap()
+            .clamp_in(&lower, &upper, s)
+            .unwrap()
+    });
+    // select broadcasts the condition -> [1, 2, 3, 4], then clamp(2, 3).
+    let expected = [2.0_f64, 2.0, 3.0, 3.0];
+    assert_close(session.as_slice::<f64>().unwrap(), &expected);
+    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
+}
+
+#[test]
+fn session_in_dynamic_structural_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let x = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+
+    let one_shot = x
+        .transpose(&[1, 0], &mut backend)
+        .unwrap()
+        .reshape(&[6], &mut backend)
+        .unwrap()
+        .reshape(&[2, 3], &mut backend)
+        .unwrap()
+        .transpose(&[1, 0], &mut backend)
+        .unwrap();
+
+    let session = backend.with_backend_session(|s| {
+        x.transpose_in(&[1, 0], s)
+            .unwrap()
+            .reshape_in(&[6], s)
+            .unwrap()
+            .reshape_in(&[2, 3], s)
+            .unwrap()
+            .transpose_in(&[1, 0], s)
+            .unwrap()
+    });
+
+    // Independent permutation math: reshape preserves the col-major storage
+    // order, so the chain is two transposes of [2,3] layouts on the original
+    // storage, ending in a [3,2] layout.
+    let transposed = transpose_col_major(&[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]);
+    let expected = transpose_col_major(&transposed, &[2, 3]);
+    assert_eq!(expected, vec![1.0, 5.0, 4.0, 3.0, 2.0, 6.0]);
+    assert_eq!(session.shape(), &[3, 2]);
+    assert_close(session.as_slice::<f64>().unwrap(), &expected);
+    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
+}
+
+#[test]
+fn session_in_dynamic_dtype_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let x = Tensor::from_vec_col_major(vec![4], vec![1.2_f64, -2.8, 3.5, 0.4]).unwrap();
+
+    let one_shot = x.cast(DType::I32, &mut backend).unwrap();
+    let session = backend
+        .with_backend_session(|s| x.cast_in(DType::I32, s))
+        .unwrap();
+    let expected = [1_i32, -2, 3, 0];
+    assert_eq!(session.as_slice::<i32>().unwrap(), &expected);
+    assert_eq!(one_shot.as_slice::<i32>().unwrap(), &expected);
+
+    // convert uses the checked lattice: f64 -> C64 preserves values, and the
+    // round trip back through cast reproduces them.
+    let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let one_shot = y.convert(DType::C64, &mut backend).unwrap();
+    let session = backend
+        .with_backend_session(|s| y.convert_in(DType::C64, s))
+        .unwrap();
+    assert_eq!(session.dtype(), DType::C64);
+    assert_eq!(one_shot.dtype(), DType::C64);
+    let back = backend
+        .with_backend_session(|s| session.cast_in(DType::F64, s))
+        .unwrap();
+    assert_close(back.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+}
+
+#[test]
+fn session_in_dynamic_matmul_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let a_values = vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0];
+    let b_values = vec![7.0_f64, 9.0, 11.0, 8.0, 10.0, 12.0];
+    let a = Tensor::from_vec_col_major(vec![2, 3], a_values.clone()).unwrap();
+    let b = Tensor::from_vec_col_major(vec![3, 2], b_values.clone()).unwrap();
+
+    let one_shot = a.matmul(&b, &mut backend).unwrap();
+    let session = backend
+        .with_backend_session(|s| a.matmul_in(&b, s))
+        .unwrap();
+
+    // Independent value check with plain triple loops over col-major indices.
+    let mut expected = vec![0.0_f64; 4];
+    for i in 0..2 {
+        for j in 0..2 {
+            for k in 0..3 {
+                expected[j * 2 + i] += a_values[k * 2 + i] * b_values[j * 3 + k];
+            }
+        }
+    }
+    assert_eq!(session.shape(), &[2, 2]);
+    assert_close(session.as_slice::<f64>().unwrap(), &expected);
+    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
+}
+
+#[test]
+fn session_in_dynamic_errors_match_one_shot() {
+    let mut backend = CpuBackend::new();
+    let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
+
+    // Binary broadcast error.
+    let one_shot_error = a.sub(&b, &mut backend).unwrap_err();
+    let session_error = backend
+        .with_backend_session(|s| a.sub_in(&b, s))
+        .unwrap_err();
+    assert_incompatible_shapes_error(one_shot_error);
+    assert_incompatible_shapes_error(session_error);
+
+    // Ternary broadcast error through clamp ([2] vs [3] bounds).
+    let lower = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let upper = Tensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
+    let one_shot_error = a.clamp(&lower, &upper, &mut backend).unwrap_err();
+    let session_error = backend
+        .with_backend_session(|s| a.clamp_in(&lower, &upper, s))
+        .unwrap_err();
+    assert_incompatible_shapes_error(one_shot_error);
+    assert_incompatible_shapes_error(session_error);
+
+    // Matmul rank error for rank-1 operands.
+    let one_shot_error = a.matmul(&b, &mut backend).unwrap_err();
+    let session_error = backend
+        .with_backend_session(|s| a.matmul_in(&b, s))
+        .unwrap_err();
+    assert_rank_mismatch_error(one_shot_error);
+    assert_rank_mismatch_error(session_error);
+
+    // Dtype mismatch error for sub.
+    let c = Tensor::from_vec_col_major(vec![2], vec![1_i32; 2]).unwrap();
+    let one_shot_error = a.sub(&c, &mut backend).unwrap_err();
+    let session_error = backend
+        .with_backend_session(|s| a.sub_in(&c, s))
+        .unwrap_err();
+    for error in [one_shot_error, session_error] {
+        let Error::Validation {
+            op: "sub",
+            source: ValidationError::DTypeMismatch { expected, actual },
+        } = &error
+        else {
+            panic!("expected sub DTypeMismatch, got {error:?}");
+        };
+        assert_eq!(*expected, tenferro_tensor::core::DType::F64);
+        assert_eq!(*actual, tenferro_tensor::core::DType::I32);
+    }
+}
+
+#[test]
+fn session_in_typed_binary_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+
+    // Equal-shape arm: sub -> div -> pow -> maximum -> minimum.
+    let a_values = vec![4.0_f64, 9.0, 6.0, 12.0];
+    let b_values = vec![2.0_f64, 3.0, 2.0, 4.0];
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], a_values.clone()).unwrap();
+    let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], b_values.clone()).unwrap();
+
+    let one_shot = a
+        .sub(&b, &mut backend)
+        .unwrap()
+        .div(&b, &mut backend)
+        .unwrap()
+        .pow(&b, &mut backend)
+        .unwrap()
+        .maximum(&b, &mut backend)
+        .unwrap()
+        .minimum(&b, &mut backend)
+        .unwrap();
+
+    let session = backend.with_backend_session(|s| {
+        a.sub_in(&b, s)
+            .unwrap()
+            .div_in(&b, s)
+            .unwrap()
+            .pow_in(&b, s)
+            .unwrap()
+            .maximum_in(&b, s)
+            .unwrap()
+            .minimum_in(&b, s)
+            .unwrap()
+    });
+
+    let expected: Vec<f64> = a_values
+        .iter()
+        .zip(&b_values)
+        .map(|(&x, &y)| {
+            let v = (x - y) / y;
+            let v = v.powf(y);
+            let v = v.max(y);
+            v.min(y)
+        })
+        .collect();
+    assert_close(session.host_data().unwrap(), &expected);
+    assert_close(one_shot.host_data().unwrap(), &expected);
+    assert_eq!(session.shape(), one_shot.shape());
+
+    // Real broadcast arm: [1] vs [4].
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![3.0]).unwrap();
+    let b = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![2.0; 4]).unwrap();
+    let one_shot = a
+        .sub(&b, &mut backend)
+        .unwrap()
+        .div(&b, &mut backend)
+        .unwrap()
+        .pow(&b, &mut backend)
+        .unwrap()
+        .maximum(&b, &mut backend)
+        .unwrap()
+        .minimum(&b, &mut backend)
+        .unwrap();
+    let session = backend.with_backend_session(|s| {
+        a.sub_in(&b, s)
+            .unwrap()
+            .div_in(&b, s)
+            .unwrap()
+            .pow_in(&b, s)
+            .unwrap()
+            .maximum_in(&b, s)
+            .unwrap()
+            .minimum_in(&b, s)
+            .unwrap()
+    });
+    let expected = [2.0_f64; 4];
+    assert_close(session.host_data().unwrap(), &expected);
+    assert_close(one_shot.host_data().unwrap(), &expected);
+}
+
+#[test]
+fn session_in_typed_unary_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let x_values = vec![2.0_f64, 3.0, 4.0, 5.0];
+    let x = TypedTensor::<f64>::from_vec_col_major(vec![4], x_values.clone()).unwrap();
+
+    let one_shot = x
+        .neg(&mut backend)
+        .unwrap()
+        .abs(&mut backend)
+        .unwrap()
+        .sqrt(&mut backend)
+        .unwrap()
+        .rsqrt(&mut backend)
+        .unwrap()
+        .sign(&mut backend)
+        .unwrap()
+        .conj(&mut backend)
+        .unwrap()
+        .log(&mut backend)
+        .unwrap()
+        .expm1(&mut backend)
+        .unwrap()
+        .log1p(&mut backend)
+        .unwrap()
+        .sin(&mut backend)
+        .unwrap()
+        .cos(&mut backend)
+        .unwrap()
+        .tanh(&mut backend)
+        .unwrap();
+
+    let session = backend.with_backend_session(|s| {
+        x.neg_in(s)
+            .unwrap()
+            .abs_in(s)
+            .unwrap()
+            .sqrt_in(s)
+            .unwrap()
+            .rsqrt_in(s)
+            .unwrap()
+            .sign_in(s)
+            .unwrap()
+            .conj_in(s)
+            .unwrap()
+            .log_in(s)
+            .unwrap()
+            .expm1_in(s)
+            .unwrap()
+            .log1p_in(s)
+            .unwrap()
+            .sin_in(s)
+            .unwrap()
+            .cos_in(s)
+            .unwrap()
+            .tanh_in(s)
+            .unwrap()
+    });
+
+    let mut expected: Vec<f64> = x_values.iter().map(|&v| -v).collect();
+    expected = expected.iter().map(|&v| v.abs()).collect();
+    expected = expected.iter().map(|&v| v.sqrt()).collect();
+    expected = expected.iter().map(|&v| 1.0 / v).collect();
+    expected = expected.iter().map(|&v| v.signum()).collect();
+    expected = expected.iter().map(|&v| v.ln()).collect();
+    expected = expected.iter().map(|&v| v.exp_m1()).collect();
+    expected = expected.iter().map(|&v| (1.0 + v).ln()).collect();
+    expected = expected.iter().map(|&v| v.sin()).collect();
+    expected = expected.iter().map(|&v| v.cos()).collect();
+    expected = expected.iter().map(|&v| v.tanh()).collect();
+    assert_close(session.host_data().unwrap(), &expected);
+    assert_close(one_shot.host_data().unwrap(), &expected);
+}
+
+#[test]
+fn session_in_typed_clamp_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+
+    // Equal-shape arm.
+    let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![-2.0, 4.0, 1.0, 5.0]).unwrap();
+    let lower = TypedTensor::<f64>::from_vec_col_major(vec![], vec![0.0]).unwrap();
+    let upper = TypedTensor::<f64>::from_vec_col_major(vec![], vec![3.0]).unwrap();
+    let one_shot = x.clamp(&lower, &upper, &mut backend).unwrap();
+    let session = backend
+        .with_backend_session(|s| x.clamp_in(&lower, &upper, s))
+        .unwrap();
+    assert_close(session.host_data().unwrap(), &[0.0, 3.0, 1.0, 3.0]);
+    assert_close(one_shot.host_data().unwrap(), &[0.0, 3.0, 1.0, 3.0]);
+
+    // Broadcast arm: singleton bounds.
+    let x = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![-1.0, 0.0, 2.0, 5.0]).unwrap();
+    let lower = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![1.0]).unwrap();
+    let upper = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![2.0]).unwrap();
+    let one_shot = x.clamp(&lower, &upper, &mut backend).unwrap();
+    let session = backend
+        .with_backend_session(|s| x.clamp_in(&lower, &upper, s))
+        .unwrap();
+    assert_close(session.host_data().unwrap(), &[1.0, 1.0, 2.0, 2.0]);
+    assert_close(one_shot.host_data().unwrap(), &[1.0, 1.0, 2.0, 2.0]);
+}
+
+#[test]
+fn session_in_typed_compare_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+
+    // Equal-shape arm: the result is a bool typed tensor.
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 5.0, 3.0, 8.0]).unwrap();
+    let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 6.0, 4.0, 7.0]).unwrap();
+    let one_shot = a.compare(&b, CompareDir::Gt, &mut backend).unwrap();
+    let session = backend
+        .with_backend_session(|s| a.compare_in(&b, CompareDir::Gt, s))
+        .unwrap();
+    let expected = [true, false, false, true];
+    assert_eq!(session.host_data().unwrap(), &expected);
+    assert_eq!(one_shot.host_data().unwrap(), &expected);
+
+    // Broadcast arm.
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![3.0]).unwrap();
+    let b = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![1.0, 4.0, 2.0, 6.0]).unwrap();
+    let one_shot = a.compare(&b, CompareDir::Gt, &mut backend).unwrap();
+    let session = backend
+        .with_backend_session(|s| a.compare_in(&b, CompareDir::Gt, s))
+        .unwrap();
+    let expected = [true, false, true, false];
+    assert_eq!(session.host_data().unwrap(), &expected);
+    assert_eq!(one_shot.host_data().unwrap(), &expected);
+}
+
+#[test]
+fn session_in_typed_structural_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
+
+    // Reshape preserves element order.
+    let one_shot = x.reshape(&[6], &mut backend).unwrap();
+    let session = backend
+        .with_backend_session(|s| x.reshape_in(&[6], s))
+        .unwrap();
+    let expected = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    assert_eq!(session.shape(), &[6]);
+    assert_close(session.host_data().unwrap(), &expected);
+    assert_close(one_shot.host_data().unwrap(), &expected);
+
+    // Transpose permutes the col-major layout.
+    let one_shot = x.transpose(&[1, 0], &mut backend).unwrap();
+    let session = backend
+        .with_backend_session(|s| x.transpose_in(&[1, 0], s))
+        .unwrap();
+    let expected = [1.0_f64, 3.0, 5.0, 2.0, 4.0, 6.0];
+    assert_eq!(session.shape(), &[3, 2]);
+    assert_close(session.host_data().unwrap(), &expected);
+    assert_close(one_shot.host_data().unwrap(), &expected);
+
+    // broadcast_in_dim duplicates the row: [[1,2,3],[1,2,3]] in col-major
+    // storage.
+    let row = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap();
+    let one_shot = row.broadcast_in_dim(&[2, 3], &[1], &mut backend).unwrap();
+    let session = backend
+        .with_backend_session(|s| row.broadcast_in_dim_in(&[2, 3], &[1], s))
+        .unwrap();
+    let expected = [1.0_f64, 1.0, 2.0, 2.0, 3.0, 3.0];
+    assert_eq!(session.shape(), &[2, 3]);
+    assert_close(session.host_data().unwrap(), &expected);
+    assert_close(one_shot.host_data().unwrap(), &expected);
+}
+
+#[test]
+fn session_in_typed_matmul_matches_one_shot() {
+    let mut backend = CpuBackend::new();
+    let a_values = vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0];
+    let b_values = vec![7.0_f64, 9.0, 11.0, 8.0, 10.0, 12.0];
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], a_values.clone()).unwrap();
+    let b = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], b_values.clone()).unwrap();
+
+    let one_shot = a.matmul(&b, &mut backend).unwrap();
+    let session = backend
+        .with_backend_session(|s| a.matmul_in(&b, s))
+        .unwrap();
+
+    let mut expected = vec![0.0_f64; 4];
+    for i in 0..2 {
+        for j in 0..2 {
+            for k in 0..3 {
+                expected[j * 2 + i] += a_values[k * 2 + i] * b_values[j * 3 + k];
+            }
+        }
+    }
+    assert_eq!(session.shape(), &[2, 2]);
+    assert_close(session.host_data().unwrap(), &expected);
+    assert_close(one_shot.host_data().unwrap(), &expected);
+}
+
+#[test]
+fn session_in_typed_errors_match_one_shot() {
+    let mut backend = CpuBackend::new();
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0; 2]).unwrap();
+    let b = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0; 3]).unwrap();
+
+    // Ternary broadcast error through clamp ([2] vs [3] bounds).
+    let one_shot_error = a.clamp(&b, &a, &mut backend).unwrap_err();
+    let session_error = backend
+        .with_backend_session(|s| a.clamp_in(&b, &a, s))
+        .unwrap_err();
+    assert_incompatible_shapes_error(one_shot_error);
+    assert_incompatible_shapes_error(session_error);
+
+    // Matmul rank error for rank-1 operands.
+    let one_shot_error = a.matmul(&b, &mut backend).unwrap_err();
+    let session_error = backend
+        .with_backend_session(|s| a.matmul_in(&b, s))
+        .unwrap_err();
+    assert_rank_mismatch_error(one_shot_error);
+    assert_rank_mismatch_error(session_error);
+}
+
+#[test]
+fn session_in_new_ops_chain_enters_one_session_one_shot_enters_five() {
+    let mut backend = SessionCountingBackend::new();
+    let a = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 5.0, 4.0, 6.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 1.0, 2.0]).unwrap();
+    let m = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1, 3], vec![1.0_f64; 3]).unwrap();
+
+    // 5 one-shot ops (sub, log, maximum, reshape, matmul): one session entry
+    // per op.
+    let one_shot = a
+        .sub(&b, &mut backend)
+        .unwrap()
+        .log(&mut backend)
+        .unwrap()
+        .maximum(&m, &mut backend)
+        .unwrap()
+        .reshape(&[4, 1], &mut backend)
+        .unwrap()
+        .matmul(&rhs, &mut backend)
+        .unwrap();
+    assert_eq!(
+        backend.entries.get(),
+        5,
+        "one-shot chain must enter one session per op"
+    );
+
+    backend.entries.set(0);
+    let session = backend.with_backend_session(|s| {
+        a.sub_in(&b, s)
+            .unwrap()
+            .log_in(s)
+            .unwrap()
+            .maximum_in(&m, s)
+            .unwrap()
+            .reshape_in(&[4, 1], s)
+            .unwrap()
+            .matmul_in(&rhs, s)
+            .unwrap()
+    });
+    assert_eq!(
+        backend.entries.get(),
+        1,
+        "session chain must enter exactly one session"
+    );
+
+    // Independent scalar math: v_i = max(log(a_i - b_i), 1.0), and the
+    // [4,1] x [1,3] matmul repeats each v_i across the three rhs columns.
+    let values: Vec<f64> = [3.0_f64, 5.0, 4.0, 6.0]
+        .iter()
+        .zip([1.0_f64, 2.0, 1.0, 2.0])
+        .map(|(&x, y)| (x - y).ln().max(1.0))
+        .collect();
+    let expected: Vec<f64> = (0..3).flat_map(|_| values.iter().copied()).collect();
+    assert_close(session.as_slice::<f64>().unwrap(), &expected);
+    assert_close(
+        session.as_slice::<f64>().unwrap(),
+        one_shot.as_slice::<f64>().unwrap(),
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Test backends
 // ---------------------------------------------------------------------------
 
@@ -396,6 +1228,9 @@ impl SessionCountingBackend {
 /// requested dtype, so the typed `_in` surface must reject the output through
 /// `into_typed_result`.
 struct WrongDTypeSessionBackend;
+
+/// Session-type marker for [`WrongDTypeSessionBackend`].
+struct WrongDTypeSessionBackendMarker;
 
 macro_rules! panic_backend_methods {
     ($($name:ident($($arg:ident : $argty:ty),*) -> $ret:ty;)+) => {
@@ -577,20 +1412,132 @@ impl BackendSessionHost for SessionCountingBackend {
     }
 }
 
-test_backend_impls!(WrongDTypeSessionBackend, WrongDTypeSessionBackendMarker);
+// WrongDTypeSessionBackend hand-writes the structural, dot, elementwise, and
+// analytic impls so every op family the typed `_in` surface routes through can
+// return an F64 tensor regardless of the requested dtype.
+
+impl BackendRuntimeCache for WrongDTypeSessionBackend {
+    type RuntimeCache = <CpuBackend as BackendRuntimeCache>::RuntimeCache;
+}
+
+impl TensorStructural for WrongDTypeSessionBackend {
+    fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> TensorResult {
+        CpuBackend::new().to_contiguous_read(input)
+    }
+
+    fn copy_read_into(
+        &mut self,
+        src: TensorRead<'_>,
+        dst: TensorWrite<'_>,
+    ) -> tenferro_tensor::Result<()> {
+        CpuBackend::new().copy_read_into(src, dst)
+    }
+
+    fn reshape(&mut self, _input: &Tensor, _shape: &[usize]) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn reshape_read(&mut self, _input: TensorRead<'_>, _shape: &[usize]) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn transpose(&mut self, _input: &Tensor, _perm: &[usize]) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn transpose_read(&mut self, _input: TensorRead<'_>, _perm: &[usize]) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn broadcast_in_dim(
+        &mut self,
+        _input: &Tensor,
+        _shape: &[usize],
+        _dims: &[usize],
+    ) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn broadcast_in_dim_read(
+        &mut self,
+        _input: TensorRead<'_>,
+        _shape: &[usize],
+        _dims: &[usize],
+    ) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    panic_backend_methods! {
+        cast(input: &Tensor, to: DType) -> TensorResult;
+        convert(input: &Tensor, to: DType) -> TensorResult;
+        extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> TensorResult;
+        embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> TensorResult;
+        tril(input: &Tensor, k: i64) -> TensorResult;
+        triu(input: &Tensor, k: i64) -> TensorResult;
+    }
+}
+
+impl TensorIndexing for WrongDTypeSessionBackend {
+    panic_backend_methods! {
+        gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> TensorResult;
+        scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> TensorResult;
+        slice(input: &Tensor, config: &SliceConfig) -> TensorResult;
+        dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> TensorResult;
+        dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) -> TensorResult;
+        pad(input: &Tensor, config: &PadConfig) -> TensorResult;
+        concatenate(inputs: &[&Tensor], axis: usize) -> TensorResult;
+        reverse(input: &Tensor, axes: &[usize]) -> TensorResult;
+    }
+}
+
+impl TensorDot for WrongDTypeSessionBackend {
+    fn dot_general(
+        &mut self,
+        _lhs: &Tensor,
+        _rhs: &Tensor,
+        _config: &DotGeneralConfig,
+    ) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+}
+
+impl TensorFusion for WrongDTypeSessionBackend {}
+impl TensorBuffer for WrongDTypeSessionBackend {}
+
+impl TensorDeviceTransfer for WrongDTypeSessionBackend {
+    fn download_to_host(&mut self, _tensor: TensorRead<'_>) -> TensorResult {
+        Err(Error::unsupported(
+            "WrongDTypeSessionBackend::download_to_host",
+            "test backend does not transfer tensors",
+        ))
+    }
+
+    fn upload_host_tensor(&mut self, _tensor: TensorRead<'_>) -> TensorResult {
+        Err(Error::unsupported(
+            "WrongDTypeSessionBackend::upload_host_tensor",
+            "test backend does not transfer tensors",
+        ))
+    }
+}
+
+impl BackendCachedDot for WrongDTypeSessionBackend {}
+
+impl BackendSession for WrongDTypeSessionBackend {
+    fn session_type_id(&self) -> std::any::TypeId {
+        std::any::TypeId::of::<WrongDTypeSessionBackendMarker>()
+    }
+
+    unsafe fn session_data_mut(&mut self) -> *mut () {
+        self as *mut Self as *mut ()
+    }
+}
+
+impl TensorBackend for WrongDTypeSessionBackend {}
 
 impl TensorElementwise for WrongDTypeSessionBackend {
     panic_backend_methods! {
-        sub(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
-        neg(input: &Tensor) -> TensorResult;
-        div(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
-        abs(input: &Tensor) -> TensorResult;
-        sign(input: &Tensor) -> TensorResult;
-        maximum(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
-        minimum(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
-        compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> TensorResult;
+        rem(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
         select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> TensorResult;
-        clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> TensorResult;
     }
 
     fn add(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> TensorResult {
@@ -598,6 +1545,14 @@ impl TensorElementwise for WrongDTypeSessionBackend {
     }
 
     fn add_read(&mut self, _lhs: TensorRead<'_>, _rhs: TensorRead<'_>) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn sub(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn sub_read(&mut self, _lhs: TensorRead<'_>, _rhs: TensorRead<'_>) -> TensorResult {
         Ok(wrong_dtype_tensor())
     }
 
@@ -609,6 +1564,72 @@ impl TensorElementwise for WrongDTypeSessionBackend {
         Ok(wrong_dtype_tensor())
     }
 
+    fn div(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn div_read(&mut self, _lhs: TensorRead<'_>, _rhs: TensorRead<'_>) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn maximum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn maximum_read(&mut self, _lhs: TensorRead<'_>, _rhs: TensorRead<'_>) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn minimum(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn neg(&mut self, _input: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn neg_read(&mut self, _input: TensorRead<'_>) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn abs(&mut self, _input: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn abs_read(&mut self, _input: TensorRead<'_>) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn sign(&mut self, _input: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn compare(&mut self, _lhs: &Tensor, _rhs: &Tensor, _dir: &CompareDir) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn compare_read(
+        &mut self,
+        _lhs: TensorRead<'_>,
+        _rhs: TensorRead<'_>,
+        _dir: &CompareDir,
+    ) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn clamp(&mut self, _input: &Tensor, _lower: &Tensor, _upper: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn clamp_read(
+        &mut self,
+        _input: TensorRead<'_>,
+        _lower: TensorRead<'_>,
+        _upper: TensorRead<'_>,
+    ) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
     fn conj(&mut self, input: &Tensor) -> TensorResult {
         CpuBackend::new().conj(input)
     }
@@ -616,13 +1637,10 @@ impl TensorElementwise for WrongDTypeSessionBackend {
 
 impl TensorAnalytic for WrongDTypeSessionBackend {
     panic_backend_methods! {
-        log(input: &Tensor) -> TensorResult;
         sin(input: &Tensor) -> TensorResult;
         cos(input: &Tensor) -> TensorResult;
         tanh(input: &Tensor) -> TensorResult;
-        sqrt(input: &Tensor) -> TensorResult;
         rsqrt(input: &Tensor) -> TensorResult;
-        pow(lhs: &Tensor, rhs: &Tensor) -> TensorResult;
         expm1(input: &Tensor) -> TensorResult;
         log1p(input: &Tensor) -> TensorResult;
     }
@@ -632,6 +1650,30 @@ impl TensorAnalytic for WrongDTypeSessionBackend {
     }
 
     fn exp_read(&mut self, _input: TensorRead<'_>) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn log(&mut self, _input: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn log_read(&mut self, _input: TensorRead<'_>) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn sqrt(&mut self, _input: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn sqrt_read(&mut self, _input: TensorRead<'_>) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn pow(&mut self, _lhs: &Tensor, _rhs: &Tensor) -> TensorResult {
+        Ok(wrong_dtype_tensor())
+    }
+
+    fn pow_read(&mut self, _lhs: TensorRead<'_>, _rhs: TensorRead<'_>) -> TensorResult {
         Ok(wrong_dtype_tensor())
     }
 }

--- a/docs/design/session-oriented-concrete-apis.md
+++ b/docs/design/session-oriented-concrete-apis.md
@@ -403,3 +403,86 @@ outputs inside the iter.
   recommended repeated-execution API; trait variants are follow-up if the
   plan-level surface proves out).
 - Any change to the semantic/graph/AD einsum paths.
+
+## Migration specification (issue #1680, Phase 1: complete the `_in` surface)
+
+Extends the PR-B prototype to the FULL concrete op vocabulary, keeping the
+transitional `_in`/`_in_session` names (final plain-name rename + one-shot
+removal is Phase 2, a release-boundary breaking change). Additive and
+non-breaking.
+
+### Op inventory (PR-B already covers add/mul/exp/reduce_sum)
+
+**`TensorOpsExt` (dynamic `Tensor`) — 26 new ops**:
+- convert, cast (dtype)
+- sub, div, rem, pow, maximum, minimum (binary + broadcast)
+- neg, abs, sign, conj, log, expm1, log1p, sin, cos, tanh, sqrt, rsqrt
+  (unary)
+- compare (binary + broadcast, `CompareDir`)
+- where_select, clamp (ternary + broadcast)
+- matmul (`dot_general`)
+- reshape, transpose (structural)
+
+**`TypedTensorOpsExt<T>` (typed) — 24 new ops**: the dynamic set minus
+`convert`, `cast`, and `where_select` (typed `where_select` lives on the
+separate mask trait), plus `broadcast_in_dim`.
+
+### Per-family implementation (mirror the PR-B patterns exactly)
+
+- **Dynamic (owned)**: `broadcast_to_in` + `broadcast_binary_in` exist from
+  PR B; add `broadcast_ternary_in` for where_select/clamp. Each `_in` =
+  broadcast via the `_in` helpers + the session op, all on the borrowed
+  session; error mapping reuses `broadcast_error_to_validation`.
+- **Typed ternary**: add `broadcast_ternary_in_read` built from
+  `broadcast_shapes` + three `broadcast_to_in_read` calls (the existing typed
+  `broadcast_ternary_read` re-enters a session via `broadcast_to_read` and
+  must NOT be reused); typed `clamp_in` uses it before `session.clamp_read`.
+- **Unary**: `session.<op>` directly (`neg_in` → `session.neg`, `log_in` →
+  `session.log`, etc.).
+- **Structural**: `reshape_in` → `session.reshape`, `transpose_in` →
+  `session.transpose`.
+- **Dtype**: `convert_in` → `session.convert`, `cast_in` → `session.cast`
+  (the checked lattice / explicit projection live in the session ops).
+- **matmul**: `matmul_in` → `session.dot_general` with the standard
+  matmul config. **Cache-ownership decision (resolves the PR-B deferral)**:
+  the concrete surface uses the plain `with_backend_session`/borrowed-session
+  entry; `with_backend_session_cached` stays internal to the runtime
+  scheduler/eager execution paths. No `SessionCachedDot` in the concrete
+  surface.
+- **Typed (borrowed, read-based)**: mirror PR-B's typed path —
+  `reshape_read`/`broadcast_in_dim_read`/`<op>_read` + `into_typed_result`,
+  reusing the existing `ReadInput` and the typed manual broadcast-error
+  mapping.
+- **One-shot delegation**: every one-shot method becomes
+  `backend.with_backend_session(|s| self.<op>_in(...))`. Same accepted
+  validation-ordering change as PR B/C (invalid calls pay one entry before
+  the identical error; error-parity tested).
+
+### Tests
+
+- Per-family parity: `_in` == one-shot values (equal-shape + real broadcast
+  arms), structured-error parity, typed dtype conversion, session-counting
+  no-nested-entry (one entry for a chain using multiple new `_in` ops).
+- Runnable doctests (no ignore/no_run) on all new public methods.
+- One-shot delegation no-regression: the PR-B `session_chain` bench still
+  passes and the one-shot arms do not regress (re-measure; the delegation
+  can only reduce session entries).
+
+### Bench
+
+Extend `crates/tenferro-runtime/benches/session_chain.rs` with a second
+chain using the NEW ops — one-shot vs single-session arms, pinned reporting.
+Keep the PR-B chain (add/exp/mul/reduce_sum) as the gate bench. Exact chain
+(10 ops, shapes valid throughout): `[2,2]` f64 through
+sub→log→pow→maximum→neg (elementwise, operands chosen so values stay
+positive through `log`), reshape to `[4,1]`, transpose to `[1,4]`,
+scalar-broadcast clamp, matmul by a `[4,1]` rhs to `[1,1]`, then cast
+F64→F32. Validate a known result outside the timed region; `black_box`
+inputs/outputs inside.
+
+### Out of scope for Phase 1
+
+- One-shot trait removal and the `_in`→plain rename (Phase 2).
+- Top-level einsum-trait `_in_session` variants (plan-level surface suffices;
+  revisit only if Phase-1 callers need them).
+- GPU (CUDA/WebGPU) nested-entry enforcement (tracked gap from PR A).

--- a/docs/worklogs/2026-08-14-phase1-full-surface.md
+++ b/docs/worklogs/2026-08-14-phase1-full-surface.md
@@ -1,0 +1,77 @@
+# 2026-08-14 — #1680 Phase 1: complete the `_in` surface (full op vocabulary)
+
+## Session summary
+
+Extended the PR-B session-explicit prototype to the full concrete op
+vocabulary (additive, non-breaking; transitional `_in`/`_in_session` names
+kept — rename/removal is Phase 2). 26 dynamic (`TensorSessionOpsExt`) + 24
+typed (`TypedTensorSessionOpsExt<T>`) new `_in` methods; every one-shot
+method now delegates via `with_backend_session(|s| ..._in(...))`; dead
+session-reentering broadcast helpers removed; session-safe ternary helpers
+added for the dynamic and typed paths.
+
+## Gate record (frontier review, per AGENTS.md)
+
+- **Pre-implementation design gate** (reviewer-gpt on
+  `docs/design/session-oriented-concrete-apis.md` §"Migration specification
+  (issue #1680, Phase 1)"): 2 rounds → **approved**. Round 1: 2 blocking
+  (op inventory missed `expm1`/`log1p` → 26/24 not 24/22; typed `clamp_in`
+  needs a session-safe `broadcast_ternary_in_read`, the legacy typed
+  `broadcast_ternary_read` re-enters sessions) + 1 minor (Phase-1 bench chain
+  under-specified → exact [2,2] chain given).
+- **Post-implementation diff gate** (reviewer-gpt on the full diff): 1
+  blocking (Phase-1 worklog + fresh measurements missing — this file) → fixed.
+
+## Design decisions
+
+- Matmul cache ownership (resolves the PR-B deferral): `matmul_in` =
+  `matmul_config_for_shapes` + `session.dot_general` on the plain entry;
+  `with_backend_session_cached` stays internal to the runtime scheduler/
+  eager paths. No `SessionCachedDot` in the concrete surface.
+- Typed ternary: new `broadcast_ternary_in_read` built from
+  `broadcast_shapes` + three `broadcast_to_in_read`; the legacy typed
+  `broadcast_ternary_read` is retained ONLY for the mask-trait
+  `where_select` one-shot (which legitimately enters a session).
+- Spelling: `compare_in` takes `CompareDir` by value →
+  `session.compare(..., &dir)`; `where_select_in` → `session.select`;
+  typed compare returns `TypedTensor<bool>`; convert/cast →
+  `session.convert`/`session.cast`; reshape/transpose → session ops.
+- One-shot validation moves inside the session entry (accepted, PR-B/C
+  precedent); error-parity tested.
+
+## Measurements (release, pinned to idle core 40, criterion medians; 2 runs each)
+
+| chain | arm | origin/main | Phase-1 | Δ (run1 / run2) |
+|---|---|---|---|---|
+| PR-B no_broadcast | one_shot | 107.7 / 118.8 µs | 112.7 / 117.3 µs | +4.6% / −1.2% |
+| PR-B no_broadcast | one_session | 37.2 / 38.5 µs | 36.2 / 38.9 µs | −2.7% / +1.1% |
+| PR-B broadcast | one_shot | 119.2 / 124.2 µs | 129.0 / 120.7 µs | +8.2% / −2.8% |
+| PR-B broadcast | one_session | 45.3 / 46.0 µs | 43.7 / 44.6 µs | −3.5% / −3.2% |
+| **Phase-1 chain** | one_shot | — | 120.8 / 117.3 µs | — |
+| **Phase-1 chain** | one_session | — | 45.1 / 44.6 µs | **2.68× / 2.63×** |
+
+One-shot arms differ by −2.8%..+8.2% across runs with no consistent sign →
+**within machine noise (±4-6 µs), no regression**. One-session arms are
+consistently equal-or-better. The Phase-1 chain (10 new ops) shows the same
+≈2.6-2.7× session-reuse speedup as the PR-B gate chain (3.0-3.1×), and the
+session-count test proves 5 ops in 1 entry vs 5 entries.
+
+## Verification
+
+- `cargo test -p tenferro-runtime` — 402 + 146 + 1 + 475 doctests, 0 failed
+- `cargo test -p tenferro-runtime --doc` — 475 (58 new `_in` examples), 0
+  failed
+- `cargo build --workspace`, `cargo test -p tenferro-ad` — pass; fmt clean;
+  clippy 0 warnings
+- PR gates (`check-pr-fast.sh`, `repository-rules-review.py`) run at PR time;
+  recorded in the PR body
+
+## Residual risks
+
+- Transitional `_in`/`_in_session` names remain (Phase 2 renames to plain
+  names + removes the one-shot API — release-boundary breaking change).
+- One-shot arms carry run-to-run noise on this shared machine; the
+  no-regression conclusion rests on the two-run median and the consistent
+  one-session direction, not a single measurement.
+- Typed `where_select` (mask trait) still enters a session via the legacy
+  ternary helper; converting it is a Phase-2 or follow-up item.


### PR DESCRIPTION
## Summary

Issue #1680 Phase 1 (additive, non-breaking): complete the session-explicit
`_in` surface for the **full concrete op vocabulary**. `TensorSessionOpsExt`
grows 4 → 30 methods, `TypedTensorSessionOpsExt<T>` 4 → 28:

- **26 new dynamic + 24 new typed `_in` methods**: dtype (convert/cast),
  binary+compare (sub/div/rem/pow/maximum/minimum/compare), unary
  (neg/abs/sign/conj/log/expm1/log1p/sin/cos/tanh/sqrt/rsqrt), ternary
  (where_select/clamp), matmul, structural (reshape/transpose/
  broadcast_in_dim).
- **Every one-shot method delegates** via
  `with_backend_session(|s| ..._in(...))` — one session entry per op, no
  nested entry.
- **Session-safe broadcast**: `broadcast_ternary_in` (dynamic) and
  `broadcast_ternary_in_read` (typed, new) — typed `clamp_in` no longer
  re-enters a session; dead session-reentering helpers removed.
- **Matmul cache-ownership decision** (resolves the PR-B deferral):
  `matmul_in` = `matmul_config_for_shapes` + `session.dot_general` on the
  plain entry; `with_backend_session_cached` stays internal to the runtime
  scheduler/eager paths.

## Measurements (release, pinned core 40, criterion medians, 2 runs)

| chain | one_shot | one_session | speedup |
|---|---|---|---|
| Phase-1 (10 new ops) | 120.8 µs | 45.1 µs | **2.68×** |
| PR-B no_broadcast (gate) | 112.7 µs | 36.2 µs | 3.11× |
| PR-B broadcast (gate) | 129.0 µs | 43.7 µs | 2.95× |

One-shot arms: −2.8%..+8.2% across two runs, no consistent sign → **within
machine noise, no regression** (session-count test also proves 5 ops in 1
entry vs 5 entries).

## Gate record (frontier review, per AGENTS.md)

- **Pre-implementation design gate** (reviewer-gpt): 2 rounds → **approved**
  (inventory: expm1/log1p → 26/24; typed ternary session-safety; bench chain
  exact spec).
- **Post-implementation diff gate** (reviewer-gpt): 2 rounds →
  **Correct-to-merge** (worklog + fresh measurements; noise disclosure
  accepted).

## Verification

`check-pr-fast.sh` green (402 unit + 146 integration + 475 doctests),
repository-rules review pass, fmt/clippy clean, workspace builds,
tenferro-ad tests pass.

Worklog: `docs/worklogs/2026-08-14-phase1-full-surface.md`.

Phase 2 (one-shot removal + `_in`→plain rename, release-boundary breaking
change) is tracked on #1680.
