### PR TITLE
docs(readme): drop map_err boilerplate in Quickstart B via Box<dyn Error> (#1682)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,32 +139,13 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
     }
 }
 
-fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runtime::Error> {
+fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, Box<dyn std::error::Error>> {
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(tensor)?;
     let backend = CpuBackend::new();
     let mut builder = Runtime::builder();
-    let registration = tenferro_cpu::runtime_engine_registration(&backend).map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tutorial_runtime",
-            tenferro_runtime::ErrorPhase::Execution,
-            source,
-        )
-    })?;
-    builder.register_engine(registration).map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tutorial_runtime",
-            tenferro_runtime::ErrorPhase::Execution,
-            source,
-        )
-    })?;
-    let runtime = builder.build().map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tutorial_runtime",
-            tenferro_runtime::ErrorPhase::Execution,
-            source,
-        )
-    })?;
+    builder.register_engine(tenferro_cpu::runtime_engine_registration(&backend)?)?;
+    let runtime = builder.build()?;
     let mut outputs = runtime.run_compiled(&program, &[])?;
     assert_eq!(outputs.len(), 1);
     Ok(outputs.remove(0))

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -209,32 +209,13 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
     }
 }
 
-fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runtime::Error> {
+fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, Box<dyn std::error::Error>> {
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(tensor)?;
     let backend = CpuBackend::new();
     let mut builder = Runtime::builder();
-    let registration = tenferro_cpu::runtime_engine_registration(&backend).map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tutorial_runtime",
-            tenferro_runtime::ErrorPhase::Execution,
-            source,
-        )
-    })?;
-    builder.register_engine(registration).map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tutorial_runtime",
-            tenferro_runtime::ErrorPhase::Execution,
-            source,
-        )
-    })?;
-    let runtime = builder.build().map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tutorial_runtime",
-            tenferro_runtime::ErrorPhase::Execution,
-            source,
-        )
-    })?;
+    builder.register_engine(tenferro_cpu::runtime_engine_registration(&backend)?)?;
+    let runtime = builder.build()?;
     let mut outputs = runtime.run_compiled(&program, &[])?;
     assert_eq!(outputs.len(), 1);
     Ok(outputs.remove(0))

--- a/docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs
+++ b/docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs
@@ -13,32 +13,13 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
     }
 }
 
-fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runtime::Error> {
+fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, Box<dyn std::error::Error>> {
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(tensor)?;
     let backend = CpuBackend::new();
     let mut builder = Runtime::builder();
-    let registration = tenferro_cpu::runtime_engine_registration(&backend).map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tutorial_runtime",
-            tenferro_runtime::ErrorPhase::Execution,
-            source,
-        )
-    })?;
-    builder.register_engine(registration).map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tutorial_runtime",
-            tenferro_runtime::ErrorPhase::Execution,
-            source,
-        )
-    })?;
-    let runtime = builder.build().map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tutorial_runtime",
-            tenferro_runtime::ErrorPhase::Execution,
-            source,
-        )
-    })?;
+    builder.register_engine(tenferro_cpu::runtime_engine_registration(&backend)?)?;
+    let runtime = builder.build()?;
     let mut outputs = runtime.run_compiled(&program, &[])?;
     assert_eq!(outputs.len(), 1);
     Ok(outputs.remove(0))

--- a/docs/tutorials/traced-autodiff-jax-style.md
+++ b/docs/tutorials/traced-autodiff-jax-style.md
@@ -25,32 +25,13 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
     }
 }
 
-fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runtime::Error> {
+fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, Box<dyn std::error::Error>> {
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(tensor)?;
     let backend = CpuBackend::new();
     let mut builder = Runtime::builder();
-    let registration = tenferro_cpu::runtime_engine_registration(&backend).map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tutorial_runtime",
-            tenferro_runtime::ErrorPhase::Execution,
-            source,
-        )
-    })?;
-    builder.register_engine(registration).map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tutorial_runtime",
-            tenferro_runtime::ErrorPhase::Execution,
-            source,
-        )
-    })?;
-    let runtime = builder.build().map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tutorial_runtime",
-            tenferro_runtime::ErrorPhase::Execution,
-            source,
-        )
-    })?;
+    builder.register_engine(tenferro_cpu::runtime_engine_registration(&backend)?)?;
+    let runtime = builder.build()?;
     let mut outputs = runtime.run_compiled(&program, &[])?;
     assert_eq!(outputs.len(), 1);
     Ok(outputs.remove(0))


### PR DESCRIPTION
## Summary

Per #1682: the Quickstart B tutorial `run()` now returns `Result<Tensor, Box<dyn std::error::Error>>`, matching `main()`. The std blanket `From` lets `?` handle all error conversions, removing the three repeated `map_err(... runtime_state_source ...)` blocks (21 lines shorter). No library code changes.

Snippets re-synced with `scripts/check-doc-snippets.py` (README.md, getting-started, traced-autodiff tutorial).

## Verification

On this branch (based on e5618b17):
- `cargo run --bin traced_autodiff_jax_style` compiles and runs cleanly; all assertions pass (value 14.0, gradient [2, 4, 6], JVP -7.8)
- `scripts/check-doc-snippets.py --check` passes
- `cargo fmt --check` clean

Closes #1682

🤖 Generated with [Claude Code](https://claude.com/claude-code)