### PR TITLE
feat(runtime): single canonical session-explicit core API (#1680 Phase 2)

### DIFF
--- a/.agents/skills/tenferro-compute/references/api-cheatsheet.md
+++ b/.agents/skills/tenferro-compute/references/api-cheatsheet.md
@@ -1,17 +1,19 @@
 # API cheatsheet
 
-Choose the tier before choosing the method. Direct operations receive an
-explicit mutable backend; eager operations run through an `EagerRuntime`; traced
-operations build a graph and execute it later.
+Choose the tier before choosing the method. Direct operations run inside an explicit
+`with_backend_session` entry; eager operations run through an `EagerRuntime`;
+traced operations build a graph and execute it later.
 
 ## Direct concrete tensors
 
-Import the backend and the extension trait that owns the method:
+Import the backend, `BackendSessionHost`, and the extension trait that owns
+the session method:
 
 <!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#concrete-operation -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 // The leftmost dimension varies fastest: this is a 2 x 3 column-major tensor.
@@ -23,14 +25,16 @@ let weights = TypedTensor::<f64>::from_vec_col_major(
     vec![3, 2],
     vec![0.5, -1.0, 1.5, 1.0, 2.0, -0.5],
 )?;
-let projected = x.matmul(&weights, &mut backend)?;
+let projected = backend.with_backend_session(|session| x.matmul(&weights, session))?;
 assert_eq!(projected.shape(), &[2, 2]);
 assert_eq!(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
 ```
 <!-- end-snippet-source -->
 
-The important shape is `x.matmul(&weights, &mut backend)`. For dynamic dtypes
-use `TensorOpsExt`; for static scalar types use `TypedTensorOpsExt`.
+The important shape is
+`backend.with_backend_session(|session| x.matmul(&weights, session))`. For
+dynamic dtypes use `TensorSessionOpsExt`; for static scalar types use
+`TypedTensorSessionOpsExt`.
 
 ## Eager tensors
 

--- a/.agents/skills/tenferro-compute/references/pitfalls.md
+++ b/.agents/skills/tenferro-compute/references/pitfalls.md
@@ -51,8 +51,8 @@ Same traps, keyed by the priors you arrived with.
   `TypedTensorView::from_slice` (see the [API cheatsheet](api-cheatsheet.md#borrowing-external-memory)).
 - `cargo add tenferro` fails: there is no facade crate. Add
   `tenferro-runtime` + `tenferro-cpu` (plus operation crates).
-- `Array2::dot` is a free-standing habit; tenferro direct ops take an explicit
-  `&mut CpuBackend` argument: `a.matmul(&b, &mut backend)`.
+- `Array2::dot` is a free-standing habit; tenferro direct ops run inside an
+  explicit session: `backend.with_backend_session(|s| a.matmul(&b, s))`.
 - Your priors do not include a dtype-erased tensor; `Tensor` (runtime dtype)
   has no ndarray counterpart — use `TypedTensor<T>`.
 
@@ -61,7 +61,7 @@ Same traps, keyed by the priors you arrived with.
 - nalgebra is column-major like tenferro, so `.data` / `as_slice()` buffers map
   directly to `from_vec_col_major`.
 - `Matrix::dot` / `gemm` are methods without an execution context; tenferro
-  direct ops need the explicit backend argument. Eager and traced tiers drop
+  direct ops need the explicit backend session. Eager and traced tiers drop
   it: `EagerTensor` methods run through the `EagerRuntime`, traced methods
   build a graph.
 - A single `DMatrix<T>` maps to `TypedTensor<T>`; there is no separate runtime

--- a/.claude/skills/tenferro-compute/references/api-cheatsheet.md
+++ b/.claude/skills/tenferro-compute/references/api-cheatsheet.md
@@ -1,17 +1,19 @@
 # API cheatsheet
 
-Choose the tier before choosing the method. Direct operations receive an
-explicit mutable backend; eager operations run through an `EagerRuntime`; traced
-operations build a graph and execute it later.
+Choose the tier before choosing the method. Direct operations run inside an explicit
+`with_backend_session` entry; eager operations run through an `EagerRuntime`;
+traced operations build a graph and execute it later.
 
 ## Direct concrete tensors
 
-Import the backend and the extension trait that owns the method:
+Import the backend, `BackendSessionHost`, and the extension trait that owns
+the session method:
 
 <!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#concrete-operation -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 // The leftmost dimension varies fastest: this is a 2 x 3 column-major tensor.
@@ -23,14 +25,16 @@ let weights = TypedTensor::<f64>::from_vec_col_major(
     vec![3, 2],
     vec![0.5, -1.0, 1.5, 1.0, 2.0, -0.5],
 )?;
-let projected = x.matmul(&weights, &mut backend)?;
+let projected = backend.with_backend_session(|session| x.matmul(&weights, session))?;
 assert_eq!(projected.shape(), &[2, 2]);
 assert_eq!(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
 ```
 <!-- end-snippet-source -->
 
-The important shape is `x.matmul(&weights, &mut backend)`. For dynamic dtypes
-use `TensorOpsExt`; for static scalar types use `TypedTensorOpsExt`.
+The important shape is
+`backend.with_backend_session(|session| x.matmul(&weights, session))`. For
+dynamic dtypes use `TensorSessionOpsExt`; for static scalar types use
+`TypedTensorSessionOpsExt`.
 
 ## Eager tensors
 

--- a/.claude/skills/tenferro-compute/references/pitfalls.md
+++ b/.claude/skills/tenferro-compute/references/pitfalls.md
@@ -61,7 +61,7 @@ Same traps, keyed by the priors you arrived with.
 - nalgebra is column-major like tenferro, so `.data` / `as_slice()` buffers map
   directly to `from_vec_col_major`.
 - `Matrix::dot` / `gemm` are methods without an execution context; tenferro
-  direct ops need the explicit backend argument. Eager and traced tiers drop
+  direct ops need the explicit backend session. Eager and traced tiers drop
   it: `EagerTensor` methods run through the `EagerRuntime`, traced methods
   build a graph.
 - A single `DMatrix<T>` maps to `TypedTensor<T>`; there is no separate runtime

--- a/.claude/skills/tenferro-compute/references/pitfalls.md
+++ b/.claude/skills/tenferro-compute/references/pitfalls.md
@@ -51,8 +51,8 @@ Same traps, keyed by the priors you arrived with.
   `TypedTensorView::from_slice` (see the [API cheatsheet](api-cheatsheet.md#borrowing-external-memory)).
 - `cargo add tenferro` fails: there is no facade crate. Add
   `tenferro-runtime` + `tenferro-cpu` (plus operation crates).
-- `Array2::dot` is a free-standing habit; tenferro direct ops take an explicit
-  `&mut CpuBackend` argument: `a.matmul(&b, &mut backend)`.
+- `Array2::dot` is a free-standing habit; tenferro direct ops run inside an
+  explicit session: `backend.with_backend_session(|s| a.matmul(&b, s))`.
 - Your priors do not include a dtype-erased tensor; `Tensor` (runtime dtype)
   has no ndarray counterpart — use `TypedTensor<T>`.
 

--- a/.kimi/skills/tenferro-compute/references/api-cheatsheet.md
+++ b/.kimi/skills/tenferro-compute/references/api-cheatsheet.md
@@ -1,17 +1,19 @@
 # API cheatsheet
 
-Choose the tier before choosing the method. Direct operations receive an
-explicit mutable backend; eager operations run through an `EagerRuntime`; traced
-operations build a graph and execute it later.
+Choose the tier before choosing the method. Direct operations run inside an explicit
+`with_backend_session` entry; eager operations run through an `EagerRuntime`;
+traced operations build a graph and execute it later.
 
 ## Direct concrete tensors
 
-Import the backend and the extension trait that owns the method:
+Import the backend, `BackendSessionHost`, and the extension trait that owns
+the session method:
 
 <!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#concrete-operation -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 // The leftmost dimension varies fastest: this is a 2 x 3 column-major tensor.
@@ -23,14 +25,16 @@ let weights = TypedTensor::<f64>::from_vec_col_major(
     vec![3, 2],
     vec![0.5, -1.0, 1.5, 1.0, 2.0, -0.5],
 )?;
-let projected = x.matmul(&weights, &mut backend)?;
+let projected = backend.with_backend_session(|session| x.matmul(&weights, session))?;
 assert_eq!(projected.shape(), &[2, 2]);
 assert_eq!(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
 ```
 <!-- end-snippet-source -->
 
-The important shape is `x.matmul(&weights, &mut backend)`. For dynamic dtypes
-use `TensorOpsExt`; for static scalar types use `TypedTensorOpsExt`.
+The important shape is
+`backend.with_backend_session(|session| x.matmul(&weights, session))`. For
+dynamic dtypes use `TensorSessionOpsExt`; for static scalar types use
+`TypedTensorSessionOpsExt`.
 
 ## Eager tensors
 

--- a/.kimi/skills/tenferro-compute/references/pitfalls.md
+++ b/.kimi/skills/tenferro-compute/references/pitfalls.md
@@ -61,7 +61,7 @@ Same traps, keyed by the priors you arrived with.
 - nalgebra is column-major like tenferro, so `.data` / `as_slice()` buffers map
   directly to `from_vec_col_major`.
 - `Matrix::dot` / `gemm` are methods without an execution context; tenferro
-  direct ops need the explicit backend argument. Eager and traced tiers drop
+  direct ops need the explicit backend session. Eager and traced tiers drop
   it: `EagerTensor` methods run through the `EagerRuntime`, traced methods
   build a graph.
 - A single `DMatrix<T>` maps to `TypedTensor<T>`; there is no separate runtime

--- a/.kimi/skills/tenferro-compute/references/pitfalls.md
+++ b/.kimi/skills/tenferro-compute/references/pitfalls.md
@@ -51,8 +51,8 @@ Same traps, keyed by the priors you arrived with.
   `TypedTensorView::from_slice` (see the [API cheatsheet](api-cheatsheet.md#borrowing-external-memory)).
 - `cargo add tenferro` fails: there is no facade crate. Add
   `tenferro-runtime` + `tenferro-cpu` (plus operation crates).
-- `Array2::dot` is a free-standing habit; tenferro direct ops take an explicit
-  `&mut CpuBackend` argument: `a.matmul(&b, &mut backend)`.
+- `Array2::dot` is a free-standing habit; tenferro direct ops run inside an
+  explicit session: `backend.with_backend_session(|s| a.matmul(&b, s))`.
 - Your priors do not include a dtype-erased tensor; `Tensor` (runtime dtype)
   has no ndarray counterpart — use `TypedTensor<T>`.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![3.0, 0.0, 0.0, 1.0])?;
     let identity = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0])?;
 
-    let product = a.matmul(&identity, &mut backend)?;
+    let product = backend.with_backend_session(|session| a.matmul(&identity, session))?;
     assert_eq!(product.shape(), &[2, 2]);
     assert_close(product.host_data()?, &[3.0, 0.0, 0.0, 1.0]);
 

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -1141,10 +1141,12 @@ diff-scoped review bot.
   with no natural receiver (`EagerTensor::where_select(...)`,
   `TracedTensor::concatenate(...)`).
 - **Non-AD concrete ops**: `Tensor` and dynamic-rank `TypedTensor<T>` use
-  crate-root extension-trait methods with an explicit backend (`TensorOpsExt`,
-  `TypedTensorOpsExt`, and `TypedTensorMaskOpsExt`). The implementation may use
-  private helper modules, but public `tensor` / `typed_tensor` module free
-  functions are not part of the release API.
+  crate-root session extension traits (`TensorSessionOpsExt`,
+  `TypedTensorSessionOpsExt`, and `TypedTensorMaskSessionOpsExt`) whose methods
+  run inside a caller-provided `BackendSession` (entered via
+  `TensorBackend::with_backend_session`). The implementation may use private
+  helper modules, but public `tensor` / `typed_tensor` module free functions
+  are not part of the release API.
 - **Extension families**: extension crates cannot add inherent methods to
   external tensor types, so their canonical tensor-facing surface is extension
   traits (`TracedTensorLinalgExt`, `EagerEinsumExt`,

--- a/crates/tenferro-ad/tests/integration/numpy_api.rs
+++ b/crates/tenferro-ad/tests/integration/numpy_api.rs
@@ -6,10 +6,11 @@ use tenferro_ad::{EagerRuntime, EagerTensor};
 use tenferro_cpu::CpuBackend;
 use tenferro_ops::{ext_op::ExtensionOp, std_tensor_op::StdTensorOp, SymDim};
 use tenferro_runtime::{
-    CompareDir, DType, Error as RuntimeError, ErrorPhase, GraphCompiler, Tensor, TensorOpsExt,
-    TracedTensor, TypedTensor, TypedTensorMaskOpsExt, TypedTensorOpsExt,
+    CompareDir, DType, Error as RuntimeError, ErrorPhase, GraphCompiler, Tensor,
+    TensorSessionOpsExt, TracedTensor, TypedTensor, TypedTensorMaskSessionOpsExt,
+    TypedTensorSessionOpsExt,
 };
-use tenferro_tensor::ValidationError;
+use tenferro_tensor::{BackendSessionHost, ValidationError};
 
 use crate::support::{cpu_runtime, run_compiled_one};
 
@@ -361,7 +362,9 @@ fn tensor_add_uses_numpy_broadcasting_with_explicit_backend() {
     let lhs = Tensor::from_vec_col_major(vec![3, 1], vec![1.0_f64, 2.0, 3.0]).unwrap();
     let rhs = Tensor::from_vec_col_major(vec![1, 4], vec![10.0_f64, 20.0, 30.0, 40.0]).unwrap();
 
-    let out = lhs.add(&rhs, &mut backend).unwrap();
+    let out = backend
+        .with_backend_session(|session| lhs.add(&rhs, session))
+        .unwrap();
 
     assert_eq!(out.shape(), &[3, 4]);
     assert_eq!(
@@ -375,29 +378,35 @@ fn tensor_extension_trait_exposes_initial_elementwise_methods() {
     let mut backend = CpuBackend::new();
     let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
     let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
-    let cond = x.compare(&y, CompareDir::Gt, &mut backend).unwrap();
 
-    let _ = x.sub(&y, &mut backend).unwrap();
-    let _ = x.mul(&y, &mut backend).unwrap();
-    let _ = x.div(&y, &mut backend).unwrap();
-    let _ = x.pow(&y, &mut backend).unwrap();
-    let _ = x.maximum(&y, &mut backend).unwrap();
-    let _ = x.minimum(&y, &mut backend).unwrap();
-    let _ = cond.where_select(&x, &y, &mut backend).unwrap();
-    let _ = x.clamp(&y, &x, &mut backend).unwrap();
-    let _ = x.neg(&mut backend).unwrap();
-    let _ = x.abs(&mut backend).unwrap();
-    let _ = x.sign(&mut backend).unwrap();
-    let _ = x.conj(&mut backend).unwrap();
-    let _ = x.exp(&mut backend).unwrap();
-    let _ = x.log(&mut backend).unwrap();
-    let _ = x.sin(&mut backend).unwrap();
-    let _ = x.cos(&mut backend).unwrap();
-    let _ = x.tanh(&mut backend).unwrap();
-    let _ = x.sqrt(&mut backend).unwrap();
-    let _ = x.rsqrt(&mut backend).unwrap();
-    let _ = x.expm1(&mut backend).unwrap();
-    let _ = x.log1p(&mut backend).unwrap();
+    // The whole elementwise surface runs in one backend session.
+    backend
+        .with_backend_session(|session| -> tenferro_tensor::Result<Tensor> {
+            let cond = x.compare(&y, CompareDir::Gt, session)?;
+            let _ = x.sub(&y, session)?;
+            let _ = x.mul(&y, session)?;
+            let _ = x.div(&y, session)?;
+            let _ = x.pow(&y, session)?;
+            let _ = x.maximum(&y, session)?;
+            let _ = x.minimum(&y, session)?;
+            let _ = cond.where_select(&x, &y, session)?;
+            let _ = x.clamp(&y, &x, session)?;
+            let _ = x.neg(session)?;
+            let _ = x.abs(session)?;
+            let _ = x.sign(session)?;
+            let _ = x.conj(session)?;
+            let _ = x.exp(session)?;
+            let _ = x.log(session)?;
+            let _ = x.sin(session)?;
+            let _ = x.cos(session)?;
+            let _ = x.tanh(session)?;
+            let _ = x.sqrt(session)?;
+            let _ = x.rsqrt(session)?;
+            let _ = x.expm1(session)?;
+            let _ = x.log1p(session)?;
+            Ok(cond)
+        })
+        .unwrap();
 }
 
 #[test]
@@ -406,8 +415,13 @@ fn tensor_compare_returns_bool_and_where_select_accepts_bool_condition() {
     let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
     let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
 
-    let cond = x.compare(&y, CompareDir::Gt, &mut backend).unwrap();
-    let selected = cond.where_select(&x, &y, &mut backend).unwrap();
+    let (cond, selected) = backend
+        .with_backend_session(|session| -> tenferro_tensor::Result<(Tensor, Tensor)> {
+            let cond = x.compare(&y, CompareDir::Gt, session)?;
+            let selected = cond.where_select(&x, &y, session)?;
+            Ok((cond, selected))
+        })
+        .unwrap();
 
     assert_eq!(cond.dtype(), DType::Bool);
     assert_eq!(cond.as_slice::<bool>().unwrap(), &[true, false]);
@@ -424,7 +438,9 @@ fn typed_tensor_add_uses_numpy_broadcasting_with_explicit_backend() {
     let rhs =
         TypedTensor::<f64>::from_vec_col_major(vec![1, 4], vec![10.0, 20.0, 30.0, 40.0]).unwrap();
 
-    let out = lhs.add(&rhs, &mut backend).unwrap();
+    let out = backend
+        .with_backend_session(|session| lhs.add(&rhs, session))
+        .unwrap();
 
     assert_eq!(out.shape(), &[3, 4]);
     assert_eq!(
@@ -438,29 +454,35 @@ fn typed_tensor_extension_trait_exposes_initial_elementwise_methods() {
     let mut backend = CpuBackend::new();
     let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
     let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
-    let cond = x.compare(&y, CompareDir::Gt, &mut backend).unwrap();
 
-    let _ = x.sub(&y, &mut backend).unwrap();
-    let _ = x.mul(&y, &mut backend).unwrap();
-    let _ = x.div(&y, &mut backend).unwrap();
-    let _ = x.pow(&y, &mut backend).unwrap();
-    let _ = x.maximum(&y, &mut backend).unwrap();
-    let _ = x.minimum(&y, &mut backend).unwrap();
-    let _ = cond.where_select(&x, &y, &mut backend).unwrap();
-    let _ = x.clamp(&y, &x, &mut backend).unwrap();
-    let _ = x.neg(&mut backend).unwrap();
-    let _ = x.abs(&mut backend).unwrap();
-    let _ = x.sign(&mut backend).unwrap();
-    let _ = x.conj(&mut backend).unwrap();
-    let _ = x.exp(&mut backend).unwrap();
-    let _ = x.log(&mut backend).unwrap();
-    let _ = x.sin(&mut backend).unwrap();
-    let _ = x.cos(&mut backend).unwrap();
-    let _ = x.tanh(&mut backend).unwrap();
-    let _ = x.sqrt(&mut backend).unwrap();
-    let _ = x.rsqrt(&mut backend).unwrap();
-    let _ = x.expm1(&mut backend).unwrap();
-    let _ = x.log1p(&mut backend).unwrap();
+    // The whole elementwise surface runs in one backend session.
+    backend
+        .with_backend_session(|session| -> tenferro_tensor::Result<TypedTensor<bool>> {
+            let cond = x.compare(&y, CompareDir::Gt, session)?;
+            let _ = x.sub(&y, session)?;
+            let _ = x.mul(&y, session)?;
+            let _ = x.div(&y, session)?;
+            let _ = x.pow(&y, session)?;
+            let _ = x.maximum(&y, session)?;
+            let _ = x.minimum(&y, session)?;
+            let _ = cond.where_select(&x, &y, session)?;
+            let _ = x.clamp(&y, &x, session)?;
+            let _ = x.neg(session)?;
+            let _ = x.abs(session)?;
+            let _ = x.sign(session)?;
+            let _ = x.conj(session)?;
+            let _ = x.exp(session)?;
+            let _ = x.log(session)?;
+            let _ = x.sin(session)?;
+            let _ = x.cos(session)?;
+            let _ = x.tanh(session)?;
+            let _ = x.sqrt(session)?;
+            let _ = x.rsqrt(session)?;
+            let _ = x.expm1(session)?;
+            let _ = x.log1p(session)?;
+            Ok(cond)
+        })
+        .unwrap();
 }
 
 #[test]
@@ -469,8 +491,13 @@ fn typed_tensor_compare_returns_bool_and_where_select_accepts_bool_condition() {
     let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
     let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
 
-    let cond: TypedTensor<bool> = x.compare(&y, CompareDir::Gt, &mut backend).unwrap();
-    let selected = cond.where_select(&x, &y, &mut backend).unwrap();
+    let (cond, selected) = backend
+        .with_backend_session(|session| {
+            let cond: TypedTensor<bool> = x.compare(&y, CompareDir::Gt, session)?;
+            let selected = cond.where_select(&x, &y, session)?;
+            Ok::<_, tenferro_tensor::Error>((cond, selected))
+        })
+        .unwrap();
 
     assert_eq!(cond.host_data().unwrap(), &[true, false]);
     assert_eq!(selected.into_vec_col_major().unwrap().1, vec![2.0, 8.0]);

--- a/crates/tenferro-cpu/src/analytic.rs
+++ b/crates/tenferro-cpu/src/analytic.rs
@@ -273,7 +273,7 @@ where
 
 fn unsupported_analytic_dtype_message(dtype: DType) -> String {
     let remedy = matches!(dtype, DType::I32 | DType::I64)
-        .then_some("; convert to F64 with TensorOpsExt::convert before this operation");
+        .then_some("; convert to F64 before this operation");
     format!(
         "CPU backend does not support this operation for {dtype:?}; supported dtypes: F32/F64/C32/C64{}",
         remedy.unwrap_or("")

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -94,9 +94,8 @@ use crate::buffer_pool::BufferPool;
 pub(crate) use tenferro_tensor::*;
 
 pub(crate) fn cpu_contraction_unsupported_dtype_message(dtype: DType) -> String {
-    let remedy = matches!(dtype, DType::I32 | DType::I64).then_some(format!(
-        "; convert {dtype:?} to F64 with TensorOpsExt::convert before contraction"
-    ));
+    let remedy = matches!(dtype, DType::I32 | DType::I64)
+        .then_some(format!("; convert {dtype:?} to F64 before contraction"));
     format!(
         "CPU contraction providers support F32/F64/C32/C64{}",
         remedy.unwrap_or_default()

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -25,8 +25,8 @@ fn unsupported_dtype_with_supported(
 }
 
 fn unsupported_sum_squares_dtype(op: &'static str, dtype: DType) -> crate::Error {
-    let remedy = matches!(dtype, DType::I32 | DType::I64)
-        .then_some("; convert to F64 with TensorOpsExt::convert before reduction");
+    let remedy =
+        matches!(dtype, DType::I32 | DType::I64).then_some("; convert to F64 before reduction");
     crate::Error::unsupported(
         op,
         format!(

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -2091,7 +2091,7 @@ fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
             op: "exp",
             dtype: DType::I64,
             message,
-        }) if message == "CPU backend does not support this operation for I64; supported dtypes: F32/F64/C32/C64; convert to F64 with TensorOpsExt::convert before this operation"
+        }) if message == "CPU backend does not support this operation for I64; supported dtypes: F32/F64/C32/C64; convert to F64 before this operation"
     ));
     assert!(matches!(
         crate::analytic::exp_read_with_pool(
@@ -2102,7 +2102,7 @@ fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
             op: "exp",
             dtype: DType::I64,
             message,
-        }) if message == "CPU backend does not support this operation for I64; supported dtypes: F32/F64/C32/C64; convert to F64 with TensorOpsExt::convert before this operation"
+        }) if message == "CPU backend does not support this operation for I64; supported dtypes: F32/F64/C32/C64; convert to F64 before this operation"
     ));
     assert!(crate::analytic::pow(&real, &base).is_err());
 }
@@ -2111,7 +2111,7 @@ fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
 fn contraction_unsupported_dtype_message_lists_recovery() {
     assert_eq!(
         crate::cpu_contraction_unsupported_dtype_message(DType::I64),
-        "CPU contraction providers support F32/F64/C32/C64; convert I64 to F64 with TensorOpsExt::convert before contraction"
+        "CPU contraction providers support F32/F64/C32/C64; convert I64 to F64 before contraction"
     );
     assert_eq!(
         crate::cpu_contraction_unsupported_dtype_message(DType::Bool),

--- a/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
@@ -743,7 +743,7 @@ fn unsupported_reduction_dtype_messages_prescribe_known_recovery() {
         crate::Error::Unsupported {
             op: "reduce_sum_squares",
             message,
-        } if message == "unsupported dtype I64; supported dtypes: F32/F64; convert to F64 with TensorOpsExt::convert before reduction"
+        } if message == "unsupported dtype I64; supported dtypes: F32/F64; convert to F64 before reduction"
     ));
 
     let complex = Tensor::C64(

--- a/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
@@ -655,7 +655,7 @@ fn unsupported_elementwise_dtype_messages_list_operation_sets() {
     assert!(matches!(
         conj(&i64_tensor),
         Err(crate::Error::Unsupported { op: "conj", message })
-            if message == "unsupported dtype I64; supported dtypes: F32/F64/C32/C64; convert to F64 with TensorOpsExt::convert before this operation"
+            if message == "unsupported dtype I64; supported dtypes: F32/F64/C32/C64; convert to F64 before this operation"
     ));
 }
 

--- a/crates/tenferro-einsum/benches/einsum_session_chain.rs
+++ b/crates/tenferro-einsum/benches/einsum_session_chain.rs
@@ -1,7 +1,6 @@
-//! Session-entry cost comparison for a prepared [`ConcreteEinsumPlan`]:
-//! one-shot executes (one session entry per call) vs `_in_session` executes
-//! inside a single borrowed session, and a mixed chain
-//! (einsum + exp + reduce_sum) in both spellings.
+//! Session-entry cost benchmark for a prepared [`ConcreteEinsumPlan`]:
+//! repeated executes inside a single borrowed session, and a mixed chain
+//! (einsum + exp + reduce_sum) in the same session.
 //!
 //! Workload (design doc "Prototype specification (PR C)"): a prepared plan
 //! for `"ij,jk->ik"` on 8×8 f64 column-major inputs, executed 10 times per
@@ -10,7 +9,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::ConcreteEinsumPlan;
-use tenferro_runtime::{Tensor, TensorOpsExt, TensorSessionOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 use tenferro_tensor::BackendSessionHost;
 
 const N: usize = 8;
@@ -31,7 +30,7 @@ fn bench_einsum_session_chain(c: &mut Criterion) {
 
     // Correctness validation outside the timed region: shape [8, 8], finite.
     let check = backend
-        .with_backend_session(|session| plan.execute_in_session([&lhs, &rhs], session))
+        .with_backend_session(|session| plan.execute([&lhs, &rhs], session))
         .unwrap();
     assert_eq!(check.shape(), &[8, 8]);
     assert!(check
@@ -42,51 +41,29 @@ fn bench_einsum_session_chain(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("einsum_session_chain/f64_8x8_10calls/threads1");
 
-    group.bench_function("A_one_shot", |b| {
-        b.iter(|| {
-            let inputs = black_box([&lhs, &rhs]);
-            for _ in 0..CALLS {
-                let out = plan.execute(inputs, &mut backend).unwrap();
-                black_box(out);
-            }
-        });
-    });
-
-    group.bench_function("B_in_session", |b| {
+    group.bench_function("B_one_session", |b| {
         b.iter(|| {
             backend.with_backend_session(|session| {
                 let inputs = black_box([&lhs, &rhs]);
                 for _ in 0..CALLS {
-                    let out = plan.execute_in_session(inputs, session).unwrap();
+                    let out = plan.execute(inputs, session).unwrap();
                     black_box(out);
                 }
             });
         });
     });
 
-    group.bench_function("C_mixed_in_session", |b| {
+    group.bench_function("C_mixed_one_session", |b| {
         b.iter(|| {
             backend.with_backend_session(|session| {
                 let inputs = black_box([&lhs, &rhs]);
                 for _ in 0..CALLS {
-                    let x = plan.execute_in_session(inputs, session).unwrap();
-                    let x = x.exp_in(session).unwrap();
-                    let out = x.reduce_sum_in(&[0], session).unwrap();
+                    let x = plan.execute(inputs, session).unwrap();
+                    let x = x.exp(session).unwrap();
+                    let out = x.reduce_sum(&[0], session).unwrap();
                     black_box(out);
                 }
             });
-        });
-    });
-
-    group.bench_function("C_mixed_one_shot", |b| {
-        b.iter(|| {
-            let inputs = black_box([&lhs, &rhs]);
-            for _ in 0..CALLS {
-                let x = plan.execute(inputs, &mut backend).unwrap();
-                let x = x.exp(&mut backend).unwrap();
-                let out = x.reduce_sum(&[0], &mut backend).unwrap();
-                black_box(out);
-            }
         });
     });
 

--- a/crates/tenferro-einsum/src/concrete.rs
+++ b/crates/tenferro-einsum/src/concrete.rs
@@ -854,14 +854,15 @@ impl<'a, const N: usize> TensorReadEinsumIntoExt for [TensorRead<'a>; N] {
 /// ```
 /// use tenferro_cpu::CpuBackend;
 /// use tenferro_einsum::ConcreteEinsumPlan;
-/// use tenferro_tensor::Tensor;
+/// use tenferro_tensor::{BackendSessionHost, Tensor};
 ///
 /// let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
 /// let rhs = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
 /// let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik")?;
 ///
 /// let mut backend = CpuBackend::new();
-/// let out = plan.execute([&lhs, &rhs], &mut backend)?;
+/// let out = backend
+///     .with_backend_session(|session| plan.execute([&lhs, &rhs], session))?;
 /// assert_eq!(out.shape(), &[2, 4]);
 /// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
@@ -970,22 +971,9 @@ impl ConcreteEinsumPlan {
         Self::prepare_subscripts_internal(read_input_specs(inputs.as_ref()), &subscripts)
     }
 
-    /// Execute this plan on dtype-erased concrete tensor inputs.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Validation`] when inputs violate the prepared rank,
-    /// shape, or input-count contract, [`Error::Tensor`] with a
-    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when an
-    /// input dtype differs from the prepared contract, or [`Error::Tensor`]
-    /// for a typed backend failure.
-    pub fn execute<'a, I, B>(&self, inputs: I, backend: &mut B) -> Result<Tensor>
-    where
-        I: AsRef<[&'a Tensor]>,
-        B: TensorBackend,
-    {
-        let inputs = inputs.as_ref();
-        backend.with_backend_session(|session| self.execute_in_session(inputs, session))
+    /// Number of binary contraction steps in the prepared tree (diagnostics).
+    pub(crate) fn step_count(&self) -> usize {
+        self.tree.step_count()
     }
 
     /// Execute this plan on dtype-erased concrete tensor inputs inside a
@@ -1007,7 +995,7 @@ impl ConcreteEinsumPlan {
     ///
     /// let mut backend = CpuBackend::new();
     /// let out = backend
-    ///     .with_backend_session(|session| plan.execute_in_session([&lhs, &rhs], session))?;
+    ///     .with_backend_session(|session| plan.execute([&lhs, &rhs], session))?;
     /// assert_eq!(out.shape(), &[2, 4]);
     /// # Ok::<(), tenferro_einsum::Error>(())
     /// ```
@@ -1019,36 +1007,13 @@ impl ConcreteEinsumPlan {
     /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when an
     /// input dtype differs from the prepared contract, or [`Error::Tensor`]
     /// for a typed backend failure.
-    pub fn execute_in_session<'a, I>(
-        &self,
-        inputs: I,
-        session: &mut dyn BackendSession,
-    ) -> Result<Tensor>
+    pub fn execute<'a, I>(&self, inputs: I, session: &mut dyn BackendSession) -> Result<Tensor>
     where
         I: AsRef<[&'a Tensor]>,
     {
         let inputs = inputs.as_ref();
         self.validate_inputs(&input_specs(inputs), PLAN_EXECUTE_OP)?;
         eager_einsum_exec(session, inputs, &self.tree).map_err(Error::from)
-    }
-
-    /// Execute this plan on typed concrete tensor inputs.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Validation`] when inputs violate the prepared rank,
-    /// shape, or input-count contract, [`Error::Tensor`] with a
-    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when the
-    /// prepared dtype differs from `T` or the eager result dtype, or
-    /// [`Error::Tensor`] for a typed backend failure.
-    pub fn execute_typed<'a, T, I, B>(&self, inputs: I, backend: &mut B) -> Result<TypedTensor<T>>
-    where
-        T: TensorScalar,
-        I: AsRef<[&'a TypedTensor<T>]>,
-        B: TensorBackend,
-    {
-        let inputs = inputs.as_ref();
-        backend.with_backend_session(|session| self.execute_typed_in_session(inputs, session))
     }
 
     /// Execute this plan on typed concrete tensor inputs inside a borrowed
@@ -1070,7 +1035,7 @@ impl ConcreteEinsumPlan {
     ///
     /// let mut backend = CpuBackend::new();
     /// let out = backend
-    ///     .with_backend_session(|session| plan.execute_typed_in_session([&lhs, &rhs], session))?;
+    ///     .with_backend_session(|session| plan.execute_typed([&lhs, &rhs], session))?;
     /// assert_eq!(out.shape(), &[2, 4]);
     /// # Ok::<(), tenferro_einsum::Error>(())
     /// ```
@@ -1082,7 +1047,7 @@ impl ConcreteEinsumPlan {
     /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when the
     /// prepared dtype differs from `T` or the eager result dtype, or
     /// [`Error::Tensor`] for a typed backend failure.
-    pub fn execute_typed_in_session<'a, T, I>(
+    pub fn execute_typed<'a, T, I>(
         &self,
         inputs: I,
         session: &mut dyn BackendSession,
@@ -1096,24 +1061,6 @@ impl ConcreteEinsumPlan {
         let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
         let result = eager_einsum_exec_read(session, &reads, &self.tree)?;
         into_typed_result(result, PLAN_EXECUTE_OP)
-    }
-
-    /// Execute this plan on read-only tensor inputs.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Validation`] when inputs violate the prepared rank,
-    /// shape, or input-count contract, [`Error::Tensor`] with a
-    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when an
-    /// input dtype differs from the prepared contract, or [`Error::Tensor`]
-    /// for a typed backend failure.
-    pub fn execute_read<'a, I, B>(&self, inputs: I, backend: &mut B) -> Result<Tensor>
-    where
-        I: AsRef<[TensorRead<'a>]>,
-        B: TensorBackend,
-    {
-        let inputs = inputs.as_ref();
-        backend.with_backend_session(|session| self.execute_read_in_session(inputs, session))
     }
 
     /// Execute this plan on read-only tensor inputs inside a borrowed backend
@@ -1139,7 +1086,7 @@ impl ConcreteEinsumPlan {
     /// let mut backend = CpuBackend::new();
     /// let reads = [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)];
     /// let out = backend
-    ///     .with_backend_session(|session| plan.execute_read_in_session(reads, session))?;
+    ///     .with_backend_session(|session| plan.execute_read(reads, session))?;
     /// assert_eq!(out.shape(), &[2, 4]);
     /// # Ok::<(), tenferro_einsum::Error>(())
     /// ```
@@ -1151,39 +1098,13 @@ impl ConcreteEinsumPlan {
     /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when an
     /// input dtype differs from the prepared contract, or [`Error::Tensor`]
     /// for a typed backend failure.
-    pub fn execute_read_in_session<'a, I>(
-        &self,
-        inputs: I,
-        session: &mut dyn BackendSession,
-    ) -> Result<Tensor>
+    pub fn execute_read<'a, I>(&self, inputs: I, session: &mut dyn BackendSession) -> Result<Tensor>
     where
         I: AsRef<[TensorRead<'a>]>,
     {
         let inputs = inputs.as_ref();
         self.validate_inputs(&read_input_specs(inputs), PLAN_EXECUTE_OP)?;
         eager_einsum_exec_read(session, inputs, &self.tree).map_err(Error::from)
-    }
-
-    /// Execute this plan on dtype-erased concrete tensor inputs into caller-provided output.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Validation`] for input or output rank, shape, or
-    /// input-count contract violations, [`Error::Tensor`] with a
-    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload for dtype
-    /// mismatches, or [`Error::Tensor`] for a typed backend failure.
-    pub fn execute_into<'a, I, B>(
-        &self,
-        inputs: I,
-        backend: &mut B,
-        out: TensorWrite<'_>,
-    ) -> Result<()>
-    where
-        I: AsRef<[&'a Tensor]>,
-        B: TensorBackend,
-    {
-        let inputs = inputs.as_ref();
-        backend.with_backend_session(|session| self.execute_into_in_session(inputs, session, out))
     }
 
     /// Execute this plan on dtype-erased concrete tensor inputs into
@@ -1206,7 +1127,7 @@ impl ConcreteEinsumPlan {
     /// let mut backend = CpuBackend::new();
     /// let mut out = Tensor::from_vec_col_major(vec![2, 4], vec![0.0_f64; 8]).unwrap();
     /// backend.with_backend_session(|session| {
-    ///     plan.execute_into_in_session(
+    ///     plan.execute_into(
     ///         [&lhs, &rhs],
     ///         session,
     ///         TensorWrite::from_tensor(&mut out),
@@ -1222,7 +1143,7 @@ impl ConcreteEinsumPlan {
     /// input-count contract violations, [`Error::Tensor`] with a
     /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload for dtype
     /// mismatches, or [`Error::Tensor`] for a typed backend failure.
-    pub fn execute_into_in_session<'a, I>(
+    pub fn execute_into<'a, I>(
         &self,
         inputs: I,
         session: &mut dyn BackendSession,
@@ -1240,34 +1161,6 @@ impl ConcreteEinsumPlan {
             .map(|tensor| TensorRead::from_tensor(tensor))
             .collect();
         eager_einsum_exec_read_into(session, &reads, &self.tree, out).map_err(Error::from)
-    }
-
-    /// Execute this plan on typed concrete tensor inputs into caller-provided output.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Validation`] for input or output rank, shape, or
-    /// input-count contract violations, [`Error::Tensor`] with a
-    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when the
-    /// prepared dtype differs from `T` or the output dtype, or
-    /// [`Error::Tensor`] for a typed backend failure.
-    pub fn execute_typed_into<'a, 'out, T, I, B, O>(
-        &self,
-        inputs: I,
-        backend: &mut B,
-        out: O,
-    ) -> Result<()>
-    where
-        T: TensorScalar,
-        I: AsRef<[&'a TypedTensor<T>]>,
-        B: TensorBackend,
-        O: Into<TypedTensorWrite<'out, T>>,
-    {
-        let inputs = inputs.as_ref();
-        let out = out.into();
-        backend.with_backend_session(|session| {
-            self.execute_typed_into_in_session(inputs, session, out)
-        })
     }
 
     /// Execute this plan on typed concrete tensor inputs into caller-provided
@@ -1290,7 +1183,7 @@ impl ConcreteEinsumPlan {
     /// let mut backend = CpuBackend::new();
     /// let mut out = TypedTensor::<f64>::from_vec_col_major(vec![2, 4], vec![0.0; 8]).unwrap();
     /// backend.with_backend_session(|session| {
-    ///     plan.execute_typed_into_in_session([&lhs, &rhs], session, &mut out)
+    ///     plan.execute_typed_into([&lhs, &rhs], session, &mut out)
     /// })?;
     /// assert_eq!(out.as_slice()?, vec![3.0_f64; 8].as_slice());
     /// # Ok::<(), tenferro_einsum::Error>(())
@@ -1303,7 +1196,7 @@ impl ConcreteEinsumPlan {
     /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload when the
     /// prepared dtype differs from `T` or the output dtype, or
     /// [`Error::Tensor`] for a typed backend failure.
-    pub fn execute_typed_into_in_session<'a, 'out, T, I, O>(
+    pub fn execute_typed_into<'a, 'out, T, I, O>(
         &self,
         inputs: I,
         session: &mut dyn BackendSession,
@@ -1321,29 +1214,6 @@ impl ConcreteEinsumPlan {
         validate_output(&self.inputs, &self.tree, &out, PLAN_EXECUTE_OP)?;
         let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
         eager_einsum_exec_read_into(session, &reads, &self.tree, out).map_err(Error::from)
-    }
-
-    /// Execute this plan on read-only tensor inputs into caller-provided output.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Validation`] for input or output rank, shape, or
-    /// input-count contract violations, [`Error::Tensor`] with a
-    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload for dtype
-    /// mismatches, or [`Error::Tensor`] for a typed backend failure.
-    pub fn execute_read_into<'a, I, B>(
-        &self,
-        inputs: I,
-        backend: &mut B,
-        out: TensorWrite<'_>,
-    ) -> Result<()>
-    where
-        I: AsRef<[TensorRead<'a>]>,
-        B: TensorBackend,
-    {
-        let inputs = inputs.as_ref();
-        backend
-            .with_backend_session(|session| self.execute_read_into_in_session(inputs, session, out))
     }
 
     /// Execute this plan on read-only tensor inputs into caller-provided output
@@ -1370,7 +1240,7 @@ impl ConcreteEinsumPlan {
     /// let mut out = Tensor::from_vec_col_major(vec![2, 4], vec![0.0_f64; 8]).unwrap();
     /// let reads = [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)];
     /// backend.with_backend_session(|session| {
-    ///     plan.execute_read_into_in_session(reads, session, TensorWrite::from_tensor(&mut out))
+    ///     plan.execute_read_into(reads, session, TensorWrite::from_tensor(&mut out))
     /// })?;
     /// assert_eq!(out.as_slice::<f64>()?, vec![3.0_f64; 8].as_slice());
     /// # Ok::<(), tenferro_einsum::Error>(())
@@ -1382,7 +1252,7 @@ impl ConcreteEinsumPlan {
     /// input-count contract violations, [`Error::Tensor`] with a
     /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload for dtype
     /// mismatches, or [`Error::Tensor`] for a typed backend failure.
-    pub fn execute_read_into_in_session<'a, I>(
+    pub fn execute_read_into<'a, I>(
         &self,
         inputs: I,
         session: &mut dyn BackendSession,
@@ -1396,59 +1266,6 @@ impl ConcreteEinsumPlan {
         self.validate_inputs(&specs, PLAN_EXECUTE_OP)?;
         validate_output(&self.inputs, &self.tree, &out, PLAN_EXECUTE_OP)?;
         eager_einsum_exec_read_into(session, inputs, &self.tree, out).map_err(Error::from)
-    }
-
-    /// Execute this plan on read-only inputs with scaled output accumulation.
-    ///
-    /// `accumulation` follows the dot-general contract:
-    /// `out = alpha * einsum(inputs) + beta * out`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_cpu::CpuBackend;
-    /// use tenferro_einsum::ConcreteEinsumPlan;
-    /// use tenferro_tensor::{
-    ///     DotGeneralAccumulation, DType, Tensor, TensorRead, TensorWrite,
-    /// };
-    ///
-    /// let lhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64])?;
-    /// let rhs = Tensor::from_vec_col_major(vec![1], vec![3.0_f64])?;
-    /// let mut out = Tensor::from_vec_col_major(vec![], vec![1.0_f64])?;
-    /// let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "i,i->")?;
-    /// let mut backend = CpuBackend::new();
-    /// plan.execute_read_into_accum(
-    ///     [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
-    ///     &mut backend,
-    ///     DotGeneralAccumulation::add_to(DType::F64)?,
-    ///     TensorWrite::from_tensor(&mut out),
-    /// )?;
-    /// assert_eq!(out.as_slice::<f64>()?, &[7.0]);
-    /// # Ok::<(), tenferro_einsum::Error>(())
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Validation`] for input or output rank, shape, or
-    /// input-count contract violations, [`Error::Tensor`] with a
-    /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload for dtype
-    /// mismatches, [`Error::Numerical`] for an invalid accumulation, or
-    /// [`Error::Tensor`] for a typed backend failure.
-    pub fn execute_read_into_accum<'a, I, B>(
-        &self,
-        inputs: I,
-        backend: &mut B,
-        accumulation: DotGeneralAccumulation,
-        out: TensorWrite<'_>,
-    ) -> Result<()>
-    where
-        I: AsRef<[TensorRead<'a>]>,
-        B: TensorBackend,
-    {
-        let inputs = inputs.as_ref();
-        backend.with_backend_session(|session| {
-            self.execute_read_into_accum_in_session(inputs, session, accumulation, out)
-        })
     }
 
     /// Execute this plan on read-only inputs with scaled output accumulation
@@ -1472,7 +1289,7 @@ impl ConcreteEinsumPlan {
     /// let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "i,i->")?;
     /// let mut backend = CpuBackend::new();
     /// backend.with_backend_session(|session| {
-    ///     plan.execute_read_into_accum_in_session(
+    ///     plan.execute_read_into_accum(
     ///         [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
     ///         session,
     ///         DotGeneralAccumulation::add_to(DType::F64)?,
@@ -1490,7 +1307,7 @@ impl ConcreteEinsumPlan {
     /// `tenferro_tensor::Error::Validation` `DTypeMismatch` payload for dtype
     /// mismatches, [`Error::Numerical`] for an invalid accumulation, or
     /// [`Error::Tensor`] for a typed backend failure.
-    pub fn execute_read_into_accum_in_session<'a, I>(
+    pub fn execute_read_into_accum<'a, I>(
         &self,
         inputs: I,
         session: &mut dyn BackendSession,
@@ -1577,18 +1394,6 @@ fn typed_input_specs<T: TensorScalar>(inputs: &[&TypedTensor<T>]) -> Vec<Concret
         .collect()
 }
 
-fn typed_view_input_specs<T: TensorScalar>(
-    inputs: &[TypedTensorView<'_, T>],
-) -> Vec<ConcreteEinsumInputSpec> {
-    inputs
-        .iter()
-        .map(|tensor| ConcreteEinsumInputSpec {
-            dtype: T::dtype(),
-            shape: tensor.shape().to_vec(),
-        })
-        .collect()
-}
-
 fn read_input_specs(inputs: &[TensorRead<'_>]) -> Vec<ConcreteEinsumInputSpec> {
     inputs
         .iter()
@@ -1610,7 +1415,9 @@ fn typed_view_einsum_subscripts<T: TensorScalar>(
         .cloned()
         .map(|view| TensorRead::from_view(T::tensor_view(view)))
         .collect();
-    let result = eager_einsum_read_subscripts(backend, &reads, subscripts)?;
+    let plan =
+        ConcreteEinsumPlan::prepare_subscripts_internal(read_input_specs(&reads), subscripts)?;
+    let result = backend.with_backend_session(|session| plan.execute_read(&reads, session))?;
     into_typed_result(result, op)
 }
 
@@ -1621,16 +1428,9 @@ fn tensor_einsum_into_subscripts(
     out: TensorWrite<'_>,
     op: &'static str,
 ) -> Result<()> {
-    let specs = input_specs(inputs);
-    let plan = ConcreteEinsumPlan::prepare_subscripts_internal(specs.clone(), subscripts)?;
-    validate_output(&specs, &plan.tree, &out, op)?;
-    let reads: Vec<_> = inputs
-        .iter()
-        .map(|tensor| TensorRead::from_tensor(tensor))
-        .collect();
-    backend
-        .with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))
-        .map_err(Error::from)
+    let plan = ConcreteEinsumPlan::prepare_subscripts_internal(input_specs(inputs), subscripts)?;
+    validate_output(&plan.inputs, &plan.tree, &out, op)?;
+    backend.with_backend_session(|session| plan.execute_into(inputs, session, out))
 }
 
 fn typed_view_einsum_into_subscripts<T: TensorScalar>(
@@ -1640,18 +1440,16 @@ fn typed_view_einsum_into_subscripts<T: TensorScalar>(
     out: TypedTensorWrite<'_, T>,
     op: &'static str,
 ) -> Result<()> {
-    let specs = typed_view_input_specs(inputs);
-    let plan = ConcreteEinsumPlan::prepare_subscripts_internal(specs.clone(), subscripts)?;
-    let out = out.into_tensor_write();
-    validate_output(&specs, &plan.tree, &out, op)?;
     let reads: Vec<_> = inputs
         .iter()
         .cloned()
         .map(|view| TensorRead::from_view(T::tensor_view(view)))
         .collect();
-    backend
-        .with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))
-        .map_err(Error::from)
+    let plan =
+        ConcreteEinsumPlan::prepare_subscripts_internal(read_input_specs(&reads), subscripts)?;
+    let out = out.into_tensor_write();
+    validate_output(&plan.inputs, &plan.tree, &out, op)?;
+    backend.with_backend_session(|session| plan.execute_read_into(&reads, session, out))
 }
 
 fn typed_einsum_into_subscripts<T: TensorScalar>(
@@ -1661,14 +1459,12 @@ fn typed_einsum_into_subscripts<T: TensorScalar>(
     out: TypedTensorWrite<'_, T>,
     op: &'static str,
 ) -> Result<()> {
-    let specs = typed_input_specs(inputs);
-    let plan = ConcreteEinsumPlan::prepare_subscripts_internal(specs.clone(), subscripts)?;
-    let out = out.into_tensor_write();
-    validate_output(&specs, &plan.tree, &out, op)?;
     let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
-    backend
-        .with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))
-        .map_err(Error::from)
+    let plan =
+        ConcreteEinsumPlan::prepare_subscripts_internal(read_input_specs(&reads), subscripts)?;
+    let out = out.into_tensor_write();
+    validate_output(&plan.inputs, &plan.tree, &out, op)?;
+    backend.with_backend_session(|session| plan.execute_read_into(&reads, session, out))
 }
 
 fn tensor_read_einsum_into_subscripts(
@@ -1678,12 +1474,10 @@ fn tensor_read_einsum_into_subscripts(
     out: TensorWrite<'_>,
     op: &'static str,
 ) -> Result<()> {
-    let specs = read_input_specs(inputs);
-    let plan = ConcreteEinsumPlan::prepare_subscripts_internal(specs.clone(), subscripts)?;
-    validate_output(&specs, &plan.tree, &out, op)?;
-    backend
-        .with_backend_session(|exec| eager_einsum_exec_read_into(exec, inputs, &plan.tree, out))
-        .map_err(Error::from)
+    let plan =
+        ConcreteEinsumPlan::prepare_subscripts_internal(read_input_specs(inputs), subscripts)?;
+    validate_output(&plan.inputs, &plan.tree, &out, op)?;
+    backend.with_backend_session(|session| plan.execute_read_into(inputs, session, out))
 }
 
 fn validate_output(
@@ -1757,7 +1551,9 @@ fn typed_einsum_subscripts<T: TensorScalar>(
     op: &'static str,
 ) -> Result<TypedTensor<T>> {
     let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
-    let result = eager_einsum_read_subscripts(backend, &reads, subscripts)?;
+    let plan =
+        ConcreteEinsumPlan::prepare_subscripts_internal(read_input_specs(&reads), subscripts)?;
+    let result = backend.with_backend_session(|session| plan.execute_read(&reads, session))?;
     into_typed_result(result, op)
 }
 

--- a/crates/tenferro-einsum/src/concrete_tests.rs
+++ b/crates/tenferro-einsum/src/concrete_tests.rs
@@ -96,7 +96,9 @@ fn public_typed_tensor_einsum_ext_preserves_complex_dtype() {
         .einsum_subscripts(&subscripts, &mut backend)
         .unwrap();
     let plan = ConcreteEinsumPlan::prepare_typed_subscripts([&lhs, &rhs], &subscripts).unwrap();
-    let planned_result = plan.execute_typed([&lhs, &rhs], &mut backend).unwrap();
+    let planned_result = backend
+        .with_backend_session(|session| plan.execute_typed([&lhs, &rhs], session))
+        .unwrap();
 
     assert_eq!(result.shape(), &[2, 1]);
     assert_eq!(
@@ -359,7 +361,7 @@ fn einsum_into_gemm_fast_path_dispatches_to_backend_into_before_owned_fallback()
         .expect("missing eager_einsum_exec_read_into");
     let tail = &source[start..];
     let end = tail
-        .find("fn tensor_value_from_read")
+        .find("pub(crate) fn eager_einsum_exec_read_into_accum")
         .expect("missing following function");
     let body = &tail[..end];
 
@@ -387,8 +389,13 @@ fn concrete_einsum_plan_executes_without_replanning_contract() {
     let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
 
     let mut backend = CpuBackend::new();
-    let first = plan.execute([&lhs, &rhs], &mut backend).unwrap();
-    let second = plan.execute([&lhs, &rhs2], &mut backend).unwrap();
+    let (first, second) = backend
+        .with_backend_session(|session| -> crate::Result<(Tensor, Tensor)> {
+            let first = plan.execute([&lhs, &rhs], session)?;
+            let second = plan.execute([&lhs, &rhs2], session)?;
+            Ok((first, second))
+        })
+        .unwrap();
 
     assert_f64_tensor(&first, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
     assert_f64_tensor(&second, &[2, 2], &[7.0, 10.0, 40.0, 52.0]);
@@ -406,20 +413,15 @@ fn concrete_einsum_plan_execute_into_writes_reused_outputs() {
     let mut backend = CpuBackend::new();
     let mut out = Tensor::from_vec_col_major(vec![2, 2], vec![-1.0_f64; 4]).unwrap();
 
-    plan.execute_into(
-        [&lhs, &rhs],
-        &mut backend,
-        TensorWrite::from_tensor(&mut out),
-    )
-    .unwrap();
-    assert_f64_tensor(&out, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
-
-    plan.execute_into(
-        [&lhs, &rhs2],
-        &mut backend,
-        TensorWrite::from_tensor(&mut out),
-    )
-    .unwrap();
+    let first = backend
+        .with_backend_session(|session| -> crate::Result<Tensor> {
+            plan.execute_into([&lhs, &rhs], session, TensorWrite::from_tensor(&mut out))?;
+            let first = out.duplicate().unwrap();
+            plan.execute_into([&lhs, &rhs2], session, TensorWrite::from_tensor(&mut out))?;
+            Ok(first)
+        })
+        .unwrap();
+    assert_f64_tensor(&first, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
     assert_f64_tensor(&out, &[2, 2], &[7.0, 10.0, 40.0, 52.0]);
 }
 
@@ -433,28 +435,28 @@ fn concrete_einsum_plan_execute_read_into_accum_updates_outputs() {
 
     let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
     let mut out = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
-    plan.execute_read_into_accum(
-        [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
-        &mut backend,
-        DotGeneralAccumulation::add_to(DType::F64).unwrap(),
-        TensorWrite::from_tensor(&mut out),
-    )
-    .unwrap();
-    assert_f64_tensor(&out, &[2, 2], &[23.0, 29.0, 50.0, 65.0]);
-
     let fallback_plan = ConcreteEinsumPlan::prepare([&lhs], "ij->").unwrap();
     let mut scalar_out = Tensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
     let accumulation =
         DotGeneralAccumulation::scaled(ContractionScalar::F64(0.5), ContractionScalar::F64(2.0))
             .unwrap();
-    fallback_plan
-        .execute_read_into_accum(
-            [TensorRead::from_tensor(&lhs)],
-            &mut backend,
-            accumulation,
-            TensorWrite::from_tensor(&mut scalar_out),
-        )
+    backend
+        .with_backend_session(|session| -> crate::Result<()> {
+            plan.execute_read_into_accum(
+                [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
+                session,
+                DotGeneralAccumulation::add_to(DType::F64).unwrap(),
+                TensorWrite::from_tensor(&mut out),
+            )?;
+            fallback_plan.execute_read_into_accum(
+                [TensorRead::from_tensor(&lhs)],
+                session,
+                accumulation,
+                TensorWrite::from_tensor(&mut scalar_out),
+            )
+        })
         .unwrap();
+    assert_f64_tensor(&out, &[2, 2], &[23.0, 29.0, 50.0, 65.0]);
     assert_f64_tensor(&scalar_out, &[], &[14.5]);
 }
 
@@ -470,21 +472,16 @@ fn concrete_einsum_plan_execute_typed_and_read_into_outputs() {
     let mut backend = CpuBackend::new();
 
     let mut typed_out = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![-1.0; 4]).unwrap();
-    plan.execute_typed_into([&lhs, &rhs], &mut backend, &mut typed_out)
+    let mut typed_strided_data = [-1.0_f64; 8];
+    backend
+        .with_backend_session(|session| -> crate::Result<()> {
+            plan.execute_typed_into([&lhs, &rhs], session, &mut typed_out)?;
+            let out_view =
+                TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut typed_strided_data).unwrap();
+            plan.execute_typed_into([&lhs, &rhs], session, TypedTensorWrite::from_view(out_view))
+        })
         .unwrap();
     assert_eq!(typed_out.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
-
-    let mut typed_strided_data = [-1.0_f64; 8];
-    {
-        let out_view =
-            TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut typed_strided_data).unwrap();
-        plan.execute_typed_into(
-            [&lhs, &rhs],
-            &mut backend,
-            TypedTensorWrite::from_view(out_view),
-        )
-        .unwrap();
-    }
     assert_eq!(
         typed_strided_data,
         [-1.0, 22.0, 28.0, -1.0, 49.0, 64.0, -1.0, -1.0]
@@ -493,20 +490,21 @@ fn concrete_einsum_plan_execute_typed_and_read_into_outputs() {
     let lhs_erased = Tensor::from(lhs.duplicate().unwrap());
     let rhs_erased = Tensor::from(rhs.duplicate().unwrap());
     let mut strided_data = [-1.0_f64; 8];
-    {
-        let out_view = TensorViewMut::F64(
-            TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut strided_data).unwrap(),
-        );
-        plan.execute_read_into(
-            [
-                TensorRead::from_tensor(&lhs_erased),
-                TensorRead::from_tensor(&rhs_erased),
-            ],
-            &mut backend,
-            TensorWrite::from_view(out_view),
-        )
+    backend
+        .with_backend_session(|session| {
+            let out_view = TensorViewMut::F64(
+                TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut strided_data).unwrap(),
+            );
+            plan.execute_read_into(
+                [
+                    TensorRead::from_tensor(&lhs_erased),
+                    TensorRead::from_tensor(&rhs_erased),
+                ],
+                session,
+                TensorWrite::from_view(out_view),
+            )
+        })
         .unwrap();
-    }
     assert_eq!(
         strided_data,
         [-1.0, 22.0, 28.0, -1.0, 49.0, 64.0, -1.0, -1.0]
@@ -523,12 +521,14 @@ fn concrete_einsum_plan_execute_into_rejects_incompatible_output() {
     let mut backend = CpuBackend::new();
     let mut wrong_shape = Tensor::from_vec_col_major(vec![4], vec![0.0_f64; 4]).unwrap();
 
-    let err = plan
-        .execute_into(
-            [&lhs, &rhs],
-            &mut backend,
-            TensorWrite::from_tensor(&mut wrong_shape),
-        )
+    let err = backend
+        .with_backend_session(|session| {
+            plan.execute_into(
+                [&lhs, &rhs],
+                session,
+                TensorWrite::from_tensor(&mut wrong_shape),
+            )
+        })
         .unwrap_err();
 
     assert!(matches!(
@@ -566,15 +566,20 @@ fn concrete_einsum_plan_prepares_integer_and_read_variants() {
     let debug = format!("{tensor_plan:?}");
 
     let mut backend = CpuBackend::new();
-    let tensor_result = tensor_plan.execute([&lhs, &rhs], &mut backend).unwrap();
-    let typed_result = typed_plan
-        .execute_typed([&typed_lhs, &typed_rhs], &mut backend)
+    let tensor_result = backend
+        .with_backend_session(|session| tensor_plan.execute([&lhs, &rhs], session))
         .unwrap();
-    let read_string_result = read_string_plan
-        .execute_read(read_inputs.as_slice(), &mut backend)
-        .unwrap();
-    let read_integer_result = read_integer_plan
-        .execute_read(read_inputs.as_slice(), &mut backend)
+    let (typed_result, read_string_result, read_integer_result) = backend
+        .with_backend_session(
+            |session| -> crate::Result<(TypedTensor<f64>, Tensor, Tensor)> {
+                let typed_result = typed_plan.execute_typed([&typed_lhs, &typed_rhs], session)?;
+                let read_string_result =
+                    read_string_plan.execute_read(read_inputs.as_slice(), session)?;
+                let read_integer_result =
+                    read_integer_plan.execute_read(read_inputs.as_slice(), session)?;
+                Ok((typed_result, read_string_result, read_integer_result))
+            },
+        )
         .unwrap();
 
     assert!(debug.contains("ConcreteEinsumPlan"));
@@ -598,15 +603,18 @@ fn concrete_einsum_plan_executes_read_and_typed_inputs() {
     let rhs_erased = Tensor::from(rhs.duplicate().unwrap());
 
     let mut backend = CpuBackend::new();
-    let typed = plan.execute_typed([&lhs, &rhs], &mut backend).unwrap();
-    let read = plan
-        .execute_read(
-            [
-                TensorRead::from_tensor(&lhs_erased),
-                TensorRead::from_tensor(&rhs_erased),
-            ],
-            &mut backend,
-        )
+    let (typed, read) = backend
+        .with_backend_session(|session| -> crate::Result<(TypedTensor<f64>, Tensor)> {
+            let typed = plan.execute_typed([&lhs, &rhs], session)?;
+            let read = plan.execute_read(
+                [
+                    TensorRead::from_tensor(&lhs_erased),
+                    TensorRead::from_tensor(&rhs_erased),
+                ],
+                session,
+            )?;
+            Ok((typed, read))
+        })
         .unwrap();
 
     assert_eq!(typed.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
@@ -624,12 +632,11 @@ fn concrete_einsum_plan_rejects_shape_and_dtype_mismatches() {
     let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
 
     let mut backend = CpuBackend::new();
-    let shape_err = plan
-        .execute([&lhs, &wrong_shape], &mut backend)
-        .unwrap_err();
-    let dtype_err = plan
-        .execute([&lhs, &wrong_dtype], &mut backend)
-        .unwrap_err();
+    let (shape_err, dtype_err) = backend.with_backend_session(|session| {
+        let shape_err = plan.execute([&lhs, &wrong_shape], session).unwrap_err();
+        let dtype_err = plan.execute([&lhs, &wrong_dtype], session).unwrap_err();
+        (shape_err, dtype_err)
+    });
 
     assert!(matches!(
         shape_err,
@@ -659,7 +666,9 @@ fn concrete_einsum_public_api_reports_parse_and_input_count_errors() {
         .einsum("ij,(jk)->ik", &mut backend)
         .unwrap_err();
     let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
-    let count_err = plan.execute([&lhs], &mut backend).unwrap_err();
+    let count_err = backend
+        .with_backend_session(|session| plan.execute([&lhs], session))
+        .unwrap_err();
 
     assert!(matches!(parse_err, Error::InvalidSubscripts { .. }));
     assert!(matches!(
@@ -687,16 +696,8 @@ fn concrete_einsum_typed_result_reports_defensive_dtype_mismatch() {
 }
 
 // ---------------------------------------------------------------------------
-// `_in_session` surface parity with the one-shot execute methods
+// Direct session tests for the ConcreteEinsumPlan execute surface
 // ---------------------------------------------------------------------------
-
-fn assert_same_error(one_shot: &Error, in_session: &Error) {
-    assert_eq!(
-        format!("{in_session:?}"),
-        format!("{one_shot:?}"),
-        "in-session error must match the one-shot error structurally"
-    );
-}
 
 fn f64_plan_fixture() -> (Tensor, Tensor, ConcreteEinsumPlan) {
     let lhs =
@@ -708,30 +709,20 @@ fn f64_plan_fixture() -> (Tensor, Tensor, ConcreteEinsumPlan) {
 }
 
 #[test]
-fn concrete_einsum_plan_in_session_values_match_one_shot() {
+fn concrete_einsum_plan_execute_in_session_matches_expected_values() {
     let (lhs, rhs, plan) = f64_plan_fixture();
     let mut backend = CpuBackend::new();
 
-    let one_shot = plan.execute([&lhs, &rhs], &mut backend).unwrap();
     let in_session = backend
-        .with_backend_session(|session| plan.execute_in_session([&lhs, &rhs], session))
+        .with_backend_session(|session| plan.execute([&lhs, &rhs], session))
         .unwrap();
     assert_f64_tensor(&in_session, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
-    assert_eq!(
-        one_shot.as_slice::<f64>().unwrap(),
-        in_session.as_slice::<f64>().unwrap()
-    );
 
     let reads = [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)];
-    let one_shot = plan.execute_read(reads.clone(), &mut backend).unwrap();
     let in_session = backend
-        .with_backend_session(|session| plan.execute_read_in_session(reads.clone(), session))
+        .with_backend_session(|session| plan.execute_read(reads.clone(), session))
         .unwrap();
     assert_f64_tensor(&in_session, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
-    assert_eq!(
-        one_shot.as_slice::<f64>().unwrap(),
-        in_session.as_slice::<f64>().unwrap()
-    );
 
     let typed_lhs =
         TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
@@ -741,32 +732,22 @@ fn concrete_einsum_plan_in_session_values_match_one_shot() {
             .unwrap();
     let typed_plan =
         ConcreteEinsumPlan::prepare_typed([&typed_lhs, &typed_rhs], "ij,jk->ik").unwrap();
-    let one_shot = typed_plan
-        .execute_typed([&typed_lhs, &typed_rhs], &mut backend)
-        .unwrap();
     let in_session = backend
-        .with_backend_session(|session| {
-            typed_plan.execute_typed_in_session([&typed_lhs, &typed_rhs], session)
-        })
+        .with_backend_session(|session| typed_plan.execute_typed([&typed_lhs, &typed_rhs], session))
         .unwrap();
     assert_eq!(in_session.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
-    assert_eq!(one_shot.as_slice().unwrap(), in_session.as_slice().unwrap());
 }
 
 #[test]
-fn concrete_einsum_plan_in_session_errors_match_one_shot() {
+fn concrete_einsum_plan_execute_in_session_rejects_bad_inputs() {
     let (lhs, _rhs, plan) = f64_plan_fixture();
     let wrong_shape = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
     let wrong_dtype = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f32; 6]).unwrap();
     let mut backend = CpuBackend::new();
 
-    let one_shot = plan
-        .execute([&lhs, &wrong_shape], &mut backend)
-        .unwrap_err();
     let in_session = backend
-        .with_backend_session(|session| plan.execute_in_session([&lhs, &wrong_shape], session))
+        .with_backend_session(|session| plan.execute([&lhs, &wrong_shape], session))
         .unwrap_err();
-    assert_same_error(&one_shot, &in_session);
     assert!(matches!(
         in_session,
         Error::Validation {
@@ -775,13 +756,9 @@ fn concrete_einsum_plan_in_session_errors_match_one_shot() {
         }
     ));
 
-    let one_shot = plan
-        .execute([&lhs, &wrong_dtype], &mut backend)
-        .unwrap_err();
     let in_session = backend
-        .with_backend_session(|session| plan.execute_in_session([&lhs, &wrong_dtype], session))
+        .with_backend_session(|session| plan.execute([&lhs, &wrong_dtype], session))
         .unwrap_err();
-    assert_same_error(&one_shot, &in_session);
     assert!(matches!(
         in_session,
         Error::Tensor(tenferro_tensor::Error::Validation {
@@ -790,11 +767,9 @@ fn concrete_einsum_plan_in_session_errors_match_one_shot() {
         })
     ));
 
-    let one_shot = plan.execute([&lhs], &mut backend).unwrap_err();
     let in_session = backend
-        .with_backend_session(|session| plan.execute_in_session([&lhs], session))
+        .with_backend_session(|session| plan.execute([&lhs], session))
         .unwrap_err();
-    assert_same_error(&one_shot, &in_session);
     assert!(matches!(
         in_session,
         Error::Validation {
@@ -805,7 +780,7 @@ fn concrete_einsum_plan_in_session_errors_match_one_shot() {
 }
 
 #[test]
-fn concrete_einsum_plan_in_session_typed_dtype_conversion_matches_one_shot() {
+fn concrete_einsum_plan_execute_typed_in_session_validates_dtype() {
     let typed_lhs =
         TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
             .unwrap();
@@ -815,30 +790,18 @@ fn concrete_einsum_plan_in_session_typed_dtype_conversion_matches_one_shot() {
     let plan = ConcreteEinsumPlan::prepare_typed([&typed_lhs, &typed_rhs], "ij,jk->ik").unwrap();
     let mut backend = CpuBackend::new();
 
-    let one_shot = plan
-        .execute_typed([&typed_lhs, &typed_rhs], &mut backend)
-        .unwrap();
     let in_session = backend
-        .with_backend_session(|session| {
-            plan.execute_typed_in_session([&typed_lhs, &typed_rhs], session)
-        })
+        .with_backend_session(|session| plan.execute_typed([&typed_lhs, &typed_rhs], session))
         .unwrap();
     assert_eq!(in_session.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
-    assert_eq!(one_shot.as_slice().unwrap(), in_session.as_slice().unwrap());
 
     // Requesting a scalar type different from the prepared dtype must fail
-    // identically in both forms (validate_inputs dtype contract).
+    // through validate_inputs' dtype contract.
     let f32_lhs = TypedTensor::<f32>::from_vec_col_major(vec![2, 3], vec![1.0_f32; 6]).unwrap();
     let f32_rhs = TypedTensor::<f32>::from_vec_col_major(vec![3, 2], vec![1.0_f32; 6]).unwrap();
-    let one_shot = plan
-        .execute_typed([&f32_lhs, &f32_rhs], &mut backend)
-        .unwrap_err();
     let in_session = backend
-        .with_backend_session(|session| {
-            plan.execute_typed_in_session([&f32_lhs, &f32_rhs], session)
-        })
+        .with_backend_session(|session| plan.execute_typed([&f32_lhs, &f32_rhs], session))
         .unwrap_err();
-    assert_same_error(&one_shot, &in_session);
     assert!(matches!(
         in_session,
         Error::Tensor(tenferro_tensor::Error::Validation {
@@ -849,29 +812,21 @@ fn concrete_einsum_plan_in_session_typed_dtype_conversion_matches_one_shot() {
 }
 
 #[test]
-fn concrete_einsum_plan_in_session_into_output_validation_matches_one_shot() {
+fn concrete_einsum_plan_execute_into_in_session_validates_output() {
     let (lhs, rhs, plan) = f64_plan_fixture();
     let mut backend = CpuBackend::new();
 
     // execute_into: incompatible output shape.
     let mut wrong_shape = Tensor::from_vec_col_major(vec![4], vec![0.0_f64; 4]).unwrap();
-    let one_shot = plan
-        .execute_into(
-            [&lhs, &rhs],
-            &mut backend,
-            TensorWrite::from_tensor(&mut wrong_shape),
-        )
-        .unwrap_err();
     let in_session = backend
         .with_backend_session(|session| {
-            plan.execute_into_in_session(
+            plan.execute_into(
                 [&lhs, &rhs],
                 session,
                 TensorWrite::from_tensor(&mut wrong_shape),
             )
         })
         .unwrap_err();
-    assert_same_error(&one_shot, &in_session);
     assert!(matches!(
         in_session,
         Error::Validation {
@@ -882,23 +837,22 @@ fn concrete_einsum_plan_in_session_into_output_validation_matches_one_shot() {
 
     // execute_read_into: incompatible output dtype.
     let mut wrong_dtype_out = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f32; 4]).unwrap();
-    let one_shot = plan
-        .execute_read_into(
-            [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
-            &mut backend,
-            TensorWrite::from_tensor(&mut wrong_dtype_out),
-        )
-        .unwrap_err();
     let in_session = backend
         .with_backend_session(|session| {
-            plan.execute_read_into_in_session(
+            plan.execute_read_into(
                 [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
                 session,
                 TensorWrite::from_tensor(&mut wrong_dtype_out),
             )
         })
         .unwrap_err();
-    assert_same_error(&one_shot, &in_session);
+    assert!(matches!(
+        in_session,
+        Error::Tensor(tenferro_tensor::Error::Validation {
+            op: "ConcreteEinsumPlan::execute",
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
+    ));
 
     // execute_typed_into: incompatible output shape.
     let typed_lhs =
@@ -910,34 +864,25 @@ fn concrete_einsum_plan_in_session_into_output_validation_matches_one_shot() {
     let typed_plan =
         ConcreteEinsumPlan::prepare_typed([&typed_lhs, &typed_rhs], "ij,jk->ik").unwrap();
     let mut typed_out = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![0.0; 3]).unwrap();
-    let one_shot = typed_plan
-        .execute_typed_into([&typed_lhs, &typed_rhs], &mut backend, &mut typed_out)
-        .unwrap_err();
     let in_session = backend
         .with_backend_session(|session| {
-            typed_plan.execute_typed_into_in_session(
-                [&typed_lhs, &typed_rhs],
-                session,
-                &mut typed_out,
-            )
+            typed_plan.execute_typed_into([&typed_lhs, &typed_rhs], session, &mut typed_out)
         })
         .unwrap_err();
-    assert_same_error(&one_shot, &in_session);
+    assert!(matches!(
+        in_session,
+        Error::Validation {
+            op: "ConcreteEinsumPlan::execute",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        }
+    ));
 
     // execute_read_into_accum: incompatible output shape.
     let mut accum_out = Tensor::from_vec_col_major(vec![4], vec![0.0_f64; 4]).unwrap();
     let accumulation = DotGeneralAccumulation::add_to(DType::F64).unwrap();
-    let one_shot = plan
-        .execute_read_into_accum(
-            [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
-            &mut backend,
-            accumulation,
-            TensorWrite::from_tensor(&mut accum_out),
-        )
-        .unwrap_err();
     let in_session = backend
         .with_backend_session(|session| {
-            plan.execute_read_into_accum_in_session(
+            plan.execute_read_into_accum(
                 [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)],
                 session,
                 accumulation,
@@ -945,38 +890,29 @@ fn concrete_einsum_plan_in_session_into_output_validation_matches_one_shot() {
             )
         })
         .unwrap_err();
-    assert_same_error(&one_shot, &in_session);
+    assert!(matches!(
+        in_session,
+        Error::Validation {
+            op: "ConcreteEinsumPlan::execute",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        }
+    ));
 
-    // Valid into execution parity (values).
-    let mut out_a = Tensor::from_vec_col_major(vec![2, 2], vec![-1.0_f64; 4]).unwrap();
-    let mut out_b = Tensor::from_vec_col_major(vec![2, 2], vec![-1.0_f64; 4]).unwrap();
-    plan.execute_into(
-        [&lhs, &rhs],
-        &mut backend,
-        TensorWrite::from_tensor(&mut out_a),
-    )
-    .unwrap();
+    // Valid into execution writes the expected values.
+    let mut out = Tensor::from_vec_col_major(vec![2, 2], vec![-1.0_f64; 4]).unwrap();
     backend
         .with_backend_session(|session| {
-            plan.execute_into_in_session(
-                [&lhs, &rhs],
-                session,
-                TensorWrite::from_tensor(&mut out_b),
-            )
+            plan.execute_into([&lhs, &rhs], session, TensorWrite::from_tensor(&mut out))
         })
         .unwrap();
-    assert_eq!(
-        out_a.as_slice::<f64>().unwrap(),
-        out_b.as_slice::<f64>().unwrap()
-    );
-    assert_eq!(out_b.as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
 }
 
 /// A non-`Send` output adapter: `PhantomData<Rc<()>>` makes the type `!Send`
-/// (a `Cell` would not — `Cell<T>` is `Send` but `!Sync`). Calling
-/// `ConcreteEinsumPlan::execute_typed_into` with this type only compiles
-/// because the one-shot converts `out` to `TypedTensorWrite` before the
-/// backend session closure, so `O` itself never needs `Send`.
+/// (a `Cell` would not — `Cell<T>` is `Send` but `!Sync`). Passing this
+/// adapter to `ConcreteEinsumPlan::execute_typed_into` only compiles because
+/// the caller converts `out` to `TypedTensorWrite` before the
+/// `with_backend_session` closure, so `O` itself never needs `Send`.
 struct NonSendIntoWrite<'a, T> {
     write: TypedTensorWrite<'a, T>,
     _not_send: std::marker::PhantomData<std::rc::Rc<()>>,
@@ -1000,14 +936,14 @@ fn concrete_einsum_plan_execute_typed_into_accepts_non_send_adapter() {
 
     let mut backend = CpuBackend::new();
     let mut out = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![0.0; 4]).unwrap();
-    plan.execute_typed_into(
-        [&typed_lhs, &typed_rhs],
-        &mut backend,
-        NonSendIntoWrite {
-            write: TypedTensorWrite::from_tensor(&mut out),
-            _not_send: std::marker::PhantomData,
-        },
-    )
-    .unwrap();
+    let write = TypedTensorWrite::from(NonSendIntoWrite {
+        write: TypedTensorWrite::from_tensor(&mut out),
+        _not_send: std::marker::PhantomData,
+    });
+    backend
+        .with_backend_session(|session| {
+            plan.execute_typed_into([&typed_lhs, &typed_rhs], session, write)
+        })
+        .unwrap();
     assert_eq!(out.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
 }

--- a/crates/tenferro-einsum/src/eager.rs
+++ b/crates/tenferro-einsum/src/eager.rs
@@ -8,7 +8,7 @@ use tenferro_tensor::{
 
 use crate::binary_dot::{try_build_binary_dot_plan, BinaryDotPlan};
 use crate::util::map_label_occurrences;
-use crate::{ContractionTree, Subscripts};
+use crate::{ConcreteEinsumPlan, ContractionTree, EinsumSubscripts, Subscripts};
 
 mod profile;
 
@@ -888,64 +888,6 @@ pub(crate) fn eager_einsum_exec_read_into_accum(
     tenferro_tensor::backend::accumulate_dot_result_into(&result, accumulation, &mut out)
 }
 
-fn tensor_value_from_read(input: TensorRead<'_>) -> TensorValue<'_> {
-    match input {
-        TensorRead::Tensor(tensor) => TensorValue::Borrowed(tensor),
-        TensorRead::View(view) => TensorValue::View(view),
-    }
-}
-
-fn eager_einsum_exec_binary_read_fast(
-    exec: &mut dyn BackendSession,
-    inputs: &[TensorRead<'_>],
-    subscripts: &Subscripts,
-    plan: BinaryDotPlan,
-) -> Result<Tensor> {
-    let lhs = LabeledTensor {
-        tensor: tensor_value_from_read(inputs[0].clone()),
-        labels: subscripts.inputs[0].clone(),
-    };
-    let rhs = LabeledTensor {
-        tensor: tensor_value_from_read(inputs[1].clone()),
-        labels: subscripts.inputs[1].clone(),
-    };
-    execute_binary_dot_fast_plan(exec, lhs, rhs, plan, true)
-        .and_then(|result| result.tensor.into_tensor(exec))
-}
-
-fn try_eager_einsum_binary_read_fast(
-    ctx: &mut impl TensorBackend,
-    inputs: &[TensorRead<'_>],
-    subscripts: &Subscripts,
-) -> Option<Result<Tensor>> {
-    let total_started = eager_einsum_profile_enabled().then(Instant::now);
-    if inputs.len() != 2 || subscripts.inputs.len() != 2 {
-        return None;
-    }
-    if inputs[0].shape().len() != subscripts.inputs[0].len()
-        || inputs[1].shape().len() != subscripts.inputs[1].len()
-    {
-        return None;
-    }
-    let plan = profile_eager_einsum_section("fast.build_plan", || {
-        try_build_binary_dot_plan(
-            &subscripts.inputs[0],
-            &subscripts.inputs[1],
-            &subscripts.output,
-        )
-    })?;
-    let result = profile_eager_einsum_section("fast.with_backend_session", || {
-        ctx.with_backend_session(|exec| {
-            eager_einsum_exec_binary_read_fast(exec, inputs, subscripts, plan)
-        })
-    });
-    if let Some(started) = total_started {
-        record_eager_einsum_profile("total", started.elapsed());
-        maybe_print_eager_einsum_profile();
-    }
-    Some(result)
-}
-
 /// Eager N-ary einsum on concrete [`Tensor`] values.
 ///
 /// This applies the same contraction-tree optimization strategy used by the
@@ -963,35 +905,27 @@ pub(crate) fn eager_einsum(
     eager_einsum_subscripts(ctx, inputs, &subscripts)
 }
 
+/// Convert a prepared-plan error into the eager core's tensor error surface.
+fn into_tensor_error(error: crate::Error) -> tenferro_tensor::Error {
+    error.into_tensor_error(EAGER_EINSUM_OP)
+}
+
 /// Eager N-ary einsum on concrete [`Tensor`] values using integer labels.
 pub(crate) fn eager_einsum_subscripts(
     ctx: &mut impl TensorBackend,
     inputs: &[&Tensor],
     subscripts: &Subscripts,
 ) -> Result<Tensor> {
-    if inputs.len() == 2 {
-        let read_inputs = [
-            TensorRead::from_tensor(inputs[0]),
-            TensorRead::from_tensor(inputs[1]),
-        ];
-        if let Some(result) = try_eager_einsum_binary_read_fast(ctx, &read_inputs, subscripts) {
-            return result;
-        }
-    }
-
     if eager_einsum_profile_enabled() {
         let total_started = Instant::now();
-        let shapes = profile_eager_einsum_section("shape_collect", || {
-            inputs
-                .iter()
-                .map(|tensor| tensor.shape())
-                .collect::<Vec<_>>()
-        });
-        let tree = profile_eager_einsum_section("plan_subscripts", || {
-            plan_subscripts(subscripts, &shapes)
-        })?;
+        let plan = profile_eager_einsum_section("plan_subscripts", || {
+            ConcreteEinsumPlan::prepare_subscripts(inputs, &EinsumSubscripts::from(subscripts))
+        })
+        .map_err(into_tensor_error)?;
         let result = profile_eager_einsum_section("with_backend_session", || {
-            ctx.with_backend_session(|exec| eager_einsum_exec(exec, inputs, &tree))
+            ctx.with_backend_session(|session| {
+                plan.execute(inputs, session).map_err(into_tensor_error)
+            })
         });
         record_eager_einsum_profile("total", total_started.elapsed());
         maybe_print_eager_einsum_profile();
@@ -1005,11 +939,15 @@ pub(crate) fn eager_einsum_subscripts(
         let shape_us = started.elapsed().as_secs_f64() * 1.0e6;
 
         let started = Instant::now();
-        let tree = plan_subscripts(subscripts, &shapes)?;
+        let plan =
+            ConcreteEinsumPlan::prepare_subscripts(inputs, &EinsumSubscripts::from(subscripts))
+                .map_err(into_tensor_error)?;
         let plan_us = started.elapsed().as_secs_f64() * 1.0e6;
 
         let started = Instant::now();
-        let result = ctx.with_backend_session(|exec| eager_einsum_exec(exec, inputs, &tree));
+        let result = ctx.with_backend_session(|session| {
+            plan.execute(inputs, session).map_err(into_tensor_error)
+        });
         let exec_us = started.elapsed().as_secs_f64() * 1.0e6;
         let total_us = total_started.elapsed().as_secs_f64() * 1.0e6;
 
@@ -1017,14 +955,14 @@ pub(crate) fn eager_einsum_subscripts(
             "tenferro_eager_einsum_profile,input_count={},shapes={:?},steps={},shape_us={shape_us:.3},plan_us={plan_us:.3},exec_us={exec_us:.3},total_us={total_us:.3}",
             inputs.len(),
             shapes,
-            tree.step_count(),
+            plan.step_count(),
         );
         return result;
     }
 
-    let shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
-    let tree = plan_subscripts(subscripts, &shapes)?;
-    ctx.with_backend_session(|exec| eager_einsum_exec(exec, inputs, &tree))
+    let plan = ConcreteEinsumPlan::prepare_subscripts(inputs, &EinsumSubscripts::from(subscripts))
+        .map_err(into_tensor_error)?;
+    ctx.with_backend_session(|session| plan.execute(inputs, session).map_err(into_tensor_error))
 }
 
 #[cfg(feature = "autodiff")]
@@ -1048,13 +986,13 @@ pub(crate) fn eager_einsum_read_subscripts(
     inputs: &[TensorRead<'_>],
     subscripts: &Subscripts,
 ) -> Result<Tensor> {
-    if let Some(result) = try_eager_einsum_binary_read_fast(ctx, inputs, subscripts) {
-        return result;
-    }
-
-    let shapes: Vec<&[usize]> = inputs.iter().map(TensorRead::shape).collect();
-    let tree = plan_subscripts(subscripts, &shapes)?;
-    ctx.with_backend_session(|exec| eager_einsum_exec_read(exec, inputs, &tree))
+    let plan =
+        ConcreteEinsumPlan::prepare_read_subscripts(inputs, &EinsumSubscripts::from(subscripts))
+            .map_err(into_tensor_error)?;
+    ctx.with_backend_session(|session| {
+        plan.execute_read(inputs, session)
+            .map_err(into_tensor_error)
+    })
 }
 
 /// Eager N-ary einsum that consumes concrete [`Tensor`] inputs.

--- a/crates/tenferro-einsum/src/eager/tests.rs
+++ b/crates/tenferro-einsum/src/eager/tests.rs
@@ -7,7 +7,7 @@ use tenferro_tensor::{
 };
 
 use super::{
-    binary_contract, eager_einsum_exec_read, try_eager_einsum_binary_read_fast, LabeledTensor,
+    binary_contract, eager_einsum_exec_read, eager_einsum_read_subscripts, LabeledTensor,
     TensorValue,
 };
 use crate::{ContractionTree, Subscripts};
@@ -463,23 +463,30 @@ fn generic_read_exec_reduces_single_view_input() {
 }
 
 #[test]
-fn binary_read_fast_path_rejects_non_fast_shapes_and_labels() {
-    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
-    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
+fn read_subscripts_routes_non_fast_cases_through_plan() {
+    let lhs = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let mut ctx = CpuBackend::new();
 
+    // Single-input call against a two-input contract: clean plan validation error.
     let subscripts = Subscripts::parse("ij,jk->ik").unwrap();
     let one_input = [TensorRead::from_tensor(&lhs)];
-    assert!(try_eager_einsum_binary_read_fast(&mut ctx, &one_input, &subscripts).is_none());
+    assert!(eager_einsum_read_subscripts(&mut ctx, &one_input, &subscripts).is_err());
 
+    // Rank-mismatched labels: clean plan validation error.
     let flat_rhs = Tensor::from_vec_col_major(vec![6], vec![1.0_f64; 6]).unwrap();
     let rank_mismatch = [
         TensorRead::from_tensor(&lhs),
         TensorRead::from_tensor(&flat_rhs),
     ];
-    assert!(try_eager_einsum_binary_read_fast(&mut ctx, &rank_mismatch, &subscripts).is_none());
+    assert!(eager_einsum_read_subscripts(&mut ctx, &rank_mismatch, &subscripts).is_err());
 
+    // Duplicate labels decline the internal binary dot plan and execute through
+    // the plan's generic path: diag(ii) * sum_j(rhs[jk]).
     let duplicate_labels = Subscripts::parse("ii,jk->ik").unwrap();
     let inputs = [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)];
-    assert!(try_eager_einsum_binary_read_fast(&mut ctx, &inputs, &duplicate_labels).is_none());
+    let result = eager_einsum_read_subscripts(&mut ctx, &inputs, &duplicate_labels).unwrap();
+    assert_eq!(result.shape(), &[2, 2]);
+    assert_eq!(result.as_slice::<f64>().unwrap(), &[6.0, 24.0, 15.0, 60.0]);
 }

--- a/crates/tenferro-einsum/tests/integration.rs
+++ b/crates/tenferro-einsum/tests/integration.rs
@@ -6,8 +6,8 @@ mod error_public;
 mod public_surface_contract;
 #[path = "integration/runtime_buffer_pool.rs"]
 mod runtime_buffer_pool;
-#[path = "integration/session_in_plan.rs"]
-mod session_in_plan;
+#[path = "integration/session_plan.rs"]
+mod session_plan;
 #[path = "integration/shape_constraints.rs"]
 mod shape_constraints;
 #[path = "integration/support.rs"]

--- a/crates/tenferro-einsum/tests/integration/session_plan.rs
+++ b/crates/tenferro-einsum/tests/integration/session_plan.rs
@@ -1,17 +1,16 @@
-//! Single-session-entry and typed-result parity tests for the
-//! `ConcreteEinsumPlan::execute*_in_session` surfaces.
+//! Single-session-entry and typed-result tests for the
+//! `ConcreteEinsumPlan::execute*` session surfaces.
 //!
-//! A mixed chain (`plan.execute_in_session` + runtime `exp_in` +
-//! `reduce_sum_in`) must execute inside exactly one backend session entry,
-//! while the one-shot counterpart enters one session per op. The typed
-//! `_in_session` surface must reject a backend-returned wrong dtype through
-//! `into_typed_result` exactly like the one-shot path.
+//! A mixed chain (`plan.execute` + runtime `exp` + `reduce_sum`) must execute
+//! inside exactly one backend session entry, matching an independent scalar
+//! expected value. The typed session surface must reject a backend-returned
+//! wrong dtype through `into_typed_result`.
 
 use std::cell::Cell;
 
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::{ConcreteEinsumPlan, Error};
-use tenferro_runtime::{Tensor, TensorOpsExt, TensorSessionOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 use tenferro_tensor::backend::{
     BackendCachedDot, TensorAnalytic, TensorBuffer, TensorDeviceTransfer, TensorDot,
     TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
@@ -357,23 +356,12 @@ panic_analytic!(WrongDTypeSessionBackend);
 panic_reduction!(WrongDTypeSessionBackend);
 impl BackendSessionHost for WrongDTypeSessionBackend {}
 
-fn assert_close(actual: &[f64], expected: &[f64]) {
-    assert_eq!(actual.len(), expected.len());
-    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
-        let error = (actual - expected).abs();
-        assert!(
-            error < 1.0e-12,
-            "value {index}: actual={actual}, expected={expected}, error={error}"
-        );
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Single-session-entry proof
 // ---------------------------------------------------------------------------
 
 #[test]
-fn einsum_plan_mixed_chain_enters_one_session_one_shot_enters_thirty() {
+fn einsum_plan_mixed_chain_enters_one_session() {
     let mut backend = SessionCountingBackend::new();
     let lhs =
         Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
@@ -381,28 +369,16 @@ fn einsum_plan_mixed_chain_enters_one_session_one_shot_enters_thirty() {
         Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
 
-    // One-shot: 10 iterations of (einsum + exp + reduce_sum) = one session
-    // entry per op.
-    let mut one_shot = lhs.duplicate().unwrap();
-    for _ in 0..10 {
-        one_shot = plan.execute([&lhs, &rhs], &mut backend).unwrap();
-        one_shot = one_shot.exp(&mut backend).unwrap();
-        one_shot = one_shot.reduce_sum(&[1], &mut backend).unwrap();
-    }
-    assert_eq!(
-        backend.entries.get(),
-        30,
-        "one-shot chain must enter one session per op"
-    );
-
+    // 10 iterations of (einsum + exp + reduce_sum) must execute inside
+    // exactly one backend session entry.
     backend.entries.set(0);
     let session = backend
         .with_backend_session(|session| -> tenferro_einsum::Result<Tensor> {
             let mut x = lhs.duplicate().unwrap();
             for _ in 0..10 {
-                x = plan.execute_in_session([&lhs, &rhs], session)?;
-                x = x.exp_in(session)?;
-                x = x.reduce_sum_in(&[1], session)?;
+                x = plan.execute([&lhs, &rhs], session)?;
+                x = x.exp(session)?;
+                x = x.reduce_sum(&[1], session)?;
             }
             Ok(x)
         })
@@ -410,13 +386,26 @@ fn einsum_plan_mixed_chain_enters_one_session_one_shot_enters_thirty() {
     assert_eq!(
         backend.entries.get(),
         1,
-        "mixed einsum plan + _in chain must enter exactly one session"
+        "mixed einsum plan + session chain must enter exactly one session"
     );
 
-    assert_close(
-        session.as_slice::<f64>().unwrap(),
-        one_shot.as_slice::<f64>().unwrap(),
-    );
+    // Independent scalar math: each iteration is
+    // einsum(lhs, rhs) -> exp -> reduce_sum(axis 1). The einsum over the
+    // [2,3] x [3,2] inputs (values 1..6 each) is [[22, 28], [49, 64]] in
+    // col-major storage, so the final value is
+    // [exp(22) + exp(49), exp(28) + exp(64)].
+    let expected = [
+        22.0_f64.exp() + 49.0_f64.exp(),
+        28.0_f64.exp() + 64.0_f64.exp(),
+    ];
+    let actual = session.as_slice::<f64>().unwrap();
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        let error = (actual - expected).abs() / expected;
+        assert!(
+            error < 1.0e-12,
+            "value {index}: actual={actual}, expected={expected}, rel error={error}"
+        );
+    }
 }
 
 #[test]
@@ -429,24 +418,24 @@ fn einsum_plan_execute_in_session_adds_no_nested_entry_to_caller_session() {
     backend.entries.set(0);
     let result = backend.with_backend_session(|session| {
         let x = plan
-            .execute_in_session([&lhs, &rhs], session)
+            .execute([&lhs, &rhs], session)
             .expect("einsum plan should execute inside the session");
-        x.exp_in(session).expect("exp should run in the session")
+        x.exp(session).expect("exp should run in the session")
     });
     assert_eq!(
         backend.entries.get(),
         1,
-        "execute_in_session must not add a nested session entry"
+        "execute must not add a nested session entry"
     );
     assert_eq!(result.shape(), &[2, 2]);
 }
 
 // ---------------------------------------------------------------------------
-// Typed-result parity through into_typed_result
+// Typed-result validation through into_typed_result
 // ---------------------------------------------------------------------------
 
 #[test]
-fn einsum_plan_typed_in_session_rejects_wrong_backend_dtype_like_one_shot() {
+fn einsum_plan_typed_execute_rejects_wrong_backend_dtype() {
     let typed_lhs =
         tenferro_tensor::TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![1.0_f32; 4])
             .unwrap();
@@ -456,21 +445,11 @@ fn einsum_plan_typed_in_session_rejects_wrong_backend_dtype_like_one_shot() {
     let plan = ConcreteEinsumPlan::prepare_typed([&typed_lhs, &typed_rhs], "ij,jk->ik").unwrap();
     let mut backend = WrongDTypeSessionBackend;
 
-    // The backend returns an F64 tensor; both surfaces must reject it through
-    // into_typed_result with the identical structured error.
-    let one_shot = plan
-        .execute_typed([&typed_lhs, &typed_rhs], &mut backend)
-        .unwrap_err();
+    // The backend returns an F64 tensor regardless of the requested dtype, so
+    // the typed session surface must reject it through into_typed_result.
     let in_session = backend
-        .with_backend_session(|session| {
-            plan.execute_typed_in_session([&typed_lhs, &typed_rhs], session)
-        })
+        .with_backend_session(|session| plan.execute_typed([&typed_lhs, &typed_rhs], session))
         .unwrap_err();
-    assert_eq!(
-        format!("{in_session:?}"),
-        format!("{one_shot:?}"),
-        "in-session typed error must match the one-shot typed error"
-    );
     assert!(matches!(
         in_session,
         Error::Tensor(tenferro_tensor::Error::Validation {

--- a/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
@@ -141,7 +141,7 @@ fn unary_dtype_error(
     recommend_f64: bool,
 ) -> crate::Error {
     let remedy = (recommend_f64 && matches!(dtype, DType::I32 | DType::I64))
-        .then_some("; convert to F64 with TensorOpsExt::convert before this operation");
+        .then_some("; convert to F64 before this operation");
     crate::Error::unsupported(
         op,
         format!(

--- a/crates/tenferro-runtime/benches/session_chain.rs
+++ b/crates/tenferro-runtime/benches/session_chain.rs
@@ -1,17 +1,16 @@
-//! Session-entry cost benchmark for the `_in` concrete-ops surface.
+//! Session-entry cost benchmark for the session-explicit concrete-ops surface.
 //!
 //! Exact 10-op chain: three repetitions of `add -> exp -> mul` (9 ops)
 //! followed by a final `reduce_sum([0])` (10th). Two shape arms (no-broadcast
-//! 1x8 duplicate path vs 1x1/1x8 real reshape+broadcast) and two execution
-//! arms (one-shot `TensorOpsExt`, one session entry per op = 10 entries, vs
-//! `TensorSessionOpsExt` inside one `with_backend_session` = 1 entry).
+//! 1x8 duplicate path vs 1x1/1x8 real reshape+broadcast), each executing the
+//! chain inside ONE `with_backend_session` entry.
 //!
 //! Constants are chosen so the chain does not overflow (`exp` of large
 //! values); the result is validated outside the timed region.
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt, TensorSessionOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 use tenferro_tensor::BackendSessionHost;
 
 /// `a` is a 1x8 constant row in the no-broadcast arm and a 1x1 row (the
@@ -29,33 +28,19 @@ fn operand_b() -> Tensor {
     Tensor::from_vec_col_major(vec![8], vec![1.0_f64; 8]).expect("benchmark tensor")
 }
 
-/// 10 ops, each entering its own backend session.
-fn run_chain_one_shot(a: &Tensor, b: &Tensor, backend: &mut CpuBackend) -> Tensor {
-    let x = a.add(b, backend).expect("add 1");
-    let x = x.exp(backend).expect("exp 1");
-    let x = x.mul(a, backend).expect("mul 1");
-    let x = x.add(b, backend).expect("add 2");
-    let x = x.exp(backend).expect("exp 2");
-    let x = x.mul(a, backend).expect("mul 2");
-    let x = x.add(b, backend).expect("add 3");
-    let x = x.exp(backend).expect("exp 3");
-    let x = x.mul(a, backend).expect("mul 3");
-    x.reduce_sum(&[0], backend).expect("reduce_sum")
-}
-
-/// The same 10 ops inside one backend session (1 entry).
+/// 10 ops inside one backend session (1 entry).
 fn run_chain_one_session(a: &Tensor, b: &Tensor, backend: &mut CpuBackend) -> Tensor {
     backend.with_backend_session(|session| {
-        let x = a.add_in(b, session).expect("add 1");
-        let x = x.exp_in(session).expect("exp 1");
-        let x = x.mul_in(a, session).expect("mul 1");
-        let x = x.add_in(b, session).expect("add 2");
-        let x = x.exp_in(session).expect("exp 2");
-        let x = x.mul_in(a, session).expect("mul 2");
-        let x = x.add_in(b, session).expect("add 3");
-        let x = x.exp_in(session).expect("exp 3");
-        let x = x.mul_in(a, session).expect("mul 3");
-        x.reduce_sum_in(&[0], session).expect("reduce_sum")
+        let x = a.add(b, session).expect("add 1");
+        let x = x.exp(session).expect("exp 1");
+        let x = x.mul(a, session).expect("mul 1");
+        let x = x.add(b, session).expect("add 2");
+        let x = x.exp(session).expect("exp 2");
+        let x = x.mul(a, session).expect("mul 2");
+        let x = x.add(b, session).expect("add 3");
+        let x = x.exp(session).expect("exp 3");
+        let x = x.mul(a, session).expect("mul 3");
+        x.reduce_sum(&[0], session).expect("reduce_sum")
     })
 }
 
@@ -66,24 +51,15 @@ fn bench_session_chain(c: &mut Criterion) {
         let b = operand_b();
         let mut backend = CpuBackend::new();
 
-        // Validation outside the timed region: finite scalar result, and the
-        // two execution arms agree.
-        let one_shot = run_chain_one_shot(&a, &b, &mut backend);
-        assert!(one_shot.shape().is_empty(), "chain must reduce to a scalar");
-        assert!(one_shot.as_slice::<f64>().unwrap()[0].is_finite());
+        // Validation outside the timed region: the chain must reduce to a
+        // finite scalar.
         let one_session = run_chain_one_session(&a, &b, &mut backend);
-        assert!(one_session.as_slice::<f64>().unwrap()[0].is_finite());
-        assert_eq!(
-            one_shot.as_slice::<f64>().unwrap(),
-            one_session.as_slice::<f64>().unwrap()
+        assert!(
+            one_session.shape().is_empty(),
+            "chain must reduce to a scalar"
         );
+        assert!(one_session.as_slice::<f64>().unwrap()[0].is_finite());
 
-        group.bench_function("one_shot", |bench| {
-            bench.iter(|| {
-                let out = run_chain_one_shot(black_box(&a), black_box(&b), &mut backend);
-                black_box(out);
-            });
-        });
         group.bench_function("one_session", |bench| {
             bench.iter(|| {
                 let out = run_chain_one_session(black_box(&a), black_box(&b), &mut backend);
@@ -157,34 +133,19 @@ impl Phase1Operands {
     }
 }
 
-/// 10 ops, each entering its own backend session.
-fn run_phase1_chain_one_shot(ops: &Phase1Operands, backend: &mut CpuBackend) -> Tensor {
-    let x = ops.a.sub(&ops.b, backend).expect("sub");
-    let x = x.log(backend).expect("log");
-    let x = x.pow(&ops.power, backend).expect("pow");
-    let x = x.maximum(&ops.max, backend).expect("maximum");
-    let x = x.neg(backend).expect("neg");
-    let x = x.reshape(&[4, 1], backend).expect("reshape");
-    let x = x.transpose(&[1, 0], backend).expect("transpose");
-    let x = x.clamp(&ops.lower, &ops.upper, backend).expect("clamp");
-    let x = x.matmul(&ops.rhs, backend).expect("matmul");
-    x.cast(tenferro_runtime::DType::F32, backend).expect("cast")
-}
-
-/// The same 10 ops inside one backend session (1 entry).
+/// 10 ops inside one backend session (1 entry).
 fn run_phase1_chain_one_session(ops: &Phase1Operands, backend: &mut CpuBackend) -> Tensor {
     backend.with_backend_session(|session| {
-        let x = ops.a.sub_in(&ops.b, session).expect("sub");
-        let x = x.log_in(session).expect("log");
-        let x = x.pow_in(&ops.power, session).expect("pow");
-        let x = x.maximum_in(&ops.max, session).expect("maximum");
-        let x = x.neg_in(session).expect("neg");
-        let x = x.reshape_in(&[4, 1], session).expect("reshape");
-        let x = x.transpose_in(&[1, 0], session).expect("transpose");
-        let x = x.clamp_in(&ops.lower, &ops.upper, session).expect("clamp");
-        let x = x.matmul_in(&ops.rhs, session).expect("matmul");
-        x.cast_in(tenferro_runtime::DType::F32, session)
-            .expect("cast")
+        let x = ops.a.sub(&ops.b, session).expect("sub");
+        let x = x.log(session).expect("log");
+        let x = x.pow(&ops.power, session).expect("pow");
+        let x = x.maximum(&ops.max, session).expect("maximum");
+        let x = x.neg(session).expect("neg");
+        let x = x.reshape(&[4, 1], session).expect("reshape");
+        let x = x.transpose(&[1, 0], session).expect("transpose");
+        let x = x.clamp(&ops.lower, &ops.upper, session).expect("clamp");
+        let x = x.matmul(&ops.rhs, session).expect("matmul");
+        x.cast(tenferro_runtime::DType::F32, session).expect("cast")
     })
 }
 
@@ -194,19 +155,11 @@ fn bench_session_chain_phase1(c: &mut Criterion) {
     let mut backend = CpuBackend::new();
 
     // Validation outside the timed region: the known scalar result -8.0
-    // (see the chain comment above), and the two execution arms agree.
-    let one_shot = run_phase1_chain_one_shot(&ops, &mut backend);
-    assert_eq!(one_shot.shape(), &[1, 1], "chain must reduce to [1,1]");
-    assert_eq!(one_shot.as_slice::<f32>().unwrap(), &[-8.0]);
+    // (see the chain comment above).
     let one_session = run_phase1_chain_one_session(&ops, &mut backend);
+    assert_eq!(one_session.shape(), &[1, 1], "chain must reduce to [1,1]");
     assert_eq!(one_session.as_slice::<f32>().unwrap(), &[-8.0]);
 
-    group.bench_function("one_shot", |bench| {
-        bench.iter(|| {
-            let out = run_phase1_chain_one_shot(black_box(&ops), &mut backend);
-            black_box(out);
-        });
-    });
     group.bench_function("one_session", |bench| {
         bench.iter(|| {
             let out = run_phase1_chain_one_session(black_box(&ops), &mut backend);

--- a/crates/tenferro-runtime/examples/cpu_quickstart.rs
+++ b/crates/tenferro-runtime/examples/cpu_quickstart.rs
@@ -1,5 +1,6 @@
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut backend = CpuBackend::new();
@@ -7,7 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])?;
     let b = Tensor::from_vec_col_major(vec![2, 2], vec![5.0_f64, 7.0, 6.0, 8.0])?;
 
-    let c = a.matmul(&b, &mut backend)?;
+    let c = backend.with_backend_session(|session| a.matmul(&b, session))?;
 
     assert_eq!(c.shape(), &[2, 2]);
     assert_eq!(c.as_slice::<f64>().unwrap(), &[19.0, 43.0, 22.0, 50.0]);

--- a/crates/tenferro-runtime/examples/direct_tensor_execution.rs
+++ b/crates/tenferro-runtime/examples/direct_tensor_execution.rs
@@ -1,5 +1,6 @@
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut backend = CpuBackend::new();
@@ -7,7 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])?;
     let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])?;
 
-    let c = a.matmul(&b, &mut backend)?;
+    let c = backend.with_backend_session(|session| a.matmul(&b, session))?;
     assert_eq!(c.shape(), &[2, 2]);
 
     Ok(())

--- a/crates/tenferro-runtime/src/lib.rs
+++ b/crates/tenferro-runtime/src/lib.rs
@@ -117,380 +117,6 @@ pub use tenferro_tensor::{
 };
 pub use trace::{TraceContext, TraceValue, TracedGraph};
 
-/// Backend-explicit concrete tensor operations.
-///
-/// `Tensor` is owned by `tenferro-tensor`, so `tenferro-runtime` exposes these
-/// operations as a crate-root extension trait rather than as inherent methods.
-///
-/// # Public API rationale
-///
-/// This trait is intentionally public: it is the supported non-AD concrete
-/// tensor operation surface for downstream users who want to run operations on
-/// an explicit backend. The old public module/free-function surface was
-/// removed; the private `tensor` module now contains implementation helpers
-/// only and must not be treated as a compatibility API.
-///
-/// # Examples
-///
-/// ```rust
-/// use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{Tensor, TensorOpsExt};
-///
-/// let mut backend = CpuBackend::new();
-/// let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
-/// let b = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64; 4]).unwrap();
-/// let c = a.matmul(&b, &mut backend).unwrap();
-/// assert_eq!(c.shape(), &[2, 2]);
-/// ```
-pub trait TensorOpsExt {
-    /// Convert to a different dtype using the checked conversion lattice.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::UnsupportedDTypeConversion`] when the
-    /// conversion is outside the checked lattice,
-    /// [`tenferro_tensor::Error::Validation`] with `DTypeMismatch` or
-    /// `InvalidArgument` for invalid tensor metadata, or
-    /// [`tenferro_tensor::Error::BackendSource`] when the backend reports a
-    /// typed failure.
-    fn convert<B: TensorBackend>(
-        &self,
-        to: DType,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Cast to a different dtype using explicit lossy projection.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::UnsupportedDTypeConversion`] when the
-    /// requested cast is unsupported, [`tenferro_tensor::Error::Validation`]
-    /// with `DTypeMismatch` or `InvalidArgument` for invalid tensor metadata,
-    /// or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn cast<B: TensorBackend>(&self, to: DType, backend: &mut B)
-        -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise addition with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with a
-    /// [`ShapeMismatch`](tenferro_tensor::ValidationError::ShapeMismatch) or
-    /// `DTypeMismatch` payload when operands are incompatible, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn add<B: TensorBackend>(
-        &self,
-        rhs: &Tensor,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise subtraction with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with
-    /// `ShapeMismatch` or `DTypeMismatch` for incompatible operands, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn sub<B: TensorBackend>(
-        &self,
-        rhs: &Tensor,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise multiplication with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with
-    /// `ShapeMismatch` or `DTypeMismatch` for incompatible operands, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn mul<B: TensorBackend>(
-        &self,
-        rhs: &Tensor,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise division with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
-    /// `DTypeMismatch` for shape/dtype incompatibility,
-    /// [`tenferro_tensor::Error::Extension`] with a numerical classification
-    /// for a detected zero divisor, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn div<B: TensorBackend>(
-        &self,
-        rhs: &Tensor,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise remainder with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
-    /// `DTypeMismatch` for shape/dtype incompatibility, a numerical
-    /// [`tenferro_tensor::Error::Extension`] for a detected zero divisor, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn rem<B: TensorBackend>(
-        &self,
-        rhs: &Tensor,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise power with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
-    /// `DTypeMismatch` for incompatible metadata, a numerical
-    /// [`tenferro_tensor::Error::Extension`] for a detected negative integer
-    /// exponent, or [`tenferro_tensor::Error::BackendSource`] for a typed
-    /// backend failure.
-    fn pow<B: TensorBackend>(
-        &self,
-        rhs: &Tensor,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise maximum with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with
-    /// `ShapeMismatch` or `DTypeMismatch` for incompatible operands, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn maximum<B: TensorBackend>(
-        &self,
-        rhs: &Tensor,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise minimum with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with
-    /// `ShapeMismatch` or `DTypeMismatch` for incompatible operands, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn minimum<B: TensorBackend>(
-        &self,
-        rhs: &Tensor,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise negation.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] when the dtype is not
-    /// supported by the operation, or [`tenferro_tensor::Error::BackendSource`]
-    /// for a typed backend failure.
-    fn neg<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise absolute value.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn abs<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise sign.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn sign<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise complex conjugate.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn conj<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise exponential.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn exp<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise natural logarithm.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn log<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise sine.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn sin<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise cosine.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn cos<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise hyperbolic tangent.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn tanh<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise square root.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn sqrt<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise reciprocal square root.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn rsqrt<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise `exp(x) - 1`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn expm1<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise `log(1 + x)`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn log1p<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
-    /// Elementwise comparison with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
-    /// `DTypeMismatch` for incompatible shape/dtype metadata, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn compare<B: TensorBackend>(
-        &self,
-        rhs: &Tensor,
-        dir: CompareDir,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Select values from `on_true` or `on_false` using this tensor as condition.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
-    /// `DTypeMismatch` when the condition and branches are incompatible, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn where_select<B: TensorBackend>(
-        &self,
-        on_true: &Tensor,
-        on_false: &Tensor,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Clamp values elementwise between lower and upper bounds.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
-    /// `DTypeMismatch` when bounds are incompatible with the input, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn clamp<B: TensorBackend>(
-        &self,
-        lower: &Tensor,
-        upper: &Tensor,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Rank-2 matrix multiplication.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch`,
-    /// `ShapeMismatch`, or `DTypeMismatch` for incompatible matrices, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn matmul<B: TensorBackend>(
-        &self,
-        rhs: &Tensor,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Reshape without changing element order.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with
-    /// `ShapeMismatch`, `RankMismatch`, or `InvalidArgument` when element
-    /// counts or ranks are invalid, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn reshape<B: TensorBackend>(
-        &self,
-        shape: &[usize],
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Permute axes.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with
-    /// `InvalidPermutationLength`, `AxisOutOfBounds`, or `DuplicateAxis` for
-    /// an invalid permutation, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn transpose<B: TensorBackend>(
-        &self,
-        perm: &[usize],
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-    /// Sum over one or more axes.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds`
-    /// or `DuplicateAxis` for invalid reductions, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn reduce_sum<B: TensorBackend>(
-        &self,
-        axes: &[usize],
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<Tensor>;
-}
-
-/// Backend-explicit session operations for concrete [`Tensor`] values.
-///
-/// These operations run inside a caller-provided [`BackendSession`], so a
-/// chain of `_in` operations executes in a single backend session entry and
-/// never enters a session of its own. Each one-shot [`TensorOpsExt`]
-/// counterpart performs its broadcast and execution inside a single session
-/// entry of its own.
-///
-/// # Examples
-///
-/// ```rust
-/// use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{Tensor, TensorSessionOpsExt};
-/// use tenferro_tensor::BackendSessionHost;
-///
-/// let mut backend = CpuBackend::new();
-/// let a = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
-/// let b = Tensor::from_vec_col_major(vec![8], vec![2.0_f64; 8]).unwrap();
-/// let total = backend.with_backend_session(|session| {
-///     let sum = a.add_in(&b, session).unwrap();
-///     let grown = sum.exp_in(session).unwrap();
-///     grown.mul_in(&a, session).unwrap().reduce_sum_in(&[0], session).unwrap()
-/// });
-/// assert!(total.as_slice::<f64>().unwrap()[0].is_finite());
-/// ```
 pub trait TensorSessionOpsExt {
     /// Elementwise addition with NumPy-style broadcasting inside a session.
     ///
@@ -508,7 +134,7 @@ pub trait TensorSessionOpsExt {
     /// let mut backend = CpuBackend::new();
     /// let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
-    /// let sum = backend.with_backend_session(|session| a.add_in(&b, session)).unwrap();
+    /// let sum = backend.with_backend_session(|session| a.add(&b, session)).unwrap();
     /// assert_eq!(sum.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
     /// ```
     ///
@@ -518,14 +144,14 @@ pub trait TensorSessionOpsExt {
     /// [`ShapeMismatch`](tenferro_tensor::ValidationError::ShapeMismatch) or
     /// `DTypeMismatch` payload when operands are incompatible, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn add_in(
+    fn add(
         &self,
         rhs: &Tensor,
         session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise multiplication with NumPy-style broadcasting inside a session.
     ///
-    /// Like [`Self::add_in`], broadcast and multiply run in the one `session`.
+    /// Like [`Self::add`], broadcast and multiply run in the one `session`.
     ///
     /// # Examples
     ///
@@ -537,7 +163,7 @@ pub trait TensorSessionOpsExt {
     /// let mut backend = CpuBackend::new();
     /// let a = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let b = Tensor::from_vec_col_major(vec![4], vec![3.0_f64; 4]).unwrap();
-    /// let product = backend.with_backend_session(|session| a.mul_in(&b, session)).unwrap();
+    /// let product = backend.with_backend_session(|session| a.mul(&b, session)).unwrap();
     /// assert_eq!(product.as_slice::<f64>().unwrap(), &[6.0; 4]);
     /// ```
     ///
@@ -546,7 +172,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
     /// `DTypeMismatch` for incompatible operands, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn mul_in(
+    fn mul(
         &self,
         rhs: &Tensor,
         session: &mut dyn BackendSession,
@@ -562,7 +188,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.exp_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.exp(session)).unwrap();
     /// let y = y.as_slice::<f64>().unwrap();
     /// assert!((y[0] - 1.0).abs() < 1.0e-12);
     /// assert!((y[1] - std::f64::consts::E).abs() < 1.0e-12);
@@ -573,7 +199,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn exp_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn exp(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Sum over one or more axes inside a session.
     ///
     /// # Examples
@@ -585,7 +211,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
-    /// let sums = backend.with_backend_session(|session| x.reduce_sum_in(&[1], session)).unwrap();
+    /// let sums = backend.with_backend_session(|session| x.reduce_sum(&[1], session)).unwrap();
     /// assert_eq!(sums.as_slice::<f64>().unwrap(), &[3.0, 3.0]);
     /// ```
     ///
@@ -594,7 +220,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds`
     /// or `DuplicateAxis` for invalid reductions, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn reduce_sum_in(
+    fn reduce_sum(
         &self,
         axes: &[usize],
         session: &mut dyn BackendSession,
@@ -610,7 +236,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.convert_in(DType::C64, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.convert(DType::C64, session)).unwrap();
     /// assert_eq!(y.dtype(), DType::C64);
     /// ```
     ///
@@ -622,7 +248,7 @@ pub trait TensorSessionOpsExt {
     /// `InvalidArgument` for invalid tensor metadata, or
     /// [`tenferro_tensor::Error::BackendSource`] when the backend reports a
     /// typed failure.
-    fn convert_in(
+    fn convert(
         &self,
         to: DType,
         session: &mut dyn BackendSession,
@@ -638,7 +264,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![1.2_f64, -2.8]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.cast_in(DType::I32, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.cast(DType::I32, session)).unwrap();
     /// assert_eq!(y.as_slice::<i32>().unwrap(), &[1, -2]);
     /// ```
     ///
@@ -649,14 +275,10 @@ pub trait TensorSessionOpsExt {
     /// with `DTypeMismatch` or `InvalidArgument` for invalid tensor metadata,
     /// or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn cast_in(
-        &self,
-        to: DType,
-        session: &mut dyn BackendSession,
-    ) -> tenferro_tensor::Result<Tensor>;
+    fn cast(&self, to: DType, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise subtraction with NumPy-style broadcasting inside a session.
     ///
-    /// Like [`Self::add_in`], the broadcast and the subtraction run in the one
+    /// Like [`Self::add`], the broadcast and the subtraction run in the one
     /// `session`.
     ///
     /// # Examples
@@ -669,7 +291,7 @@ pub trait TensorSessionOpsExt {
     /// let mut backend = CpuBackend::new();
     /// let a = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
     /// let b = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.sub_in(&b, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.sub(&b, session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, -4.0]);
     /// ```
     ///
@@ -678,7 +300,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
     /// `DTypeMismatch` for incompatible operands, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn sub_in(
+    fn sub(
         &self,
         rhs: &Tensor,
         session: &mut dyn BackendSession,
@@ -695,7 +317,7 @@ pub trait TensorSessionOpsExt {
     /// let mut backend = CpuBackend::new();
     /// let a = Tensor::from_vec_col_major(vec![2], vec![4.0_f64, 8.0]).unwrap();
     /// let b = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.div_in(&b, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.div(&b, session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[2.0, 2.0]);
     /// ```
     ///
@@ -706,7 +328,7 @@ pub trait TensorSessionOpsExt {
     /// [`tenferro_tensor::Error::Extension`] with a numerical classification
     /// for a detected zero divisor, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn div_in(
+    fn div(
         &self,
         rhs: &Tensor,
         session: &mut dyn BackendSession,
@@ -723,7 +345,7 @@ pub trait TensorSessionOpsExt {
     /// let mut backend = CpuBackend::new();
     /// let a = Tensor::from_vec_col_major(vec![2], vec![5.0_f64, 7.0]).unwrap();
     /// let b = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.rem_in(&b, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.rem(&b, session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, 3.0]);
     /// ```
     ///
@@ -733,7 +355,7 @@ pub trait TensorSessionOpsExt {
     /// `DTypeMismatch` for shape/dtype incompatibility, a numerical
     /// [`tenferro_tensor::Error::Extension`] for a detected zero divisor, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn rem_in(
+    fn rem(
         &self,
         rhs: &Tensor,
         session: &mut dyn BackendSession,
@@ -750,7 +372,7 @@ pub trait TensorSessionOpsExt {
     /// let mut backend = CpuBackend::new();
     /// let a = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap();
     /// let b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 2.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.pow_in(&b, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.pow(&b, session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[8.0, 9.0]);
     /// ```
     ///
@@ -761,7 +383,7 @@ pub trait TensorSessionOpsExt {
     /// [`tenferro_tensor::Error::Extension`] for a detected negative integer
     /// exponent, or [`tenferro_tensor::Error::BackendSource`] for a typed
     /// backend failure.
-    fn pow_in(
+    fn pow(
         &self,
         rhs: &Tensor,
         session: &mut dyn BackendSession,
@@ -778,7 +400,7 @@ pub trait TensorSessionOpsExt {
     /// let mut backend = CpuBackend::new();
     /// let a = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
     /// let b = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.maximum_in(&b, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.maximum(&b, session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[2.0, 8.0]);
     /// ```
     ///
@@ -787,7 +409,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
     /// `DTypeMismatch` for incompatible operands, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn maximum_in(
+    fn maximum(
         &self,
         rhs: &Tensor,
         session: &mut dyn BackendSession,
@@ -804,7 +426,7 @@ pub trait TensorSessionOpsExt {
     /// let mut backend = CpuBackend::new();
     /// let a = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
     /// let b = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.minimum_in(&b, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.minimum(&b, session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, 4.0]);
     /// ```
     ///
@@ -813,7 +435,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
     /// `DTypeMismatch` for incompatible operands, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn minimum_in(
+    fn minimum(
         &self,
         rhs: &Tensor,
         session: &mut dyn BackendSession,
@@ -829,7 +451,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, -2.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.neg_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.neg(session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[-1.0, 2.0]);
     /// ```
     ///
@@ -838,7 +460,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] when the dtype is not
     /// supported by the operation, or [`tenferro_tensor::Error::BackendSource`]
     /// for a typed backend failure.
-    fn neg_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn neg(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise absolute value inside a session.
     ///
     /// # Examples
@@ -850,7 +472,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![-1.0_f64, 2.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.abs_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.abs(session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
     /// ```
     ///
@@ -859,7 +481,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn abs_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn abs(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise sign inside a session.
     ///
     /// # Examples
@@ -871,7 +493,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, -2.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.sign_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.sign(session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, -1.0]);
     /// ```
     ///
@@ -880,7 +502,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn sign_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn sign(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise complex conjugate inside a session.
     ///
     /// For real dtypes the conjugate is the identity.
@@ -894,7 +516,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, -2.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.conj_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.conj(session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, -2.0]);
     /// ```
     ///
@@ -903,7 +525,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn conj_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn conj(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise natural logarithm inside a session.
     ///
     /// # Examples
@@ -915,7 +537,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, std::f64::consts::E]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.log_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.log(session)).unwrap();
     /// let y = y.as_slice::<f64>().unwrap();
     /// assert!(y[0].abs() < 1.0e-12);
     /// assert!((y[1] - 1.0).abs() < 1.0e-12);
@@ -926,7 +548,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn log_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn log(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise `exp(x) - 1` inside a session.
     ///
     /// # Examples
@@ -938,7 +560,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.expm1_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.expm1(session)).unwrap();
     /// let y = y.as_slice::<f64>().unwrap();
     /// assert!(y[0].abs() < 1.0e-12);
     /// assert!((y[1] - (std::f64::consts::E - 1.0)).abs() < 1.0e-12);
@@ -949,7 +571,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn expm1_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn expm1(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise `log(1 + x)` inside a session.
     ///
     /// # Examples
@@ -961,7 +583,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, std::f64::consts::E - 1.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.log1p_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.log1p(session)).unwrap();
     /// let y = y.as_slice::<f64>().unwrap();
     /// assert!(y[0].abs() < 1.0e-12);
     /// assert!((y[1] - 1.0).abs() < 1.0e-12);
@@ -972,7 +594,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn log1p_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn log1p(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise sine inside a session.
     ///
     /// # Examples
@@ -984,7 +606,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, std::f64::consts::FRAC_PI_2]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.sin_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.sin(session)).unwrap();
     /// let y = y.as_slice::<f64>().unwrap();
     /// assert!(y[0].abs() < 1.0e-12);
     /// assert!((y[1] - 1.0).abs() < 1.0e-12);
@@ -995,7 +617,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn sin_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn sin(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise cosine inside a session.
     ///
     /// # Examples
@@ -1007,7 +629,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, std::f64::consts::PI]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.cos_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.cos(session)).unwrap();
     /// let y = y.as_slice::<f64>().unwrap();
     /// assert!((y[0] - 1.0).abs() < 1.0e-12);
     /// assert!((y[1] + 1.0).abs() < 1.0e-12);
@@ -1018,7 +640,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn cos_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn cos(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise hyperbolic tangent inside a session.
     ///
     /// # Examples
@@ -1030,7 +652,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.tanh_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.tanh(session)).unwrap();
     /// let y = y.as_slice::<f64>().unwrap();
     /// assert!(y[0].abs() < 1.0e-12);
     /// assert!((y[1] - 0.7615941559557649).abs() < 1.0e-12);
@@ -1041,7 +663,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn tanh_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn tanh(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise square root inside a session.
     ///
     /// # Examples
@@ -1053,7 +675,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![4.0_f64, 9.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.sqrt_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.sqrt(session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
     /// ```
     ///
@@ -1062,7 +684,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn sqrt_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn sqrt(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise reciprocal square root inside a session.
     ///
     /// # Examples
@@ -1074,7 +696,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2], vec![4.0_f64, 1.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.rsqrt_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.rsqrt(session)).unwrap();
     /// let y = y.as_slice::<f64>().unwrap();
     /// assert!((y[0] - 0.5).abs() < 1.0e-12);
     /// assert!((y[1] - 1.0).abs() < 1.0e-12);
@@ -1085,7 +707,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn rsqrt_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
+    fn rsqrt(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise comparison with NumPy-style broadcasting inside a session.
     ///
     /// The result is a bool tensor.
@@ -1100,7 +722,7 @@ pub trait TensorSessionOpsExt {
     /// let mut backend = CpuBackend::new();
     /// let a = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
     /// let b = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.compare_in(&b, CompareDir::Gt, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.compare(&b, CompareDir::Gt, session)).unwrap();
     /// assert_eq!(y.as_slice::<bool>().unwrap(), &[true, false]);
     /// ```
     ///
@@ -1109,7 +731,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
     /// `DTypeMismatch` for incompatible shape/dtype metadata, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn compare_in(
+    fn compare(
         &self,
         rhs: &Tensor,
         dir: CompareDir,
@@ -1128,7 +750,7 @@ pub trait TensorSessionOpsExt {
     /// let condition = Tensor::from_vec_col_major(vec![2], vec![true, false]).unwrap();
     /// let on_true = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let on_false = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| condition.where_select_in(&on_true, &on_false, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| condition.where_select(&on_true, &on_false, session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[1.0, 4.0]);
     /// ```
     ///
@@ -1137,7 +759,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
     /// `DTypeMismatch` when the condition and branches are incompatible, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn where_select_in(
+    fn where_select(
         &self,
         on_true: &Tensor,
         on_false: &Tensor,
@@ -1156,7 +778,7 @@ pub trait TensorSessionOpsExt {
     /// let x = Tensor::from_vec_col_major(vec![2], vec![-2.0_f64, 4.0]).unwrap();
     /// let lower = Tensor::from_vec_col_major(vec![], vec![0.0_f64]).unwrap();
     /// let upper = Tensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.clamp_in(&lower, &upper, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.clamp(&lower, &upper, session)).unwrap();
     /// assert_eq!(y.as_slice::<f64>().unwrap(), &[0.0, 3.0]);
     /// ```
     ///
@@ -1165,7 +787,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
     /// `DTypeMismatch` when bounds are incompatible with the input, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn clamp_in(
+    fn clamp(
         &self,
         lower: &Tensor,
         upper: &Tensor,
@@ -1183,7 +805,7 @@ pub trait TensorSessionOpsExt {
     /// let mut backend = CpuBackend::new();
     /// let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
     /// let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
-    /// let c = backend.with_backend_session(|session| a.matmul_in(&b, session)).unwrap();
+    /// let c = backend.with_backend_session(|session| a.matmul(&b, session)).unwrap();
     /// assert_eq!(c.shape(), &[2, 2]);
     /// ```
     ///
@@ -1192,7 +814,7 @@ pub trait TensorSessionOpsExt {
     /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch`,
     /// `ShapeMismatch`, or `DTypeMismatch` for incompatible matrices, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn matmul_in(
+    fn matmul(
         &self,
         rhs: &Tensor,
         session: &mut dyn BackendSession,
@@ -1208,7 +830,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.reshape_in(&[4], session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.reshape(&[4], session)).unwrap();
     /// assert_eq!(y.shape(), &[4]);
     /// ```
     ///
@@ -1218,7 +840,7 @@ pub trait TensorSessionOpsExt {
     /// `ShapeMismatch`, `RankMismatch`, or `InvalidArgument` when element
     /// counts or ranks are invalid, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn reshape_in(
+    fn reshape(
         &self,
         shape: &[usize],
         session: &mut dyn BackendSession,
@@ -1234,7 +856,7 @@ pub trait TensorSessionOpsExt {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.transpose_in(&[1, 0], session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.transpose(&[1, 0], session)).unwrap();
     /// assert_eq!(y.shape(), &[3, 2]);
     /// ```
     ///
@@ -1244,365 +866,13 @@ pub trait TensorSessionOpsExt {
     /// `InvalidPermutationLength`, `AxisOutOfBounds`, or `DuplicateAxis` for
     /// an invalid permutation, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn transpose_in(
+    fn transpose(
         &self,
         perm: &[usize],
         session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
 }
 
-/// Backend-explicit operations for dynamic-rank typed tensors.
-///
-/// `TypedTensor` is owned by `tenferro-tensor`, so `tenferro-runtime` exposes
-/// these operations as a crate-root extension trait rather than as inherent
-/// methods.
-///
-/// # Public API rationale
-///
-/// This trait is intentionally public for the same reason as [`TensorOpsExt`]:
-/// downstream users need a supported backend-explicit typed tensor surface, and
-/// `tenferro-runtime` cannot add inherent methods to a type owned by
-/// `tenferro-tensor`. The private `typed_tensor` module is implementation
-/// detail, not a retained module/free-function API.
-///
-/// # Examples
-///
-/// ```rust
-/// use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-///
-/// let mut backend = CpuBackend::new();
-/// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
-/// let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap();
-/// let sum = x.add(&y, &mut backend).unwrap();
-/// assert_eq!(sum.host_data().unwrap(), &[4.0, 6.0]);
-/// ```
-pub trait TypedTensorOpsExt<T: TensorScalar> {
-    /// Elementwise addition with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
-    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
-    /// a typed backend failure.
-    fn add<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise subtraction with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
-    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
-    /// a typed backend failure.
-    fn sub<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise multiplication with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
-    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
-    /// a typed backend failure.
-    fn mul<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise division with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
-    /// incompatible shapes, a numerical [`tenferro_tensor::Error::Extension`]
-    /// for a detected zero divisor, or [`tenferro_tensor::Error::BackendSource`]
-    /// for a typed backend failure.
-    fn div<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise remainder with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
-    /// incompatible shapes, a numerical [`tenferro_tensor::Error::Extension`]
-    /// for a detected zero divisor, or [`tenferro_tensor::Error::BackendSource`]
-    /// for a typed backend failure.
-    fn rem<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise power with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
-    /// incompatible shapes, a numerical [`tenferro_tensor::Error::Extension`]
-    /// for a detected negative integer exponent, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn pow<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise maximum with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
-    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
-    /// a typed backend failure.
-    fn maximum<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise minimum with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
-    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
-    /// a typed backend failure.
-    fn minimum<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise negation.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn neg<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise absolute value.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn abs<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise sign.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn sign<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise complex conjugate.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn conj<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise exponential.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn exp<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise natural logarithm.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn log<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise sine.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn sin<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise cosine.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn cos<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise hyperbolic tangent.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn tanh<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise square root.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn sqrt<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise reciprocal square root.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn rsqrt<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise `exp(x) - 1`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn expm1<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise `log(1 + x)`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
-    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
-    /// failure.
-    fn log1p<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Elementwise comparison with NumPy-style broadcasting.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with
-    /// `ShapeMismatch::IncompatibleShapes` when broadcasting the operands is
-    /// impossible, or [`tenferro_tensor::Error::BackendSource`] for a typed
-    /// backend failure.
-    fn compare<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        dir: CompareDir,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<bool>>;
-    /// Clamp values elementwise between lower and upper bounds.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with
-    /// `ShapeMismatch::IncompatibleShapes` when a bound cannot broadcast to
-    /// the input, or [`tenferro_tensor::Error::BackendSource`] for a typed
-    /// backend failure.
-    fn clamp<B: TensorBackend>(
-        &self,
-        lower: &TypedTensor<T>,
-        upper: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Rank-2 matrix multiplication.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch` when
-    /// either operand is not rank two or `ShapeMismatch::ContractedDimensions`
-    /// when the inner dimensions differ, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn matmul<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Sum over one or more axes.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds`
-    /// for an axis outside the input rank or `DuplicateAxis` when `axes`
-    /// repeats an axis, or [`tenferro_tensor::Error::BackendSource`] for a
-    /// typed backend failure.
-    fn reduce_sum<B: TensorBackend>(
-        &self,
-        axes: &[usize],
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Reshape through the backend structural operation.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with
-    /// `ShapeMismatch::ReshapeElementCount` when the element counts differ,
-    /// `IntegerOverflow` when shape arithmetic overflows, or
-    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn reshape<B: TensorBackend>(
-        &self,
-        shape: &[usize],
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Permute axes through the backend structural operation.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with
-    /// `InvalidPermutationLength` when `perm` has the wrong length,
-    /// `AxisOutOfBounds` for an invalid axis, or `DuplicateAxis` for a
-    /// repeated axis, or [`tenferro_tensor::Error::BackendSource`] for a typed
-    /// backend failure.
-    fn transpose<B: TensorBackend>(
-        &self,
-        perm: &[usize],
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-    /// Broadcast into a larger shape.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch` when
-    /// `dims` does not match the input rank, `AxisOutOfBounds` or
-    /// `DuplicateAxis` for an invalid mapping, or
-    /// `ShapeMismatch::IncompatibleShapes` when known dimensions cannot
-    /// broadcast. [`tenferro_tensor::Error::BackendSource`] reports a typed
-    /// backend failure.
-    fn broadcast_in_dim<B: TensorBackend>(
-        &self,
-        shape: &[usize],
-        dims: &[usize],
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
-}
-
-/// Backend-explicit session operations for dynamic-rank typed tensors.
-///
-/// Like [`TensorSessionOpsExt`] but for [`TypedTensor`] with a statically
-/// known scalar type `T`. The typed surface keeps inputs borrowed (read-based
-/// session ops) and validates the output dtype through
-/// `into_typed_result`-style conversion before returning.
-///
-/// # Examples
-///
-/// ```rust
-/// use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
-/// use tenferro_tensor::BackendSessionHost;
-///
-/// let mut backend = CpuBackend::new();
-/// let a = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![1.0]).unwrap();
-/// let b = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![2.0; 4]).unwrap();
-/// let total = backend.with_backend_session(|session| {
-///     let sum = a.add_in(&b, session).unwrap();
-///     sum.exp_in(session).unwrap().reduce_sum_in(&[0], session).unwrap()
-/// });
-/// assert!(total.host_data().unwrap()[0].is_finite());
-/// ```
 pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Elementwise addition with NumPy-style broadcasting inside a session.
     ///
@@ -1616,7 +886,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
     /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap();
-    /// let sum = backend.with_backend_session(|session| a.add_in(&b, session)).unwrap();
+    /// let sum = backend.with_backend_session(|session| a.add(&b, session)).unwrap();
     /// assert_eq!(sum.host_data().unwrap(), &[4.0, 6.0]);
     /// ```
     ///
@@ -1625,7 +895,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
     /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
     /// a typed backend failure.
-    fn add_in(
+    fn add(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -1642,7 +912,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// let a = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![2.0]).unwrap();
     /// let b = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![3.0; 4]).unwrap();
-    /// let product = backend.with_backend_session(|session| a.mul_in(&b, session)).unwrap();
+    /// let product = backend.with_backend_session(|session| a.mul(&b, session)).unwrap();
     /// assert_eq!(product.host_data().unwrap(), &[6.0; 4]);
     /// ```
     ///
@@ -1651,7 +921,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
     /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
     /// a typed backend failure.
-    fn mul_in(
+    fn mul(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -1667,7 +937,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, 1.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.exp_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.exp(session)).unwrap();
     /// let y = y.host_data().unwrap();
     /// assert!((y[0] - 1.0).abs() < 1.0e-12);
     /// assert!((y[1] - std::f64::consts::E).abs() < 1.0e-12);
@@ -1678,7 +948,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn exp_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn exp(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Sum over one or more axes inside a session.
     ///
     /// # Examples
@@ -1690,7 +960,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
-    /// let sums = backend.with_backend_session(|session| x.reduce_sum_in(&[1], session)).unwrap();
+    /// let sums = backend.with_backend_session(|session| x.reduce_sum(&[1], session)).unwrap();
     /// assert_eq!(sums.host_data().unwrap(), &[3.0, 3.0]);
     /// ```
     ///
@@ -1700,7 +970,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// for an axis outside the input rank or `DuplicateAxis` when `axes`
     /// repeats an axis, or [`tenferro_tensor::Error::BackendSource`] for a
     /// typed backend failure.
-    fn reduce_sum_in(
+    fn reduce_sum(
         &self,
         axes: &[usize],
         session: &mut dyn BackendSession,
@@ -1717,7 +987,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
     /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.sub_in(&b, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.sub(&b, session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[1.0, -4.0]);
     /// ```
     ///
@@ -1726,7 +996,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
     /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
     /// a typed backend failure.
-    fn sub_in(
+    fn sub(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -1743,7 +1013,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![4.0, 8.0]).unwrap();
     /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.div_in(&b, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.div(&b, session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[2.0, 2.0]);
     /// ```
     ///
@@ -1753,7 +1023,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// incompatible shapes, a numerical [`tenferro_tensor::Error::Extension`]
     /// for a detected zero divisor, or [`tenferro_tensor::Error::BackendSource`]
     /// for a typed backend failure.
-    fn div_in(
+    fn div(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -1770,7 +1040,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![5.0, 7.0]).unwrap();
     /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.rem_in(&b, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.rem(&b, session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[1.0, 3.0]);
     /// ```
     ///
@@ -1780,7 +1050,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// incompatible shapes, a numerical [`tenferro_tensor::Error::Extension`]
     /// for a detected zero divisor, or [`tenferro_tensor::Error::BackendSource`]
     /// for a typed backend failure.
-    fn rem_in(
+    fn rem(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -1797,7 +1067,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 3.0]).unwrap();
     /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 2.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.pow_in(&b, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.pow(&b, session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[8.0, 9.0]);
     /// ```
     ///
@@ -1807,7 +1077,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// incompatible shapes, a numerical [`tenferro_tensor::Error::Extension`]
     /// for a detected negative integer exponent, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn pow_in(
+    fn pow(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -1824,7 +1094,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
     /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.maximum_in(&b, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.maximum(&b, session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[2.0, 8.0]);
     /// ```
     ///
@@ -1833,7 +1103,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
     /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
     /// a typed backend failure.
-    fn maximum_in(
+    fn maximum(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -1850,7 +1120,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
     /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.minimum_in(&b, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.minimum(&b, session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[1.0, 4.0]);
     /// ```
     ///
@@ -1859,7 +1129,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
     /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
     /// a typed backend failure.
-    fn minimum_in(
+    fn minimum(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -1875,7 +1145,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, -2.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.neg_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.neg(session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[-1.0, 2.0]);
     /// ```
     ///
@@ -1884,7 +1154,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn neg_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn neg(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise absolute value inside a session.
     ///
     /// # Examples
@@ -1896,7 +1166,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![-1.0, 2.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.abs_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.abs(session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[1.0, 2.0]);
     /// ```
     ///
@@ -1905,7 +1175,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn abs_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn abs(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise sign inside a session.
     ///
     /// # Examples
@@ -1917,7 +1187,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, -2.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.sign_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.sign(session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[1.0, -1.0]);
     /// ```
     ///
@@ -1926,7 +1196,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn sign_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn sign(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise complex conjugate inside a session.
     ///
     /// For real dtypes the conjugate is the identity.
@@ -1940,7 +1210,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, -2.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.conj_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.conj(session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[1.0, -2.0]);
     /// ```
     ///
@@ -1949,7 +1219,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn conj_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn conj(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise natural logarithm inside a session.
     ///
     /// # Examples
@@ -1961,7 +1231,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, std::f64::consts::E]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.log_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.log(session)).unwrap();
     /// let y = y.host_data().unwrap();
     /// assert!(y[0].abs() < 1.0e-12);
     /// assert!((y[1] - 1.0).abs() < 1.0e-12);
@@ -1972,7 +1242,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn log_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn log(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise `exp(x) - 1` inside a session.
     ///
     /// # Examples
@@ -1984,7 +1254,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, 1.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.expm1_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.expm1(session)).unwrap();
     /// let y = y.host_data().unwrap();
     /// assert!(y[0].abs() < 1.0e-12);
     /// assert!((y[1] - (std::f64::consts::E - 1.0)).abs() < 1.0e-12);
@@ -1995,8 +1265,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn expm1_in(&self, session: &mut dyn BackendSession)
-        -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn expm1(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise `log(1 + x)` inside a session.
     ///
     /// # Examples
@@ -2008,7 +1277,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, std::f64::consts::E - 1.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.log1p_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.log1p(session)).unwrap();
     /// let y = y.host_data().unwrap();
     /// assert!(y[0].abs() < 1.0e-12);
     /// assert!((y[1] - 1.0).abs() < 1.0e-12);
@@ -2019,8 +1288,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn log1p_in(&self, session: &mut dyn BackendSession)
-        -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn log1p(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise sine inside a session.
     ///
     /// # Examples
@@ -2032,7 +1300,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, std::f64::consts::FRAC_PI_2]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.sin_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.sin(session)).unwrap();
     /// let y = y.host_data().unwrap();
     /// assert!(y[0].abs() < 1.0e-12);
     /// assert!((y[1] - 1.0).abs() < 1.0e-12);
@@ -2043,7 +1311,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn sin_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn sin(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise cosine inside a session.
     ///
     /// # Examples
@@ -2055,7 +1323,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, std::f64::consts::PI]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.cos_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.cos(session)).unwrap();
     /// let y = y.host_data().unwrap();
     /// assert!((y[0] - 1.0).abs() < 1.0e-12);
     /// assert!((y[1] + 1.0).abs() < 1.0e-12);
@@ -2066,7 +1334,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn cos_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn cos(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise hyperbolic tangent inside a session.
     ///
     /// # Examples
@@ -2078,7 +1346,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, 1.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.tanh_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.tanh(session)).unwrap();
     /// let y = y.host_data().unwrap();
     /// assert!(y[0].abs() < 1.0e-12);
     /// assert!((y[1] - 0.7615941559557649).abs() < 1.0e-12);
@@ -2089,7 +1357,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn tanh_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn tanh(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise square root inside a session.
     ///
     /// # Examples
@@ -2101,7 +1369,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![4.0, 9.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.sqrt_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.sqrt(session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[2.0, 3.0]);
     /// ```
     ///
@@ -2110,7 +1378,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn sqrt_in(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn sqrt(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise reciprocal square root inside a session.
     ///
     /// # Examples
@@ -2122,7 +1390,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![4.0, 1.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.rsqrt_in(session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.rsqrt(session)).unwrap();
     /// let y = y.host_data().unwrap();
     /// assert!((y[0] - 0.5).abs() < 1.0e-12);
     /// assert!((y[1] - 1.0).abs() < 1.0e-12);
@@ -2133,8 +1401,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
     /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
     /// failure.
-    fn rsqrt_in(&self, session: &mut dyn BackendSession)
-        -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn rsqrt(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise comparison with NumPy-style broadcasting inside a session.
     ///
     /// The result is a bool typed tensor.
@@ -2149,7 +1416,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
     /// let b = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| a.compare_in(&b, CompareDir::Gt, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| a.compare(&b, CompareDir::Gt, session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[true, false]);
     /// ```
     ///
@@ -2159,7 +1426,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// `ShapeMismatch::IncompatibleShapes` when broadcasting the operands is
     /// impossible, or [`tenferro_tensor::Error::BackendSource`] for a typed
     /// backend failure.
-    fn compare_in(
+    fn compare(
         &self,
         rhs: &TypedTensor<T>,
         dir: CompareDir,
@@ -2178,7 +1445,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![-2.0, 4.0]).unwrap();
     /// let lower = TypedTensor::<f64>::from_vec_col_major(vec![], vec![0.0]).unwrap();
     /// let upper = TypedTensor::<f64>::from_vec_col_major(vec![], vec![3.0]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.clamp_in(&lower, &upper, session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.clamp(&lower, &upper, session)).unwrap();
     /// assert_eq!(y.host_data().unwrap(), &[0.0, 3.0]);
     /// ```
     ///
@@ -2188,7 +1455,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// `ShapeMismatch::IncompatibleShapes` when a bound cannot broadcast to
     /// the input, or [`tenferro_tensor::Error::BackendSource`] for a typed
     /// backend failure.
-    fn clamp_in(
+    fn clamp(
         &self,
         lower: &TypedTensor<T>,
         upper: &TypedTensor<T>,
@@ -2206,7 +1473,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
     /// let b = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0; 6]).unwrap();
-    /// let c = backend.with_backend_session(|session| a.matmul_in(&b, session)).unwrap();
+    /// let c = backend.with_backend_session(|session| a.matmul(&b, session)).unwrap();
     /// assert_eq!(c.shape(), &[2, 2]);
     /// ```
     ///
@@ -2216,7 +1483,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// either operand is not rank two or `ShapeMismatch::ContractedDimensions`
     /// when the inner dimensions differ, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn matmul_in(
+    fn matmul(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -2232,7 +1499,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.reshape_in(&[3, 2], session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.reshape(&[3, 2], session)).unwrap();
     /// assert_eq!(y.shape(), &[3, 2]);
     /// ```
     ///
@@ -2242,7 +1509,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// `ShapeMismatch::ReshapeElementCount` when the element counts differ,
     /// `IntegerOverflow` when shape arithmetic overflows, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn reshape_in(
+    fn reshape(
         &self,
         shape: &[usize],
         session: &mut dyn BackendSession,
@@ -2258,7 +1525,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
-    /// let y = backend.with_backend_session(|session| x.transpose_in(&[1, 0], session)).unwrap();
+    /// let y = backend.with_backend_session(|session| x.transpose(&[1, 0], session)).unwrap();
     /// assert_eq!(y.shape(), &[3, 2]);
     /// ```
     ///
@@ -2269,7 +1536,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// `AxisOutOfBounds` for an invalid axis, or `DuplicateAxis` for a
     /// repeated axis, or [`tenferro_tensor::Error::BackendSource`] for a typed
     /// backend failure.
-    fn transpose_in(
+    fn transpose(
         &self,
         perm: &[usize],
         session: &mut dyn BackendSession,
@@ -2285,7 +1552,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ///
     /// let mut backend = CpuBackend::new();
     /// let row = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap();
-    /// let matrix = backend.with_backend_session(|session| row.broadcast_in_dim_in(&[2, 3], &[1], session)).unwrap();
+    /// let matrix = backend.with_backend_session(|session| row.broadcast_in_dim(&[2, 3], &[1], session)).unwrap();
     /// assert_eq!(matrix.shape(), &[2, 3]);
     /// ```
     ///
@@ -2297,7 +1564,7 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     /// `ShapeMismatch::IncompatibleShapes` when known dimensions cannot
     /// broadcast. [`tenferro_tensor::Error::BackendSource`] reports a typed
     /// backend failure.
-    fn broadcast_in_dim_in(
+    fn broadcast_in_dim(
         &self,
         shape: &[usize],
         dims: &[usize],
@@ -2305,15 +1572,31 @@ pub trait TypedTensorSessionOpsExt<T: TensorScalar> {
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
 }
 
-/// Backend-explicit bool-mask operations for typed tensors.
-///
-/// # Public API rationale
+/// Backend-explicit bool-mask session operations for typed tensors.
 ///
 /// This trait keeps `where_select` available as a method on bool
 /// `TypedTensor`s while preserving the crate-root extension-trait surface. It
 /// is public because downstream users call it directly; the implementation
 /// helper in the private `typed_tensor` module is not a compatibility API.
-pub trait TypedTensorMaskOpsExt {
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_runtime::{TypedTensor, TypedTensorMaskSessionOpsExt};
+/// use tenferro_tensor::BackendSessionHost;
+///
+/// let mut backend = CpuBackend::new();
+/// let condition =
+///     TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]).unwrap();
+/// let on_true = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
+/// let on_false = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap();
+/// let selected = backend
+///     .with_backend_session(|session| condition.where_select(&on_true, &on_false, session))
+///     .unwrap();
+/// assert_eq!(selected.host_data().unwrap(), &[1.0, 4.0]);
+/// ```
+pub trait TypedTensorMaskSessionOpsExt {
     /// Select typed values using this bool tensor as condition.
     ///
     /// # Errors
@@ -2322,12 +1605,12 @@ pub trait TypedTensorMaskOpsExt {
     /// `ShapeMismatch::IncompatibleShapes` when the condition or either branch
     /// cannot broadcast to the other operands, or
     /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
-    fn where_select<T: TensorScalar, B: TensorBackend>(
+    fn where_select<U: TensorScalar>(
         &self,
-        on_true: &TypedTensor<T>,
-        on_false: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+        on_true: &TypedTensor<U>,
+        on_false: &TypedTensor<U>,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedTensor<U>>;
 }
 
 pub use traced::TracedTensor;

--- a/crates/tenferro-runtime/src/prelude.rs
+++ b/crates/tenferro-runtime/src/prelude.rs
@@ -1,7 +1,7 @@
 //! Common runtime tensor and graph types plus backend-explicit operations.
 
 pub use crate::{
-    CompareDir, DType, GraphCompiler, Runtime, Tensor, TensorBackend, TensorOpsExt, TensorScalar,
+    CompareDir, DType, GraphCompiler, Runtime, Tensor, TensorBackend, TensorScalar,
     TensorSessionOpsExt, TraceContext, TraceValue, TracedGraph, TracedTensor, TypedTensor,
-    TypedTensorMaskOpsExt, TypedTensorOpsExt, TypedTensorSessionOpsExt,
+    TypedTensorMaskSessionOpsExt, TypedTensorSessionOpsExt,
 };

--- a/crates/tenferro-runtime/src/tensor.rs
+++ b/crates/tenferro-runtime/src/tensor.rs
@@ -1,260 +1,124 @@
 //! Concrete tensor operation extension trait.
 //!
 //! `tenferro-tensor` owns storage and backend traits. This runtime crate
-//! provides backend-parametric operation methods through [`TensorOpsExt`].
+//! provides backend-parametric session-explicit operation methods through
+//! [`TensorSessionOpsExt`].
 
 use tenferro_ops::broadcast::{
     broadcast_error_to_validation, broadcast_input_plan, broadcast_shape, broadcast_shapes,
 };
 use tenferro_tensor::validate::matmul_config_for_shapes;
-use tenferro_tensor::{BackendSession, CompareDir, DType, Error, Result, TensorBackend};
+use tenferro_tensor::{BackendSession, CompareDir, DType, Error, Result};
 
-use crate::{TensorOpsExt, TensorSessionOpsExt};
+use crate::TensorSessionOpsExt;
 use tenferro_tensor::Tensor;
 
-impl TensorOpsExt for Tensor {
-    fn convert<B: TensorBackend>(&self, to: DType, backend: &mut B) -> Result<Tensor> {
-        convert(self, to, backend)
-    }
-
-    fn cast<B: TensorBackend>(&self, to: DType, backend: &mut B) -> Result<Tensor> {
-        cast(self, to, backend)
-    }
-
-    fn add<B: TensorBackend>(&self, rhs: &Tensor, backend: &mut B) -> Result<Tensor> {
-        add(self, rhs, backend)
-    }
-
-    fn sub<B: TensorBackend>(&self, rhs: &Tensor, backend: &mut B) -> Result<Tensor> {
-        sub(self, rhs, backend)
-    }
-
-    fn mul<B: TensorBackend>(&self, rhs: &Tensor, backend: &mut B) -> Result<Tensor> {
-        mul(self, rhs, backend)
-    }
-
-    fn div<B: TensorBackend>(&self, rhs: &Tensor, backend: &mut B) -> Result<Tensor> {
-        div(self, rhs, backend)
-    }
-
-    fn rem<B: TensorBackend>(&self, rhs: &Tensor, backend: &mut B) -> Result<Tensor> {
-        rem(self, rhs, backend)
-    }
-
-    fn pow<B: TensorBackend>(&self, rhs: &Tensor, backend: &mut B) -> Result<Tensor> {
-        pow(self, rhs, backend)
-    }
-
-    fn maximum<B: TensorBackend>(&self, rhs: &Tensor, backend: &mut B) -> Result<Tensor> {
-        maximum(self, rhs, backend)
-    }
-
-    fn minimum<B: TensorBackend>(&self, rhs: &Tensor, backend: &mut B) -> Result<Tensor> {
-        minimum(self, rhs, backend)
-    }
-
-    fn neg<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        neg(self, backend)
-    }
-
-    fn abs<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        abs(self, backend)
-    }
-
-    fn sign<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        sign(self, backend)
-    }
-
-    fn conj<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        conj(self, backend)
-    }
-
-    fn exp<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        exp(self, backend)
-    }
-
-    fn log<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        log(self, backend)
-    }
-
-    fn sin<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        sin(self, backend)
-    }
-
-    fn cos<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        cos(self, backend)
-    }
-
-    fn tanh<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        tanh(self, backend)
-    }
-
-    fn sqrt<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        sqrt(self, backend)
-    }
-
-    fn rsqrt<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        rsqrt(self, backend)
-    }
-
-    fn expm1<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        expm1(self, backend)
-    }
-
-    fn log1p<B: TensorBackend>(&self, backend: &mut B) -> Result<Tensor> {
-        log1p(self, backend)
-    }
-
-    fn compare<B: TensorBackend>(
-        &self,
-        rhs: &Tensor,
-        dir: CompareDir,
-        backend: &mut B,
-    ) -> Result<Tensor> {
-        compare(self, rhs, dir, backend)
-    }
-
-    fn where_select<B: TensorBackend>(
-        &self,
-        on_true: &Tensor,
-        on_false: &Tensor,
-        backend: &mut B,
-    ) -> Result<Tensor> {
-        where_select(self, on_true, on_false, backend)
-    }
-
-    fn clamp<B: TensorBackend>(
-        &self,
-        lower: &Tensor,
-        upper: &Tensor,
-        backend: &mut B,
-    ) -> Result<Tensor> {
-        clamp(self, lower, upper, backend)
-    }
-
-    fn matmul<B: TensorBackend>(&self, rhs: &Tensor, backend: &mut B) -> Result<Tensor> {
-        matmul(self, rhs, backend)
-    }
-
-    fn reshape<B: TensorBackend>(&self, shape: &[usize], backend: &mut B) -> Result<Tensor> {
-        reshape(self, shape, backend)
-    }
-
-    fn transpose<B: TensorBackend>(&self, perm: &[usize], backend: &mut B) -> Result<Tensor> {
-        transpose(self, perm, backend)
-    }
-
-    fn reduce_sum<B: TensorBackend>(&self, axes: &[usize], backend: &mut B) -> Result<Tensor> {
-        reduce_sum(self, axes, backend)
-    }
-}
-
 impl TensorSessionOpsExt for Tensor {
-    fn add_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn add(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
         session.add(&lhs, &rhs)
     }
 
-    fn mul_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn mul(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
         session.mul(&lhs, &rhs)
     }
 
-    fn exp_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn exp(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.exp(self)
     }
 
-    fn reduce_sum_in(&self, axes: &[usize], session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn reduce_sum(&self, axes: &[usize], session: &mut dyn BackendSession) -> Result<Tensor> {
         session.reduce_sum(self, axes)
     }
 
-    fn convert_in(&self, to: DType, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn convert(&self, to: DType, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.convert(self, to)
     }
 
-    fn cast_in(&self, to: DType, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn cast(&self, to: DType, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.cast(self, to)
     }
 
-    fn sub_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn sub(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
         session.sub(&lhs, &rhs)
     }
 
-    fn div_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn div(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
         session.div(&lhs, &rhs)
     }
 
-    fn rem_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn rem(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
         session.rem(&lhs, &rhs)
     }
 
-    fn pow_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn pow(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
         session.pow(&lhs, &rhs)
     }
 
-    fn maximum_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn maximum(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
         session.maximum(&lhs, &rhs)
     }
 
-    fn minimum_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn minimum(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
         session.minimum(&lhs, &rhs)
     }
 
-    fn neg_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn neg(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.neg(self)
     }
 
-    fn abs_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn abs(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.abs(self)
     }
 
-    fn sign_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn sign(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.sign(self)
     }
 
-    fn conj_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn conj(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.conj(self)
     }
 
-    fn log_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn log(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.log(self)
     }
 
-    fn expm1_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn expm1(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.expm1(self)
     }
 
-    fn log1p_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn log1p(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.log1p(self)
     }
 
-    fn sin_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn sin(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.sin(self)
     }
 
-    fn cos_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn cos(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.cos(self)
     }
 
-    fn tanh_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn tanh(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.tanh(self)
     }
 
-    fn sqrt_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn sqrt(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.sqrt(self)
     }
 
-    fn rsqrt_in(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn rsqrt(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
         session.rsqrt(self)
     }
 
-    fn compare_in(
+    fn compare(
         &self,
         rhs: &Tensor,
         dir: CompareDir,
@@ -264,7 +128,7 @@ impl TensorSessionOpsExt for Tensor {
         session.compare(&lhs, &rhs, &dir)
     }
 
-    fn where_select_in(
+    fn where_select(
         &self,
         on_true: &Tensor,
         on_false: &Tensor,
@@ -275,7 +139,7 @@ impl TensorSessionOpsExt for Tensor {
         session.select(&condition, &on_true, &on_false)
     }
 
-    fn clamp_in(
+    fn clamp(
         &self,
         lower: &Tensor,
         upper: &Tensor,
@@ -285,344 +149,18 @@ impl TensorSessionOpsExt for Tensor {
         session.clamp(&input, &lower, &upper)
     }
 
-    fn matmul_in(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn matmul(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let config = matmul_config_for_shapes("matmul", self.shape(), rhs.shape())?;
         session.dot_general(self, rhs, &config)
     }
 
-    fn reshape_in(&self, shape: &[usize], session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn reshape(&self, shape: &[usize], session: &mut dyn BackendSession) -> Result<Tensor> {
         session.reshape(self, shape)
     }
 
-    fn transpose_in(&self, perm: &[usize], session: &mut dyn BackendSession) -> Result<Tensor> {
+    fn transpose(&self, perm: &[usize], session: &mut dyn BackendSession) -> Result<Tensor> {
         session.transpose(self, perm)
     }
-}
-
-/// Convert a tensor to a different dtype using the checked conversion lattice.
-///
-/// Use [`cast`] for explicit lossy dtype projection.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{DType, Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-/// let y = x.convert(DType::C64, &mut backend).unwrap();
-/// assert_eq!(y.dtype(), DType::C64);
-/// ```
-///
-/// # Errors
-///
-/// Returns an error when the requested conversion is outside tenferro's checked
-/// dtype-promotion lattice, or when the backend does not support the requested
-/// conversion.
-fn convert(input: &Tensor, to: DType, backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|session| input.convert_in(to, session))
-}
-
-/// Cast a tensor to a different dtype using explicit dtype projection.
-///
-/// Unlike [`convert`], `cast` may truncate, narrow precision, project complex
-/// values to their real component, or use boolean truthiness where the backend
-/// supports the requested projection.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{DType, Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = Tensor::from_vec_col_major(vec![2], vec![1.2_f64, -2.8]).unwrap();
-/// let y = x.cast(DType::I32, &mut backend).unwrap();
-/// assert_eq!(y.as_slice::<i32>().unwrap(), &[1, -2]);
-/// ```
-///
-/// # Errors
-///
-/// Returns an error when the backend does not support the requested explicit
-/// dtype projection.
-fn cast(input: &Tensor, to: DType, backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|session| input.cast_in(to, session))
-}
-
-/// Elementwise addition with NumPy-style broadcasting.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-/// # let y = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
-/// let z = x.add(&y, &mut backend).unwrap();
-/// ```
-fn add(lhs: &Tensor, rhs: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|session| lhs.add_in(rhs, session))
-}
-
-macro_rules! unary_fn {
-    ($name:ident, $method:ident, $summary:literal) => {
-        #[doc = $summary]
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// # use tenferro_cpu::CpuBackend;
-        /// use tenferro_runtime::{Tensor, TensorOpsExt};
-        /// # let mut backend = CpuBackend::new();
-        /// # let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap();
-        #[doc = concat!("let y = x.", stringify!($name), "(&mut backend).unwrap();")]
-        /// ```
-        fn $name(input: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
-            backend.with_backend_session(|session| input.$method(session))
-        }
-    };
-}
-
-macro_rules! binary_fn {
-    ($name:ident, $method:ident, $summary:literal) => {
-        #[doc = $summary]
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// # use tenferro_cpu::CpuBackend;
-        /// use tenferro_runtime::{Tensor, TensorOpsExt};
-        /// # let mut backend = CpuBackend::new();
-        /// # let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
-        /// # let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
-        #[doc = concat!("let z = x.", stringify!($name), "(&y, &mut backend).unwrap();")]
-        /// ```
-        fn $name(lhs: &Tensor, rhs: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
-            backend.with_backend_session(|session| lhs.$method(rhs, session))
-        }
-    };
-}
-
-binary_fn!(
-    div,
-    div_in,
-    "Elementwise division with NumPy-style broadcasting."
-);
-binary_fn!(
-    rem,
-    rem_in,
-    "Elementwise remainder with NumPy-style broadcasting."
-);
-binary_fn!(
-    pow,
-    pow_in,
-    "Elementwise power with NumPy-style broadcasting."
-);
-binary_fn!(
-    maximum,
-    maximum_in,
-    "Elementwise maximum with NumPy-style broadcasting."
-);
-binary_fn!(
-    minimum,
-    minimum_in,
-    "Elementwise minimum with NumPy-style broadcasting."
-);
-
-unary_fn!(neg, neg_in, "Elementwise negation.");
-unary_fn!(abs, abs_in, "Elementwise absolute value.");
-unary_fn!(sign, sign_in, "Elementwise sign.");
-unary_fn!(conj, conj_in, "Elementwise complex conjugate.");
-unary_fn!(log, log_in, "Elementwise natural logarithm.");
-unary_fn!(sin, sin_in, "Elementwise sine.");
-unary_fn!(cos, cos_in, "Elementwise cosine.");
-unary_fn!(tanh, tanh_in, "Elementwise hyperbolic tangent.");
-unary_fn!(sqrt, sqrt_in, "Elementwise square root.");
-unary_fn!(rsqrt, rsqrt_in, "Elementwise reciprocal square root.");
-unary_fn!(expm1, expm1_in, "Elementwise `exp(x) - 1`.");
-unary_fn!(log1p, log1p_in, "Elementwise `log(1 + x)`.");
-
-/// Elementwise multiplication with NumPy-style broadcasting.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
-/// # let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
-/// let z = x.mul(&y, &mut backend).unwrap();
-/// ```
-fn mul(lhs: &Tensor, rhs: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|session| lhs.mul_in(rhs, session))
-}
-
-/// Elementwise exponential.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap();
-/// let y = x.exp(&mut backend).unwrap();
-/// ```
-fn exp(input: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|session| input.exp_in(session))
-}
-
-/// Elementwise subtraction with NumPy-style broadcasting.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
-/// # let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
-/// let z = x.sub(&y, &mut backend).unwrap();
-/// ```
-fn sub(lhs: &Tensor, rhs: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|session| lhs.sub_in(rhs, session))
-}
-
-/// Elementwise comparison with NumPy-style broadcasting.
-///
-/// The result is a bool tensor.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{CompareDir, Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
-/// # let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
-/// let z = x.compare(&y, CompareDir::Gt, &mut backend).unwrap();
-/// assert_eq!(z.as_slice::<bool>().unwrap(), &[true, false]);
-/// ```
-fn compare(
-    lhs: &Tensor,
-    rhs: &Tensor,
-    dir: CompareDir,
-    backend: &mut impl TensorBackend,
-) -> Result<Tensor> {
-    backend.with_backend_session(|session| lhs.compare_in(rhs, dir, session))
-}
-
-/// Select values from `on_true` or `on_false` using a condition tensor.
-///
-/// This corresponds to NumPy `where(condition, x, y)`.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{CompareDir, Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
-/// # let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
-/// # let condition = x.compare(&y, CompareDir::Gt, &mut backend).unwrap();
-/// let z = condition.where_select(&x, &y, &mut backend).unwrap();
-/// ```
-fn where_select(
-    condition: &Tensor,
-    on_true: &Tensor,
-    on_false: &Tensor,
-    backend: &mut impl TensorBackend,
-) -> Result<Tensor> {
-    backend.with_backend_session(|session| condition.where_select_in(on_true, on_false, session))
-}
-
-/// Clamp values elementwise between lower and upper bounds.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = Tensor::from_vec_col_major(vec![2], vec![-2.0_f64, 4.0]).unwrap();
-/// # let lower = Tensor::from_vec_col_major(vec![], vec![0.0_f64]).unwrap();
-/// # let upper = Tensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap();
-/// let z = x.clamp(&lower, &upper, &mut backend).unwrap();
-/// ```
-fn clamp(
-    input: &Tensor,
-    lower: &Tensor,
-    upper: &Tensor,
-    backend: &mut impl TensorBackend,
-) -> Result<Tensor> {
-    backend.with_backend_session(|session| input.clamp_in(lower, upper, session))
-}
-
-/// Matrix multiplication helper for rank-2 tensors.
-///
-/// This contracts the last dimension of `a` with the first dimension of `b`.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
-/// # let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
-/// let c = a.matmul(&b, &mut backend).unwrap();
-/// ```
-fn matmul(a: &Tensor, b: &Tensor, backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|session| a.matmul_in(b, session))
-}
-
-/// Reshape a tensor without changing element order.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
-/// let y = x.reshape(&[4], &mut backend).unwrap();
-/// assert_eq!(y.shape(), &[4]);
-/// ```
-fn reshape(input: &Tensor, shape: &[usize], backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|session| input.reshape_in(shape, session))
-}
-
-/// Permute tensor axes.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
-/// let y = x.transpose(&[1, 0], &mut backend).unwrap();
-/// assert_eq!(y.shape(), &[3, 2]);
-/// ```
-fn transpose(input: &Tensor, perm: &[usize], backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|session| input.transpose_in(perm, session))
-}
-
-/// Sum a tensor over one or more axes.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{Tensor, TensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
-/// let y = x.reduce_sum(&[0], &mut backend).unwrap();
-/// assert_eq!(y.shape(), &[2]);
-/// ```
-fn reduce_sum(input: &Tensor, axes: &[usize], backend: &mut impl TensorBackend) -> Result<Tensor> {
-    backend.with_backend_session(|session| input.reduce_sum_in(axes, session))
 }
 
 fn broadcast_to_in(

--- a/crates/tenferro-runtime/src/typed_tensor.rs
+++ b/crates/tenferro-runtime/src/typed_tensor.rs
@@ -8,192 +8,15 @@ use tenferro_ops::broadcast::{
 };
 use tenferro_tensor::validate::matmul_config_for_shapes;
 use tenferro_tensor::{
-    BackendSession, CompareDir, DType, Error, Result, Tensor, TensorBackend, TensorRead,
-    TensorScalar, ValidationError,
+    BackendSession, CompareDir, DType, Error, Result, Tensor, TensorRead, TensorScalar,
+    ValidationError,
 };
 
-use crate::{TypedTensorMaskOpsExt, TypedTensorOpsExt, TypedTensorSessionOpsExt};
+use crate::{TypedTensorMaskSessionOpsExt, TypedTensorSessionOpsExt};
 use tenferro_tensor::TypedTensor;
 
-impl<T: TensorScalar> TypedTensorOpsExt<T> for TypedTensor<T> {
-    fn add<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        add(self, rhs, backend)
-    }
-
-    fn sub<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        sub(self, rhs, backend)
-    }
-
-    fn mul<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        mul(self, rhs, backend)
-    }
-
-    fn div<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        div(self, rhs, backend)
-    }
-
-    fn rem<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        rem(self, rhs, backend)
-    }
-
-    fn pow<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        pow(self, rhs, backend)
-    }
-
-    fn maximum<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        maximum(self, rhs, backend)
-    }
-
-    fn minimum<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        minimum(self, rhs, backend)
-    }
-
-    fn neg<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        neg(self, backend)
-    }
-
-    fn abs<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        abs(self, backend)
-    }
-
-    fn sign<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        sign(self, backend)
-    }
-
-    fn conj<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        conj(self, backend)
-    }
-
-    fn exp<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        exp(self, backend)
-    }
-
-    fn log<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        log(self, backend)
-    }
-
-    fn sin<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        sin(self, backend)
-    }
-
-    fn cos<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        cos(self, backend)
-    }
-
-    fn tanh<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        tanh(self, backend)
-    }
-
-    fn sqrt<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        sqrt(self, backend)
-    }
-
-    fn rsqrt<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        rsqrt(self, backend)
-    }
-
-    fn expm1<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        expm1(self, backend)
-    }
-
-    fn log1p<B: TensorBackend>(&self, backend: &mut B) -> Result<TypedTensor<T>> {
-        log1p(self, backend)
-    }
-
-    fn compare<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        dir: CompareDir,
-        backend: &mut B,
-    ) -> Result<TypedTensor<bool>> {
-        compare(self, rhs, dir, backend)
-    }
-
-    fn clamp<B: TensorBackend>(
-        &self,
-        lower: &TypedTensor<T>,
-        upper: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        clamp(self, lower, upper, backend)
-    }
-
-    fn matmul<B: TensorBackend>(
-        &self,
-        rhs: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        matmul(self, rhs, backend)
-    }
-
-    fn reduce_sum<B: TensorBackend>(
-        &self,
-        axes: &[usize],
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        reduce_sum(self, axes, backend)
-    }
-
-    fn reshape<B: TensorBackend>(
-        &self,
-        shape: &[usize],
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        reshape(self, shape, backend)
-    }
-
-    fn transpose<B: TensorBackend>(
-        &self,
-        perm: &[usize],
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        transpose(self, perm, backend)
-    }
-
-    fn broadcast_in_dim<B: TensorBackend>(
-        &self,
-        shape: &[usize],
-        dims: &[usize],
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        broadcast_in_dim(self, shape, dims, backend)
-    }
-}
-
 impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
-    fn add_in(
+    fn add(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -203,7 +26,7 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("add", out)
     }
 
-    fn mul_in(
+    fn mul(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -213,12 +36,12 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("mul", out)
     }
 
-    fn exp_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn exp(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.exp_read(T::tensor_read(self))?;
         into_typed_result("exp", out)
     }
 
-    fn reduce_sum_in(
+    fn reduce_sum(
         &self,
         axes: &[usize],
         session: &mut dyn BackendSession,
@@ -227,7 +50,7 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("reduce_sum", out)
     }
 
-    fn sub_in(
+    fn sub(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -237,7 +60,7 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("sub", out)
     }
 
-    fn div_in(
+    fn div(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -247,7 +70,7 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("div", out)
     }
 
-    fn rem_in(
+    fn rem(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -257,7 +80,7 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("rem", out)
     }
 
-    fn pow_in(
+    fn pow(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -267,7 +90,7 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("pow", out)
     }
 
-    fn maximum_in(
+    fn maximum(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -277,7 +100,7 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("maximum", out)
     }
 
-    fn minimum_in(
+    fn minimum(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -287,67 +110,67 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("minimum", out)
     }
 
-    fn neg_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn neg(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.neg_read(T::tensor_read(self))?;
         into_typed_result("neg", out)
     }
 
-    fn abs_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn abs(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.abs_read(T::tensor_read(self))?;
         into_typed_result("abs", out)
     }
 
-    fn sign_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn sign(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.sign_read(T::tensor_read(self))?;
         into_typed_result("sign", out)
     }
 
-    fn conj_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn conj(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.conj_read(T::tensor_read(self))?;
         into_typed_result("conj", out)
     }
 
-    fn log_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn log(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.log_read(T::tensor_read(self))?;
         into_typed_result("log", out)
     }
 
-    fn expm1_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn expm1(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.expm1_read(T::tensor_read(self))?;
         into_typed_result("expm1", out)
     }
 
-    fn log1p_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn log1p(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.log1p_read(T::tensor_read(self))?;
         into_typed_result("log1p", out)
     }
 
-    fn sin_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn sin(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.sin_read(T::tensor_read(self))?;
         into_typed_result("sin", out)
     }
 
-    fn cos_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn cos(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.cos_read(T::tensor_read(self))?;
         into_typed_result("cos", out)
     }
 
-    fn tanh_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn tanh(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.tanh_read(T::tensor_read(self))?;
         into_typed_result("tanh", out)
     }
 
-    fn sqrt_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn sqrt(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.sqrt_read(T::tensor_read(self))?;
         into_typed_result("sqrt", out)
     }
 
-    fn rsqrt_in(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+    fn rsqrt(&self, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.rsqrt_read(T::tensor_read(self))?;
         into_typed_result("rsqrt", out)
     }
 
-    fn compare_in(
+    fn compare(
         &self,
         rhs: &TypedTensor<T>,
         dir: CompareDir,
@@ -358,7 +181,7 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("compare", out)
     }
 
-    fn clamp_in(
+    fn clamp(
         &self,
         lower: &TypedTensor<T>,
         upper: &TypedTensor<T>,
@@ -373,7 +196,7 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("clamp", out)
     }
 
-    fn matmul_in(
+    fn matmul(
         &self,
         rhs: &TypedTensor<T>,
         session: &mut dyn BackendSession,
@@ -383,16 +206,12 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("matmul", out)
     }
 
-    fn reshape_in(
-        &self,
-        shape: &[usize],
-        session: &mut dyn BackendSession,
-    ) -> Result<TypedTensor<T>> {
+    fn reshape(&self, shape: &[usize], session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let out = session.reshape_read(T::tensor_read(self), shape)?;
         into_typed_result("reshape", out)
     }
 
-    fn transpose_in(
+    fn transpose(
         &self,
         perm: &[usize],
         session: &mut dyn BackendSession,
@@ -401,7 +220,7 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
         into_typed_result("transpose", out)
     }
 
-    fn broadcast_in_dim_in(
+    fn broadcast_in_dim(
         &self,
         shape: &[usize],
         dims: &[usize],
@@ -412,367 +231,22 @@ impl<T: TensorScalar> TypedTensorSessionOpsExt<T> for TypedTensor<T> {
     }
 }
 
-impl TypedTensorMaskOpsExt for TypedTensor<bool> {
-    fn where_select<T: TensorScalar, B: TensorBackend>(
+impl TypedTensorMaskSessionOpsExt for TypedTensor<bool> {
+    fn where_select<U: TensorScalar>(
         &self,
-        on_true: &TypedTensor<T>,
-        on_false: &TypedTensor<T>,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        where_select(self, on_true, on_false, backend)
-    }
-}
-
-/// Elementwise addition with NumPy-style broadcasting.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
-/// # let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap();
-/// let z = x.add(&y, &mut backend).unwrap();
-/// ```
-fn add<T: TensorScalar>(
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-    backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<T>> {
-    backend.with_backend_session(|session| lhs.add_in(rhs, session))
-}
-
-macro_rules! unary_fn {
-    ($name:ident, $method:ident, $summary:literal) => {
-        #[doc = $summary]
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// # use tenferro_cpu::CpuBackend;
-        /// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-        /// # let mut backend = CpuBackend::new();
-        /// # let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 4.0]).unwrap();
-        #[doc = concat!("let y = x.", stringify!($name), "(&mut backend).unwrap();")]
-        /// ```
-        fn $name<T: TensorScalar>(
-            input: &TypedTensor<T>,
-            backend: &mut impl TensorBackend,
-        ) -> Result<TypedTensor<T>> {
-            backend.with_backend_session(|session| input.$method(session))
-        }
-    };
-}
-
-macro_rules! binary_fn {
-    ($name:ident, $method:ident, $summary:literal) => {
-        #[doc = $summary]
-        ///
-        /// # Examples
-        ///
-        /// ```rust
-        /// # use tenferro_cpu::CpuBackend;
-        /// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-        /// # let mut backend = CpuBackend::new();
-        /// # let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
-        /// # let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
-        #[doc = concat!("let z = x.", stringify!($name), "(&y, &mut backend).unwrap();")]
-        /// ```
-        fn $name<T: TensorScalar>(
-            lhs: &TypedTensor<T>,
-            rhs: &TypedTensor<T>,
-            backend: &mut impl TensorBackend,
-        ) -> Result<TypedTensor<T>> {
-            backend.with_backend_session(|session| lhs.$method(rhs, session))
-        }
-    };
-}
-
-binary_fn!(
-    div,
-    div_in,
-    "Elementwise division with NumPy-style broadcasting."
-);
-binary_fn!(
-    rem,
-    rem_in,
-    "Elementwise remainder with NumPy-style broadcasting."
-);
-binary_fn!(
-    pow,
-    pow_in,
-    "Elementwise power with NumPy-style broadcasting."
-);
-binary_fn!(
-    maximum,
-    maximum_in,
-    "Elementwise maximum with NumPy-style broadcasting."
-);
-binary_fn!(
-    minimum,
-    minimum_in,
-    "Elementwise minimum with NumPy-style broadcasting."
-);
-
-unary_fn!(neg, neg_in, "Elementwise negation.");
-unary_fn!(abs, abs_in, "Elementwise absolute value.");
-unary_fn!(sign, sign_in, "Elementwise sign.");
-unary_fn!(conj, conj_in, "Elementwise complex conjugate.");
-unary_fn!(log, log_in, "Elementwise natural logarithm.");
-unary_fn!(sin, sin_in, "Elementwise sine.");
-unary_fn!(cos, cos_in, "Elementwise cosine.");
-unary_fn!(tanh, tanh_in, "Elementwise hyperbolic tangent.");
-unary_fn!(sqrt, sqrt_in, "Elementwise square root.");
-unary_fn!(rsqrt, rsqrt_in, "Elementwise reciprocal square root.");
-unary_fn!(expm1, expm1_in, "Elementwise `exp(x) - 1`.");
-unary_fn!(log1p, log1p_in, "Elementwise `log(1 + x)`.");
-
-/// Elementwise multiplication with NumPy-style broadcasting.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
-/// # let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
-/// let z = x.mul(&y, &mut backend).unwrap();
-/// ```
-fn mul<T: TensorScalar>(
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-    backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<T>> {
-    backend.with_backend_session(|session| lhs.mul_in(rhs, session))
-}
-
-/// Elementwise exponential.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 4.0]).unwrap();
-/// let y = x.exp(&mut backend).unwrap();
-/// ```
-fn exp<T: TensorScalar>(
-    input: &TypedTensor<T>,
-    backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<T>> {
-    backend.with_backend_session(|session| input.exp_in(session))
-}
-
-/// Elementwise subtraction with NumPy-style broadcasting.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
-/// # let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
-/// let z = x.sub(&y, &mut backend).unwrap();
-/// ```
-fn sub<T: TensorScalar>(
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-    backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<T>> {
-    backend.with_backend_session(|session| lhs.sub_in(rhs, session))
-}
-
-/// Elementwise comparison with NumPy-style broadcasting.
-///
-/// The result is a bool tensor.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{CompareDir, TypedTensor, TypedTensorMaskOpsExt, TypedTensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
-/// # let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
-/// let z = x.compare(&y, CompareDir::Gt, &mut backend).unwrap();
-/// assert_eq!(z.host_data().unwrap(), &[true, false]);
-/// ```
-fn compare<T: TensorScalar>(
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
-    dir: CompareDir,
-    backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<bool>> {
-    backend.with_backend_session(|session| lhs.compare_in(rhs, dir, session))
-}
-
-/// Select values from `on_true` or `on_false` using a condition tensor.
-///
-/// This corresponds to NumPy `where(condition, x, y)`.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{CompareDir, TypedTensor, TypedTensorMaskOpsExt, TypedTensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
-/// # let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
-/// # let condition = x.compare(&y, CompareDir::Gt, &mut backend).unwrap();
-/// let z = condition.where_select(&x, &y, &mut backend).unwrap();
-/// ```
-fn where_select<T: TensorScalar>(
-    condition: &TypedTensor<bool>,
-    on_true: &TypedTensor<T>,
-    on_false: &TypedTensor<T>,
-    backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<T>> {
-    let (condition, on_true, on_false) =
-        broadcast_ternary_read(condition, on_true, on_false, backend)?;
-    let out = backend.with_backend_session(|exec| {
-        exec.select_read(
+        on_true: &TypedTensor<U>,
+        on_false: &TypedTensor<U>,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<U>> {
+        let (condition, on_true, on_false) =
+            broadcast_ternary_in_read(self, on_true, on_false, session)?;
+        let out = session.select_read(
             condition.tensor_read(),
             on_true.tensor_read(),
             on_false.tensor_read(),
-        )
-    })?;
-    into_typed_result("where_select", out)
-}
-
-/// Clamp values elementwise between lower and upper bounds.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![-2.0, 4.0]).unwrap();
-/// # let lower = TypedTensor::<f64>::from_vec_col_major(vec![], vec![0.0]).unwrap();
-/// # let upper = TypedTensor::<f64>::from_vec_col_major(vec![], vec![3.0]).unwrap();
-/// let z = x.clamp(&lower, &upper, &mut backend).unwrap();
-/// ```
-fn clamp<T: TensorScalar>(
-    input: &TypedTensor<T>,
-    lower: &TypedTensor<T>,
-    upper: &TypedTensor<T>,
-    backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<T>> {
-    backend.with_backend_session(|session| input.clamp_in(lower, upper, session))
-}
-
-/// Matrix multiplication helper for rank-2 typed tensors.
-///
-/// This contracts the last dimension of `a` with the first dimension of `b`.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
-/// # let b = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0; 6]).unwrap();
-/// let c = a.matmul(&b, &mut backend).unwrap();
-/// ```
-fn matmul<T: TensorScalar>(
-    a: &TypedTensor<T>,
-    b: &TypedTensor<T>,
-    backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<T>> {
-    backend.with_backend_session(|session| a.matmul_in(b, session))
-}
-
-/// Sum elements across one or more axes.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// let x = TypedTensor::<f64>::from_vec_col_major(
-///     vec![2, 3],
-///     vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
-/// )?;
-/// let row_sums = x.reduce_sum(&[1], &mut backend).unwrap();
-/// assert_eq!(row_sums.host_data()?, &[6.0, 15.0]);
-/// # Ok::<(), tenferro_runtime::Error>(())
-/// ```
-fn reduce_sum<T: TensorScalar>(
-    input: &TypedTensor<T>,
-    axes: &[usize],
-    backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<T>> {
-    backend.with_backend_session(|session| input.reduce_sum_in(axes, session))
-}
-
-/// Reshape a typed tensor through the backend structural operation.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
-/// let y = x.reshape(&[3, 2], &mut backend).unwrap();
-/// assert_eq!(y.shape(), &[3, 2]);
-/// ```
-fn reshape<T: TensorScalar>(
-    input: &TypedTensor<T>,
-    shape: &[usize],
-    backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<T>> {
-    backend.with_backend_session(|session| input.reshape_in(shape, session))
-}
-
-/// Permute typed tensor axes through the backend structural operation.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
-/// let y = x.transpose(&[1, 0], &mut backend).unwrap();
-/// assert_eq!(y.shape(), &[3, 2]);
-/// ```
-fn transpose<T: TensorScalar>(
-    input: &TypedTensor<T>,
-    perm: &[usize],
-    backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<T>> {
-    backend.with_backend_session(|session| input.transpose_in(perm, session))
-}
-
-/// Broadcast a typed tensor into a larger shape.
-///
-/// `dims` maps each input axis to its output axis, following the concrete
-/// backend `broadcast_in_dim` contract.
-///
-/// # Examples
-///
-/// ```rust
-/// # use tenferro_cpu::CpuBackend;
-/// use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-/// # let mut backend = CpuBackend::new();
-/// let row = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap();
-/// let matrix = row.broadcast_in_dim(&[2, 3], &[1], &mut backend).unwrap();
-/// assert_eq!(matrix.shape(), &[2, 3]);
-/// ```
-fn broadcast_in_dim<T: TensorScalar>(
-    input: &TypedTensor<T>,
-    shape: &[usize],
-    dims: &[usize],
-    backend: &mut impl TensorBackend,
-) -> Result<TypedTensor<T>> {
-    backend.with_backend_session(|session| input.broadcast_in_dim_in(shape, dims, session))
+        )?;
+        into_typed_result("where_select", out)
+    }
 }
 
 // INVARIANT: this private adapter keeps borrowed reads borrowed and owns only
@@ -837,45 +311,6 @@ fn broadcast_ternary_in_read<'a, C: TensorScalar, T: TensorScalar>(
         broadcast_to_in_read(second, &shape, session)?,
         broadcast_to_in_read(third, &shape, session)?,
     ))
-}
-
-fn broadcast_ternary_read<'a, C: TensorScalar, T: TensorScalar>(
-    first: &'a TypedTensor<C>,
-    second: &'a TypedTensor<T>,
-    third: &'a TypedTensor<T>,
-    backend: &mut impl TensorBackend,
-) -> Result<(ReadInput<'a>, ReadInput<'a>, ReadInput<'a>)> {
-    let shape = broadcast_shapes([first.shape(), second.shape(), third.shape()])
-        .map_err(broadcast_error)?;
-    Ok((
-        broadcast_to_read(first, &shape, backend)?,
-        broadcast_to_read(second, &shape, backend)?,
-        broadcast_to_read(third, &shape, backend)?,
-    ))
-}
-
-fn broadcast_to_read<'a, T: TensorScalar>(
-    input: &'a TypedTensor<T>,
-    target_shape: &[usize],
-    backend: &mut impl TensorBackend,
-) -> Result<ReadInput<'a>> {
-    if input.shape() == target_shape {
-        return Ok(ReadInput::Borrowed(T::tensor_read(input)));
-    }
-
-    let plan = broadcast_input_plan(input.shape(), target_shape).map_err(broadcast_error)?;
-    let source = if plan.source_shape == input.shape() {
-        ReadInput::Borrowed(T::tensor_read(input))
-    } else {
-        let reshaped = backend.with_backend_session(|exec| {
-            exec.reshape_read(T::tensor_read(input), &plan.source_shape)
-        })?;
-        ReadInput::Owned(reshaped)
-    };
-    let out = backend.with_backend_session(|exec| {
-        exec.broadcast_in_dim_read(source.tensor_read(), target_shape, &plan.dims)
-    })?;
-    Ok(ReadInput::Owned(out))
 }
 
 fn broadcast_error(err: BroadcastError) -> Error {

--- a/crates/tenferro-runtime/tests/integration.rs
+++ b/crates/tenferro-runtime/tests/integration.rs
@@ -16,8 +16,8 @@ mod runtime_foundations;
 mod runtime_preparation_api;
 #[path = "integration/runtime_public_api.rs"]
 mod runtime_public_api;
-#[path = "integration/session_in_ops.rs"]
-mod session_in_ops;
+#[path = "integration/session_ops.rs"]
+mod session_ops;
 #[path = "integration/trace_context.rs"]
 mod trace_context;
 #[path = "integration/typed_tensor_contract.rs"]

--- a/crates/tenferro-runtime/tests/integration/runtime_public_api.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_public_api.rs
@@ -2,9 +2,9 @@ use tenferro_cpu::CpuBackend;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_runtime::{
     CompiledGraph, DType, DotGeneralConfig, Error, ErrorPhase, GatherConfig, GraphCompiler,
-    PadConfig, Runtime, ScatterConfig, SliceConfig, Tensor, TensorOpsExt, TracedTensor,
+    PadConfig, Runtime, ScatterConfig, SliceConfig, Tensor, TensorSessionOpsExt, TracedTensor,
 };
-use tenferro_tensor::{Error as TensorError, ValidationError};
+use tenferro_tensor::{BackendSessionHost, Error as TensorError, ValidationError};
 
 fn cpu_runtime() -> Runtime {
     let backend = CpuBackend::new();
@@ -109,23 +109,26 @@ fn tensor_extension_trait_covers_eager_runtime_paths() {
     let input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let f32_input = Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap();
 
-    let converted = f32_input.convert(DType::F64, &mut backend).unwrap();
+    let (converted, casted, reshaped, transposed, summed) = backend
+        .with_backend_session(
+            |session| -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)> {
+                let converted = f32_input.convert(DType::F64, session)?;
+                let casted = input.cast(DType::F32, session)?;
+                let reshaped = input.reshape(&[4], session)?;
+                let transposed = input.transpose(&[1, 0], session)?;
+                let summed = input.reduce_sum(&[0], session)?;
+                Ok((converted, casted, reshaped, transposed, summed))
+            },
+        )
+        .unwrap();
     assert_eq!(converted.dtype(), DType::F64);
     assert_eq!(converted.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
-
-    let casted = input.cast(DType::F32, &mut backend).unwrap();
     assert_eq!(casted.dtype(), DType::F32);
     assert_eq!(casted.as_slice::<f32>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
-
-    let reshaped = input.reshape(&[4], &mut backend).unwrap();
     assert_eq!(reshaped.shape(), &[4]);
     assert_eq!(reshaped.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
-
-    let transposed = input.transpose(&[1, 0], &mut backend).unwrap();
     assert_eq!(transposed.shape(), &[2, 2]);
     assert_eq!(transposed.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
-
-    let summed = input.reduce_sum(&[0], &mut backend).unwrap();
     assert_eq!(summed.shape(), &[2]);
     assert_eq!(summed.as_slice::<f64>().unwrap(), &[3.0, 7.0]);
 }
@@ -136,7 +139,9 @@ fn concrete_tensor_matmul_rejects_non_matrix_inputs_without_rank_underflow() {
     let scalar = Tensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
     let vector = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
 
-    let err = scalar.matmul(&vector, &mut backend).unwrap_err();
+    let err = backend
+        .with_backend_session(|session| scalar.matmul(&vector, session))
+        .unwrap_err();
 
     assert!(matches!(
         err,

--- a/crates/tenferro-runtime/tests/integration/session_ops.rs
+++ b/crates/tenferro-runtime/tests/integration/session_ops.rs
@@ -1,19 +1,16 @@
-//! Parity and single-session-entry tests for the `_in` session surfaces.
+//! Value, error, and single-session-entry tests for the session-explicit
+//! concrete-ops surface.
 //!
 //! Covers, per surface (dynamic [`Tensor`] and typed [`TypedTensor`]):
-//! equal-shape ops, real broadcast, invalid-broadcast structured-error parity
-//! with the one-shot path, dtype parity, typed output dtype validation
-//! (`into_typed_result`), and a deterministic proof that an `_in` chain
-//! executes inside exactly one backend session entry while the one-shot
-//! counterpart enters one session per op.
+//! equal-shape ops, real broadcast, invalid-broadcast structured errors, dtype
+//! conversion, typed output dtype validation (`into_typed_result`), and a
+//! deterministic proof that a session chain executes inside exactly one
+//! backend session entry.
 
 use std::cell::Cell;
 
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{
-    Tensor, TensorOpsExt, TensorSessionOpsExt, TypedTensor, TypedTensorOpsExt,
-    TypedTensorSessionOpsExt,
-};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt, TypedTensor, TypedTensorSessionOpsExt};
 use tenferro_tensor::backend::{
     BackendCachedDot, TensorAnalytic, TensorBuffer, TensorDeviceTransfer, TensorDot,
     TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
@@ -84,28 +81,18 @@ fn assert_rank_mismatch_error(error: Error) {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn session_in_dynamic_equal_shape_matches_one_shot() {
+fn session_dynamic_equal_shape_chain() {
     let mut backend = CpuBackend::new();
     let a_values = vec![1.5_f64; 8];
     let b_values = vec![2.25_f64; 8];
     let a = Tensor::from_vec_col_major(vec![8], a_values.clone()).unwrap();
     let b = Tensor::from_vec_col_major(vec![8], b_values.clone()).unwrap();
 
-    let one_shot = a
-        .add(&b, &mut backend)
-        .unwrap()
-        .exp(&mut backend)
-        .unwrap()
-        .mul(&b, &mut backend)
-        .unwrap()
-        .reduce_sum(&[0], &mut backend)
-        .unwrap();
-
     let session = backend.with_backend_session(|s| {
-        let x = a.add_in(&b, s).unwrap();
-        let x = x.exp_in(s).unwrap();
-        let x = x.mul_in(&b, s).unwrap();
-        x.reduce_sum_in(&[0], s).unwrap()
+        let x = a.add(&b, s).unwrap();
+        let x = x.exp(s).unwrap();
+        let x = x.mul(&b, s).unwrap();
+        x.reduce_sum(&[0], s).unwrap()
     });
 
     // Independent value check in plain scalar math: the chain computes
@@ -117,37 +104,21 @@ fn session_in_dynamic_equal_shape_matches_one_shot() {
         .map(|(&x, &y)| (x + y).exp() * y)
         .sum();
     assert_close(session.as_slice::<f64>().unwrap(), &[expected]);
-
-    assert_eq!(session.shape(), one_shot.shape());
-    assert_close(
-        session.as_slice::<f64>().unwrap(),
-        one_shot.as_slice::<f64>().unwrap(),
-    );
 }
 
 #[test]
-fn session_in_dynamic_broadcast_matches_one_shot() {
+fn session_dynamic_broadcast_chain() {
     let mut backend = CpuBackend::new();
     let a_values = vec![1.0_f64];
     let b_values = vec![2.0_f64; 8];
     let a = Tensor::from_vec_col_major(vec![1], a_values.clone()).unwrap();
     let b = Tensor::from_vec_col_major(vec![8], b_values.clone()).unwrap();
 
-    let one_shot = a
-        .add(&b, &mut backend)
-        .unwrap()
-        .exp(&mut backend)
-        .unwrap()
-        .mul(&a, &mut backend)
-        .unwrap()
-        .reduce_sum(&[0], &mut backend)
-        .unwrap();
-
     let session = backend.with_backend_session(|s| {
-        let x = a.add_in(&b, s).unwrap();
-        let x = x.exp_in(s).unwrap();
-        let x = x.mul_in(&a, s).unwrap();
-        x.reduce_sum_in(&[0], s).unwrap()
+        let x = a.add(&b, s).unwrap();
+        let x = x.exp(s).unwrap();
+        let x = x.mul(&a, s).unwrap();
+        x.reduce_sum(&[0], s).unwrap()
     });
 
     // Independent value check: the broadcast chain computes
@@ -157,53 +128,38 @@ fn session_in_dynamic_broadcast_matches_one_shot() {
         .map(|&y| (a_values[0] + y).exp() * a_values[0])
         .sum();
     assert_close(session.as_slice::<f64>().unwrap(), &[expected]);
-
-    assert_eq!(session.shape(), one_shot.shape());
-    assert_close(
-        session.as_slice::<f64>().unwrap(),
-        one_shot.as_slice::<f64>().unwrap(),
-    );
 }
 
 #[test]
-fn session_in_dynamic_invalid_broadcast_matches_one_shot_error() {
+fn session_dynamic_invalid_broadcast_error() {
     let mut backend = CpuBackend::new();
     let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]).unwrap();
     let b = Tensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
 
-    let one_shot_error = a.add(&b, &mut backend).unwrap_err();
-    let session_error = backend
-        .with_backend_session(|s| a.add_in(&b, s))
-        .unwrap_err();
+    let session_error = backend.with_backend_session(|s| a.add(&b, s)).unwrap_err();
 
-    assert_incompatible_shapes_error(one_shot_error);
     assert_incompatible_shapes_error(session_error);
 }
 
 #[test]
-fn session_in_dynamic_dtype_error_matches_one_shot() {
+fn session_dynamic_dtype_error() {
     let mut backend = CpuBackend::new();
     let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]).unwrap();
     let b = Tensor::from_vec_col_major(vec![2], vec![1_i32; 2]).unwrap();
 
-    let one_shot_error = a.add(&b, &mut backend).unwrap_err();
-    let session_error = backend
-        .with_backend_session(|s| a.add_in(&b, s))
-        .unwrap_err();
+    let session_error = backend.with_backend_session(|s| a.add(&b, s)).unwrap_err();
 
     // Assert the full payload (op name, source lhs dtype as expected, rhs
     // dtype as actual) for both paths, not just the error kind.
-    for error in [one_shot_error, session_error] {
-        let Error::Validation {
-            op: "add",
-            source: ValidationError::DTypeMismatch { expected, actual },
-        } = &error
-        else {
-            panic!("expected add DTypeMismatch, got {error:?}");
-        };
-        assert_eq!(*expected, tenferro_tensor::core::DType::F64);
-        assert_eq!(*actual, tenferro_tensor::core::DType::I32);
-    }
+    let Error::Validation {
+        op: "add",
+        source: ValidationError::DTypeMismatch { expected, actual },
+    } = &session_error
+    else {
+        panic!("expected add DTypeMismatch, got {session_error:?}");
+    };
+    assert_eq!(*expected, tenferro_tensor::core::DType::F64);
+    assert_eq!(*actual, tenferro_tensor::core::DType::I32);
 }
 
 // ---------------------------------------------------------------------------
@@ -211,28 +167,18 @@ fn session_in_dynamic_dtype_error_matches_one_shot() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn session_in_typed_equal_shape_matches_one_shot() {
+fn session_typed_equal_shape_chain() {
     let mut backend = CpuBackend::new();
     let a_values = vec![1.5_f64; 8];
     let b_values = vec![2.25_f64; 8];
     let a = TypedTensor::<f64>::from_vec_col_major(vec![8], a_values.clone()).unwrap();
     let b = TypedTensor::<f64>::from_vec_col_major(vec![8], b_values.clone()).unwrap();
 
-    let one_shot = a
-        .add(&b, &mut backend)
-        .unwrap()
-        .exp(&mut backend)
-        .unwrap()
-        .mul(&b, &mut backend)
-        .unwrap()
-        .reduce_sum(&[0], &mut backend)
-        .unwrap();
-
     let session = backend.with_backend_session(|s| {
-        let x = a.add_in(&b, s).unwrap();
-        let x = x.exp_in(s).unwrap();
-        let x = x.mul_in(&b, s).unwrap();
-        x.reduce_sum_in(&[0], s).unwrap()
+        let x = a.add(&b, s).unwrap();
+        let x = x.exp(s).unwrap();
+        let x = x.mul(&b, s).unwrap();
+        x.reduce_sum(&[0], s).unwrap()
     });
 
     // Independent value check in plain scalar math (see the dynamic twin).
@@ -242,34 +188,21 @@ fn session_in_typed_equal_shape_matches_one_shot() {
         .map(|(&x, &y)| (x + y).exp() * y)
         .sum();
     assert_close(session.host_data().unwrap(), &[expected]);
-
-    assert_eq!(session.shape(), one_shot.shape());
-    assert_close(session.host_data().unwrap(), one_shot.host_data().unwrap());
 }
 
 #[test]
-fn session_in_typed_broadcast_matches_one_shot() {
+fn session_typed_broadcast_chain() {
     let mut backend = CpuBackend::new();
     let a_values = vec![1.0_f64];
     let b_values = vec![2.0_f64; 8];
     let a = TypedTensor::<f64>::from_vec_col_major(vec![1], a_values.clone()).unwrap();
     let b = TypedTensor::<f64>::from_vec_col_major(vec![8], b_values.clone()).unwrap();
 
-    let one_shot = a
-        .add(&b, &mut backend)
-        .unwrap()
-        .exp(&mut backend)
-        .unwrap()
-        .mul(&a, &mut backend)
-        .unwrap()
-        .reduce_sum(&[0], &mut backend)
-        .unwrap();
-
     let session = backend.with_backend_session(|s| {
-        let x = a.add_in(&b, s).unwrap();
-        let x = x.exp_in(s).unwrap();
-        let x = x.mul_in(&a, s).unwrap();
-        x.reduce_sum_in(&[0], s).unwrap()
+        let x = a.add(&b, s).unwrap();
+        let x = x.exp(s).unwrap();
+        let x = x.mul(&a, s).unwrap();
+        x.reduce_sum(&[0], s).unwrap()
     });
 
     // Independent value check: sum_i exp(a_0 + b_i) * a_0 in plain scalar math.
@@ -278,23 +211,16 @@ fn session_in_typed_broadcast_matches_one_shot() {
         .map(|&y| (a_values[0] + y).exp() * a_values[0])
         .sum();
     assert_close(session.host_data().unwrap(), &[expected]);
-
-    assert_eq!(session.shape(), one_shot.shape());
-    assert_close(session.host_data().unwrap(), one_shot.host_data().unwrap());
 }
 
 #[test]
-fn session_in_typed_invalid_broadcast_matches_one_shot_error() {
+fn session_typed_invalid_broadcast_error() {
     let mut backend = CpuBackend::new();
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0; 2]).unwrap();
     let b = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0; 3]).unwrap();
 
-    let one_shot_error = a.add(&b, &mut backend).unwrap_err();
-    let session_error = backend
-        .with_backend_session(|s| a.add_in(&b, s))
-        .unwrap_err();
+    let session_error = backend.with_backend_session(|s| a.add(&b, s)).unwrap_err();
 
-    assert_incompatible_shapes_error(one_shot_error);
     assert_incompatible_shapes_error(session_error);
 }
 
@@ -309,100 +235,90 @@ fn session_in_typed_validates_output_dtype() {
     let errors = [
         (
             "add",
-            backend
-                .with_backend_session(|s| a.add_in(&a, s))
-                .unwrap_err(),
+            backend.with_backend_session(|s| a.add(&a, s)).unwrap_err(),
         ),
         (
             "mul",
-            backend
-                .with_backend_session(|s| a.mul_in(&a, s))
-                .unwrap_err(),
+            backend.with_backend_session(|s| a.mul(&a, s)).unwrap_err(),
         ),
         (
             "exp",
-            backend.with_backend_session(|s| a.exp_in(s)).unwrap_err(),
+            backend.with_backend_session(|s| a.exp(s)).unwrap_err(),
         ),
         (
             "reduce_sum",
             backend
-                .with_backend_session(|s| a.reduce_sum_in(&[0], s))
+                .with_backend_session(|s| a.reduce_sum(&[0], s))
                 .unwrap_err(),
         ),
         (
             "sub",
-            backend
-                .with_backend_session(|s| a.sub_in(&a, s))
-                .unwrap_err(),
+            backend.with_backend_session(|s| a.sub(&a, s)).unwrap_err(),
         ),
         (
             "div",
-            backend
-                .with_backend_session(|s| a.div_in(&a, s))
-                .unwrap_err(),
+            backend.with_backend_session(|s| a.div(&a, s)).unwrap_err(),
         ),
         (
             "pow",
-            backend
-                .with_backend_session(|s| a.pow_in(&a, s))
-                .unwrap_err(),
+            backend.with_backend_session(|s| a.pow(&a, s)).unwrap_err(),
         ),
         (
             "maximum",
             backend
-                .with_backend_session(|s| a.maximum_in(&a, s))
+                .with_backend_session(|s| a.maximum(&a, s))
                 .unwrap_err(),
         ),
         (
             "neg",
-            backend.with_backend_session(|s| a.neg_in(s)).unwrap_err(),
+            backend.with_backend_session(|s| a.neg(s)).unwrap_err(),
         ),
         (
             "abs",
-            backend.with_backend_session(|s| a.abs_in(s)).unwrap_err(),
+            backend.with_backend_session(|s| a.abs(s)).unwrap_err(),
         ),
         (
             "log",
-            backend.with_backend_session(|s| a.log_in(s)).unwrap_err(),
+            backend.with_backend_session(|s| a.log(s)).unwrap_err(),
         ),
         (
             "sqrt",
-            backend.with_backend_session(|s| a.sqrt_in(s)).unwrap_err(),
+            backend.with_backend_session(|s| a.sqrt(s)).unwrap_err(),
         ),
         (
             "clamp",
             backend
-                .with_backend_session(|s| a.clamp_in(&lower, &upper, s))
+                .with_backend_session(|s| a.clamp(&lower, &upper, s))
                 .unwrap_err(),
         ),
         (
             "matmul",
             backend
-                .with_backend_session(|s| matrix.matmul_in(&matrix, s))
+                .with_backend_session(|s| matrix.matmul(&matrix, s))
                 .unwrap_err(),
         ),
         (
             "reshape",
             backend
-                .with_backend_session(|s| matrix.reshape_in(&[4], s))
+                .with_backend_session(|s| matrix.reshape(&[4], s))
                 .unwrap_err(),
         ),
         (
             "transpose",
             backend
-                .with_backend_session(|s| matrix.transpose_in(&[1, 0], s))
+                .with_backend_session(|s| matrix.transpose(&[1, 0], s))
                 .unwrap_err(),
         ),
         (
             "broadcast_in_dim",
             backend
-                .with_backend_session(|s| matrix.broadcast_in_dim_in(&[2, 2], &[0, 1], s))
+                .with_backend_session(|s| matrix.broadcast_in_dim(&[2, 2], &[0, 1], s))
                 .unwrap_err(),
         ),
         (
             "compare",
             backend
-                .with_backend_session(|s| a.compare_in(&a, CompareDir::Gt, s))
+                .with_backend_session(|s| a.compare(&a, CompareDir::Gt, s))
                 .unwrap_err(),
         ),
     ];
@@ -432,52 +348,25 @@ fn session_in_typed_validates_output_dtype() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn session_in_chain_enters_one_session_one_shot_enters_ten() {
+fn session_chain_enters_one_session() {
     let mut backend = SessionCountingBackend::new();
     let a = Tensor::from_vec_col_major(vec![1], vec![0.5_f64]).unwrap();
     let b = Tensor::from_vec_col_major(vec![8], vec![1.0_f64; 8]).unwrap();
 
-    // 10 one-shot ops (3x add->exp->mul + final reduce_sum): one session entry
-    // per op.
-    let one_shot = a
-        .add(&b, &mut backend)
-        .unwrap()
-        .exp(&mut backend)
-        .unwrap()
-        .mul(&a, &mut backend)
-        .unwrap()
-        .add(&b, &mut backend)
-        .unwrap()
-        .exp(&mut backend)
-        .unwrap()
-        .mul(&a, &mut backend)
-        .unwrap()
-        .add(&b, &mut backend)
-        .unwrap()
-        .exp(&mut backend)
-        .unwrap()
-        .mul(&a, &mut backend)
-        .unwrap()
-        .reduce_sum(&[0], &mut backend)
-        .unwrap();
-    assert_eq!(
-        backend.entries.get(),
-        10,
-        "one-shot chain must enter one session per op"
-    );
-
+    // A 10-op session chain (3x add->exp->mul + final reduce_sum) must
+    // execute inside exactly one backend session entry.
     backend.entries.set(0);
     let session = backend.with_backend_session(|s| {
-        let x = a.add_in(&b, s).unwrap();
-        let x = x.exp_in(s).unwrap();
-        let x = x.mul_in(&a, s).unwrap();
-        let x = x.add_in(&b, s).unwrap();
-        let x = x.exp_in(s).unwrap();
-        let x = x.mul_in(&a, s).unwrap();
-        let x = x.add_in(&b, s).unwrap();
-        let x = x.exp_in(s).unwrap();
-        let x = x.mul_in(&a, s).unwrap();
-        x.reduce_sum_in(&[0], s).unwrap()
+        let x = a.add(&b, s).unwrap();
+        let x = x.exp(s).unwrap();
+        let x = x.mul(&a, s).unwrap();
+        let x = x.add(&b, s).unwrap();
+        let x = x.exp(s).unwrap();
+        let x = x.mul(&a, s).unwrap();
+        let x = x.add(&b, s).unwrap();
+        let x = x.exp(s).unwrap();
+        let x = x.mul(&a, s).unwrap();
+        x.reduce_sum(&[0], s).unwrap()
     });
     assert_eq!(
         backend.entries.get(),
@@ -485,18 +374,27 @@ fn session_in_chain_enters_one_session_one_shot_enters_ten() {
         "session chain must enter exactly one session"
     );
 
-    assert_close(
-        session.as_slice::<f64>().unwrap(),
-        one_shot.as_slice::<f64>().unwrap(),
+    // Independent scalar math: every element follows v_{n+1} = exp(v_n + 1) * 0.5
+    // starting from v_0 = exp(1.5) * 0.5, and the final reduce_sum adds the 8
+    // identical elements. The chain magnitude is ~4e6, so the check is
+    // relative (repeated `exp` amplifies 1-ULP rounding differences).
+    let mut value = (0.5_f64 + 1.0).exp() * 0.5;
+    value = (value + 1.0).exp() * 0.5;
+    value = (value + 1.0).exp() * 0.5;
+    let expected = 8.0 * value;
+    let actual = session.as_slice::<f64>().unwrap()[0];
+    assert!(
+        (actual - expected).abs() / expected < 1.0e-12,
+        "chain result {actual} diverges from independent math {expected}"
     );
 }
 
 // ---------------------------------------------------------------------------
-// Phase 1 (issue #1680): full `_in` surface parity
+// Phase 1 (issue #1680) full-surface direct session tests
 // ---------------------------------------------------------------------------
 
 #[test]
-fn session_in_dynamic_binary_matches_one_shot() {
+fn session_dynamic_binary_chain() {
     let mut backend = CpuBackend::new();
 
     // Equal-shape arm: sub -> div -> pow -> maximum -> minimum.
@@ -505,28 +403,16 @@ fn session_in_dynamic_binary_matches_one_shot() {
     let a = Tensor::from_vec_col_major(vec![2, 2], a_values.clone()).unwrap();
     let b = Tensor::from_vec_col_major(vec![2, 2], b_values.clone()).unwrap();
 
-    let one_shot = a
-        .sub(&b, &mut backend)
-        .unwrap()
-        .div(&b, &mut backend)
-        .unwrap()
-        .pow(&b, &mut backend)
-        .unwrap()
-        .maximum(&b, &mut backend)
-        .unwrap()
-        .minimum(&b, &mut backend)
-        .unwrap();
-
     let session = backend.with_backend_session(|s| {
-        a.sub_in(&b, s)
+        a.sub(&b, s)
             .unwrap()
-            .div_in(&b, s)
+            .div(&b, s)
             .unwrap()
-            .pow_in(&b, s)
+            .pow(&b, s)
             .unwrap()
-            .maximum_in(&b, s)
+            .maximum(&b, s)
             .unwrap()
-            .minimum_in(&b, s)
+            .minimum(&b, s)
             .unwrap()
     });
 
@@ -542,96 +428,57 @@ fn session_in_dynamic_binary_matches_one_shot() {
         })
         .collect();
     assert_close(session.as_slice::<f64>().unwrap(), &expected);
-    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
-    assert_eq!(session.shape(), one_shot.shape());
 
     // Real broadcast arm: [1] vs [4].
     let a = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
     let b = Tensor::from_vec_col_major(vec![4], vec![2.0_f64; 4]).unwrap();
-    let one_shot = a
-        .sub(&b, &mut backend)
-        .unwrap()
-        .div(&b, &mut backend)
-        .unwrap()
-        .pow(&b, &mut backend)
-        .unwrap()
-        .maximum(&b, &mut backend)
-        .unwrap()
-        .minimum(&b, &mut backend)
-        .unwrap();
+
     let session = backend.with_backend_session(|s| {
-        a.sub_in(&b, s)
+        a.sub(&b, s)
             .unwrap()
-            .div_in(&b, s)
+            .div(&b, s)
             .unwrap()
-            .pow_in(&b, s)
+            .pow(&b, s)
             .unwrap()
-            .maximum_in(&b, s)
+            .maximum(&b, s)
             .unwrap()
-            .minimum_in(&b, s)
+            .minimum(&b, s)
             .unwrap()
     });
     let expected = [2.0_f64; 4];
     assert_close(session.as_slice::<f64>().unwrap(), &expected);
-    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
 }
 
 #[test]
-fn session_in_dynamic_unary_matches_one_shot() {
+fn session_dynamic_unary_chain() {
     let mut backend = CpuBackend::new();
     let x_values = vec![2.0_f64, 3.0, 4.0, 5.0];
     let x = Tensor::from_vec_col_major(vec![4], x_values.clone()).unwrap();
 
-    let one_shot = x
-        .neg(&mut backend)
-        .unwrap()
-        .abs(&mut backend)
-        .unwrap()
-        .sqrt(&mut backend)
-        .unwrap()
-        .rsqrt(&mut backend)
-        .unwrap()
-        .sign(&mut backend)
-        .unwrap()
-        .conj(&mut backend)
-        .unwrap()
-        .log(&mut backend)
-        .unwrap()
-        .expm1(&mut backend)
-        .unwrap()
-        .log1p(&mut backend)
-        .unwrap()
-        .sin(&mut backend)
-        .unwrap()
-        .cos(&mut backend)
-        .unwrap()
-        .tanh(&mut backend)
-        .unwrap();
-
     let session = backend.with_backend_session(|s| {
-        x.neg_in(s)
+        x.neg(s)
             .unwrap()
-            .abs_in(s)
+            .abs(s)
             .unwrap()
-            .sqrt_in(s)
+            .sqrt(s)
             .unwrap()
-            .rsqrt_in(s)
+            .rsqrt(s)
             .unwrap()
-            .sign_in(s)
+            .sign(s)
             .unwrap()
-            .conj_in(s)
+            .conj(s)
             .unwrap()
-            .log_in(s)
+            .log(s)
             .unwrap()
-            .expm1_in(s)
+            .expm1(s)
             .unwrap()
-            .log1p_in(s)
+            .log1p(s)
             .unwrap()
-            .sin_in(s)
+            .sin(s)
             .unwrap()
-            .cos_in(s)
+            .cos(s)
             .unwrap()
-            .tanh_in(s)
+            .tanh(s)
             .unwrap()
     });
 
@@ -649,11 +496,10 @@ fn session_in_dynamic_unary_matches_one_shot() {
     expected = expected.iter().map(|&v| v.cos()).collect();
     expected = expected.iter().map(|&v| v.tanh()).collect();
     assert_close(session.as_slice::<f64>().unwrap(), &expected);
-    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
 }
 
 #[test]
-fn session_in_dynamic_ternary_matches_one_shot() {
+fn session_dynamic_ternary_chain() {
     let mut backend = CpuBackend::new();
     let on_true = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let on_false = Tensor::from_vec_col_major(vec![4], vec![5.0_f64, 6.0, 7.0, 8.0]).unwrap();
@@ -663,69 +509,47 @@ fn session_in_dynamic_ternary_matches_one_shot() {
     let lower = Tensor::from_vec_col_major(vec![], vec![0.0_f64]).unwrap();
     let upper = Tensor::from_vec_col_major(vec![], vec![5.0_f64]).unwrap();
 
-    let one_shot = condition
-        .where_select(&on_true, &on_false, &mut backend)
-        .unwrap()
-        .clamp(&lower, &upper, &mut backend)
-        .unwrap();
     let session = backend.with_backend_session(|s| {
         condition
-            .where_select_in(&on_true, &on_false, s)
+            .where_select(&on_true, &on_false, s)
             .unwrap()
-            .clamp_in(&lower, &upper, s)
+            .clamp(&lower, &upper, s)
             .unwrap()
     });
     // select -> [1, 6, 3, 8], then clamp(0, 5).
     let expected = [1.0_f64, 5.0, 3.0, 5.0];
     assert_close(session.as_slice::<f64>().unwrap(), &expected);
-    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
 
     // Broadcast arm: singleton condition and bounds.
     let condition = Tensor::from_vec_col_major(vec![1], vec![true]).unwrap();
     let lower = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     let upper = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
 
-    let one_shot = condition
-        .where_select(&on_true, &on_false, &mut backend)
-        .unwrap()
-        .clamp(&lower, &upper, &mut backend)
-        .unwrap();
     let session = backend.with_backend_session(|s| {
         condition
-            .where_select_in(&on_true, &on_false, s)
+            .where_select(&on_true, &on_false, s)
             .unwrap()
-            .clamp_in(&lower, &upper, s)
+            .clamp(&lower, &upper, s)
             .unwrap()
     });
     // select broadcasts the condition -> [1, 2, 3, 4], then clamp(2, 3).
     let expected = [2.0_f64, 2.0, 3.0, 3.0];
     assert_close(session.as_slice::<f64>().unwrap(), &expected);
-    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
 }
 
 #[test]
-fn session_in_dynamic_structural_matches_one_shot() {
+fn session_dynamic_structural_chain() {
     let mut backend = CpuBackend::new();
     let x = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
 
-    let one_shot = x
-        .transpose(&[1, 0], &mut backend)
-        .unwrap()
-        .reshape(&[6], &mut backend)
-        .unwrap()
-        .reshape(&[2, 3], &mut backend)
-        .unwrap()
-        .transpose(&[1, 0], &mut backend)
-        .unwrap();
-
     let session = backend.with_backend_session(|s| {
-        x.transpose_in(&[1, 0], s)
+        x.transpose(&[1, 0], s)
             .unwrap()
-            .reshape_in(&[6], s)
+            .reshape(&[6], s)
             .unwrap()
-            .reshape_in(&[2, 3], s)
+            .reshape(&[2, 3], s)
             .unwrap()
-            .transpose_in(&[1, 0], s)
+            .transpose(&[1, 0], s)
             .unwrap()
     });
 
@@ -737,49 +561,43 @@ fn session_in_dynamic_structural_matches_one_shot() {
     assert_eq!(expected, vec![1.0, 5.0, 4.0, 3.0, 2.0, 6.0]);
     assert_eq!(session.shape(), &[3, 2]);
     assert_close(session.as_slice::<f64>().unwrap(), &expected);
-    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
 }
 
 #[test]
-fn session_in_dynamic_dtype_matches_one_shot() {
+fn session_dynamic_dtype_chain() {
     let mut backend = CpuBackend::new();
     let x = Tensor::from_vec_col_major(vec![4], vec![1.2_f64, -2.8, 3.5, 0.4]).unwrap();
 
-    let one_shot = x.cast(DType::I32, &mut backend).unwrap();
     let session = backend
-        .with_backend_session(|s| x.cast_in(DType::I32, s))
+        .with_backend_session(|s| x.cast(DType::I32, s))
         .unwrap();
     let expected = [1_i32, -2, 3, 0];
     assert_eq!(session.as_slice::<i32>().unwrap(), &expected);
-    assert_eq!(one_shot.as_slice::<i32>().unwrap(), &expected);
 
     // convert uses the checked lattice: f64 -> C64 preserves values, and the
     // round trip back through cast reproduces them.
     let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    let one_shot = y.convert(DType::C64, &mut backend).unwrap();
+
     let session = backend
-        .with_backend_session(|s| y.convert_in(DType::C64, s))
+        .with_backend_session(|s| y.convert(DType::C64, s))
         .unwrap();
     assert_eq!(session.dtype(), DType::C64);
-    assert_eq!(one_shot.dtype(), DType::C64);
+
     let back = backend
-        .with_backend_session(|s| session.cast_in(DType::F64, s))
+        .with_backend_session(|s| session.cast(DType::F64, s))
         .unwrap();
     assert_close(back.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
 }
 
 #[test]
-fn session_in_dynamic_matmul_matches_one_shot() {
+fn session_dynamic_matmul_chain() {
     let mut backend = CpuBackend::new();
     let a_values = vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0];
     let b_values = vec![7.0_f64, 9.0, 11.0, 8.0, 10.0, 12.0];
     let a = Tensor::from_vec_col_major(vec![2, 3], a_values.clone()).unwrap();
     let b = Tensor::from_vec_col_major(vec![3, 2], b_values.clone()).unwrap();
 
-    let one_shot = a.matmul(&b, &mut backend).unwrap();
-    let session = backend
-        .with_backend_session(|s| a.matmul_in(&b, s))
-        .unwrap();
+    let session = backend.with_backend_session(|s| a.matmul(&b, s)).unwrap();
 
     // Independent value check with plain triple loops over col-major indices.
     let mut expected = vec![0.0_f64; 4];
@@ -792,62 +610,55 @@ fn session_in_dynamic_matmul_matches_one_shot() {
     }
     assert_eq!(session.shape(), &[2, 2]);
     assert_close(session.as_slice::<f64>().unwrap(), &expected);
-    assert_close(one_shot.as_slice::<f64>().unwrap(), &expected);
 }
 
 #[test]
-fn session_in_dynamic_errors_match_one_shot() {
+fn session_dynamic_errors() {
     let mut backend = CpuBackend::new();
     let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]).unwrap();
     let b = Tensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
 
     // Binary broadcast error.
-    let one_shot_error = a.sub(&b, &mut backend).unwrap_err();
-    let session_error = backend
-        .with_backend_session(|s| a.sub_in(&b, s))
-        .unwrap_err();
-    assert_incompatible_shapes_error(one_shot_error);
+
+    let session_error = backend.with_backend_session(|s| a.sub(&b, s)).unwrap_err();
+
     assert_incompatible_shapes_error(session_error);
 
     // Ternary broadcast error through clamp ([2] vs [3] bounds).
     let lower = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
     let upper = Tensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
-    let one_shot_error = a.clamp(&lower, &upper, &mut backend).unwrap_err();
+
     let session_error = backend
-        .with_backend_session(|s| a.clamp_in(&lower, &upper, s))
+        .with_backend_session(|s| a.clamp(&lower, &upper, s))
         .unwrap_err();
-    assert_incompatible_shapes_error(one_shot_error);
+
     assert_incompatible_shapes_error(session_error);
 
     // Matmul rank error for rank-1 operands.
-    let one_shot_error = a.matmul(&b, &mut backend).unwrap_err();
+
     let session_error = backend
-        .with_backend_session(|s| a.matmul_in(&b, s))
+        .with_backend_session(|s| a.matmul(&b, s))
         .unwrap_err();
-    assert_rank_mismatch_error(one_shot_error);
+
     assert_rank_mismatch_error(session_error);
 
     // Dtype mismatch error for sub.
     let c = Tensor::from_vec_col_major(vec![2], vec![1_i32; 2]).unwrap();
-    let one_shot_error = a.sub(&c, &mut backend).unwrap_err();
-    let session_error = backend
-        .with_backend_session(|s| a.sub_in(&c, s))
-        .unwrap_err();
-    for error in [one_shot_error, session_error] {
-        let Error::Validation {
-            op: "sub",
-            source: ValidationError::DTypeMismatch { expected, actual },
-        } = &error
-        else {
-            panic!("expected sub DTypeMismatch, got {error:?}");
-        };
-        assert_eq!(*expected, tenferro_tensor::core::DType::F64);
-        assert_eq!(*actual, tenferro_tensor::core::DType::I32);
-    }
+
+    let session_error = backend.with_backend_session(|s| a.sub(&c, s)).unwrap_err();
+    let Error::Validation {
+        op: "sub",
+        source: ValidationError::DTypeMismatch { expected, actual },
+    } = &session_error
+    else {
+        panic!("expected sub DTypeMismatch, got {session_error:?}");
+    };
+    assert_eq!(*expected, tenferro_tensor::core::DType::F64);
+    assert_eq!(*actual, tenferro_tensor::core::DType::I32);
 }
 
 #[test]
-fn session_in_typed_binary_matches_one_shot() {
+fn session_typed_binary_chain() {
     let mut backend = CpuBackend::new();
 
     // Equal-shape arm: sub -> div -> pow -> maximum -> minimum.
@@ -856,28 +667,16 @@ fn session_in_typed_binary_matches_one_shot() {
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], a_values.clone()).unwrap();
     let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], b_values.clone()).unwrap();
 
-    let one_shot = a
-        .sub(&b, &mut backend)
-        .unwrap()
-        .div(&b, &mut backend)
-        .unwrap()
-        .pow(&b, &mut backend)
-        .unwrap()
-        .maximum(&b, &mut backend)
-        .unwrap()
-        .minimum(&b, &mut backend)
-        .unwrap();
-
     let session = backend.with_backend_session(|s| {
-        a.sub_in(&b, s)
+        a.sub(&b, s)
             .unwrap()
-            .div_in(&b, s)
+            .div(&b, s)
             .unwrap()
-            .pow_in(&b, s)
+            .pow(&b, s)
             .unwrap()
-            .maximum_in(&b, s)
+            .maximum(&b, s)
             .unwrap()
-            .minimum_in(&b, s)
+            .minimum(&b, s)
             .unwrap()
     });
 
@@ -892,96 +691,57 @@ fn session_in_typed_binary_matches_one_shot() {
         })
         .collect();
     assert_close(session.host_data().unwrap(), &expected);
-    assert_close(one_shot.host_data().unwrap(), &expected);
-    assert_eq!(session.shape(), one_shot.shape());
 
     // Real broadcast arm: [1] vs [4].
     let a = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![3.0]).unwrap();
     let b = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![2.0; 4]).unwrap();
-    let one_shot = a
-        .sub(&b, &mut backend)
-        .unwrap()
-        .div(&b, &mut backend)
-        .unwrap()
-        .pow(&b, &mut backend)
-        .unwrap()
-        .maximum(&b, &mut backend)
-        .unwrap()
-        .minimum(&b, &mut backend)
-        .unwrap();
+
     let session = backend.with_backend_session(|s| {
-        a.sub_in(&b, s)
+        a.sub(&b, s)
             .unwrap()
-            .div_in(&b, s)
+            .div(&b, s)
             .unwrap()
-            .pow_in(&b, s)
+            .pow(&b, s)
             .unwrap()
-            .maximum_in(&b, s)
+            .maximum(&b, s)
             .unwrap()
-            .minimum_in(&b, s)
+            .minimum(&b, s)
             .unwrap()
     });
     let expected = [2.0_f64; 4];
     assert_close(session.host_data().unwrap(), &expected);
-    assert_close(one_shot.host_data().unwrap(), &expected);
 }
 
 #[test]
-fn session_in_typed_unary_matches_one_shot() {
+fn session_typed_unary_chain() {
     let mut backend = CpuBackend::new();
     let x_values = vec![2.0_f64, 3.0, 4.0, 5.0];
     let x = TypedTensor::<f64>::from_vec_col_major(vec![4], x_values.clone()).unwrap();
 
-    let one_shot = x
-        .neg(&mut backend)
-        .unwrap()
-        .abs(&mut backend)
-        .unwrap()
-        .sqrt(&mut backend)
-        .unwrap()
-        .rsqrt(&mut backend)
-        .unwrap()
-        .sign(&mut backend)
-        .unwrap()
-        .conj(&mut backend)
-        .unwrap()
-        .log(&mut backend)
-        .unwrap()
-        .expm1(&mut backend)
-        .unwrap()
-        .log1p(&mut backend)
-        .unwrap()
-        .sin(&mut backend)
-        .unwrap()
-        .cos(&mut backend)
-        .unwrap()
-        .tanh(&mut backend)
-        .unwrap();
-
     let session = backend.with_backend_session(|s| {
-        x.neg_in(s)
+        x.neg(s)
             .unwrap()
-            .abs_in(s)
+            .abs(s)
             .unwrap()
-            .sqrt_in(s)
+            .sqrt(s)
             .unwrap()
-            .rsqrt_in(s)
+            .rsqrt(s)
             .unwrap()
-            .sign_in(s)
+            .sign(s)
             .unwrap()
-            .conj_in(s)
+            .conj(s)
             .unwrap()
-            .log_in(s)
+            .log(s)
             .unwrap()
-            .expm1_in(s)
+            .expm1(s)
             .unwrap()
-            .log1p_in(s)
+            .log1p(s)
             .unwrap()
-            .sin_in(s)
+            .sin(s)
             .unwrap()
-            .cos_in(s)
+            .cos(s)
             .unwrap()
-            .tanh_in(s)
+            .tanh(s)
             .unwrap()
     });
 
@@ -997,114 +757,103 @@ fn session_in_typed_unary_matches_one_shot() {
     expected = expected.iter().map(|&v| v.cos()).collect();
     expected = expected.iter().map(|&v| v.tanh()).collect();
     assert_close(session.host_data().unwrap(), &expected);
-    assert_close(one_shot.host_data().unwrap(), &expected);
 }
 
 #[test]
-fn session_in_typed_clamp_matches_one_shot() {
+fn session_typed_clamp_chain() {
     let mut backend = CpuBackend::new();
 
     // Equal-shape arm.
     let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![-2.0, 4.0, 1.0, 5.0]).unwrap();
     let lower = TypedTensor::<f64>::from_vec_col_major(vec![], vec![0.0]).unwrap();
     let upper = TypedTensor::<f64>::from_vec_col_major(vec![], vec![3.0]).unwrap();
-    let one_shot = x.clamp(&lower, &upper, &mut backend).unwrap();
+
     let session = backend
-        .with_backend_session(|s| x.clamp_in(&lower, &upper, s))
+        .with_backend_session(|s| x.clamp(&lower, &upper, s))
         .unwrap();
     assert_close(session.host_data().unwrap(), &[0.0, 3.0, 1.0, 3.0]);
-    assert_close(one_shot.host_data().unwrap(), &[0.0, 3.0, 1.0, 3.0]);
 
     // Broadcast arm: singleton bounds.
     let x = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![-1.0, 0.0, 2.0, 5.0]).unwrap();
     let lower = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![1.0]).unwrap();
     let upper = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![2.0]).unwrap();
-    let one_shot = x.clamp(&lower, &upper, &mut backend).unwrap();
+
     let session = backend
-        .with_backend_session(|s| x.clamp_in(&lower, &upper, s))
+        .with_backend_session(|s| x.clamp(&lower, &upper, s))
         .unwrap();
     assert_close(session.host_data().unwrap(), &[1.0, 1.0, 2.0, 2.0]);
-    assert_close(one_shot.host_data().unwrap(), &[1.0, 1.0, 2.0, 2.0]);
 }
 
 #[test]
-fn session_in_typed_compare_matches_one_shot() {
+fn session_typed_compare_chain() {
     let mut backend = CpuBackend::new();
 
     // Equal-shape arm: the result is a bool typed tensor.
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 5.0, 3.0, 8.0]).unwrap();
     let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 6.0, 4.0, 7.0]).unwrap();
-    let one_shot = a.compare(&b, CompareDir::Gt, &mut backend).unwrap();
+
     let session = backend
-        .with_backend_session(|s| a.compare_in(&b, CompareDir::Gt, s))
+        .with_backend_session(|s| a.compare(&b, CompareDir::Gt, s))
         .unwrap();
     let expected = [true, false, false, true];
     assert_eq!(session.host_data().unwrap(), &expected);
-    assert_eq!(one_shot.host_data().unwrap(), &expected);
 
     // Broadcast arm.
     let a = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![3.0]).unwrap();
     let b = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![1.0, 4.0, 2.0, 6.0]).unwrap();
-    let one_shot = a.compare(&b, CompareDir::Gt, &mut backend).unwrap();
+
     let session = backend
-        .with_backend_session(|s| a.compare_in(&b, CompareDir::Gt, s))
+        .with_backend_session(|s| a.compare(&b, CompareDir::Gt, s))
         .unwrap();
     let expected = [true, false, true, false];
     assert_eq!(session.host_data().unwrap(), &expected);
-    assert_eq!(one_shot.host_data().unwrap(), &expected);
 }
 
 #[test]
-fn session_in_typed_structural_matches_one_shot() {
+fn session_typed_structural_chain() {
     let mut backend = CpuBackend::new();
     let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
         .unwrap();
 
     // Reshape preserves element order.
-    let one_shot = x.reshape(&[6], &mut backend).unwrap();
+
     let session = backend
-        .with_backend_session(|s| x.reshape_in(&[6], s))
+        .with_backend_session(|s| x.reshape(&[6], s))
         .unwrap();
     let expected = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
     assert_eq!(session.shape(), &[6]);
     assert_close(session.host_data().unwrap(), &expected);
-    assert_close(one_shot.host_data().unwrap(), &expected);
 
     // Transpose permutes the col-major layout.
-    let one_shot = x.transpose(&[1, 0], &mut backend).unwrap();
+
     let session = backend
-        .with_backend_session(|s| x.transpose_in(&[1, 0], s))
+        .with_backend_session(|s| x.transpose(&[1, 0], s))
         .unwrap();
     let expected = [1.0_f64, 3.0, 5.0, 2.0, 4.0, 6.0];
     assert_eq!(session.shape(), &[3, 2]);
     assert_close(session.host_data().unwrap(), &expected);
-    assert_close(one_shot.host_data().unwrap(), &expected);
 
     // broadcast_in_dim duplicates the row: [[1,2,3],[1,2,3]] in col-major
     // storage.
     let row = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap();
-    let one_shot = row.broadcast_in_dim(&[2, 3], &[1], &mut backend).unwrap();
+
     let session = backend
-        .with_backend_session(|s| row.broadcast_in_dim_in(&[2, 3], &[1], s))
+        .with_backend_session(|s| row.broadcast_in_dim(&[2, 3], &[1], s))
         .unwrap();
     let expected = [1.0_f64, 1.0, 2.0, 2.0, 3.0, 3.0];
     assert_eq!(session.shape(), &[2, 3]);
     assert_close(session.host_data().unwrap(), &expected);
-    assert_close(one_shot.host_data().unwrap(), &expected);
 }
 
 #[test]
-fn session_in_typed_matmul_matches_one_shot() {
+fn session_typed_matmul_chain() {
     let mut backend = CpuBackend::new();
     let a_values = vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0];
     let b_values = vec![7.0_f64, 9.0, 11.0, 8.0, 10.0, 12.0];
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], a_values.clone()).unwrap();
     let b = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], b_values.clone()).unwrap();
 
-    let one_shot = a.matmul(&b, &mut backend).unwrap();
-    let session = backend
-        .with_backend_session(|s| a.matmul_in(&b, s))
-        .unwrap();
+    let session = backend.with_backend_session(|s| a.matmul(&b, s)).unwrap();
 
     let mut expected = vec![0.0_f64; 4];
     for i in 0..2 {
@@ -1116,70 +865,52 @@ fn session_in_typed_matmul_matches_one_shot() {
     }
     assert_eq!(session.shape(), &[2, 2]);
     assert_close(session.host_data().unwrap(), &expected);
-    assert_close(one_shot.host_data().unwrap(), &expected);
 }
 
 #[test]
-fn session_in_typed_errors_match_one_shot() {
+fn session_typed_errors() {
     let mut backend = CpuBackend::new();
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0; 2]).unwrap();
     let b = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0; 3]).unwrap();
 
     // Ternary broadcast error through clamp ([2] vs [3] bounds).
-    let one_shot_error = a.clamp(&b, &a, &mut backend).unwrap_err();
+
     let session_error = backend
-        .with_backend_session(|s| a.clamp_in(&b, &a, s))
+        .with_backend_session(|s| a.clamp(&b, &a, s))
         .unwrap_err();
-    assert_incompatible_shapes_error(one_shot_error);
+
     assert_incompatible_shapes_error(session_error);
 
     // Matmul rank error for rank-1 operands.
-    let one_shot_error = a.matmul(&b, &mut backend).unwrap_err();
+
     let session_error = backend
-        .with_backend_session(|s| a.matmul_in(&b, s))
+        .with_backend_session(|s| a.matmul(&b, s))
         .unwrap_err();
-    assert_rank_mismatch_error(one_shot_error);
+
     assert_rank_mismatch_error(session_error);
 }
 
 #[test]
-fn session_in_new_ops_chain_enters_one_session_one_shot_enters_five() {
+fn session_new_ops_chain_enters_one_session() {
     let mut backend = SessionCountingBackend::new();
     let a = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 5.0, 4.0, 6.0]).unwrap();
     let b = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 1.0, 2.0]).unwrap();
     let m = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
     let rhs = Tensor::from_vec_col_major(vec![1, 3], vec![1.0_f64; 3]).unwrap();
 
-    // 5 one-shot ops (sub, log, maximum, reshape, matmul): one session entry
-    // per op.
-    let one_shot = a
-        .sub(&b, &mut backend)
-        .unwrap()
-        .log(&mut backend)
-        .unwrap()
-        .maximum(&m, &mut backend)
-        .unwrap()
-        .reshape(&[4, 1], &mut backend)
-        .unwrap()
-        .matmul(&rhs, &mut backend)
-        .unwrap();
-    assert_eq!(
-        backend.entries.get(),
-        5,
-        "one-shot chain must enter one session per op"
-    );
-
+    // A 5-op session chain (sub, log, maximum, reshape, matmul) must execute
+    // inside exactly one backend session entry.
     backend.entries.set(0);
     let session = backend.with_backend_session(|s| {
-        a.sub_in(&b, s)
+        a.sub(&b, s)
             .unwrap()
-            .log_in(s)
+            .log(s)
             .unwrap()
-            .maximum_in(&m, s)
+            .maximum(&m, s)
             .unwrap()
-            .reshape_in(&[4, 1], s)
+            .reshape(&[4, 1], s)
             .unwrap()
-            .matmul_in(&rhs, s)
+            .matmul(&rhs, s)
             .unwrap()
     });
     assert_eq!(
@@ -1197,10 +928,6 @@ fn session_in_new_ops_chain_enters_one_session_one_shot_enters_five() {
         .collect();
     let expected: Vec<f64> = (0..3).flat_map(|_| values.iter().copied()).collect();
     assert_close(session.as_slice::<f64>().unwrap(), &expected);
-    assert_close(
-        session.as_slice::<f64>().unwrap(),
-        one_shot.as_slice::<f64>().unwrap(),
-    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1225,7 +952,7 @@ impl SessionCountingBackend {
 }
 
 /// Test backend whose session ops return an `F64` tensor regardless of the
-/// requested dtype, so the typed `_in` surface must reject the output through
+/// requested dtype, so the typed session surface must reject the output through
 /// `into_typed_result`.
 struct WrongDTypeSessionBackend;
 
@@ -1413,7 +1140,7 @@ impl BackendSessionHost for SessionCountingBackend {
 }
 
 // WrongDTypeSessionBackend hand-writes the structural, dot, elementwise, and
-// analytic impls so every op family the typed `_in` surface routes through can
+// analytic impls so every op family the typed session surface routes through can
 // return an F64 tensor regardless of the requested dtype.
 
 impl BackendRuntimeCache for WrongDTypeSessionBackend {

--- a/crates/tenferro-runtime/tests/integration/typed_tensor_ops.rs
+++ b/crates/tenferro-runtime/tests/integration/typed_tensor_ops.rs
@@ -1,6 +1,6 @@
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{TensorOpsExt, TypedTensor, TypedTensorOpsExt};
-use tenferro_tensor::{Error as TensorError, ShapeMismatch, ValidationError};
+use tenferro_runtime::{TensorSessionOpsExt, TypedTensor, TypedTensorSessionOpsExt};
+use tenferro_tensor::{BackendSessionHost, Error as TensorError, ShapeMismatch, ValidationError};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -19,30 +19,34 @@ fn typed_tensor_reduction_and_structural_wrappers_preserve_values() {
     let x = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0])
         .unwrap();
 
-    let row_sums = x.reduce_sum(&[1], &mut backend).unwrap();
+    let row = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![10.0, 20.0, 30.0]).unwrap();
+    let [row_sums, total, reshaped, transposed, broadcast] = backend
+        .with_backend_session(
+            |session| -> tenferro_tensor::Result<[TypedTensor<f64>; 5]> {
+                Ok([
+                    x.reduce_sum(&[1], session)?,
+                    x.reduce_sum(&[0, 1], session)?,
+                    x.reshape(&[3, 2], session)?,
+                    x.transpose(&[1, 0], session)?,
+                    row.broadcast_in_dim(&[2, 3], &[1], session)?,
+                ])
+            },
+        )
+        .unwrap();
     assert_eq!(row_sums.shape(), &[2]);
     assert_close(row_sums.host_data().unwrap(), &[6.0, 15.0]);
-
-    let total = x.reduce_sum(&[0, 1], &mut backend).unwrap();
     assert!(total.shape().is_empty());
     assert_close(total.host_data().unwrap(), &[21.0]);
-
-    let reshaped = x.reshape(&[3, 2], &mut backend).unwrap();
     assert_eq!(reshaped.shape(), &[3, 2]);
     assert_close(
         reshaped.host_data().unwrap(),
         &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
     );
-
-    let transposed = x.transpose(&[1, 0], &mut backend).unwrap();
     assert_eq!(transposed.shape(), &[3, 2]);
     assert_close(
         transposed.host_data().unwrap(),
         &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     );
-
-    let row = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![10.0, 20.0, 30.0]).unwrap();
-    let broadcast = row.broadcast_in_dim(&[2, 3], &[1], &mut backend).unwrap();
     assert_eq!(broadcast.shape(), &[2, 3]);
     assert_close(
         broadcast.host_data().unwrap(),
@@ -56,7 +60,9 @@ fn typed_tensor_matmul_rejects_non_matrix_inputs_without_rank_underflow() {
     let scalar = TypedTensor::<f64>::from_vec_col_major(vec![], vec![1.0]).unwrap();
     let vector = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![1.0]).unwrap();
 
-    let err = scalar.matmul(&vector, &mut backend).unwrap_err();
+    let err = backend
+        .with_backend_session(|session| scalar.matmul(&vector, session))
+        .unwrap_err();
 
     assert!(matches!(
         err,
@@ -76,7 +82,9 @@ fn direct_tensor_broadcast_uses_the_shared_shape_payload() {
     let lhs = tenferro_tensor::Tensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]).unwrap();
     let rhs = tenferro_tensor::Tensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
 
-    let error = lhs.add(&rhs, &mut backend).unwrap_err();
+    let error = backend
+        .with_backend_session(|session| lhs.add(&rhs, session))
+        .unwrap_err();
 
     assert!(matches!(
         error,

--- a/crates/tenferro-runtime/tests/prelude.rs
+++ b/crates/tenferro-runtime/tests/prelude.rs
@@ -1,11 +1,14 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::prelude::*;
+use tenferro_tensor::BackendSessionHost;
 
 #[test]
 fn prelude_calls_backend_explicit_tensor_operation() {
     let lhs = Tensor::from_vec_col_major([2], vec![1.0_f64, 2.0]).unwrap();
     let rhs = Tensor::from_vec_col_major([2], vec![3.0_f64, 4.0]).unwrap();
     let mut backend = CpuBackend::new();
-    let sum = lhs.add(&rhs, &mut backend).unwrap();
+    let sum = backend
+        .with_backend_session(|session| lhs.add(&rhs, session))
+        .unwrap();
     assert_eq!(sum.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
 }

--- a/docs/design/session-oriented-concrete-apis.md
+++ b/docs/design/session-oriented-concrete-apis.md
@@ -486,3 +486,93 @@ inputs/outputs inside.
 - Top-level einsum-trait `_in_session` variants (plan-level surface suffices;
   revisit only if Phase-1 callers need them).
 - GPU (CUDA/WebGPU) nested-entry enforcement (tracked gap from PR A).
+## Migration specification (issue #1680, Phase 2: single canonical core API)
+
+The release-boundary breaking change for the **tenferro-runtime core traits
+and the einsum plan surface**. Removes the one-shot core API, renames the
+transitional `_in`/`_in_session` methods to the final plain names, and
+migrates every workspace call site of those APIs. End state for THIS phase:
+one session-explicit concrete API for the core op vocabulary and
+`ConcreteEinsumPlan`.
+
+**Scope boundary (explicit)**: other backend-taking concrete surfaces are
+NOT migrated in this phase and are enumerated as follow-ups — the einsum
+top-level `einsum*`-trait methods (crates/tenferro-einsum/src/concrete.rs
+traits), `TensorFftExt`/`TensorReadFftExt` (tenferro-fft), the linalg
+concrete traits (tenferro-linalg/src/tensor_ext.rs), and
+`Tensor::index_select`/`Tensor::stack` (tenferro-tensor shape_packing).
+This phase covers the runtime core + plan-level einsum; the others migrate
+in follow-up PRs toward the same end state.
+
+### Removals
+
+- `TensorOpsExt` (crates/tenferro-runtime/src/lib.rs) and its impl.
+- `TypedTensorOpsExt<T>` and its impl.
+- `TypedTensorMaskOpsExt` (typed `where_select`, implemented only for
+  `TypedTensor<bool>` with a generic branch scalar) — replaced by a
+  **session-only mask trait** `TypedTensorMaskSessionOpsExt`, implemented for
+  `TypedTensor<bool>`, with `where_select(&self, on_true: &TypedTensor<U>,
+  on_false: &TypedTensor<U>, session)` using `broadcast_ternary_in_read` +
+  `session.select_read` + `into_typed_result` (preserves the compile-time
+  bool-condition contract; NOT folded into the generic
+  `TypedTensorSessionOpsExt<T>`).
+- `ConcreteEinsumPlan`'s seven backend-taking `execute*` methods (execute,
+  execute_typed, execute_read, execute_into, execute_typed_into,
+  execute_read_into, execute_read_into_accum).
+- The prelude re-exports only the session-explicit traits.
+
+### Renames (final plain names)
+
+- `TensorSessionOpsExt`: every `*_in` → the plain op name
+  (`add_in`→`add`, `convert_in`→`convert`, `matmul_in`→`matmul`, ...).
+- `TypedTensorSessionOpsExt<T>`: same rename.
+- `ConcreteEinsumPlan`: each `execute*_in_session` becomes the sole
+  unsuffixed `execute*` (the backend-taking forms are removed, so no
+  collision).
+- No receiver collisions: tensor-extension methods take `&Tensor`, backend
+  ops take `&mut self`.
+
+### Call-site migration (~58 sites + tests/examples/docs/skills)
+
+Mechanical rule, behavior-preserving:
+1. Single-op call `x.add(&y, &mut backend)` →
+   `backend.with_backend_session(|s| x.add(&y, s))?`; the closure's result
+   type is the op's `Result<Tensor>` (annotate when the closure contains
+   `?`-chains so error types are unambiguous).
+2. Consecutive session-capable ops on the same backend in one function are
+   grouped in ONE `with_backend_session`; grouping stops at helpers or
+   extension calls that still need `&mut backend` (avoid nested entry /
+   borrow conflicts).
+3. Reusable helpers that take `&mut TensorBackend` migrate to take
+   `&mut dyn BackendSession` where they are pure op sequences.
+4. Sites already inside a session call the ops directly.
+Diagnostics, README, docs/spec, tutorials, and shipped skills that reference
+the one-shot API migrate in the same PR. The Phase-1 one-shot-vs-`_in`
+parity tests become direct session tests against the independent expected
+values they already assert; the einsum mixed-session test gains independent
+expected values (drops the one-shot comparison arm).
+
+### Verification and gates (exact)
+
+- Workspace builds; full suites green (runtime, einsum, ad, cpu,
+  dependents).
+- **Scoped grep evidence** (exclude intentionally retained internal
+  spellings): no `\.(add|sub|...)_in\(` or `\.execute\w*_in_session\(` calls
+  on the core/plan surfaces; `PreparedOperation::execute_in_session`
+  (runtime capability.rs), `EagerTensor::from_tensor_in` (tenferro-ad), and
+  the einsum top-level/FFT/linalg/shape-packing surfaces are explicit
+  exclusions. Command: grep for `_in(`/`_in_session(` in tenferro-runtime,
+  tenferro-einsum (plan scope), and the migrated call sites, review each hit
+  against the exclusion list.
+- **Benches**: the one-shot arms are removed with the API; re-run the
+  remaining single-session arms (PR-B gate chain, Phase-1 chain, einsum
+  chain) and compare against the recorded Phase-1 medians (no regression;
+  the one-shot numbers are historical). Report pinned.
+- Public API change is the intended release boundary; documented in the PR
+  body/changelog.
+
+### Out of scope for Phase 2 (follow-up issues)
+
+- Einsum top-level traits, FFT, linalg, shape-packing one-shot surfaces.
+- GPU (CUDA/WebGPU) nested-entry enforcement.
+- Behavioral changes to any op (rename/removal only).

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -74,7 +74,8 @@ ordinary tensor computation without autodiff when runtime dtype is useful.
 <!-- snippet-source: crates/tenferro-runtime/examples/direct_tensor_execution.rs -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut backend = CpuBackend::new();
@@ -82,7 +83,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])?;
     let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])?;
 
-    let c = a.matmul(&b, &mut backend)?;
+    let c = backend.with_backend_session(|session| a.matmul(&b, session))?;
     assert_eq!(c.shape(), &[2, 2]);
 
     Ok(())

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -155,7 +155,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![3.0, 0.0, 0.0, 1.0])?;
     let identity = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0])?;
 
-    let product = a.matmul(&identity, &mut backend)?;
+    let product = backend.with_backend_session(|session| a.matmul(&identity, session))?;
     assert_eq!(product.shape(), &[2, 2]);
     assert_close(product.host_data()?, &[3.0, 0.0, 0.0, 1.0]);
 

--- a/docs/getting-started/ndarray-nalgebra-mapping.md
+++ b/docs/getting-started/ndarray-nalgebra-mapping.md
@@ -102,14 +102,15 @@ backends are pushed into method signatures. Compare with `ndarray`'s
 
 | Tier | Tenferro | Notes |
 | --- | --- | --- |
-| Direct | `a.matmul(&b, &mut backend)?` | explicit mutable backend argument |
+| Direct | `backend.with_backend_session(\|s\| a.matmul(&b, s))?` | explicit backend session argument |
 | Eager | `a.matmul(&b)?` | `EagerRuntime` owns the backend |
 | Traced | `a.matmul(&b)?` | builds a graph; returns `Result` |
 
 <!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#concrete-operation -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 // The leftmost dimension varies fastest: this is a 2 x 3 column-major tensor.
@@ -121,15 +122,15 @@ let weights = TypedTensor::<f64>::from_vec_col_major(
     vec![3, 2],
     vec![0.5, -1.0, 1.5, 1.0, 2.0, -0.5],
 )?;
-let projected = x.matmul(&weights, &mut backend)?;
+let projected = backend.with_backend_session(|session| x.matmul(&weights, session))?;
 assert_eq!(projected.shape(), &[2, 2]);
 assert_eq!(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
 ```
 <!-- end-snippet-source -->
 
 In the direct tier the explicit backend moves from "linked somehow" to "passed
-per call"; in the eager and traced tiers it is owned by the runtime and the
-signature matches what `ndarray` users expect.
+into a backend session per operation chain"; in the eager and traced tiers it
+is owned by the runtime and the signature matches what `ndarray` users expect.
 
 ## Tensor vs TypedTensor
 

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -5,7 +5,7 @@ This page is a translation guide for readers who already know `torch` or `jax.nu
 ## Import styles
 
 A focused module can keep its dependencies explicit with direct imports such as
-`use tenferro_runtime::{Tensor, TensorOpsExt};` and
+`use tenferro_runtime::{Tensor, TensorSessionOpsExt};` and
 `use tenferro_linalg::{LinalgBackend, TensorLinalgExt};`. A tutorial or a
 module that uses several operation families can use the equivalent crate-local
 preludes: `use tenferro_runtime::prelude::*;` and
@@ -33,11 +33,11 @@ backend and device choices remain explicit.
 |---|---|---|---|---|
 | Create typed tensor | `torch.tensor(data, dtype=...)` | `jnp.array(data, dtype=...)` | `TypedTensor::<T>::from_vec_col_major(shape, data)` | — |
 | Create dynamic tensor | `torch.tensor(data)` | `jnp.array(data)` | `Tensor::from_vec_col_major(shape, data)` | `TracedTensor::from_vec_col_major(shape, data)` |
-| Matrix multiply | `torch.matmul(a, b)` | `jnp.matmul(a, b)` | `a.matmul(&b, &mut ctx)` via `TensorOpsExt` | `a.matmul(&b)` |
-| Reshape | `x.reshape(shape)` | `jnp.reshape(x, shape)` | `x.reshape(&shape, &mut ctx)` via `TensorOpsExt` | `x.reshape(&shape)?` |
-| Transpose | `x.transpose(0, 1)` | `jnp.transpose(x, axes)` | `x.transpose(&perm, &mut ctx)` via `TensorOpsExt` | `x.transpose(&perm)` |
+| Matrix multiply | `torch.matmul(a, b)` | `jnp.matmul(a, b)` | `ctx.with_backend_session(\|s\| a.matmul(&b, s))` via `TensorSessionOpsExt` | `a.matmul(&b)` |
+| Reshape | `x.reshape(shape)` | `jnp.reshape(x, shape)` | `ctx.with_backend_session(\|s\| x.reshape(&shape, s))` via `TensorSessionOpsExt` | `x.reshape(&shape)?` |
+| Transpose | `x.transpose(0, 1)` | `jnp.transpose(x, axes)` | `ctx.with_backend_session(\|s\| x.transpose(&perm, s))` via `TensorSessionOpsExt` | `x.transpose(&perm)` |
 | Broadcast | `x.expand(...)` / implicit broadcast | implicit broadcast in many ops | backend-level op | `x.broadcast_in_dim(&shape, &dims)` |
-| Reduce sum | `x.sum(dim=...)` | `jnp.sum(x, axis=...)` | `x.reduce_sum(&axes, &mut ctx)` via `TensorOpsExt` | `x.reduce_sum(Some(&axes))` |
+| Reduce sum | `x.sum(dim=...)` | `jnp.sum(x, axis=...)` | `ctx.with_backend_session(\|s\| x.reduce_sum(&axes, s))` via `TensorSessionOpsExt` | `x.reduce_sum(Some(&axes))` |
 | Einsum | `torch.einsum(spec, ...)` | `jnp.einsum(spec, ...)` | `[&a, &b].einsum(...)` via `EagerEinsumExt` | `trace.einsum(...)` via `TraceContextEinsumExt` plus extension module installation |
 | SVD | `torch.linalg.svd(x)` | `jnp.linalg.svd(x)` | `tenferro_linalg::LinalgBackend::svd(&mut ctx, &x)?` | `x.svd()?` via `TracedTensorLinalgExt` |
 | QR | `torch.linalg.qr(x)` | `jnp.linalg.qr(x)` | `tenferro_linalg::LinalgBackend::qr(&mut ctx, &x)?` | `x.qr()?` via `TracedTensorLinalgExt` |

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -27,7 +27,7 @@ Quick reference:
 ## Import Style
 
 Use direct imports when a small module should make its dependencies explicit:
-`use tenferro_runtime::{Tensor, TensorOpsExt};` and
+`use tenferro_runtime::{Tensor, TensorSessionOpsExt};` and
 `use tenferro_linalg::{LinalgBackend, TensorLinalgExt};`. For tutorials or
 modules using several operation traits, the equivalent crate-local preludes are
 `use tenferro_runtime::prelude::*;` and `use tenferro_linalg::prelude::*;`.
@@ -99,7 +99,7 @@ operations.
 
 | Need | Without autodiff | Eager path | Traced path |
 | --- | --- | --- | --- |
-| Everyday tensor ops | `TensorOpsExt` / `TypedTensorOpsExt` backend-explicit methods | `EagerTensor` methods / associated functions | `TracedTensor` methods / associated functions |
+| Everyday tensor ops | `TensorSessionOpsExt` / `TypedTensorSessionOpsExt` session-explicit methods | `EagerTensor` methods / associated functions | `TracedTensor` methods / associated functions |
 | Einsum | `[&a, &b].einsum(...)` via `TensorEinsumExt` / `TypedTensorEinsumExt`; `TensorReadEinsumExt` / `TypedTensorReadEinsumExt` for views; `ConcreteEinsumPlan` for repeated fixed metadata | `[&a, &b].einsum(...)` via `EagerEinsumExt` | `trace.einsum(...)` via `TraceContextEinsumExt` plus `extension_module` |
 | FFT | `x.fft(...)` via `TensorFftExt`; `read.fft_read(...)` via `TensorReadFftExt` | `x.fft(...)` via `EagerTensorFftExt` with `autodiff` | `x.fft(...)` via `TracedTensorFftExt` plus `extension_module` |
 | Tensordot sugar | Use `matmul` or `dot_general` directly | `a.tensordot(&b, axes)` via `EagerTensorEinsumExt` | `a.tensordot(&b, axes)` via `TracedTensorEinsumExt` |

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -64,8 +64,8 @@ tracked eager tensors. Untracked eager tensors are forward-only. If you share
 one context across multiple tracked tensors, their gradients accumulate into
 the same state and you can reset them together with `clear_grads()`.
 
-Most broad non-AD concrete operations are available as `TensorOpsExt` /
-`TypedTensorOpsExt` methods with an explicit backend. AD workflows use the
+Most broad non-AD concrete operations are available as `TensorSessionOpsExt` /
+`TypedTensorSessionOpsExt` methods inside an explicit backend session. AD workflows use the
 `EagerTensor` method surface instead. `TypedTensor<T, R>` is the first layer to
 consider when you want compile-time dtype safety, optional rank typing, or typed
 data that may live on the host or in backend-owned storage. Einsum is provided
@@ -163,15 +163,19 @@ canonicalization never performs a hidden CPU/GPU transfer.
 <!-- snippet-source: docs/tutorial-code/src/bin/core_tensor_snippets.rs#eager_operations_4 -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0])?;
 let b = Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0])?;
 
-let sum = a.add(&b, &mut backend).unwrap();
-let product = a.mul(&b, &mut backend).unwrap();
-let negated = a.neg(&mut backend).unwrap();
+let (sum, product, negated) = backend.with_backend_session(|session| {
+    let sum = a.add(&b, session).unwrap();
+    let product = a.mul(&b, session).unwrap();
+    let negated = a.neg(session).unwrap();
+    (sum, product, negated)
+});
 
 assert_eq!(sum.as_slice::<f64>().unwrap(), &[5.0, 7.0, 9.0]);
 assert_eq!(product.as_slice::<f64>().unwrap(), &[4.0, 10.0, 18.0]);
@@ -217,21 +221,21 @@ backend.with_backend_session(|session| {
 <!-- snippet-source: docs/tutorial-code/src/bin/core_tensor_snippets.rs#eager_operations_6 -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])?;
 
-// Transpose
-let at = a.transpose(&[1, 0], &mut backend).unwrap();
+// Transpose / Reshape / Reduce in one backend session.
+let (at, flat, col_sum) = backend.with_backend_session(|session| {
+    let at = a.transpose(&[1, 0], session).unwrap();
+    let flat = a.reshape(&[6], session).unwrap();
+    let col_sum = a.reduce_sum(&[0], session).unwrap();
+    (at, flat, col_sum)
+});
 assert_eq!(at.shape(), &[3, 2]);
-
-// Reshape
-let flat = a.reshape(&[6], &mut backend).unwrap();
 assert_eq!(flat.shape(), &[6]);
-
-// Reduce
-let col_sum = a.reduce_sum(&[0], &mut backend).unwrap();
 assert_eq!(col_sum.shape(), &[3]);
 ```
 <!-- end-snippet-source -->

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -148,7 +148,7 @@ running the stored tree.
 ```rust
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::{ConcreteEinsumPlan, TensorReadEinsumExt, TensorReadEinsumIntoExt};
-use tenferro_tensor::{Tensor, TensorRead, TensorView, TensorWrite, TypedTensorView};
+use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead, TensorView, TensorWrite, TypedTensorView};
 
 let matrix_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
 let matrix = TypedTensorView::from_slice([2, 3], [3, 1], 0, &matrix_data)?;
@@ -163,7 +163,8 @@ let result = inputs.einsum_read("ij,j->i", &mut backend)?;
 assert_eq!(result.as_slice::<f64>()?, &[140.0, 320.0]);
 
 let plan = ConcreteEinsumPlan::prepare_read(inputs.clone(), "ij,j->i")?;
-let planned = plan.execute_read(inputs, &mut backend)?;
+let planned = backend
+    .with_backend_session(|session| plan.execute_read(inputs, session))?;
 assert_eq!(planned.as_slice::<f64>()?, &[140.0, 320.0]);
 
 let mut planned_out = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2])?;

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -128,7 +128,7 @@ assert_eq!(x.as_slice::<f64>()?, &[2.0, 3.0]);
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Error> {
     let lhs = lhs.as_slice::<f64>()?;
@@ -141,15 +141,18 @@ fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Erro
 }
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0])?;
 let mut backend = CpuBackend::new();
-let factor = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| a.cholesky(exec_session))
+let (factor, reconstructed) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor, Tensor)> {
+    // Double `?`: `with_cpu_exec_session` yields `Option<Result<..>>`; the
+    // first `?` surfaces the session, the second unwraps the op result.
+    let factor = with_cpu_exec_session(session, |exec_session| a.cholesky(exec_session))
         .ok_or_else(|| tenferro_tensor::Error::Unsupported {
                 op: "documentation",
                 message: "CPU execution session is unavailable".to_owned(),
-            })?
+            })??;
+    let factor_t = factor.transpose(&[1, 0], session)?;
+    let reconstructed = factor.matmul(&factor_t, session)?;
+    Ok((factor, reconstructed))
 })?;
-let factor_t = factor.transpose(&[1, 0], &mut backend)?;
-let reconstructed = factor.matmul(&factor_t, &mut backend)?;
 
 assert_eq!(factor.shape(), &[2, 2]);
 assert_eq!(a.shape(), &[2, 2]);
@@ -188,7 +191,7 @@ let ad = AdContext::builder()
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Error> {
     let lhs = lhs.as_slice::<f64>()?;
@@ -217,8 +220,11 @@ let sigma = Tensor::from_vec_col_major(
     vec![2, 2],
     vec![s_values[0], 0.0, 0.0, s_values[1]],
 )?;
-let us = u.matmul(&sigma, &mut backend)?;
-let reconstructed = us.matmul(&vt, &mut backend)?;
+let (reconstructed,) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor,)> {
+    let us = u.matmul(&sigma, session)?;
+    let reconstructed = us.matmul(&vt, session)?;
+    Ok((reconstructed,))
+})?;
 
 assert_eq!(a.shape(), &[2, 2]);
 assert!(max_abs_diff(&reconstructed, &a)? < 1.0e-12);
@@ -295,7 +301,7 @@ assert_eq!(repeated.concrete_shape()?, vec![3]);
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::{QrGauge, QrOptions, TensorLinalgExt};
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Error> {
     let lhs = lhs.as_slice::<f64>()?;
@@ -332,9 +338,12 @@ let identity = Tensor::from_vec_col_major(
     vec![3, 3],
     vec![1.0_f64, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
 )?;
-let reconstructed = q.matmul(&r, &mut backend)?;
-let qt = q.transpose(&[1, 0], &mut backend)?;
-let qtq = qt.matmul(&q, &mut backend)?;
+let (reconstructed, qtq) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor, Tensor)> {
+    let reconstructed = q.matmul(&r, session)?;
+    let qt = q.transpose(&[1, 0], session)?;
+    let qtq = qt.matmul(&q, session)?;
+    Ok((reconstructed, qtq))
+})?;
 
 assert_eq!(q.shape(), &[4, 3]);
 assert_eq!(r.shape(), &[3, 3]);
@@ -351,7 +360,7 @@ assert!(max_abs_diff(&qtq, &identity)? < 1.0e-12);
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Error> {
     let lhs = lhs.as_slice::<f64>()?;
@@ -380,9 +389,12 @@ let diagonal = Tensor::from_vec_col_major(
     vec![2, 2],
     vec![value_slice[0], 0.0, 0.0, value_slice[1]],
 )?;
-let vd = vectors.matmul(&diagonal, &mut backend)?;
-let vt = vectors.transpose(&[1, 0], &mut backend)?;
-let reconstructed = vd.matmul(&vt, &mut backend)?;
+let (reconstructed,) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor,)> {
+    let vd = vectors.matmul(&diagonal, session)?;
+    let vt = vectors.transpose(&[1, 0], session)?;
+    let reconstructed = vd.matmul(&vt, session)?;
+    Ok((reconstructed,))
+})?;
 
 assert_eq!(a.shape(), &[2, 2]);
 assert!(max_abs_diff(&reconstructed, &a)? < 1.0e-12);
@@ -464,7 +476,7 @@ exposes an explicit transpose flag.
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::LinalgBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Error> {
     let lhs = lhs.as_slice::<f64>()?;
@@ -502,10 +514,13 @@ let l = &outputs[1];
 let u = &outputs[2];
 let q = &outputs[3];
 let parity = &outputs[4];
-let pt = p.transpose(&[1, 0], &mut backend)?;
-let pt_l = pt.matmul(l, &mut backend)?;
-let pt_lu = pt_l.matmul(u, &mut backend)?;
-let reconstructed = pt_lu.matmul(q, &mut backend)?;
+let (reconstructed,) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor,)> {
+    let pt = p.transpose(&[1, 0], session)?;
+    let pt_l = pt.matmul(l, session)?;
+    let pt_lu = pt_l.matmul(u, session)?;
+    let reconstructed = pt_lu.matmul(q, session)?;
+    Ok((reconstructed,))
+})?;
 let x = backend.with_backend_session(|session| {
     with_cpu_exec_session(session, |exec_session| {
         LinalgBackend::full_piv_lu_solve(exec_session, &a, &b, false)

--- a/docs/guides/tensor-operations.md
+++ b/docs/guides/tensor-operations.md
@@ -22,8 +22,8 @@ Choose the tensor API first, then choose the operation entry point.
 
 | Layer | Start here when | Operation entry point | AD |
 | --- | --- | --- | --- |
-| `TypedTensor<T, R>` | No autodiff, scalar type known at compile time | direct typed accessors; `TypedTensorOpsExt` backend-explicit methods for dynamic-rank `TypedTensor<T>` | No |
-| `Tensor` | No autodiff, dtype selected at runtime or passed through backend dispatch | `TensorOpsExt` backend-explicit methods | No |
+| `TypedTensor<T, R>` | No autodiff, scalar type known at compile time | direct typed accessors; `TypedTensorSessionOpsExt` session-explicit methods for dynamic-rank `TypedTensor<T>` | No |
+| `Tensor` | No autodiff, dtype selected at runtime or passed through backend dispatch | `TensorSessionOpsExt` session-explicit methods | No |
 | `EagerTensor` | Immediate execution in an `EagerRuntime`, optionally with `backward()` or functional `grad`/`vjp`/`jvp` | `EagerTensor` methods and associated functions | Yes, for tracked values |
 | `TracedTensor` | Graph transforms, compilation, `grad`, `vjp`, `jvp`, or graph reuse | `TracedTensor` methods and associated functions | Yes, through graph transforms |
 
@@ -105,24 +105,30 @@ and they do not configure CPU parallelism.
 
 ## TypedTensor Backend Operations
 
-For common typed math without autodiff, `TypedTensorOpsExt` provides selected
-backend-explicit methods that accept dynamic-rank `TypedTensor<T>` values and
-return typed results.
+For common typed math without autodiff, `TypedTensorSessionOpsExt` provides
+selected session-explicit methods that accept dynamic-rank `TypedTensor<T>`
+values and return typed results.
 
 <!-- snippet-source: docs/tutorial-code/src/bin/core_tensor_snippets.rs#tensor_operations_15 -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{CompareDir, TypedTensor, TypedTensorMaskOpsExt, TypedTensorOpsExt};
+use tenferro_runtime::{
+    CompareDir, TypedTensor, TypedTensorMaskSessionOpsExt, TypedTensorSessionOpsExt,
+};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 let x = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap();
 let y = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![4.0, 5.0, 6.0]).unwrap();
 
-let sum = x.add(&y, &mut backend).unwrap();
-let product = x.mul(&y, &mut backend).unwrap();
-let total = product.reduce_sum(&[0], &mut backend).unwrap();
-let mask = sum.compare(&product, CompareDir::Lt, &mut backend).unwrap();
-let selected = mask.where_select(&sum, &product, &mut backend).unwrap();
+let (sum, product, total, mask, selected) = backend.with_backend_session(|session| {
+    let sum = x.add(&y, session).unwrap();
+    let product = x.mul(&y, session).unwrap();
+    let total = product.reduce_sum(&[0], session).unwrap();
+    let mask = sum.compare(&product, CompareDir::Lt, session).unwrap();
+    let selected = mask.where_select(&sum, &product, session).unwrap();
+    (sum, product, total, mask, selected)
+});
 
 assert_eq!(sum.as_slice().unwrap(), &[5.0, 7.0, 9.0]);
 assert_eq!(product.as_slice().unwrap(), &[4.0, 10.0, 18.0]);
@@ -213,14 +219,18 @@ should remain dynamic.
 <!-- snippet-source: docs/tutorial-code/src/bin/core_tensor_snippets.rs#tensor_operations_17 -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0])?;
 let b = Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0])?;
 
-let sum = a.add(&b, &mut backend).unwrap();
-let product = a.mul(&b, &mut backend).unwrap();
+let (sum, product) = backend.with_backend_session(|session| {
+    let sum = a.add(&b, session).unwrap();
+    let product = a.mul(&b, session).unwrap();
+    (sum, product)
+});
 
 assert_eq!(sum.as_slice::<f64>().unwrap(), &[5.0, 7.0, 9.0]);
 assert_eq!(product.as_slice::<f64>().unwrap(), &[4.0, 10.0, 18.0]);
@@ -335,15 +345,19 @@ Ok(())
 <!-- snippet-source: docs/tutorial-code/src/bin/core_tensor_snippets.rs#tensor_operations_22 -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(
     vec![2, 3],
     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
 )?;
-let reshaped = a.reshape(&[6], &mut backend).unwrap();
-let transposed = a.transpose(&[1, 0], &mut backend).unwrap();
+let (reshaped, transposed) = backend.with_backend_session(|session| {
+    let reshaped = a.reshape(&[6], session).unwrap();
+    let transposed = a.transpose(&[1, 0], session).unwrap();
+    (reshaped, transposed)
+});
 
 assert_eq!(reshaped.shape(), &[6]);
 assert_eq!(reshaped.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
@@ -375,7 +389,8 @@ Ok(())
 <!-- snippet-source: docs/tutorial-code/src/bin/core_tensor_snippets.rs#tensor_operations_24 -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(
@@ -385,8 +400,11 @@ let a = Tensor::from_vec_col_major(
 // Logical matrix:
 // [[1.0, 3.0, 5.0],
 //  [2.0, 4.0, 6.0]]
-let row_sums = a.reduce_sum(&[1], &mut backend).unwrap();
-let total = a.reduce_sum(&[0, 1], &mut backend).unwrap();
+let (row_sums, total) = backend.with_backend_session(|session| {
+    let row_sums = a.reduce_sum(&[1], session).unwrap();
+    let total = a.reduce_sum(&[0, 1], session).unwrap();
+    (row_sums, total)
+});
 
 assert_eq!(row_sums.shape(), &[2]);
 assert_eq!(row_sums.as_slice::<f64>().unwrap(), &[9.0, 12.0]);

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![3.0, 0.0, 0.0, 1.0])?;
     let identity = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0])?;
 
-    let product = a.matmul(&identity, &mut backend)?;
+    let product = backend.with_backend_session(|session| a.matmul(&identity, session))?;
     assert_eq!(product.shape(), &[2, 2]);
     assert_close(product.host_data()?, &[3.0, 0.0, 0.0, 1.0]);
 

--- a/docs/spec/api-conventions.md
+++ b/docs/spec/api-conventions.md
@@ -49,8 +49,9 @@ The default stratum is internal.
    trait methods, not public module free functions. Core AD operations in
    `tenferro-runtime` and `tenferro-ad` use inherent `TracedTensor` /
    `EagerTensor` methods or associated functions. Concrete non-AD operations
-   use crate-root `TensorOpsExt` / `TypedTensorOpsExt` extension traits because
-   `Tensor` and `TypedTensor` are owned by `tenferro-tensor`. Extension-family
+   use crate-root `TensorSessionOpsExt` / `TypedTensorSessionOpsExt` session
+   extension traits because `Tensor` and `TypedTensor` are owned by
+   `tenferro-tensor`. Extension-family
    crates use crate-root extension traits because they cannot add inherent
    methods to external tensor types.
 8. User-facing backend features use concrete backend family names such as

--- a/docs/spec/operation-categories.md
+++ b/docs/spec/operation-categories.md
@@ -29,9 +29,10 @@ or associated functions, not module free functions. Single-output operations use
 methods (`x.exp()`, `x.matmul(&y)`, `x.gather(&idx, config)`); operations with no
 natural receiver use associated functions (`TracedTensor::concatenate(...)`,
 `EagerTensor::where_select(...)`). Non-AD concrete operations use
-backend-explicit crate-root extension traits (`TensorOpsExt`,
-`TypedTensorOpsExt`, and `TypedTensorMaskOpsExt`) because `Tensor` and
-`TypedTensor` are owned by `tenferro-tensor`, not `tenferro-runtime`. Extension
+backend-explicit crate-root session extension traits (`TensorSessionOpsExt`,
+`TypedTensorSessionOpsExt`, and `TypedTensorMaskSessionOpsExt`) because
+`Tensor` and `TypedTensor` are owned by `tenferro-tensor`, not
+`tenferro-runtime`. Extension
 families likewise use crate-root extension traits because Rust does not let
 extension crates add inherent methods to external tensor types: linalg/FFT are
 tensor receiver methods, eager einsum is an input slice/array method, and

--- a/docs/tutorial-code/src/bin/core_tensor_snippets.rs
+++ b/docs/tutorial-code/src/bin/core_tensor_snippets.rs
@@ -77,15 +77,19 @@ assert_eq!(compact.as_slice().unwrap(), &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
     fn snippet_eager_operations_4() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:eager_operations_4
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0])?;
 let b = Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0])?;
 
-let sum = a.add(&b, &mut backend).unwrap();
-let product = a.mul(&b, &mut backend).unwrap();
-let negated = a.neg(&mut backend).unwrap();
+let (sum, product, negated) = backend.with_backend_session(|session| {
+    let sum = a.add(&b, session).unwrap();
+    let product = a.mul(&b, session).unwrap();
+    let negated = a.neg(session).unwrap();
+    (sum, product, negated)
+});
 
 assert_eq!(sum.as_slice::<f64>().unwrap(), &[5.0, 7.0, 9.0]);
 assert_eq!(product.as_slice::<f64>().unwrap(), &[4.0, 10.0, 18.0]);
@@ -135,21 +139,21 @@ backend.with_backend_session(|session| {
     fn snippet_eager_operations_6() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:eager_operations_6
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])?;
 
-// Transpose
-let at = a.transpose(&[1, 0], &mut backend).unwrap();
+// Transpose / Reshape / Reduce in one backend session.
+let (at, flat, col_sum) = backend.with_backend_session(|session| {
+    let at = a.transpose(&[1, 0], session).unwrap();
+    let flat = a.reshape(&[6], session).unwrap();
+    let col_sum = a.reduce_sum(&[0], session).unwrap();
+    (at, flat, col_sum)
+});
 assert_eq!(at.shape(), &[3, 2]);
-
-// Reshape
-let flat = a.reshape(&[6], &mut backend).unwrap();
 assert_eq!(flat.shape(), &[6]);
-
-// Reduce
-let col_sum = a.reduce_sum(&[0], &mut backend).unwrap();
 assert_eq!(col_sum.shape(), &[3]);
         // snippet-end:eager_operations_6
         Ok(())
@@ -401,17 +405,23 @@ assert_eq!(static_rank.rank(), 2);
     fn snippet_tensor_operations_15() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:tensor_operations_15
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{CompareDir, TypedTensor, TypedTensorMaskOpsExt, TypedTensorOpsExt};
+use tenferro_runtime::{
+    CompareDir, TypedTensor, TypedTensorMaskSessionOpsExt, TypedTensorSessionOpsExt,
+};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 let x = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap();
 let y = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![4.0, 5.0, 6.0]).unwrap();
 
-let sum = x.add(&y, &mut backend).unwrap();
-let product = x.mul(&y, &mut backend).unwrap();
-let total = product.reduce_sum(&[0], &mut backend).unwrap();
-let mask = sum.compare(&product, CompareDir::Lt, &mut backend).unwrap();
-let selected = mask.where_select(&sum, &product, &mut backend).unwrap();
+let (sum, product, total, mask, selected) = backend.with_backend_session(|session| {
+    let sum = x.add(&y, session).unwrap();
+    let product = x.mul(&y, session).unwrap();
+    let total = product.reduce_sum(&[0], session).unwrap();
+    let mask = sum.compare(&product, CompareDir::Lt, session).unwrap();
+    let selected = mask.where_select(&sum, &product, session).unwrap();
+    (sum, product, total, mask, selected)
+});
 
 assert_eq!(sum.as_slice().unwrap(), &[5.0, 7.0, 9.0]);
 assert_eq!(product.as_slice().unwrap(), &[4.0, 10.0, 18.0]);
@@ -444,14 +454,18 @@ assert_eq!(x.as_slice().unwrap(), &[2.0, 4.0, 6.0]);
     fn snippet_tensor_operations_17() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:tensor_operations_17
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0])?;
 let b = Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0])?;
 
-let sum = a.add(&b, &mut backend).unwrap();
-let product = a.mul(&b, &mut backend).unwrap();
+let (sum, product) = backend.with_backend_session(|session| {
+    let sum = a.add(&b, session).unwrap();
+    let product = a.mul(&b, session).unwrap();
+    (sum, product)
+});
 
 assert_eq!(sum.as_slice::<f64>().unwrap(), &[5.0, 7.0, 9.0]);
 assert_eq!(product.as_slice::<f64>().unwrap(), &[4.0, 10.0, 18.0]);
@@ -559,15 +573,19 @@ Ok(())
     fn snippet_tensor_operations_22() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:tensor_operations_22
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(
     vec![2, 3],
     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
 )?;
-let reshaped = a.reshape(&[6], &mut backend).unwrap();
-let transposed = a.transpose(&[1, 0], &mut backend).unwrap();
+let (reshaped, transposed) = backend.with_backend_session(|session| {
+    let reshaped = a.reshape(&[6], session).unwrap();
+    let transposed = a.transpose(&[1, 0], session).unwrap();
+    (reshaped, transposed)
+});
 
 assert_eq!(reshaped.shape(), &[6]);
 assert_eq!(reshaped.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
@@ -603,7 +621,8 @@ Ok(())
     fn snippet_tensor_operations_24() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:tensor_operations_24
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(
@@ -613,8 +632,11 @@ let a = Tensor::from_vec_col_major(
 // Logical matrix:
 // [[1.0, 3.0, 5.0],
 //  [2.0, 4.0, 6.0]]
-let row_sums = a.reduce_sum(&[1], &mut backend).unwrap();
-let total = a.reduce_sum(&[0, 1], &mut backend).unwrap();
+let (row_sums, total) = backend.with_backend_session(|session| {
+    let row_sums = a.reduce_sum(&[1], session).unwrap();
+    let total = a.reduce_sum(&[0, 1], session).unwrap();
+    (row_sums, total)
+});
 
 assert_eq!(row_sums.shape(), &[2]);
 assert_eq!(row_sums.as_slice::<f64>().unwrap(), &[9.0, 12.0]);

--- a/docs/tutorial-code/src/bin/direct_linalg_quickstart.rs
+++ b/docs/tutorial-code/src/bin/direct_linalg_quickstart.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![3.0, 0.0, 0.0, 1.0])?;
     let identity = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0])?;
 
-    let product = a.matmul(&identity, &mut backend)?;
+    let product = backend.with_backend_session(|session| a.matmul(&identity, session))?;
     assert_eq!(product.shape(), &[2, 2]);
     assert_close(product.host_data()?, &[3.0, 0.0, 0.0, 1.0]);
 

--- a/docs/tutorial-code/src/bin/math_snippets.rs
+++ b/docs/tutorial-code/src/bin/math_snippets.rs
@@ -47,7 +47,7 @@ assert_eq!(x.as_slice::<f64>()?, &[2.0, 3.0]);
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Error> {
     let lhs = lhs.as_slice::<f64>()?;
@@ -60,15 +60,18 @@ fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Erro
 }
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0])?;
 let mut backend = CpuBackend::new();
-let factor = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| a.cholesky(exec_session))
+let (factor, reconstructed) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor, Tensor)> {
+    // Double `?`: `with_cpu_exec_session` yields `Option<Result<..>>`; the
+    // first `?` surfaces the session, the second unwraps the op result.
+    let factor = with_cpu_exec_session(session, |exec_session| a.cholesky(exec_session))
         .ok_or_else(|| tenferro_tensor::Error::Unsupported {
                 op: "documentation",
                 message: "CPU execution session is unavailable".to_owned(),
-            })?
+            })??;
+    let factor_t = factor.transpose(&[1, 0], session)?;
+    let reconstructed = factor.matmul(&factor_t, session)?;
+    Ok((factor, reconstructed))
 })?;
-let factor_t = factor.transpose(&[1, 0], &mut backend)?;
-let reconstructed = factor.matmul(&factor_t, &mut backend)?;
 
 assert_eq!(factor.shape(), &[2, 2]);
 assert_eq!(a.shape(), &[2, 2]);
@@ -99,7 +102,7 @@ let ad = AdContext::builder()
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Error> {
     let lhs = lhs.as_slice::<f64>()?;
@@ -128,8 +131,11 @@ let sigma = Tensor::from_vec_col_major(
     vec![2, 2],
     vec![s_values[0], 0.0, 0.0, s_values[1]],
 )?;
-let us = u.matmul(&sigma, &mut backend)?;
-let reconstructed = us.matmul(&vt, &mut backend)?;
+let (reconstructed,) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor,)> {
+    let us = u.matmul(&sigma, session)?;
+    let reconstructed = us.matmul(&vt, session)?;
+    Ok((reconstructed,))
+})?;
 
 assert_eq!(a.shape(), &[2, 2]);
 assert!(max_abs_diff(&reconstructed, &a)? < 1.0e-12);
@@ -204,7 +210,7 @@ assert_eq!(repeated.concrete_shape()?, vec![3]);
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::{QrGauge, QrOptions, TensorLinalgExt};
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Error> {
     let lhs = lhs.as_slice::<f64>()?;
@@ -241,9 +247,12 @@ let identity = Tensor::from_vec_col_major(
     vec![3, 3],
     vec![1.0_f64, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
 )?;
-let reconstructed = q.matmul(&r, &mut backend)?;
-let qt = q.transpose(&[1, 0], &mut backend)?;
-let qtq = qt.matmul(&q, &mut backend)?;
+let (reconstructed, qtq) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor, Tensor)> {
+    let reconstructed = q.matmul(&r, session)?;
+    let qt = q.transpose(&[1, 0], session)?;
+    let qtq = qt.matmul(&q, session)?;
+    Ok((reconstructed, qtq))
+})?;
 
 assert_eq!(q.shape(), &[4, 3]);
 assert_eq!(r.shape(), &[3, 3]);
@@ -262,7 +271,7 @@ assert!(max_abs_diff(&qtq, &identity)? < 1.0e-12);
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Error> {
     let lhs = lhs.as_slice::<f64>()?;
@@ -291,9 +300,12 @@ let diagonal = Tensor::from_vec_col_major(
     vec![2, 2],
     vec![value_slice[0], 0.0, 0.0, value_slice[1]],
 )?;
-let vd = vectors.matmul(&diagonal, &mut backend)?;
-let vt = vectors.transpose(&[1, 0], &mut backend)?;
-let reconstructed = vd.matmul(&vt, &mut backend)?;
+let (reconstructed,) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor,)> {
+    let vd = vectors.matmul(&diagonal, session)?;
+    let vt = vectors.transpose(&[1, 0], session)?;
+    let reconstructed = vd.matmul(&vt, session)?;
+    Ok((reconstructed,))
+})?;
 
 assert_eq!(a.shape(), &[2, 2]);
 assert!(max_abs_diff(&reconstructed, &a)? < 1.0e-12);
@@ -374,7 +386,7 @@ assert_eq!(result.as_slice::<f64>()?, &[2.0, 3.0]);
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::LinalgBackend;
-use tenferro_runtime::{Tensor, TensorOpsExt};
+use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Error> {
     let lhs = lhs.as_slice::<f64>()?;
@@ -412,10 +424,13 @@ let l = &outputs[1];
 let u = &outputs[2];
 let q = &outputs[3];
 let parity = &outputs[4];
-let pt = p.transpose(&[1, 0], &mut backend)?;
-let pt_l = pt.matmul(l, &mut backend)?;
-let pt_lu = pt_l.matmul(u, &mut backend)?;
-let reconstructed = pt_lu.matmul(q, &mut backend)?;
+let (reconstructed,) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor,)> {
+    let pt = p.transpose(&[1, 0], session)?;
+    let pt_l = pt.matmul(l, session)?;
+    let pt_lu = pt_l.matmul(u, session)?;
+    let reconstructed = pt_lu.matmul(q, session)?;
+    Ok((reconstructed,))
+})?;
 let x = backend.with_backend_session(|session| {
     with_cpu_exec_session(session, |exec_session| {
         LinalgBackend::full_piv_lu_solve(exec_session, &a, &b, false)
@@ -521,7 +536,7 @@ assert_eq!(
         // snippet-start:einsum_13
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::{ConcreteEinsumPlan, TensorReadEinsumExt, TensorReadEinsumIntoExt};
-use tenferro_tensor::{Tensor, TensorRead, TensorView, TensorWrite, TypedTensorView};
+use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead, TensorView, TensorWrite, TypedTensorView};
 
 let matrix_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
 let matrix = TypedTensorView::from_slice([2, 3], [3, 1], 0, &matrix_data)?;
@@ -536,7 +551,8 @@ let result = inputs.einsum_read("ij,j->i", &mut backend)?;
 assert_eq!(result.as_slice::<f64>()?, &[140.0, 320.0]);
 
 let plan = ConcreteEinsumPlan::prepare_read(inputs.clone(), "ij,j->i")?;
-let planned = plan.execute_read(inputs, &mut backend)?;
+let planned = backend
+    .with_backend_session(|session| plan.execute_read(inputs, session))?;
 assert_eq!(planned.as_slice::<f64>()?, &[140.0, 320.0]);
 
 let mut planned_out = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2])?;

--- a/docs/tutorial-code/src/bin/tenferro_compute_skill.rs
+++ b/docs/tutorial-code/src/bin/tenferro_compute_skill.rs
@@ -4,7 +4,8 @@
 fn concrete_operation_and_column_major() -> Result<(), Box<dyn std::error::Error>> {
     // snippet-start:concrete-operation
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 let mut backend = CpuBackend::new();
 // The leftmost dimension varies fastest: this is a 2 x 3 column-major tensor.
@@ -16,7 +17,7 @@ let weights = TypedTensor::<f64>::from_vec_col_major(
     vec![3, 2],
     vec![0.5, -1.0, 1.5, 1.0, 2.0, -0.5],
 )?;
-let projected = x.matmul(&weights, &mut backend)?;
+let projected = backend.with_backend_session(|session| x.matmul(&weights, session))?;
 assert_eq!(projected.shape(), &[2, 2]);
 assert_eq!(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
     // snippet-end:concrete-operation

--- a/docs/tutorial-code/src/bin/typed_tensor_non_ad.rs
+++ b/docs/tutorial-code/src/bin/typed_tensor_non_ad.rs
@@ -1,5 +1,6 @@
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -22,21 +23,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let column_offsets =
         TypedTensor::<f64>::from_vec_col_major(vec![1, 3], vec![10.0, 20.0, 30.0])?;
-    let shifted = x.add(&column_offsets, &mut backend)?;
-    assert_close(shifted.host_data()?, &[11.0, 14.0, 22.0, 25.0, 33.0, 36.0]);
-
-    let squared = shifted.mul(&shifted, &mut backend)?;
-    let squared_total = squared.reduce_sum(&[0, 1], &mut backend)?;
-    assert_eq!(squared_total.shape(), &[]);
-    assert_close(squared_total.host_data()?, &[3811.0]);
-
-    let transposed = x.transpose(&[1, 0], &mut backend)?;
-    assert_eq!(transposed.shape(), &[3, 2]);
-    assert_close(transposed.host_data()?, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-
     let weights =
         TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![0.5, -1.0, 1.5, 1.0, 2.0, -0.5])?;
-    let projected = x.matmul(&weights, &mut backend)?;
+    let [shifted, squared_total, transposed, projected] = backend.with_backend_session(
+        |session| -> tenferro_tensor::Result<[TypedTensor<f64>; 4]> {
+            let shifted = x.add(&column_offsets, session)?;
+            let squared_total = shifted
+                .mul(&shifted, session)?
+                .reduce_sum(&[0, 1], session)?;
+            let transposed = x.transpose(&[1, 0], session)?;
+            let projected = x.matmul(&weights, session)?;
+            Ok([shifted, squared_total, transposed, projected])
+        },
+    )?;
+    assert_close(shifted.host_data()?, &[11.0, 14.0, 22.0, 25.0, 33.0, 36.0]);
+    assert_eq!(squared_total.shape(), &[]);
+    assert_close(squared_total.host_data()?, &[3811.0]);
+    assert_eq!(transposed.shape(), &[3, 2]);
+    assert_close(transposed.host_data()?, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     assert_eq!(projected.shape(), &[2, 2]);
     assert_close(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
 

--- a/docs/tutorials/typed-tensor-non-ad.md
+++ b/docs/tutorials/typed-tensor-non-ad.md
@@ -9,8 +9,8 @@ The example below shows four details that matter in real code:
 
 - `from_vec_col_major` accepts data already arranged in tenferro's native
   column-major layout.
-- `TypedTensorOpsExt` methods keep the scalar type fixed and return
-  `TypedTensor<T>`.
+- `TypedTensorSessionOpsExt` session methods keep the scalar type fixed and
+  return `TypedTensor<T>`.
 - Reductions such as `x.reduce_sum(...)` are backend-aware tensor operations,
   unlike small host-only checks over `iter()`.
 - Structural helpers such as `x.transpose(...)` preserve the typed workflow
@@ -19,7 +19,8 @@ The example below shows four details that matter in real code:
 <!-- snippet-source: docs/tutorial-code/src/bin/typed_tensor_non_ad.rs -->
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
+use tenferro_runtime::{TypedTensor, TypedTensorSessionOpsExt};
+use tenferro_tensor::BackendSessionHost;
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -42,21 +43,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let column_offsets =
         TypedTensor::<f64>::from_vec_col_major(vec![1, 3], vec![10.0, 20.0, 30.0])?;
-    let shifted = x.add(&column_offsets, &mut backend)?;
-    assert_close(shifted.host_data()?, &[11.0, 14.0, 22.0, 25.0, 33.0, 36.0]);
-
-    let squared = shifted.mul(&shifted, &mut backend)?;
-    let squared_total = squared.reduce_sum(&[0, 1], &mut backend)?;
-    assert_eq!(squared_total.shape(), &[]);
-    assert_close(squared_total.host_data()?, &[3811.0]);
-
-    let transposed = x.transpose(&[1, 0], &mut backend)?;
-    assert_eq!(transposed.shape(), &[3, 2]);
-    assert_close(transposed.host_data()?, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-
     let weights =
         TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![0.5, -1.0, 1.5, 1.0, 2.0, -0.5])?;
-    let projected = x.matmul(&weights, &mut backend)?;
+    let [shifted, squared_total, transposed, projected] = backend.with_backend_session(
+        |session| -> tenferro_tensor::Result<[TypedTensor<f64>; 4]> {
+            let shifted = x.add(&column_offsets, session)?;
+            let squared_total = shifted
+                .mul(&shifted, session)?
+                .reduce_sum(&[0, 1], session)?;
+            let transposed = x.transpose(&[1, 0], session)?;
+            let projected = x.matmul(&weights, session)?;
+            Ok([shifted, squared_total, transposed, projected])
+        },
+    )?;
+    assert_close(shifted.host_data()?, &[11.0, 14.0, 22.0, 25.0, 33.0, 36.0]);
+    assert_eq!(squared_total.shape(), &[]);
+    assert_close(squared_total.host_data()?, &[3811.0]);
+    assert_eq!(transposed.shape(), &[3, 2]);
+    assert_close(transposed.host_data()?, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     assert_eq!(projected.shape(), &[2, 2]);
     assert_close(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
 

--- a/docs/worklogs/2026-08-14-phase2-single-api.md
+++ b/docs/worklogs/2026-08-14-phase2-single-api.md
@@ -1,0 +1,90 @@
+# 2026-08-14 — #1680 Phase 2: single canonical core API (one-shot removal + rename)
+
+## Session summary
+
+The release-boundary breaking change. Removed the one-shot core concrete API
+(`TensorOpsExt`, `TypedTensorOpsExt<T>`, `TypedTensorMaskOpsExt`) and renamed
+the transitional `_in`/`_in_session` methods to the final plain names on the
+session-explicit traits; migrated every workspace call site (48 files,
+−2130 net lines). End state: one session-explicit concrete API for the
+tenferro-runtime core vocabulary and `ConcreteEinsumPlan`. Follow-up surfaces
+(einsum top-level traits' PUBLIC signatures, FFT, linalg, shape-packing) keep
+their backend-taking signatures — their internals now route through the
+canonical session path.
+
+## Gate record (frontier review, per AGENTS.md)
+
+- **Pre-implementation design gate** (reviewer-gpt on
+  `docs/design/session-oriented-concrete-apis.md` §"Phase 2: single
+  canonical core API"): 2 rounds → **approved**. Round 1: 4 blocking (scope
+  overclaim → narrowed to core + plan-level einsum with explicit exclusions;
+  typed mask `where_select` type contract → dedicated
+  `TypedTensorMaskSessionOpsExt` for `TypedTensor<bool>` with generic branch
+  scalar; einsum rename collides with the 7 backend-taking `execute*` →
+  they are removed; grep/bench gates not executable → scoped exclusions +
+  Phase-1-median comparison) + 1 minor + 1 nit.
+- **Post-implementation diff gate** (reviewer-gpt on the full ~8.2k-line
+  diff): 2 rounds → **Correct-to-merge**. Round 1: 5 blocking (doc-snippet
+  generator still imported removed traits; einsum plan tests bypassed
+  `with_backend_session`; top-level einsum internals bypassed the canonical
+  plan path; prelude test + published docs taught one-shot calls; worklog +
+  bench evidence missing). All fixed; Round 2 confirmed.
+
+## Design decisions
+
+- Scope boundary: runtime core traits + `ConcreteEinsumPlan` only; einsum
+  top-level / FFT / linalg / shape-packing public surfaces stay (their
+  internals migrate to the session form — einsum top-level adapters now
+  prepare the plan and call `plan.execute*` inside one session, single
+  execution path; error surface preserved via `into_tensor_error`).
+- `TypedTensorMaskSessionOpsExt` (bool receiver, generic `U` branch scalars,
+  `broadcast_ternary_in_read` + `select_read` + `into_typed_result`).
+- Call-site rule: single-op wrap; group consecutive session-capable ops in
+  one session; helpers take `&mut dyn BackendSession`; already-in-session
+  sites call ops directly; closure `?`-chains get explicit result types.
+- Benches dropped the one-shot arms (API gone); single-session arms are the
+  benches.
+
+## Measurements (release, pinned core 40; interleaved P1=main-with-Phase-1 vs P2=Phase-2, same window)
+
+| chain (one_session) | P1 mean (2 runs) | P2 mean (2 runs) | Δ |
+|---|---|---|---|
+| no_broadcast | 33.475 µs (33.45/33.50) | 33.595 µs (33.63/33.56) | +0.36% |
+| broadcast | 41.795 µs (41.86/41.73) | 42.050 µs (42.13/41.97) | +0.61% |
+| phase1 | 44.105 µs (43.92/44.29) | 43.925 µs (43.71/44.14) | −0.41% |
+| einsum B (10 calls) | — | 55.1 µs (after fast-path unification) | Phase-1 recorded 55.1 µs |
+| einsum C (mixed) | — | 89.0 µs (after fast-path unification) | Phase-1 recorded 91.8 µs |
+
+Interleaved runtime chains: **no regression (max |Δ| = 0.61%)**. Earlier
+non-interleaved runs showed +4-10% which the interleaving proved to be
+ambient machine drift (noisy shared host), not codegen. Einsum B/C match or
+improve on the recorded Phase-1 medians after the top-level fast path was
+unified through the plan (the plan's internal binary-dot optimization
+preserves the kernel).
+
+## Verification
+
+- `cargo build --workspace` — pass
+- Tests: runtime 402+146+1+413; einsum 161+24+1+87; ad 86+337+1+147; cpu
+  512+1+46+2+185 — all pass (incl. doctests: renamed methods' examples run)
+- `python3 scripts/check-guide-dependency-snippets.py` / `test-doc-consistency.py` /
+  `check-doc-snippets.py` — OK
+- fmt clean (incl. ext/tropical, ext/sparse); clippy workspace 0 findings
+- Grep evidence: zero **live** `TensorOpsExt|TypedTensorOpsExt|TypedTensorMaskOpsExt`
+  references in crates/scripts/tutorial-code (the only script hit is the
+  intentional negative-check fixture at scripts/test-doc-consistency.py:404;
+  remaining mentions are the design doc's migration-rule text + historical
+  docs); zero one-shot `.add(&/matmul(&/exp(&/reduce_sum(&...&mut backend`
+  in docs/scripts (outside historical docs/plans, worklogs, specs)
+- PR gates (`check-pr-fast.sh`, `repository-rules-review.py`) run at PR time;
+  recorded in the PR body
+
+## Residual risks
+
+- Follow-up one-shot surfaces remain (einsum top-level public signatures,
+  FFT, linalg, shape-packing) — tracked as follow-up migration issues toward
+  the same single-API end state.
+- GPU (CUDA/WebGPU) nested-entry enforcement still open.
+- The historical Phase-1 design narrative ("the one-shot API stays
+  available") is superseded by the appended Phase-2 removals section; kept
+  as history.

--- a/scripts/check-guide-dependency-snippets.py
+++ b/scripts/check-guide-dependency-snippets.py
@@ -75,7 +75,7 @@ LINALG_SOURCE = r"""
 use tenferro_ad::AdContext;
 use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
 use tenferro_linalg::LinalgBackend;
-use tenferro_runtime::{BackendSessionHost, Tensor, TensorOpsExt};
+use tenferro_runtime::{BackendSessionHost, Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
     lhs.as_slice::<f64>()
@@ -108,10 +108,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let q = &outputs[3];
     let parity = &outputs[4];
 
-    let pt = p.transpose(&[1, 0], &mut backend)?;
-    let pt_l = pt.matmul(l, &mut backend)?;
-    let pt_lu = pt_l.matmul(u, &mut backend)?;
-    let reconstructed = pt_lu.matmul(q, &mut backend)?;
+    let reconstructed = backend.with_backend_session(|session| {
+        let pt = p.transpose(&[1, 0], session)?;
+        let pt_l = pt.matmul(l, session)?;
+        let pt_lu = pt_l.matmul(u, session)?;
+        pt_lu.matmul(q, session)
+    })?;
     assert!(max_abs_diff(&reconstructed, &a) < 1.0e-12);
 
     assert_eq!(parity.shape(), &[] as &[usize]);
@@ -135,8 +137,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 TENSOR_SOURCE = r"""
 use tenferro_ad::{EagerRuntime, Tensor};
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{CompareDir, TypedTensorOpsExt};
-use tenferro_tensor::{Rank, TypedTensor};
+use tenferro_runtime::{CompareDir, TypedTensorSessionOpsExt};
+use tenferro_tensor::{BackendSessionHost, Rank, TypedTensor};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut x = TypedTensor::<f64>::from_vec_col_major(
@@ -155,9 +157,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut backend = CpuBackend::new();
     let lhs = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0])?;
     let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![4.0, 5.0, 6.0])?;
-    let sum = lhs.add(&rhs, &mut backend)?;
-    let product = lhs.mul(&rhs, &mut backend)?;
-    let mask = sum.compare(&product, CompareDir::Lt, &mut backend)?;
+    let mask = backend.with_backend_session(|session| {
+        let sum = lhs.add(&rhs, session)?;
+        let product = lhs.mul(&rhs, session)?;
+        sum.compare(&product, CompareDir::Lt, session)
+    })?;
     assert_eq!(mask.as_slice()?, &[false, true, true]);
 
     let ctx = EagerRuntime::new()?;


### PR DESCRIPTION
## Summary

Issue #1680 **Phase 2** (release-boundary breaking change): the single
canonical session-explicit core API. Removes the one-shot concrete API and
renames the transitional `_in`/`_in_session` methods to the final plain
names; migrates every workspace call site.

## What changed

- **Removed**: `TensorOpsExt`, `TypedTensorOpsExt<T>`, `TypedTensorMaskOpsExt`
  + impls; `ConcreteEinsumPlan`'s 7 backend-taking `execute*` methods.
- **Renamed**: every `_in`/`_in_session` method on
  `TensorSessionOpsExt`/`TypedTensorSessionOpsExt` to the plain op name
  (`add_in`→`add`, `matmul_in`→`matmul`, `execute_read_in_session`→`execute_read`,
  ...). The prelude exports only the session traits.
- **New**: `TypedTensorMaskSessionOpsExt` (TypedTensor<bool> receiver, generic
  branch scalar, read path).
- **Single execution path**: top-level einsum adapters now prepare the plan →
  one `with_backend_session` → `plan.execute*` (the plan's internal
  binary-dot optimization preserves the fast kernel; error surface unchanged
  via `into_tensor_error`).
- **Migrated**: ~48 files — call sites (cpu/ad/tutorial-code), tests (parity
  tests become direct session tests with independent expectations), benches
  (one-shot arms removed), docs, skills, doc-snippet generators. Net
  −2130 lines.

## Measurements (release, pinned core 40; interleaved P1=Phase-1-main vs P2)

| chain (one_session) | P1 mean | P2 mean | Δ |
|---|---|---|---|
| no_broadcast | 33.48 µs | 33.60 µs | +0.36% |
| broadcast | 41.80 µs | 42.05 µs | +0.61% |
| phase1 | 44.11 µs | 43.93 µs | −0.41% |
| einsum B / C | — | 55.1 / 89.0 µs | matches/improves Phase-1 |

**No regression (max |Δ| = 0.61%)** — earlier non-interleaved +4-10% deltas
proved to be ambient machine drift.

## Gate record (frontier review, per AGENTS.md)

- **Pre-implementation design gate** (reviewer-gpt): 2 rounds → **approved**
  (scope narrowing to core + plan-level einsum with explicit exclusions;
  typed-mask type contract; einsum rename collision; executable gates).
- **Post-implementation diff gate** (reviewer-gpt): 3 rounds →
  **Correct-to-merge** (doc-snippet generator, einsum tests bypassing the
  session entry, top-level einsum fast-path unification, prelude/docs,
  worklog evidence incl. recomputed deltas).

## Verification

check-pr-fast green (runtime 402+146+1+413, einsum 161+24+1+87, ad
86+337+1+147, cpu 512+1+46+2+185), repository-rules pass, fmt/clippy clean,
doc-consistency scripts OK, scoped grep: zero live removed-trait references.

Worklog: `docs/worklogs/2026-08-14-phase2-single-api.md`.

Follow-ups: einsum top-level / FFT / linalg / shape-packing one-shot surfaces
migrate toward the same end state (tracked on #1680).
