### PR TITLE
feat: single session-explicit API for extension surfaces + GPU guard (#1680 Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,9 @@ tenferro-linalg = "0.3"
 
 <!-- snippet-source: docs/tutorial-code/src/bin/direct_linalg_quickstart.rs -->
 ```rust
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_linalg::prelude::*;
 use tenferro_runtime::prelude::*;
-use tenferro_runtime::{TensorRead, TensorView};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -93,17 +92,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(product.shape(), &[2, 2]);
     assert_close(product.host_data()?, &[3.0, 0.0, 0.0, 1.0]);
 
-    let svd = backend.with_backend_session(|session| {
-        with_cpu_exec_session(session, |exec_session| {
-            exec_session.svd_read(TensorRead::from_view(TensorView::F64(product.as_view())))
-        })
-        .expect("CpuBackend must expose a CPU execution session")
-    })?;
-    assert_eq!(svd.len(), 3);
-    assert_eq!(svd[0].shape(), &[2, 2]);
-    assert_eq!(svd[1].shape(), &[2]);
-    assert_eq!(svd[2].shape(), &[2, 2]);
-    assert_close(svd[1].as_slice::<f64>().unwrap(), &[3.0, 1.0]);
+    let (u, s, vt) = backend.with_backend_session(|session| product.svd(session))?;
+    assert_eq!(u.shape(), &[2, 2]);
+    assert_eq!(s.shape(), &[2]);
+    assert_eq!(vt.shape(), &[2, 2]);
+    assert_close(s.as_slice()?, &[3.0, 1.0]);
 
     Ok(())
 }

--- a/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
@@ -956,7 +956,9 @@ fn tensor_index_select_trailing_axis_returns_expected_values() {
     let input =
         Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
 
-    let out = input.index_select(-1, &[2, 0, 2], &mut backend).unwrap();
+    let out = backend
+        .with_backend_session(|session| input.index_select(-1, &[2, 0, 2], session))
+        .unwrap();
 
     assert_eq!(out.shape(), &[2, 3]);
     assert_f64_close(get_f64(&out, &[0, 0]), 5.0);
@@ -972,11 +974,15 @@ fn tensor_index_select_rejects_invalid_axis_and_position() {
     let mut backend = CpuBackend::new();
     let input = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
 
-    let axis_err = input.index_select(-2, &[0], &mut backend).unwrap_err();
+    let axis_err = backend
+        .with_backend_session(|session| input.index_select(-2, &[0], session))
+        .unwrap_err();
     assert!(axis_err.to_string().contains("index_select"));
     assert!(axis_err.to_string().contains("axis"));
 
-    let position_err = input.index_select(0, &[3], &mut backend).unwrap_err();
+    let position_err = backend
+        .with_backend_session(|session| input.index_select(0, &[3], session))
+        .unwrap_err();
     assert!(position_err.to_string().contains("index_select"));
     assert!(position_err.to_string().contains("position"));
 }
@@ -987,13 +993,17 @@ fn tensor_stack_trailing_axis_packs_scalars_vectors_and_matrices() {
 
     let a = Tensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
     let b = Tensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
-    let scalars = Tensor::stack(&[&a, &b], -1, &mut backend).unwrap();
+    let scalars = backend
+        .with_backend_session(|session| Tensor::stack(&[&a, &b], -1, session))
+        .unwrap();
     assert_eq!(scalars.shape(), &[2]);
     assert_eq!(scalars.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
 
     let v0 = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let v1 = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
-    let vectors = Tensor::stack(&[&v0, &v1], -1, &mut backend).unwrap();
+    let vectors = backend
+        .with_backend_session(|session| Tensor::stack(&[&v0, &v1], -1, session))
+        .unwrap();
     assert_eq!(vectors.shape(), &[2, 2]);
     assert_f64_close(get_f64(&vectors, &[0, 0]), 1.0);
     assert_f64_close(get_f64(&vectors, &[1, 0]), 2.0);
@@ -1002,7 +1012,9 @@ fn tensor_stack_trailing_axis_packs_scalars_vectors_and_matrices() {
 
     let m0 = Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0]).unwrap();
     let m1 = Tensor::from_vec_col_major(vec![2, 1], vec![3.0_f64, 4.0]).unwrap();
-    let matrices = Tensor::stack(&[&m0, &m1], -1, &mut backend).unwrap();
+    let matrices = backend
+        .with_backend_session(|session| Tensor::stack(&[&m0, &m1], -1, session))
+        .unwrap();
     assert_eq!(matrices.shape(), &[2, 1, 2]);
     assert_f64_close(get_f64(&matrices, &[0, 0, 0]), 1.0);
     assert_f64_close(get_f64(&matrices, &[1, 0, 0]), 2.0);
@@ -1019,7 +1031,9 @@ fn tensor_index_select_reuses_reclaimed_cpu_buffer() {
 
     let input =
         Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
-    let out = input.index_select(-1, &[2, 0, 1], &mut backend).unwrap();
+    let out = backend
+        .with_backend_session(|session| input.index_select(-1, &[2, 0, 1], session))
+        .unwrap();
 
     assert_eq!(out.as_slice::<f64>().unwrap().as_ptr(), expected_ptr);
 }
@@ -1033,7 +1047,9 @@ fn tensor_stack_reuses_reclaimed_cpu_buffer() {
 
     let x0 = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let x1 = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
-    let out = Tensor::stack(&[&x0, &x1], -1, &mut backend).unwrap();
+    let out = backend
+        .with_backend_session(|session| Tensor::stack(&[&x0, &x1], -1, session))
+        .unwrap();
 
     assert_eq!(out.as_slice::<f64>().unwrap().as_ptr(), expected_ptr);
 }

--- a/crates/tenferro-einsum/src/concrete.rs
+++ b/crates/tenferro-einsum/src/concrete.rs
@@ -1,14 +1,14 @@
 //! Public concrete tensor einsum extension API.
 
 use tenferro_tensor::{
-    BackendSession, DType, DotGeneralAccumulation, Tensor, TensorBackend, TensorRead, TensorScalar,
-    TensorWrite, TypedTensor, TypedTensorView, TypedTensorWrite,
+    BackendSession, DType, DotGeneralAccumulation, Tensor, TensorRead, TensorScalar, TensorWrite,
+    TypedTensor, TypedTensorView, TypedTensorWrite,
 };
 
 use crate::eager::{
     eager_einsum_exec, eager_einsum_exec_read, eager_einsum_exec_read_into,
-    eager_einsum_exec_read_into_accum, eager_einsum_read_subscripts, eager_einsum_subscripts,
-    plan_subscripts,
+    eager_einsum_exec_read_into_accum, eager_einsum_read_subscripts_on_session,
+    eager_einsum_subscripts_on_session, plan_subscripts,
 };
 use crate::TensorDotAxes;
 use crate::{ContractionTree, EinsumSubscripts, Error, Result, Subscripts};
@@ -35,25 +35,25 @@ pub trait TensorTensordotExt {
     /// `AxisOutOfBounds`, or `ShapeMismatch` for invalid axes or incompatible
     /// contracting dimensions, or [`Error::Tensor`] when backend execution
     /// fails.
-    fn tensordot<B: TensorBackend>(
+    fn tensordot(
         &self,
         rhs: &Tensor,
         axes: TensorDotAxes<'_>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<Tensor>;
 }
 
 impl TensorTensordotExt for Tensor {
-    fn tensordot<B: TensorBackend>(
+    fn tensordot(
         &self,
         rhs: &Tensor,
         axes: TensorDotAxes<'_>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<Tensor> {
         let config =
             crate::tensordot::dot_general_config(axes, self.shape().len(), rhs.shape().len())?;
         crate::tensordot::validate_concrete_contract_dims(self.shape(), rhs.shape(), &config)?;
-        backend.dot_general(self, rhs, &config).map_err(Error::from)
+        session.dot_general(self, rhs, &config).map_err(Error::from)
     }
 }
 
@@ -67,25 +67,25 @@ pub trait TypedTensorTensordotExt<T: TensorScalar> {
     /// `AxisOutOfBounds`, or `ShapeMismatch` for invalid axes or incompatible
     /// contracting dimensions, or [`Error::Tensor`] when backend execution
     /// fails.
-    fn tensordot<B: TensorBackend>(
+    fn tensordot(
         &self,
         rhs: &TypedTensor<T>,
         axes: TensorDotAxes<'_>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>>;
 }
 
 impl<T: TensorScalar> TypedTensorTensordotExt<T> for TypedTensor<T> {
-    fn tensordot<B: TensorBackend>(
+    fn tensordot(
         &self,
         rhs: &TypedTensor<T>,
         axes: TensorDotAxes<'_>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>> {
         let config =
             crate::tensordot::dot_general_config(axes, self.shape().len(), rhs.shape().len())?;
         crate::tensordot::validate_concrete_contract_dims(self.shape(), rhs.shape(), &config)?;
-        let result = backend
+        let result = session
             .dot_general_read(T::tensor_read(self), T::tensor_read(rhs), &config)
             .map_err(Error::from)?;
         into_typed_result(result, TYPED_TENSOR_TENSORDOT_OP)
@@ -103,13 +103,15 @@ impl<T: TensorScalar> TypedTensorTensordotExt<T> for TypedTensor<T> {
 /// ```
 /// use tenferro_cpu::CpuBackend;
 /// use tenferro_einsum::TensorEinsumExt;
-/// use tenferro_tensor::Tensor;
+/// use tenferro_tensor::{BackendSessionHost, Tensor};
 ///
 /// let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
 /// let rhs = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
 /// let mut backend = CpuBackend::new();
 ///
-/// let out = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend)?;
+/// let out = backend.with_backend_session(|session| {
+///     [&lhs, &rhs].einsum("ij,jk->ik", session)
+/// })?;
 /// assert_eq!(out.shape(), &[2, 4]);
 /// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
@@ -121,7 +123,7 @@ pub trait TensorEinsumExt {
     /// Returns [`Error::InvalidSubscripts`] for malformed notation,
     /// [`Error::Validation`] with shape, rank, or dtype payloads for an invalid
     /// contraction, or [`Error::Tensor`] for a typed backend failure.
-    fn einsum<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor>;
+    fn einsum(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<Tensor>;
 
     /// Execute an einsum from parsed integer-label subscripts.
     ///
@@ -129,40 +131,40 @@ pub trait TensorEinsumExt {
     ///
     /// Returns [`Error::Validation`] with shape, rank, or dtype payloads for an
     /// invalid contraction, or [`Error::Tensor`] for a typed backend failure.
-    fn einsum_subscripts<B: TensorBackend>(
+    fn einsum_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<Tensor>;
 }
 
 impl TensorEinsumExt for [&Tensor] {
-    fn einsum<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor> {
+    fn einsum(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<Tensor> {
         let subscripts = parse_subscripts(subscripts, TENSOR_EINSUM_OP)?;
-        eager_einsum_subscripts(backend, self, &subscripts).map_err(Error::from)
+        eager_einsum_subscripts_on_session(session, self, &subscripts).map_err(Error::from)
     }
 
-    fn einsum_subscripts<B: TensorBackend>(
+    fn einsum_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<Tensor> {
         let subscripts = Subscripts::from(subscripts);
-        eager_einsum_subscripts(backend, self, &subscripts).map_err(Error::from)
+        eager_einsum_subscripts_on_session(session, self, &subscripts).map_err(Error::from)
     }
 }
 
 impl<const N: usize> TensorEinsumExt for [&Tensor; N] {
-    fn einsum<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor> {
-        self.as_slice().einsum(subscripts, backend)
+    fn einsum(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<Tensor> {
+        self.as_slice().einsum(subscripts, session)
     }
 
-    fn einsum_subscripts<B: TensorBackend>(
+    fn einsum_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<Tensor> {
-        self.as_slice().einsum_subscripts(subscripts, backend)
+        self.as_slice().einsum_subscripts(subscripts, session)
     }
 }
 
@@ -175,10 +177,10 @@ pub trait TensorEinsumIntoExt {
     /// Returns [`Error::InvalidSubscripts`] for malformed notation,
     /// [`Error::Validation`] with a shape, rank, or dtype payload when inputs or
     /// output do not match, or [`Error::Tensor`] for a typed backend failure.
-    fn einsum_into<B: TensorBackend>(
+    fn einsum_into(
         &self,
         subscripts: &str,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()>;
 
@@ -189,54 +191,54 @@ pub trait TensorEinsumIntoExt {
     /// Returns [`Error::Validation`] with a shape, rank, or dtype payload when
     /// inputs or output do not match, or [`Error::Tensor`] for a typed backend
     /// failure.
-    fn einsum_into_subscripts<B: TensorBackend>(
+    fn einsum_into_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()>;
 }
 
 impl TensorEinsumIntoExt for [&Tensor] {
-    fn einsum_into<B: TensorBackend>(
+    fn einsum_into(
         &self,
         subscripts: &str,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()> {
         let subscripts = parse_subscripts(subscripts, TENSOR_EINSUM_INTO_OP)?;
-        tensor_einsum_into_subscripts(backend, self, &subscripts, out, TENSOR_EINSUM_INTO_OP)
+        tensor_einsum_into_subscripts(session, self, &subscripts, out, TENSOR_EINSUM_INTO_OP)
     }
 
-    fn einsum_into_subscripts<B: TensorBackend>(
+    fn einsum_into_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()> {
         let subscripts = Subscripts::from(subscripts);
-        tensor_einsum_into_subscripts(backend, self, &subscripts, out, TENSOR_EINSUM_INTO_OP)
+        tensor_einsum_into_subscripts(session, self, &subscripts, out, TENSOR_EINSUM_INTO_OP)
     }
 }
 
 impl<const N: usize> TensorEinsumIntoExt for [&Tensor; N] {
-    fn einsum_into<B: TensorBackend>(
+    fn einsum_into(
         &self,
         subscripts: &str,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()> {
-        self.as_slice().einsum_into(subscripts, backend, out)
+        self.as_slice().einsum_into(subscripts, session, out)
     }
 
-    fn einsum_into_subscripts<B: TensorBackend>(
+    fn einsum_into_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()> {
         self.as_slice()
-            .einsum_into_subscripts(subscripts, backend, out)
+            .einsum_into_subscripts(subscripts, session, out)
     }
 }
 
@@ -250,13 +252,15 @@ impl<const N: usize> TensorEinsumIntoExt for [&Tensor; N] {
 /// ```
 /// use tenferro_cpu::CpuBackend;
 /// use tenferro_einsum::TypedTensorEinsumExt;
-/// use tenferro_tensor::TypedTensor;
+/// use tenferro_tensor::{BackendSessionHost, TypedTensor};
 ///
 /// let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
 /// let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 4], vec![1.0; 12]).unwrap();
 /// let mut backend = CpuBackend::new();
 ///
-/// let out = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend)?;
+/// let out = backend.with_backend_session(|session| {
+///     [&lhs, &rhs].einsum("ij,jk->ik", session)
+/// })?;
 /// assert_eq!(out.shape(), &[2, 4]);
 /// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
@@ -268,8 +272,7 @@ pub trait TypedTensorEinsumExt<T: TensorScalar> {
     /// Returns [`Error::InvalidSubscripts`] for malformed notation,
     /// [`Error::Validation`] with shape or rank payloads for an invalid
     /// contraction, or [`Error::Tensor`] for a typed backend failure.
-    fn einsum<B: TensorBackend>(&self, subscripts: &str, backend: &mut B)
-        -> Result<TypedTensor<T>>;
+    fn einsum(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<TypedTensor<T>>;
 
     /// Execute an einsum from parsed integer-label subscripts.
     ///
@@ -277,48 +280,40 @@ pub trait TypedTensorEinsumExt<T: TensorScalar> {
     ///
     /// Returns [`Error::Validation`] with shape or rank payloads for an invalid
     /// contraction, or [`Error::Tensor`] for a typed backend failure.
-    fn einsum_subscripts<B: TensorBackend>(
+    fn einsum_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>>;
 }
 
 impl<T: TensorScalar> TypedTensorEinsumExt<T> for [&TypedTensor<T>] {
-    fn einsum<B: TensorBackend>(
-        &self,
-        subscripts: &str,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
+    fn einsum(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_EINSUM_OP)?;
-        typed_einsum_subscripts(backend, self, &subscripts, TYPED_TENSOR_EINSUM_OP)
+        typed_einsum_subscripts(session, self, &subscripts, TYPED_TENSOR_EINSUM_OP)
     }
 
-    fn einsum_subscripts<B: TensorBackend>(
+    fn einsum_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>> {
         let subscripts = Subscripts::from(subscripts);
-        typed_einsum_subscripts(backend, self, &subscripts, TYPED_TENSOR_EINSUM_OP)
+        typed_einsum_subscripts(session, self, &subscripts, TYPED_TENSOR_EINSUM_OP)
     }
 }
 
 impl<T: TensorScalar, const N: usize> TypedTensorEinsumExt<T> for [&TypedTensor<T>; N] {
-    fn einsum<B: TensorBackend>(
-        &self,
-        subscripts: &str,
-        backend: &mut B,
-    ) -> Result<TypedTensor<T>> {
-        self.as_slice().einsum(subscripts, backend)
+    fn einsum(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
+        self.as_slice().einsum(subscripts, session)
     }
 
-    fn einsum_subscripts<B: TensorBackend>(
+    fn einsum_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>> {
-        self.as_slice().einsum_subscripts(subscripts, backend)
+        self.as_slice().einsum_subscripts(subscripts, session)
     }
 }
 
@@ -333,12 +328,14 @@ impl<T: TensorScalar, const N: usize> TypedTensorEinsumExt<T> for [&TypedTensor<
 /// ```
 /// use tenferro_cpu::CpuBackend;
 /// use tenferro_einsum::TypedTensorReadEinsumExt;
-/// use tenferro_tensor::TypedTensor;
+/// use tenferro_tensor::{BackendSessionHost, TypedTensor};
 ///
 /// let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0])?;
 /// let rhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0])?;
 /// let mut backend = CpuBackend::new();
-/// let result = [lhs.as_view(), rhs.as_view()].einsum_read("i,i->", &mut backend)?;
+/// let result = backend.with_backend_session(|session| {
+///     [lhs.as_view(), rhs.as_view()].einsum_read("i,i->", session)
+/// })?;
 /// assert_eq!(result.as_slice()?, &[11.0]);
 /// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
@@ -350,11 +347,13 @@ pub trait TypedTensorReadEinsumExt<T: TensorScalar> {
     /// ```
     /// use tenferro_cpu::CpuBackend;
     /// use tenferro_einsum::TypedTensorReadEinsumExt;
-    /// use tenferro_tensor::TypedTensor;
+    /// use tenferro_tensor::{BackendSessionHost, TypedTensor};
     ///
     /// let input = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 3.0])?;
     /// let mut backend = CpuBackend::new();
-    /// let result = [input.as_view()].einsum_read("i->i", &mut backend)?;
+    /// let result = backend.with_backend_session(|session| {
+    ///     [input.as_view()].einsum_read("i->i", session)
+    /// })?;
     /// assert_eq!(result.as_slice()?, &[2.0, 3.0]);
     /// # Ok::<(), tenferro_einsum::Error>(())
     /// ```
@@ -364,10 +363,10 @@ pub trait TypedTensorReadEinsumExt<T: TensorScalar> {
     /// Returns [`Error::InvalidSubscripts`] for malformed notation,
     /// [`Error::Validation`] with shape or rank payloads for incompatible
     /// views, or [`Error::Tensor`] for a typed backend failure.
-    fn einsum_read<B: TensorBackend>(
+    fn einsum_read(
         &self,
         subscripts: &str,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>>;
 
     /// Execute an einsum from parsed integer-label subscripts over typed
@@ -378,12 +377,14 @@ pub trait TypedTensorReadEinsumExt<T: TensorScalar> {
     /// ```
     /// use tenferro_cpu::CpuBackend;
     /// use tenferro_einsum::{EinsumSubscripts, TypedTensorReadEinsumExt};
-    /// use tenferro_tensor::TypedTensor;
+    /// use tenferro_tensor::{BackendSessionHost, TypedTensor};
     ///
     /// let input = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 3.0])?;
     /// let subscripts = EinsumSubscripts::new(&[&[0]], &[0]);
     /// let mut backend = CpuBackend::new();
-    /// let result = [input.as_view()].einsum_read_subscripts(&subscripts, &mut backend)?;
+    /// let result = backend.with_backend_session(|session| {
+    ///     [input.as_view()].einsum_read_subscripts(&subscripts, session)
+    /// })?;
     /// assert_eq!(result.as_slice()?, &[2.0, 3.0]);
     /// # Ok::<(), tenferro_einsum::Error>(())
     /// ```
@@ -392,50 +393,50 @@ pub trait TypedTensorReadEinsumExt<T: TensorScalar> {
     ///
     /// Returns [`Error::Validation`] with shape or rank payloads for
     /// incompatible views, or [`Error::Tensor`] for a typed backend failure.
-    fn einsum_read_subscripts<B: TensorBackend>(
+    fn einsum_read_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>>;
 }
 
 impl<'a, T: TensorScalar> TypedTensorReadEinsumExt<T> for [TypedTensorView<'a, T>] {
-    fn einsum_read<B: TensorBackend>(
+    fn einsum_read(
         &self,
         subscripts: &str,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>> {
         let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_READ_EINSUM_OP)?;
-        typed_view_einsum_subscripts(backend, self, &subscripts, TYPED_TENSOR_READ_EINSUM_OP)
+        typed_view_einsum_subscripts(session, self, &subscripts, TYPED_TENSOR_READ_EINSUM_OP)
     }
 
-    fn einsum_read_subscripts<B: TensorBackend>(
+    fn einsum_read_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>> {
         let subscripts = Subscripts::from(subscripts);
-        typed_view_einsum_subscripts(backend, self, &subscripts, TYPED_TENSOR_READ_EINSUM_OP)
+        typed_view_einsum_subscripts(session, self, &subscripts, TYPED_TENSOR_READ_EINSUM_OP)
     }
 }
 
 impl<'a, T: TensorScalar, const N: usize> TypedTensorReadEinsumExt<T>
     for [TypedTensorView<'a, T>; N]
 {
-    fn einsum_read<B: TensorBackend>(
+    fn einsum_read(
         &self,
         subscripts: &str,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>> {
-        self.as_slice().einsum_read(subscripts, backend)
+        self.as_slice().einsum_read(subscripts, session)
     }
 
-    fn einsum_read_subscripts<B: TensorBackend>(
+    fn einsum_read_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>> {
-        self.as_slice().einsum_read_subscripts(subscripts, backend)
+        self.as_slice().einsum_read_subscripts(subscripts, session)
     }
 }
 
@@ -448,9 +449,13 @@ pub trait TypedTensorEinsumIntoExt<T: TensorScalar> {
     /// Returns [`Error::InvalidSubscripts`] for malformed notation,
     /// [`Error::Validation`] with a shape, rank, or dtype payload when inputs or
     /// output do not match, or [`Error::Tensor`] for a typed backend failure.
-    fn einsum_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
+    fn einsum_into<'out, O>(
+        &self,
+        subscripts: &str,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
     where
-        B: TensorBackend,
         O: Into<TypedTensorWrite<'out, T>>;
 
     /// Execute an einsum from parsed integer-label subscripts into caller-provided typed output.
@@ -460,26 +465,29 @@ pub trait TypedTensorEinsumIntoExt<T: TensorScalar> {
     /// Returns [`Error::Validation`] with a shape, rank, or dtype payload when
     /// inputs or output do not match, or [`Error::Tensor`] for a typed backend
     /// failure.
-    fn einsum_into_subscripts<'out, B, O>(
+    fn einsum_into_subscripts<'out, O>(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: O,
     ) -> Result<()>
     where
-        B: TensorBackend,
         O: Into<TypedTensorWrite<'out, T>>;
 }
 
 impl<T: TensorScalar> TypedTensorEinsumIntoExt<T> for [&TypedTensor<T>] {
-    fn einsum_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
+    fn einsum_into<'out, O>(
+        &self,
+        subscripts: &str,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
     where
-        B: TensorBackend,
         O: Into<TypedTensorWrite<'out, T>>,
     {
         let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_EINSUM_INTO_OP)?;
         typed_einsum_into_subscripts(
-            backend,
+            session,
             self,
             &subscripts,
             out.into(),
@@ -487,19 +495,18 @@ impl<T: TensorScalar> TypedTensorEinsumIntoExt<T> for [&TypedTensor<T>] {
         )
     }
 
-    fn einsum_into_subscripts<'out, B, O>(
+    fn einsum_into_subscripts<'out, O>(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: O,
     ) -> Result<()>
     where
-        B: TensorBackend,
         O: Into<TypedTensorWrite<'out, T>>,
     {
         let subscripts = Subscripts::from(subscripts);
         typed_einsum_into_subscripts(
-            backend,
+            session,
             self,
             &subscripts,
             out.into(),
@@ -509,26 +516,29 @@ impl<T: TensorScalar> TypedTensorEinsumIntoExt<T> for [&TypedTensor<T>] {
 }
 
 impl<T: TensorScalar, const N: usize> TypedTensorEinsumIntoExt<T> for [&TypedTensor<T>; N] {
-    fn einsum_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
-    where
-        B: TensorBackend,
-        O: Into<TypedTensorWrite<'out, T>>,
-    {
-        self.as_slice().einsum_into(subscripts, backend, out)
-    }
-
-    fn einsum_into_subscripts<'out, B, O>(
+    fn einsum_into<'out, O>(
         &self,
-        subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        subscripts: &str,
+        session: &mut dyn BackendSession,
         out: O,
     ) -> Result<()>
     where
-        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
+        self.as_slice().einsum_into(subscripts, session, out)
+    }
+
+    fn einsum_into_subscripts<'out, O>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
+    where
         O: Into<TypedTensorWrite<'out, T>>,
     {
         self.as_slice()
-            .einsum_into_subscripts(subscripts, backend, out)
+            .einsum_into_subscripts(subscripts, session, out)
     }
 }
 
@@ -539,13 +549,15 @@ impl<T: TensorScalar, const N: usize> TypedTensorEinsumIntoExt<T> for [&TypedTen
 /// ```
 /// use tenferro_cpu::CpuBackend;
 /// use tenferro_einsum::TypedTensorReadEinsumIntoExt;
-/// use tenferro_tensor::TypedTensor;
+/// use tenferro_tensor::{BackendSessionHost, TypedTensor};
 ///
 /// let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0])?;
 /// let rhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0])?;
 /// let mut output = TypedTensor::<f64>::from_vec_col_major(vec![], vec![0.0])?;
 /// let mut backend = CpuBackend::new();
-/// [lhs.as_view(), rhs.as_view()].einsum_read_into("i,i->", &mut backend, &mut output)?;
+/// backend.with_backend_session(|session| {
+///     [lhs.as_view(), rhs.as_view()].einsum_read_into("i,i->", session, &mut output)
+/// })?;
 /// assert_eq!(output.as_slice()?, &[11.0]);
 /// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
@@ -558,12 +570,14 @@ pub trait TypedTensorReadEinsumIntoExt<T: TensorScalar> {
     /// ```
     /// use tenferro_cpu::CpuBackend;
     /// use tenferro_einsum::TypedTensorReadEinsumIntoExt;
-    /// use tenferro_tensor::TypedTensor;
+    /// use tenferro_tensor::{BackendSessionHost, TypedTensor};
     ///
     /// let input = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 3.0])?;
     /// let mut output = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0; 2])?;
     /// let mut backend = CpuBackend::new();
-    /// [input.as_view()].einsum_read_into("i->i", &mut backend, &mut output)?;
+    /// backend.with_backend_session(|session| {
+    ///     [input.as_view()].einsum_read_into("i->i", session, &mut output)
+    /// })?;
     /// assert_eq!(output.as_slice()?, &[2.0, 3.0]);
     /// # Ok::<(), tenferro_einsum::Error>(())
     /// ```
@@ -573,9 +587,13 @@ pub trait TypedTensorReadEinsumIntoExt<T: TensorScalar> {
     /// Returns [`Error::InvalidSubscripts`] for malformed notation,
     /// [`Error::Validation`] with a shape, rank, or dtype payload when inputs or
     /// output do not match, or [`Error::Tensor`] for a typed backend failure.
-    fn einsum_read_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
+    fn einsum_read_into<'out, O>(
+        &self,
+        subscripts: &str,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
     where
-        B: TensorBackend,
         O: Into<TypedTensorWrite<'out, T>>;
 
     /// Execute an einsum from parsed integer-label subscripts over typed
@@ -586,13 +604,15 @@ pub trait TypedTensorReadEinsumIntoExt<T: TensorScalar> {
     /// ```
     /// use tenferro_cpu::CpuBackend;
     /// use tenferro_einsum::{EinsumSubscripts, TypedTensorReadEinsumIntoExt};
-    /// use tenferro_tensor::TypedTensor;
+    /// use tenferro_tensor::{BackendSessionHost, TypedTensor};
     ///
     /// let input = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 3.0])?;
     /// let mut output = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0; 2])?;
     /// let subscripts = EinsumSubscripts::new(&[&[0]], &[0]);
     /// let mut backend = CpuBackend::new();
-    /// [input.as_view()].einsum_read_into_subscripts(&subscripts, &mut backend, &mut output)?;
+    /// backend.with_backend_session(|session| {
+    ///     [input.as_view()].einsum_read_into_subscripts(&subscripts, session, &mut output)
+    /// })?;
     /// assert_eq!(output.as_slice()?, &[2.0, 3.0]);
     /// # Ok::<(), tenferro_einsum::Error>(())
     /// ```
@@ -602,26 +622,29 @@ pub trait TypedTensorReadEinsumIntoExt<T: TensorScalar> {
     /// Returns [`Error::Validation`] with a shape, rank, or dtype payload when
     /// inputs or output do not match, or [`Error::Tensor`] for a typed backend
     /// failure.
-    fn einsum_read_into_subscripts<'out, B, O>(
+    fn einsum_read_into_subscripts<'out, O>(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: O,
     ) -> Result<()>
     where
-        B: TensorBackend,
         O: Into<TypedTensorWrite<'out, T>>;
 }
 
 impl<'a, T: TensorScalar> TypedTensorReadEinsumIntoExt<T> for [TypedTensorView<'a, T>] {
-    fn einsum_read_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
+    fn einsum_read_into<'out, O>(
+        &self,
+        subscripts: &str,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
     where
-        B: TensorBackend,
         O: Into<TypedTensorWrite<'out, T>>,
     {
         let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_READ_EINSUM_INTO_OP)?;
         typed_view_einsum_into_subscripts(
-            backend,
+            session,
             self,
             &subscripts,
             out.into(),
@@ -629,19 +652,18 @@ impl<'a, T: TensorScalar> TypedTensorReadEinsumIntoExt<T> for [TypedTensorView<'
         )
     }
 
-    fn einsum_read_into_subscripts<'out, B, O>(
+    fn einsum_read_into_subscripts<'out, O>(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: O,
     ) -> Result<()>
     where
-        B: TensorBackend,
         O: Into<TypedTensorWrite<'out, T>>,
     {
         let subscripts = Subscripts::from(subscripts);
         typed_view_einsum_into_subscripts(
-            backend,
+            session,
             self,
             &subscripts,
             out.into(),
@@ -653,26 +675,29 @@ impl<'a, T: TensorScalar> TypedTensorReadEinsumIntoExt<T> for [TypedTensorView<'
 impl<'a, T: TensorScalar, const N: usize> TypedTensorReadEinsumIntoExt<T>
     for [TypedTensorView<'a, T>; N]
 {
-    fn einsum_read_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
-    where
-        B: TensorBackend,
-        O: Into<TypedTensorWrite<'out, T>>,
-    {
-        self.as_slice().einsum_read_into(subscripts, backend, out)
-    }
-
-    fn einsum_read_into_subscripts<'out, B, O>(
+    fn einsum_read_into<'out, O>(
         &self,
-        subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        subscripts: &str,
+        session: &mut dyn BackendSession,
         out: O,
     ) -> Result<()>
     where
-        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
+        self.as_slice().einsum_read_into(subscripts, session, out)
+    }
+
+    fn einsum_read_into_subscripts<'out, O>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
+    where
         O: Into<TypedTensorWrite<'out, T>>,
     {
         self.as_slice()
-            .einsum_read_into_subscripts(subscripts, backend, out)
+            .einsum_read_into_subscripts(subscripts, session, out)
     }
 }
 
@@ -687,7 +712,7 @@ impl<'a, T: TensorScalar, const N: usize> TypedTensorReadEinsumIntoExt<T>
 /// ```
 /// use tenferro_cpu::CpuBackend;
 /// use tenferro_einsum::TensorReadEinsumExt;
-/// use tenferro_tensor::{Tensor, TensorRead, TensorView};
+/// use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead, TensorView};
 ///
 /// let shape = [2, 3];
 /// let data = [1.0_f64; 6];
@@ -698,7 +723,7 @@ impl<'a, T: TensorScalar, const N: usize> TypedTensorReadEinsumIntoExt<T>
 /// ];
 /// let mut backend = CpuBackend::new();
 ///
-/// let out = inputs.einsum_read("ij,j->i", &mut backend)?;
+/// let out = backend.with_backend_session(|session| inputs.einsum_read("ij,j->i", session))?;
 /// assert_eq!(out.shape(), &[2]);
 /// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
@@ -710,7 +735,7 @@ pub trait TensorReadEinsumExt {
     /// Returns [`Error::InvalidSubscripts`] for malformed notation,
     /// [`Error::Validation`] with shape, rank, or dtype payloads for an invalid
     /// contraction, or [`Error::Tensor`] for a typed backend failure.
-    fn einsum_read<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor>;
+    fn einsum_read(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<Tensor>;
 
     /// Execute an einsum from parsed integer-label subscripts over read-only
     /// tensor inputs.
@@ -719,40 +744,40 @@ pub trait TensorReadEinsumExt {
     ///
     /// Returns [`Error::Validation`] with shape, rank, or dtype payloads for an
     /// invalid contraction, or [`Error::Tensor`] for a typed backend failure.
-    fn einsum_read_subscripts<B: TensorBackend>(
+    fn einsum_read_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<Tensor>;
 }
 
 impl<'a> TensorReadEinsumExt for [TensorRead<'a>] {
-    fn einsum_read<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor> {
+    fn einsum_read(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<Tensor> {
         let subscripts = parse_subscripts(subscripts, TENSOR_READ_EINSUM_OP)?;
-        eager_einsum_read_subscripts(backend, self, &subscripts).map_err(Error::from)
+        eager_einsum_read_subscripts_on_session(session, self, &subscripts).map_err(Error::from)
     }
 
-    fn einsum_read_subscripts<B: TensorBackend>(
+    fn einsum_read_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<Tensor> {
         let subscripts = Subscripts::from(subscripts);
-        eager_einsum_read_subscripts(backend, self, &subscripts).map_err(Error::from)
+        eager_einsum_read_subscripts_on_session(session, self, &subscripts).map_err(Error::from)
     }
 }
 
 impl<'a, const N: usize> TensorReadEinsumExt for [TensorRead<'a>; N] {
-    fn einsum_read<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor> {
-        self.as_slice().einsum_read(subscripts, backend)
+    fn einsum_read(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<Tensor> {
+        self.as_slice().einsum_read(subscripts, session)
     }
 
-    fn einsum_read_subscripts<B: TensorBackend>(
+    fn einsum_read_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> Result<Tensor> {
-        self.as_slice().einsum_read_subscripts(subscripts, backend)
+        self.as_slice().einsum_read_subscripts(subscripts, session)
     }
 }
 
@@ -765,10 +790,10 @@ pub trait TensorReadEinsumIntoExt {
     /// Returns [`Error::InvalidSubscripts`] for malformed notation,
     /// [`Error::Validation`] with a shape, rank, or dtype payload when inputs or
     /// output do not match, or [`Error::Tensor`] for a typed backend failure.
-    fn einsum_read_into<B: TensorBackend>(
+    fn einsum_read_into(
         &self,
         subscripts: &str,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()>;
 
@@ -779,24 +804,24 @@ pub trait TensorReadEinsumIntoExt {
     /// Returns [`Error::Validation`] with a shape, rank, or dtype payload when
     /// inputs or output do not match, or [`Error::Tensor`] for a typed backend
     /// failure.
-    fn einsum_read_into_subscripts<B: TensorBackend>(
+    fn einsum_read_into_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()>;
 }
 
 impl<'a> TensorReadEinsumIntoExt for [TensorRead<'a>] {
-    fn einsum_read_into<B: TensorBackend>(
+    fn einsum_read_into(
         &self,
         subscripts: &str,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()> {
         let subscripts = parse_subscripts(subscripts, TENSOR_READ_EINSUM_INTO_OP)?;
         tensor_read_einsum_into_subscripts(
-            backend,
+            session,
             self,
             &subscripts,
             out,
@@ -804,15 +829,15 @@ impl<'a> TensorReadEinsumIntoExt for [TensorRead<'a>] {
         )
     }
 
-    fn einsum_read_into_subscripts<B: TensorBackend>(
+    fn einsum_read_into_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()> {
         let subscripts = Subscripts::from(subscripts);
         tensor_read_einsum_into_subscripts(
-            backend,
+            session,
             self,
             &subscripts,
             out,
@@ -822,23 +847,23 @@ impl<'a> TensorReadEinsumIntoExt for [TensorRead<'a>] {
 }
 
 impl<'a, const N: usize> TensorReadEinsumIntoExt for [TensorRead<'a>; N] {
-    fn einsum_read_into<B: TensorBackend>(
+    fn einsum_read_into(
         &self,
         subscripts: &str,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()> {
-        self.as_slice().einsum_read_into(subscripts, backend, out)
+        self.as_slice().einsum_read_into(subscripts, session, out)
     }
 
-    fn einsum_read_into_subscripts<B: TensorBackend>(
+    fn einsum_read_into_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()> {
         self.as_slice()
-            .einsum_read_into_subscripts(subscripts, backend, out)
+            .einsum_read_into_subscripts(subscripts, session, out)
     }
 }
 
@@ -1405,7 +1430,7 @@ fn read_input_specs(inputs: &[TensorRead<'_>]) -> Vec<ConcreteEinsumInputSpec> {
 }
 
 fn typed_view_einsum_subscripts<T: TensorScalar>(
-    backend: &mut impl TensorBackend,
+    session: &mut dyn BackendSession,
     inputs: &[TypedTensorView<'_, T>],
     subscripts: &Subscripts,
     op: &'static str,
@@ -1417,12 +1442,12 @@ fn typed_view_einsum_subscripts<T: TensorScalar>(
         .collect();
     let plan =
         ConcreteEinsumPlan::prepare_subscripts_internal(read_input_specs(&reads), subscripts)?;
-    let result = backend.with_backend_session(|session| plan.execute_read(&reads, session))?;
+    let result = plan.execute_read(&reads, session)?;
     into_typed_result(result, op)
 }
 
 fn tensor_einsum_into_subscripts(
-    backend: &mut impl TensorBackend,
+    session: &mut dyn BackendSession,
     inputs: &[&Tensor],
     subscripts: &Subscripts,
     out: TensorWrite<'_>,
@@ -1430,11 +1455,11 @@ fn tensor_einsum_into_subscripts(
 ) -> Result<()> {
     let plan = ConcreteEinsumPlan::prepare_subscripts_internal(input_specs(inputs), subscripts)?;
     validate_output(&plan.inputs, &plan.tree, &out, op)?;
-    backend.with_backend_session(|session| plan.execute_into(inputs, session, out))
+    plan.execute_into(inputs, session, out)
 }
 
 fn typed_view_einsum_into_subscripts<T: TensorScalar>(
-    backend: &mut impl TensorBackend,
+    session: &mut dyn BackendSession,
     inputs: &[TypedTensorView<'_, T>],
     subscripts: &Subscripts,
     out: TypedTensorWrite<'_, T>,
@@ -1449,11 +1474,11 @@ fn typed_view_einsum_into_subscripts<T: TensorScalar>(
         ConcreteEinsumPlan::prepare_subscripts_internal(read_input_specs(&reads), subscripts)?;
     let out = out.into_tensor_write();
     validate_output(&plan.inputs, &plan.tree, &out, op)?;
-    backend.with_backend_session(|session| plan.execute_read_into(&reads, session, out))
+    plan.execute_read_into(&reads, session, out)
 }
 
 fn typed_einsum_into_subscripts<T: TensorScalar>(
-    backend: &mut impl TensorBackend,
+    session: &mut dyn BackendSession,
     inputs: &[&TypedTensor<T>],
     subscripts: &Subscripts,
     out: TypedTensorWrite<'_, T>,
@@ -1464,11 +1489,11 @@ fn typed_einsum_into_subscripts<T: TensorScalar>(
         ConcreteEinsumPlan::prepare_subscripts_internal(read_input_specs(&reads), subscripts)?;
     let out = out.into_tensor_write();
     validate_output(&plan.inputs, &plan.tree, &out, op)?;
-    backend.with_backend_session(|session| plan.execute_read_into(&reads, session, out))
+    plan.execute_read_into(&reads, session, out)
 }
 
 fn tensor_read_einsum_into_subscripts(
-    backend: &mut impl TensorBackend,
+    session: &mut dyn BackendSession,
     inputs: &[TensorRead<'_>],
     subscripts: &Subscripts,
     out: TensorWrite<'_>,
@@ -1477,7 +1502,7 @@ fn tensor_read_einsum_into_subscripts(
     let plan =
         ConcreteEinsumPlan::prepare_subscripts_internal(read_input_specs(inputs), subscripts)?;
     validate_output(&plan.inputs, &plan.tree, &out, op)?;
-    backend.with_backend_session(|session| plan.execute_read_into(inputs, session, out))
+    plan.execute_read_into(inputs, session, out)
 }
 
 fn validate_output(
@@ -1545,7 +1570,7 @@ fn output_spec(
 }
 
 fn typed_einsum_subscripts<T: TensorScalar>(
-    backend: &mut impl TensorBackend,
+    session: &mut dyn BackendSession,
     inputs: &[&TypedTensor<T>],
     subscripts: &Subscripts,
     op: &'static str,
@@ -1553,7 +1578,7 @@ fn typed_einsum_subscripts<T: TensorScalar>(
     let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
     let plan =
         ConcreteEinsumPlan::prepare_subscripts_internal(read_input_specs(&reads), subscripts)?;
-    let result = backend.with_backend_session(|session| plan.execute_read(&reads, session))?;
+    let result = plan.execute_read(&reads, session)?;
     into_typed_result(result, op)
 }
 

--- a/crates/tenferro-einsum/src/concrete_tests.rs
+++ b/crates/tenferro-einsum/src/concrete_tests.rs
@@ -26,7 +26,9 @@ fn public_tensor_einsum_ext_executes_dtype_erased_inputs() {
     let rhs =
         Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
 
-    let result = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend).unwrap();
+    let result = backend
+        .with_backend_session(|session| [&lhs, &rhs].einsum("ij,jk->ik", session))
+        .unwrap();
 
     assert_f64_tensor(&result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
 }
@@ -36,15 +38,19 @@ fn concrete_tensordot_matches_einsum_for_erased_and_typed_tensors() {
     let mut backend = CpuBackend::new();
     let lhs = Tensor::from_vec_col_major([2], vec![1.0_f64, 2.0]).unwrap();
     let rhs = Tensor::from_vec_col_major([2], vec![3.0_f64, 4.0]).unwrap();
-    let erased = lhs
-        .tensordot(&rhs, crate::TensorDotAxes::Count(1), &mut backend)
+    let erased = backend
+        .with_backend_session(|session| {
+            lhs.tensordot(&rhs, crate::TensorDotAxes::Count(1), session)
+        })
         .unwrap();
     assert_eq!(erased.as_slice::<f64>().unwrap(), &[11.0]);
 
     let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
     let rhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap();
-    let typed = lhs
-        .tensordot(&rhs, crate::TensorDotAxes::Count(1), &mut backend)
+    let typed = backend
+        .with_backend_session(|session| {
+            lhs.tensordot(&rhs, crate::TensorDotAxes::Count(1), session)
+        })
         .unwrap();
     assert_eq!(typed.as_slice().unwrap(), &[11.0]);
 }
@@ -59,12 +65,11 @@ fn public_tensor_einsum_ext_accepts_slice_and_integer_subscripts() {
     let subscripts = parse_einsum_subscripts("ij,jk->ik").unwrap();
     let inputs = vec![&lhs, &rhs];
 
-    let slice_result = inputs
-        .as_slice()
-        .einsum_subscripts(&subscripts, &mut backend)
+    let slice_result = backend
+        .with_backend_session(|session| inputs.as_slice().einsum_subscripts(&subscripts, session))
         .unwrap();
-    let array_result = [&lhs, &rhs]
-        .einsum_subscripts(&subscripts, &mut backend)
+    let array_result = backend
+        .with_backend_session(|session| [&lhs, &rhs].einsum_subscripts(&subscripts, session))
         .unwrap();
 
     assert_f64_tensor(&slice_result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
@@ -90,10 +95,12 @@ fn public_typed_tensor_einsum_ext_preserves_complex_dtype() {
     )
     .unwrap();
 
-    let result = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend).unwrap();
+    let result = backend
+        .with_backend_session(|session| [&lhs, &rhs].einsum("ij,jk->ik", session))
+        .unwrap();
     let subscripts = parse_einsum_subscripts("ij,jk->ik").unwrap();
-    let integer_result = [&lhs, &rhs]
-        .einsum_subscripts(&subscripts, &mut backend)
+    let integer_result = backend
+        .with_backend_session(|session| [&lhs, &rhs].einsum_subscripts(&subscripts, session))
         .unwrap();
     let plan = ConcreteEinsumPlan::prepare_typed_subscripts([&lhs, &rhs], &subscripts).unwrap();
     let planned_result = backend
@@ -127,12 +134,11 @@ fn public_typed_tensor_einsum_ext_accepts_slice_and_integer_subscripts() {
     let subscripts = parse_einsum_subscripts("ij,jk->ik").unwrap();
     let inputs = vec![&lhs, &rhs];
 
-    let slice_result = inputs
-        .as_slice()
-        .einsum_subscripts(&subscripts, &mut backend)
+    let slice_result = backend
+        .with_backend_session(|session| inputs.as_slice().einsum_subscripts(&subscripts, session))
         .unwrap();
-    let array_result = [&lhs, &rhs]
-        .einsum_subscripts(&subscripts, &mut backend)
+    let array_result = backend
+        .with_backend_session(|session| [&lhs, &rhs].einsum_subscripts(&subscripts, session))
         .unwrap();
 
     assert_eq!(slice_result.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
@@ -161,11 +167,15 @@ fn public_typed_tensor_read_einsum_ext_accepts_borrowed_strided_complex_views() 
         TypedTensor::<Complex64>::from_vec_col_major(vec![2], vec![Complex64::new(0.0, 0.0); 2])
             .unwrap();
 
-    let result = [matrix_view.clone(), vector_view.clone()]
-        .einsum_read("ij,j->i", &mut backend)
+    let result = backend
+        .with_backend_session(|session| {
+            [matrix_view.clone(), vector_view.clone()].einsum_read("ij,j->i", session)
+        })
         .unwrap();
-    [matrix_view, vector_view]
-        .einsum_read_into("ij,j->i", &mut backend, &mut out)
+    backend
+        .with_backend_session(|session| {
+            [matrix_view, vector_view].einsum_read_into("ij,j->i", session, &mut out)
+        })
         .unwrap();
 
     assert_eq!(
@@ -189,7 +199,9 @@ fn public_tensor_read_einsum_ext_accepts_strided_views() {
         TensorRead::from_tensor(&vector),
     ];
 
-    let result = inputs.einsum_read("ij,j->i", &mut backend).unwrap();
+    let result = backend
+        .with_backend_session(|session| inputs.einsum_read("ij,j->i", session))
+        .unwrap();
 
     assert_f64_tensor(&result, &[2], &[140.0, 320.0]);
 }
@@ -206,12 +218,15 @@ fn public_tensor_read_einsum_ext_accepts_slice_and_integer_subscripts() {
     ];
     let subscripts = parse_einsum_subscripts("ij,j->i").unwrap();
 
-    let slice_result = inputs
-        .as_slice()
-        .einsum_read_subscripts(&subscripts, &mut backend)
+    let slice_result = backend
+        .with_backend_session(|session| {
+            inputs
+                .as_slice()
+                .einsum_read_subscripts(&subscripts, session)
+        })
         .unwrap();
-    let array_result = inputs
-        .einsum_read_subscripts(&subscripts, &mut backend)
+    let array_result = backend
+        .with_backend_session(|session| inputs.einsum_read_subscripts(&subscripts, session))
         .unwrap();
 
     assert_f64_tensor(&slice_result, &[2], &[140.0, 320.0]);
@@ -227,12 +242,14 @@ fn public_einsum_into_writes_dynamic_typed_and_read_outputs() {
         Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
 
     let mut dynamic_out = Tensor::from_vec_col_major(vec![2, 2], vec![-1.0_f64; 4]).unwrap();
-    [&lhs, &rhs]
-        .einsum_into(
-            "ij,jk->ik",
-            &mut backend,
-            TensorWrite::from_tensor(&mut dynamic_out),
-        )
+    backend
+        .with_backend_session(|session| {
+            [&lhs, &rhs].einsum_into(
+                "ij,jk->ik",
+                session,
+                TensorWrite::from_tensor(&mut dynamic_out),
+            )
+        })
         .unwrap();
     assert_f64_tensor(&dynamic_out, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
 
@@ -243,8 +260,10 @@ fn public_einsum_into_writes_dynamic_typed_and_read_outputs() {
         TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
             .unwrap();
     let mut typed_out = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![-1.0; 4]).unwrap();
-    [&typed_lhs, &typed_rhs]
-        .einsum_into("ij,jk->ik", &mut backend, &mut typed_out)
+    backend
+        .with_backend_session(|session| {
+            [&typed_lhs, &typed_rhs].einsum_into("ij,jk->ik", session, &mut typed_out)
+        })
         .unwrap();
     assert_eq!(typed_out.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
 
@@ -252,12 +271,14 @@ fn public_einsum_into_writes_dynamic_typed_and_read_outputs() {
     {
         let out_view =
             TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut typed_strided_data).unwrap();
-        [&typed_lhs, &typed_rhs]
-            .einsum_into(
-                "ij,jk->ik",
-                &mut backend,
-                TypedTensorWrite::from_view(out_view),
-            )
+        backend
+            .with_backend_session(|session| {
+                [&typed_lhs, &typed_rhs].einsum_into(
+                    "ij,jk->ik",
+                    session,
+                    TypedTensorWrite::from_view(out_view),
+                )
+            })
             .unwrap();
     }
     assert_eq!(
@@ -271,8 +292,10 @@ fn public_einsum_into_writes_dynamic_typed_and_read_outputs() {
             TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut strided_data).unwrap(),
         );
         let inputs = [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)];
-        inputs
-            .einsum_read_into("ij,jk->ik", &mut backend, TensorWrite::from_view(out_view))
+        backend
+            .with_backend_session(|session| {
+                inputs.einsum_read_into("ij,jk->ik", session, TensorWrite::from_view(out_view))
+            })
             .unwrap();
     }
     assert_eq!(
@@ -303,8 +326,8 @@ fn public_einsum_into_preserves_complex_dtype() {
         TypedTensor::<Complex64>::from_vec_col_major(vec![2, 1], vec![Complex64::new(0.0, 0.0); 2])
             .unwrap();
 
-    [&lhs, &rhs]
-        .einsum_into("ij,jk->ik", &mut backend, &mut out)
+    backend
+        .with_backend_session(|session| [&lhs, &rhs].einsum_into("ij,jk->ik", session, &mut out))
         .unwrap();
 
     assert_eq!(
@@ -321,12 +344,14 @@ fn public_einsum_into_rejects_output_shape_and_dtype_mismatch() {
     let rhs =
         Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let mut wrong_shape = Tensor::from_vec_col_major(vec![4], vec![0.0_f64; 4]).unwrap();
-    let shape_err = [&lhs, &rhs]
-        .einsum_into(
-            "ij,jk->ik",
-            &mut backend,
-            TensorWrite::from_tensor(&mut wrong_shape),
-        )
+    let shape_err = backend
+        .with_backend_session(|session| {
+            [&lhs, &rhs].einsum_into(
+                "ij,jk->ik",
+                session,
+                TensorWrite::from_tensor(&mut wrong_shape),
+            )
+        })
         .unwrap_err();
     assert!(matches!(
         shape_err,
@@ -337,12 +362,14 @@ fn public_einsum_into_rejects_output_shape_and_dtype_mismatch() {
     ));
 
     let mut wrong_dtype = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f32; 4]).unwrap();
-    let dtype_err = [&lhs, &rhs]
-        .einsum_into(
-            "ij,jk->ik",
-            &mut backend,
-            TensorWrite::from_tensor(&mut wrong_dtype),
-        )
+    let dtype_err = backend
+        .with_backend_session(|session| {
+            [&lhs, &rhs].einsum_into(
+                "ij,jk->ik",
+                session,
+                TensorWrite::from_tensor(&mut wrong_dtype),
+            )
+        })
         .unwrap_err();
     assert!(matches!(
         dtype_err,
@@ -662,8 +689,8 @@ fn concrete_einsum_public_api_reports_parse_and_input_count_errors() {
         Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let mut backend = CpuBackend::new();
 
-    let parse_err = [&lhs, &rhs]
-        .einsum("ij,(jk)->ik", &mut backend)
+    let parse_err = backend
+        .with_backend_session(|session| [&lhs, &rhs].einsum("ij,(jk)->ik", session))
         .unwrap_err();
     let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
     let count_err = backend

--- a/crates/tenferro-einsum/src/eager.rs
+++ b/crates/tenferro-einsum/src/eager.rs
@@ -1,9 +1,11 @@
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
+#[cfg(test)]
+use tenferro_tensor::TensorBackend;
 use tenferro_tensor::{
-    BackendSession, DotGeneralAccumulation, DotGeneralConfig, Error, Result, Tensor, TensorBackend,
-    TensorRank, TensorRead, TensorView, TensorWrite, TypedTensorView,
+    BackendSession, DotGeneralAccumulation, DotGeneralConfig, Error, Result, Tensor, TensorRank,
+    TensorRead, TensorView, TensorWrite, TypedTensorView,
 };
 
 use crate::binary_dot::{try_build_binary_dot_plan, BinaryDotPlan};
@@ -770,9 +772,9 @@ fn eager_einsum_exec_values<'a>(
 
 /// Run a whole einsum contraction tree in one backend session.
 ///
-/// Unlike [`eager_einsum_subscripts`], the caller supplies the contraction
-/// `tree`, so a known-good external path (e.g. cotengra `opt_flops`) can be
-/// executed whole-program without re-planning.
+/// Unlike [`eager_einsum_subscripts_on_session`], the caller supplies the
+/// contraction `tree`, so a known-good external path (e.g. cotengra
+/// `opt_flops`) can be executed whole-program without re-planning.
 #[cfg(all(feature = "autodiff", test))]
 pub(crate) fn eager_einsum_with_tree(
     exec: &mut dyn BackendSession,
@@ -911,8 +913,24 @@ fn into_tensor_error(error: crate::Error) -> tenferro_tensor::Error {
 }
 
 /// Eager N-ary einsum on concrete [`Tensor`] values using integer labels.
+#[cfg(test)]
 pub(crate) fn eager_einsum_subscripts(
     ctx: &mut impl TensorBackend,
+    inputs: &[&Tensor],
+    subscripts: &Subscripts,
+) -> Result<Tensor> {
+    ctx.with_backend_session(|session| {
+        eager_einsum_subscripts_on_session(session, inputs, subscripts)
+    })
+}
+
+/// Eager N-ary einsum on concrete [`Tensor`] values inside an existing
+/// backend session.
+///
+/// The session-taking variant used by the concrete einsum traits: the caller
+/// already holds a session, so no nested session entry happens here.
+pub(crate) fn eager_einsum_subscripts_on_session(
+    session: &mut dyn BackendSession,
     inputs: &[&Tensor],
     subscripts: &Subscripts,
 ) -> Result<Tensor> {
@@ -923,9 +941,7 @@ pub(crate) fn eager_einsum_subscripts(
         })
         .map_err(into_tensor_error)?;
         let result = profile_eager_einsum_section("with_backend_session", || {
-            ctx.with_backend_session(|session| {
-                plan.execute(inputs, session).map_err(into_tensor_error)
-            })
+            plan.execute(inputs, session).map_err(into_tensor_error)
         });
         record_eager_einsum_profile("total", total_started.elapsed());
         maybe_print_eager_einsum_profile();
@@ -945,9 +961,7 @@ pub(crate) fn eager_einsum_subscripts(
         let plan_us = started.elapsed().as_secs_f64() * 1.0e6;
 
         let started = Instant::now();
-        let result = ctx.with_backend_session(|session| {
-            plan.execute(inputs, session).map_err(into_tensor_error)
-        });
+        let result = plan.execute(inputs, session).map_err(into_tensor_error);
         let exec_us = started.elapsed().as_secs_f64() * 1.0e6;
         let total_us = total_started.elapsed().as_secs_f64() * 1.0e6;
 
@@ -962,7 +976,7 @@ pub(crate) fn eager_einsum_subscripts(
 
     let plan = ConcreteEinsumPlan::prepare_subscripts(inputs, &EinsumSubscripts::from(subscripts))
         .map_err(into_tensor_error)?;
-    ctx.with_backend_session(|session| plan.execute(inputs, session).map_err(into_tensor_error))
+    plan.execute(inputs, session).map_err(into_tensor_error)
 }
 
 #[cfg(feature = "autodiff")]
@@ -981,18 +995,33 @@ pub(crate) fn eager_einsum_subscripts_with_session(
 /// Owned tensors and borrowed host views share this entry point. Backends may
 /// consume views directly when their execution model supports it, or
 /// canonicalize them within the existing placement inside the execution session.
+#[cfg(test)]
 pub(crate) fn eager_einsum_read_subscripts(
     ctx: &mut impl TensorBackend,
+    inputs: &[TensorRead<'_>],
+    subscripts: &Subscripts,
+) -> Result<Tensor> {
+    ctx.with_backend_session(|session| {
+        eager_einsum_read_subscripts_on_session(session, inputs, subscripts)
+    })
+}
+
+/// Eager N-ary einsum on read-only tensor inputs inside an existing backend
+/// session.
+///
+/// Owned tensors and borrowed host views share this entry point. Backends may
+/// consume views directly when their execution model supports it, or
+/// canonicalize them within the existing placement inside the execution session.
+pub(crate) fn eager_einsum_read_subscripts_on_session(
+    session: &mut dyn BackendSession,
     inputs: &[TensorRead<'_>],
     subscripts: &Subscripts,
 ) -> Result<Tensor> {
     let plan =
         ConcreteEinsumPlan::prepare_read_subscripts(inputs, &EinsumSubscripts::from(subscripts))
             .map_err(into_tensor_error)?;
-    ctx.with_backend_session(|session| {
-        plan.execute_read(inputs, session)
-            .map_err(into_tensor_error)
-    })
+    plan.execute_read(inputs, session)
+        .map_err(into_tensor_error)
 }
 
 /// Eager N-ary einsum that consumes concrete [`Tensor`] inputs.

--- a/crates/tenferro-einsum/src/eager_ad.rs
+++ b/crates/tenferro-einsum/src/eager_ad.rs
@@ -248,9 +248,10 @@ fn try_direct_binary_dot_general(
 ///
 /// Prototype gate (issue #1060 follow-up): when set, untracked N-ary eager
 /// einsum runs the whole contraction in one backend session via
-/// [`crate::eager::eager_einsum_subscripts`] instead of executing the expanded
-/// program one standard op at a time. Tracked (`requires_grad`) inputs keep the
-/// existing per-op path so eager AD recording semantics are unchanged.
+/// [`crate::eager::eager_einsum_subscripts_on_session`] instead of executing
+/// the expanded program one standard op at a time. Tracked (`requires_grad`)
+/// inputs keep the existing per-op path so eager AD recording semantics are
+/// unchanged.
 fn whole_program_untracked_enabled() -> bool {
     std::env::var_os("TENFERRO_EAGER_WHOLE_PROGRAM").is_some()
 }

--- a/crates/tenferro-einsum/src/lib.rs
+++ b/crates/tenferro-einsum/src/lib.rs
@@ -35,13 +35,15 @@
 //! ```
 //! use tenferro_cpu::CpuBackend;
 //! use tenferro_einsum::TensorEinsumExt;
-//! use tenferro_tensor::Tensor;
+//! use tenferro_tensor::{BackendSessionHost, Tensor};
 //!
 //! let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
 //! let b = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
 //! let mut backend = CpuBackend::new();
 //!
-//! let out = [&a, &b].einsum("ij,jk->ik", &mut backend)?;
+//! let out = backend.with_backend_session(|session| {
+//!     [&a, &b].einsum("ij,jk->ik", session)
+//! })?;
 //! assert_eq!(out.shape(), &[2, 4]);
 //! # Ok::<(), tenferro_einsum::Error>(())
 //! ```

--- a/crates/tenferro-einsum/tests/integration/public_surface_contract.rs
+++ b/crates/tenferro-einsum/tests/integration/public_surface_contract.rs
@@ -43,9 +43,10 @@ fn typed_einsum_view_inputs_use_read_suffix_and_typed_outputs_accept_views() {
     let source = std::fs::read_to_string(root).expect("read concrete einsum source");
 
     assert!(source.contains("pub trait TypedTensorReadEinsumExt"));
-    assert!(source.contains("fn einsum_read<B: TensorBackend>"));
+    assert!(source.contains("fn einsum_read("));
+    assert!(source.contains("session: &mut dyn BackendSession,"));
     assert!(source.contains("pub trait TypedTensorReadEinsumIntoExt"));
-    assert!(source.contains("fn einsum_read_into<'out, B, O>"));
+    assert!(source.contains("fn einsum_read_into<'out, O>"));
     assert!(source.contains("O: Into<TypedTensorWrite<'out, T>>"));
 
     assert!(
@@ -59,6 +60,16 @@ fn typed_einsum_view_inputs_use_read_suffix_and_typed_outputs_accept_views() {
             "impl<'a, T: TensorScalar> TypedTensorEinsumIntoExt<T> for [TypedTensorView<'a, T>]"
         ),
         "borrowed typed inputs must not implement the unsuffixed einsum_into surface"
+    );
+    // The concrete einsum traits are backend-session explicit: no
+    // backend-taking `B: TensorBackend` surface remains on the public traits.
+    assert!(
+        !source.contains("fn einsum_read<B: TensorBackend>"),
+        "concrete einsum traits must not take a generic TensorBackend"
+    );
+    assert!(
+        !source.contains("fn einsum_read_into<'out, B, O>"),
+        "concrete einsum traits must not take a generic TensorBackend"
     );
 }
 

--- a/crates/tenferro-einsum/tests/prelude.rs
+++ b/crates/tenferro-einsum/tests/prelude.rs
@@ -1,12 +1,15 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::prelude::*;
+use tenferro_tensor::BackendSessionHost;
 
 #[test]
 fn prelude_calls_concrete_einsum() {
     let lhs = Tensor::from_vec_col_major([2, 3], vec![1.0_f64; 6]).unwrap();
     let rhs = Tensor::from_vec_col_major([3, 2], vec![1.0_f64; 6]).unwrap();
     let mut backend = CpuBackend::new();
-    let result = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend).unwrap();
+    let result = backend
+        .with_backend_session(|session| [&lhs, &rhs].einsum("ij,jk->ik", session))
+        .unwrap();
     assert_eq!(result.shape(), &[2, 2]);
 }
 

--- a/crates/tenferro-fft/benches/fft_plan_cache.rs
+++ b/crates/tenferro-fft/benches/fft_plan_cache.rs
@@ -1,22 +1,10 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use num_complex::Complex64;
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend, CpuExecSession};
+use tenferro_cpu::CpuBackend;
 use tenferro_fft::{FftExecutor, FftNorm, TensorFftExt};
 use tenferro_tensor::{BackendSessionHost, Tensor};
 
 const CASES: &[(usize, usize)] = &[(256, 1), (1024, 16)];
-
-fn with_cpu_session<R>(
-    backend: &mut CpuBackend,
-    f: impl for<'a> FnOnce(&'a mut CpuExecSession<'a>) -> R + Send,
-) -> R
-where
-    R: Send,
-{
-    backend.with_backend_session(|session| {
-        with_cpu_exec_session(session, f).expect("CpuBackend must expose a CPU execution session")
-    })
-}
 
 fn c64_input(fft_len: usize, lanes: usize) -> Tensor {
     let len = fft_len * lanes;
@@ -48,29 +36,28 @@ fn bench_c64_fft_plan_cache(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("direct_one_shot", &id), |bench| {
             let mut backend = CpuBackend::new();
             bench.iter(|| {
-                let output = with_cpu_session(&mut backend, |session| {
+                let output = backend.with_backend_session(|session| {
                     black_box(&input).fft(None, 0, FftNorm::Backward, session)
-                })
-                .unwrap();
-                black_box(output);
+                });
+                black_box(output.unwrap());
             });
         });
 
         group.bench_function(BenchmarkId::new("executor_warm_cache", &id), |bench| {
             let mut backend = CpuBackend::new();
             let mut executor = FftExecutor::default();
-            with_cpu_session(&mut backend, |session| {
-                executor.fft(&input, None, 0, FftNorm::Backward, session)
-            })
-            .unwrap();
+            backend
+                .with_backend_session(|session| {
+                    executor.fft(&input, None, 0, FftNorm::Backward, session)
+                })
+                .unwrap();
             assert_eq!(executor.cache_stats().entries, 1);
 
             bench.iter(|| {
-                let output = with_cpu_session(&mut backend, |session| {
+                let output = backend.with_backend_session(|session| {
                     executor.fft(black_box(&input), None, 0, FftNorm::Backward, session)
-                })
-                .unwrap();
-                black_box(output);
+                });
+                black_box(output.unwrap());
             });
         });
     }
@@ -87,29 +74,28 @@ fn bench_f64_rfft_plan_cache(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("direct_one_shot", &id), |bench| {
             let mut backend = CpuBackend::new();
             bench.iter(|| {
-                let output = with_cpu_session(&mut backend, |session| {
+                let output = backend.with_backend_session(|session| {
                     black_box(&input).rfft(None, 0, FftNorm::Backward, session)
-                })
-                .unwrap();
-                black_box(output);
+                });
+                black_box(output.unwrap());
             });
         });
 
         group.bench_function(BenchmarkId::new("executor_warm_cache", &id), |bench| {
             let mut backend = CpuBackend::new();
             let mut executor = FftExecutor::default();
-            with_cpu_session(&mut backend, |session| {
-                executor.rfft(&input, None, 0, FftNorm::Backward, session)
-            })
-            .unwrap();
+            backend
+                .with_backend_session(|session| {
+                    executor.rfft(&input, None, 0, FftNorm::Backward, session)
+                })
+                .unwrap();
             assert_eq!(executor.cache_stats().entries, 1);
 
             bench.iter(|| {
-                let output = with_cpu_session(&mut backend, |session| {
+                let output = backend.with_backend_session(|session| {
                     executor.rfft(black_box(&input), None, 0, FftNorm::Backward, session)
-                })
-                .unwrap();
-                black_box(output);
+                });
+                black_box(output.unwrap());
             });
         });
     }

--- a/crates/tenferro-fft/src/backend.rs
+++ b/crates/tenferro-fft/src/backend.rs
@@ -82,32 +82,37 @@ impl<'a> FftExecutionCache<'a> {
 /// transfer the tensor or select a different backend.
 ///
 /// # Examples
+/// Backend surface required by the FFT extension runtime and the built-in
+/// concrete FFT dispatch.
+///
+/// This is a backend SPI: third-party backend implementers implement this
+/// trait on their execution sessions to provide FFT capability. The concrete
+/// [`TensorFftExt`]/[`TensorReadFftExt`] methods and [`FftExecutor`] take an
+/// erased `&mut dyn BackendSession` and dispatch **internally** to the
+/// built-in CPU/CUDA/WebGPU execution sessions; a session without this
+/// capability returns a typed `Error::Unsupported` instead of being accepted
+/// as an arbitrary third-party backend (issue #1680 Phase 3).
+///
+/// # Examples
 ///
 /// ```
-/// use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+/// use tenferro_cpu::CpuExecSession;
 /// use tenferro_fft::FftBackend;
-/// use tenferro_tensor::BackendSessionHost;
 ///
-/// fn accepts_fft_backend<B: FftBackend>(_backend: &mut B) {}
+/// fn accepts_fft_backend<B: FftBackend>() {}
 ///
-/// let mut backend = CpuBackend::new();
-/// backend.with_backend_session(|session| {
-///     with_cpu_exec_session(session, |exec_session| accepts_fft_backend(exec_session))
-///         .expect("CpuBackend must expose a CPU execution session");
-/// });
+/// accepts_fft_backend::<CpuExecSession<'static>>();
 /// ```
 ///
-/// A generic tensor backend without this explicit capability cannot build
-/// the FFT extension module:
+/// A generic tensor backend does not expose the FFT capability at the SPI
+/// level:
 ///
 /// ```compile_fail
 /// use tenferro_tensor::{Tensor, TensorBackend};
-/// use tenferro_fft::{FftNorm, TensorFftExt};
+/// use tenferro_fft::FftBackend;
 ///
-/// fn use_without_fft_capability<B: TensorBackend + 'static>(backend: &mut B, input: &Tensor) {
-///     let _module =
-///         tenferro_fft::extension_module::<B>(tenferro_cpu::runtime_engine_id().unwrap()).unwrap();
-///     let _ = input.fft(None, -1, FftNorm::Backward, backend);
+/// fn requires_fft_backend<B: TensorBackend>(backend: &mut B) {
+///     let _: &mut dyn FftBackend = backend;
 /// }
 /// ```
 pub trait FftBackend: BackendSession {

--- a/crates/tenferro-fft/src/concrete_tests.rs
+++ b/crates/tenferro-fft/src/concrete_tests.rs
@@ -1,23 +1,11 @@
 use num_complex::Complex64;
 use std::num::NonZeroUsize;
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend, CpuExecSession};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::ExtensionCacheLimits;
 use tenferro_tensor::BackendSessionHost;
 use tenferro_tensor::{ErrorKind, Tensor, TensorRead, TensorView, TypedTensorView};
 
 use crate::{FftExecutor, FftNorm, FftPlanCache, TensorFftExt, TensorReadFftExt};
-
-fn with_cpu_session<R>(
-    backend: &mut CpuBackend,
-    f: impl for<'a> FnOnce(&'a mut CpuExecSession<'a>) -> R + Send,
-) -> R
-where
-    R: Send,
-{
-    backend.with_backend_session(|session| {
-        with_cpu_exec_session(session, f).expect("CpuBackend must expose a CPU execution session")
-    })
-}
 
 fn assert_complex_close(actual: &[Complex64], expected: &[Complex64]) {
     assert_eq!(actual.len(), expected.len());
@@ -43,12 +31,12 @@ fn assert_real_close(actual: &[f64], expected: &[f64]) {
 fn public_tensor_fft_ext_executes_real_and_complex_transforms() {
     let mut backend = CpuBackend::new();
     let real = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
-    let (full, onesided, recovered, recovered_real) = with_cpu_session(&mut backend, |backend| {
-        let full = real.fft(None, -1, FftNorm::Backward, backend).unwrap();
-        let onesided = real.rfft(None, -1, FftNorm::Backward, backend).unwrap();
-        let recovered = full.ifft(None, -1, FftNorm::Backward, backend).unwrap();
+    let (full, onesided, recovered, recovered_real) = backend.with_backend_session(|session| {
+        let full = real.fft(None, -1, FftNorm::Backward, session).unwrap();
+        let onesided = real.rfft(None, -1, FftNorm::Backward, session).unwrap();
+        let recovered = full.ifft(None, -1, FftNorm::Backward, session).unwrap();
         let recovered_real = onesided
-            .irfft(Some(4), -1, FftNorm::Backward, backend)
+            .irfft(Some(4), -1, FftNorm::Backward, session)
             .unwrap();
         (full, onesided, recovered, recovered_real)
     });
@@ -96,12 +84,12 @@ fn public_tensor_read_fft_ext_accepts_strided_host_views() {
     let view = TypedTensorView::from_slice([4], [2], 0, &data).unwrap();
     let input = TensorRead::from_view(TensorView::F64(view));
 
-    let (full, onesided) = with_cpu_session(&mut backend, |backend| {
+    let (full, onesided) = backend.with_backend_session(|session| {
         let full = input
-            .fft_read(None, -1, FftNorm::Backward, backend)
+            .fft_read(None, -1, FftNorm::Backward, session)
             .unwrap();
         let onesided = input
-            .rfft_read(None, -1, FftNorm::Backward, backend)
+            .rfft_read(None, -1, FftNorm::Backward, session)
             .unwrap();
         (full, onesided)
     });
@@ -139,10 +127,10 @@ fn public_tensor_fft_ext_reports_invalid_dtype_and_shape_errors() {
     )
     .unwrap();
 
-    let (dtype_err, shape_err) = with_cpu_session(&mut backend, |backend| {
-        let dtype_err = bools.fft(None, -1, FftNorm::Backward, backend).unwrap_err();
+    let (dtype_err, shape_err) = backend.with_backend_session(|session| {
+        let dtype_err = bools.fft(None, -1, FftNorm::Backward, session).unwrap_err();
         let shape_err = spectrum
-            .irfft(Some(6), -1, FftNorm::Backward, backend)
+            .irfft(Some(6), -1, FftNorm::Backward, session)
             .unwrap_err();
         (dtype_err, shape_err)
     });
@@ -238,18 +226,18 @@ fn caller_owned_fft_executor_reuses_plans() {
     let input = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let mut executor = FftExecutor::default();
 
-    with_cpu_session(&mut backend, |backend| {
+    backend.with_backend_session(|session| {
         let full = executor
-            .fft(&input, None, -1, FftNorm::Backward, backend)
+            .fft(&input, None, -1, FftNorm::Backward, session)
             .unwrap();
         executor
-            .ifft(&full, None, -1, FftNorm::Backward, backend)
+            .ifft(&full, None, -1, FftNorm::Backward, session)
             .unwrap();
         let onesided = executor
-            .rfft(&input, None, -1, FftNorm::Backward, backend)
+            .rfft(&input, None, -1, FftNorm::Backward, session)
             .unwrap();
         executor
-            .irfft(&onesided, Some(4), -1, FftNorm::Backward, backend)
+            .irfft(&onesided, Some(4), -1, FftNorm::Backward, session)
             .unwrap();
     });
 
@@ -272,18 +260,18 @@ fn configured_fft_executor_validates_each_public_operation_before_dispatch() {
     )
     .unwrap();
 
-    with_cpu_session(&mut backend, |backend| {
+    backend.with_backend_session(|session| {
         assert!(executor
-            .fft(&real, Some(0), -1, FftNorm::Backward, backend)
+            .fft(&real, Some(0), -1, FftNorm::Backward, session)
             .is_err());
         assert!(executor
-            .ifft(&real, None, -1, FftNorm::Backward, backend)
+            .ifft(&real, None, -1, FftNorm::Backward, session)
             .is_err());
         assert!(executor
-            .rfft(&complex, None, -1, FftNorm::Backward, backend)
+            .rfft(&complex, None, -1, FftNorm::Backward, session)
             .is_err());
         assert!(executor
-            .irfft(&complex, Some(0), -1, FftNorm::Backward, backend)
+            .irfft(&complex, Some(0), -1, FftNorm::Backward, session)
             .is_err());
     });
 }

--- a/crates/tenferro-fft/src/cpu/managed_tests.rs
+++ b/crates/tenferro-fft/src/cpu/managed_tests.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use num_complex::{Complex32, Complex64};
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend, CpuExecSession};
+use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{
     AllocationDomainId, AllocationId, BackendSessionHost, BackendStorage, DType, HostAccessError,
     HostReadGuard, HostWriteGuard, MemoryKind, Placement, SharedTensorAllocationDomain,
@@ -165,18 +165,6 @@ fn backend(domain: &Arc<FakeDomain>) -> CpuBackend {
     CpuBackend::new().with_allocation_domain(erased)
 }
 
-fn with_cpu_session<R>(
-    backend: &mut CpuBackend,
-    f: impl for<'a> FnOnce(&'a mut CpuExecSession<'a>) -> R + Send,
-) -> R
-where
-    R: Send,
-{
-    backend.with_backend_session(|session| {
-        with_cpu_exec_session(session, f).expect("CpuBackend must expose a CPU execution session")
-    })
-}
-
 fn assert_managed_output(output: &Tensor, domain: &FakeDomain, input_id: Option<AllocationId>) {
     let (output_domain, output_id) = match output {
         Tensor::F32(output) => (output.allocation_domain(), output.allocation_id()),
@@ -196,10 +184,9 @@ fn domain_bound_backend_accepts_host_owned_fft() {
     let host = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let mut backend = backend(&domain);
 
-    let output = with_cpu_session(&mut backend, |backend| {
-        host.rfft(None, 0, FftNorm::Backward, backend)
-    })
-    .unwrap();
+    let output = backend
+        .with_backend_session(|session| host.rfft(None, 0, FftNorm::Backward, session))
+        .unwrap();
     let Tensor::C64(output) = output else {
         panic!("expected C64 host FFT output")
     };
@@ -226,10 +213,9 @@ fn domain_bound_backend_accepts_host_read_fft() {
     let input = TensorRead::from_tensor(&host);
     let mut backend = backend(&domain);
 
-    let output = with_cpu_session(&mut backend, |backend| {
-        input.rfft_read(None, 0, FftNorm::Backward, backend)
-    })
-    .unwrap();
+    let output = backend
+        .with_backend_session(|session| input.rfft_read(None, 0, FftNorm::Backward, session))
+        .unwrap();
     let Tensor::C64(output) = output else {
         panic!("expected C64 host FFT output")
     };
@@ -256,10 +242,9 @@ fn domain_bound_backend_rejects_foreign_fft_input() {
     let input = Tensor::F64(foreign.tensor(&[4], vec![1.0_f64, 2.0, 3.0, 4.0]));
     let mut backend = backend(&domain);
 
-    let error = with_cpu_session(&mut backend, |backend| {
-        input.rfft(None, 0, FftNorm::Backward, backend)
-    })
-    .unwrap_err();
+    let error = backend
+        .with_backend_session(|session| input.rfft(None, 0, FftNorm::Backward, session))
+        .unwrap_err();
 
     assert!(matches!(
         error,
@@ -275,54 +260,54 @@ fn managed_cpu_fft_covers_all_supported_scalar_and_operation_paths() {
     let domain = FakeDomain::new();
     let mut backend = backend(&domain);
 
-    with_cpu_session(&mut backend, |backend| {
+    backend.with_backend_session(|session| {
         let real32 = domain.tensor(&[4], vec![1.0_f32, 2.0, 3.0, 4.0]);
         let real32_id = real32.allocation_id();
         let full32 = Tensor::F32(real32)
-            .fft(None, 0, FftNorm::Backward, backend)
+            .fft(None, 0, FftNorm::Backward, session)
             .unwrap();
         assert_managed_output(&full32, &domain, real32_id);
         let real32 = domain.tensor(&[4], vec![1.0_f32, 2.0, 3.0, 4.0]);
         let one_sided32 = Tensor::F32(real32)
-            .rfft(None, 0, FftNorm::Backward, backend)
+            .rfft(None, 0, FftNorm::Backward, session)
             .unwrap();
         let Tensor::C32(one_sided32) = one_sided32 else {
             unreachable!()
         };
         let recovered32 = Tensor::C32(one_sided32)
-            .irfft(Some(4), 0, FftNorm::Backward, backend)
+            .irfft(Some(4), 0, FftNorm::Backward, session)
             .unwrap();
         assert_managed_output(&recovered32, &domain, None);
 
         let real64 = domain.tensor(&[4], vec![1.0_f64, 2.0, 3.0, 4.0]);
         let real64_id = real64.allocation_id();
         let one_sided64 = Tensor::F64(real64)
-            .rfft(None, 0, FftNorm::Backward, backend)
+            .rfft(None, 0, FftNorm::Backward, session)
             .unwrap();
         assert_managed_output(&one_sided64, &domain, real64_id);
         let Tensor::C64(one_sided64) = one_sided64 else {
             unreachable!()
         };
         let recovered64 = Tensor::C64(one_sided64)
-            .irfft(Some(4), 0, FftNorm::Backward, backend)
+            .irfft(Some(4), 0, FftNorm::Backward, session)
             .unwrap();
         assert_managed_output(&recovered64, &domain, None);
 
         let complex32 = domain.tensor(&[4], vec![Complex32::new(1.0, 0.0); 4]);
         let transformed32 = Tensor::C32(complex32)
-            .fft(None, 0, FftNorm::Backward, backend)
+            .fft(None, 0, FftNorm::Backward, session)
             .unwrap();
         let inverted32 = transformed32
-            .ifft(None, 0, FftNorm::Backward, backend)
+            .ifft(None, 0, FftNorm::Backward, session)
             .unwrap();
         assert_managed_output(&inverted32, &domain, None);
 
         let complex64 = domain.tensor(&[4], vec![Complex64::new(1.0, 0.0); 4]);
         let transformed64 = Tensor::C64(complex64)
-            .fft(None, 0, FftNorm::Backward, backend)
+            .fft(None, 0, FftNorm::Backward, session)
             .unwrap();
         let inverted64 = transformed64
-            .ifft(None, 0, FftNorm::Backward, backend)
+            .ifft(None, 0, FftNorm::Backward, session)
             .unwrap();
         assert_managed_output(&inverted64, &domain, None);
     });

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -61,9 +61,9 @@
 //! # #[cfg(all(feature = "webgpu", target_os = "macos"))]
 //! # {
 //! use num_complex::Complex32;
-//! use tenferro_cpu::with_cpu_exec_session;
+//! use tenferro_cpu::CpuBackend;
 //! use tenferro_fft::{FftNorm, TensorFftExt};
-//! use tenferro_gpu::{webgpu::with_webgpu_exec_session, apple::AppleContext};
+//! use tenferro_gpu::apple::AppleContext;
 //! use tenferro_tensor::{BackendSessionHost, Tensor};
 //!
 //! if let Ok(context) = AppleContext::new() {
@@ -75,30 +75,13 @@
 //!     let after_creation = context.transfer_stats();
 //!     let mut cpu = context.cpu_backend().clone();
 //!     let cpu_output = cpu
-//!         .with_backend_session(|session| {
-//!             with_cpu_exec_session(session, |exec_session| {
-//!                 input.fft(None, 0, FftNorm::Backward, exec_session)
-//!             })
-//!             .expect("CpuBackend must expose a CPU execution session")
-//!         })
+//!         .with_backend_session(|session| input.fft(None, 0, FftNorm::Backward, session))
 //!         .unwrap();
 //!     let mut metal = context.metal_backend().clone();
 //!     let output = metal
-//!         .with_backend_session(|session| {
-//!             with_webgpu_exec_session(session, |exec_session| {
-//!                 input.fft(None, 0, FftNorm::Backward, exec_session)
-//!             })
-//!             .expect("WebGpuBackend must expose a WebGPU execution session")
-//!         })
+//!         .with_backend_session(|session| input.fft(None, 0, FftNorm::Backward, session))
 //!         .unwrap();
-//!     metal
-//!         .with_backend_session(|session| {
-//!             with_webgpu_exec_session(session, |exec_session| {
-//!                 exec_session.runtime().synchronize()
-//!             })
-//!             .expect("WebGpuBackend must expose a WebGPU execution session")
-//!         })
-//!         .unwrap();
+//!     metal.synchronize().unwrap();
 //!     assert_eq!(output.shape(), &[4]);
 //!     assert_eq!(cpu_output.shape(), output.shape());
 //!     assert_eq!(context.transfer_stats(), after_creation);
@@ -108,19 +91,14 @@
 //!
 //! ```
 //! use num_complex::Complex64;
-//! use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+//! use tenferro_cpu::CpuBackend;
 //! use tenferro_fft::{FftNorm, TensorFftExt};
 //! use tenferro_tensor::{BackendSessionHost, Tensor};
 //!
 //! let x = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
 //! let mut backend = CpuBackend::new();
 //! let out = backend
-//!     .with_backend_session(|session| {
-//!         with_cpu_exec_session(session, |exec_session| {
-//!             x.fft(None, -1, FftNorm::Backward, exec_session)
-//!         })
-//!         .expect("CpuBackend must expose a CPU execution session")
-//!     })
+//!     .with_backend_session(|session| x.fft(None, -1, FftNorm::Backward, session))
 //!     .unwrap();
 //!
 //! assert_eq!(out.as_slice::<Complex64>().unwrap()[0], Complex64::new(10.0, 0.0));
@@ -232,14 +210,16 @@ impl FftExecutor {
     /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
     /// `InvalidArgument` for invalid `axis`/`n`,
     /// [`tenferro_tensor::Error::Extension`] with [`ErrorKind::Unsupported`]
-    /// for unsupported dtypes, or a typed backend source for execution.
-    pub fn fft<B: FftBackend>(
+    /// for unsupported dtypes, a typed capability error when the session does
+    /// not expose an FFT execution capability, or a typed backend source for
+    /// execution.
+    pub fn fft(
         &mut self,
         input: &Tensor,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
         self.execute(
             input,
@@ -248,7 +228,7 @@ impl FftExecutor {
             n,
             axis,
             norm,
-            backend,
+            session,
         )
     }
 
@@ -259,14 +239,16 @@ impl FftExecutor {
     /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
     /// `InvalidArgument` for invalid `axis`/`n`,
     /// [`tenferro_tensor::Error::Extension`] with [`ErrorKind::Unsupported`]
-    /// for a non-complex input, or a typed backend source for execution.
-    pub fn ifft<B: FftBackend>(
+    /// for a non-complex input, a typed capability error when the session does
+    /// not expose an FFT execution capability, or a typed backend source for
+    /// execution.
+    pub fn ifft(
         &mut self,
         input: &Tensor,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
         self.execute(
             input,
@@ -275,7 +257,7 @@ impl FftExecutor {
             n,
             axis,
             norm,
-            backend,
+            session,
         )
     }
 
@@ -286,14 +268,16 @@ impl FftExecutor {
     /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
     /// `InvalidArgument` for invalid `axis`/`n`,
     /// [`tenferro_tensor::Error::Extension`] with [`ErrorKind::Unsupported`]
-    /// for a non-real input, or a typed backend source for execution.
-    pub fn rfft<B: FftBackend>(
+    /// for a non-real input, a typed capability error when the session does not
+    /// expose an FFT execution capability, or a typed backend source for
+    /// execution.
+    pub fn rfft(
         &mut self,
         input: &Tensor,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
         self.execute(
             input,
@@ -302,7 +286,7 @@ impl FftExecutor {
             n,
             axis,
             norm,
-            backend,
+            session,
         )
     }
 
@@ -313,14 +297,16 @@ impl FftExecutor {
     /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds`,
     /// `InvalidArgument`, or spectrum-length details,
     /// [`tenferro_tensor::Error::Extension`] with [`ErrorKind::Unsupported`]
-    /// for a non-complex input, or a typed backend source for execution.
-    pub fn irfft<B: FftBackend>(
+    /// for a non-complex input, a typed capability error when the session does
+    /// not expose an FFT execution capability, or a typed backend source for
+    /// execution.
+    pub fn irfft(
         &mut self,
         input: &Tensor,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
         self.execute(
             input,
@@ -329,12 +315,12 @@ impl FftExecutor {
             n,
             axis,
             norm,
-            backend,
+            session,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn execute<B: FftBackend>(
+    fn execute(
         &mut self,
         input: &Tensor,
         operation: FftOperation,
@@ -342,7 +328,7 @@ impl FftExecutor {
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
         let spec = concrete_fft_spec(
             op_name,
@@ -353,11 +339,16 @@ impl FftExecutor {
             axis,
             norm,
         )?;
-        backend.execute_fft(
-            input,
-            &spec,
-            FftExecutionCache::caller_owned(&mut self.plans),
-        )
+        // The executor calls the concrete backend directly (no internal
+        // session entry); the built-in dispatch only bridges the borrowed
+        // session to its FFT execution capability.
+        with_fft_exec_session(session, op_name, |backend| {
+            backend.execute_fft(
+                input,
+                &spec,
+                FftExecutionCache::caller_owned(&mut self.plans),
+            )
+        })
     }
 }
 
@@ -454,19 +445,15 @@ impl TracedTensorFftExt for TracedTensor {
 ///
 /// ```
 /// use num_complex::Complex64;
-/// use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+/// use tenferro_cpu::CpuBackend;
 /// use tenferro_fft::{FftNorm, TensorFftExt};
 /// use tenferro_tensor::{BackendSessionHost, Tensor};
 ///
 /// let input = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0])?;
 /// let mut backend = CpuBackend::new();
 ///
-/// let spectrum = backend.with_backend_session(|session| {
-///     with_cpu_exec_session(session, |exec_session| {
-///         input.fft(None, -1, FftNorm::Backward, exec_session)
-///     })
-///     .expect("CpuBackend must expose a CPU execution session")
-/// })?;
+/// let spectrum = backend
+///     .with_backend_session(|session| input.fft(None, -1, FftNorm::Backward, session))?;
 /// assert_eq!(spectrum.shape(), &[4]);
 /// assert_eq!(spectrum.as_slice::<Complex64>()?[0], Complex64::new(10.0, 0.0));
 /// # Ok::<(), tenferro_tensor::Error>(())
@@ -478,13 +465,15 @@ pub trait TensorFftExt {
     ///
     /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
     /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for an
-    /// integer or boolean input, or a typed backend source for execution.
-    fn fft<B: FftBackend>(
+    /// integer or boolean input, a typed capability error when the session
+    /// does not expose an FFT execution capability, or a typed backend source
+    /// for execution.
+    fn fft(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Execute a one-dimensional inverse FFT along `axis`.
@@ -493,13 +482,15 @@ pub trait TensorFftExt {
     ///
     /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
     /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for a
-    /// non-complex input, or a typed backend source for execution.
-    fn ifft<B: FftBackend>(
+    /// non-complex input, a typed capability error when the session does not
+    /// expose an FFT execution capability, or a typed backend source for
+    /// execution.
+    fn ifft(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Execute a one-dimensional real FFT along `axis`.
@@ -508,13 +499,15 @@ pub trait TensorFftExt {
     ///
     /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
     /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for a
-    /// non-`F32`/`F64` input, or a typed backend source for execution.
-    fn rfft<B: FftBackend>(
+    /// non-`F32`/`F64` input, a typed capability error when the session does
+    /// not expose an FFT execution capability, or a typed backend source for
+    /// execution.
+    fn rfft(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Execute a one-dimensional inverse real FFT along `axis`.
@@ -523,24 +516,25 @@ pub trait TensorFftExt {
     ///
     /// Returns `Error::Validation` with `AxisOutOfBounds`, `InvalidArgument`,
     /// or spectrum-length details, `Error::Extension` with
-    /// `ErrorKind::Unsupported` for a non-complex input, or a typed backend
-    /// source for execution.
-    fn irfft<B: FftBackend>(
+    /// `ErrorKind::Unsupported` for a non-complex input, a typed capability
+    /// error when the session does not expose an FFT execution capability, or
+    /// a typed backend source for execution.
+    fn irfft(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
 }
 
 impl TensorFftExt for Tensor {
-    fn fft<B: FftBackend>(
+    fn fft(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
         let spec = concrete_fft_spec(
             "TensorFftExt::fft",
@@ -551,15 +545,17 @@ impl TensorFftExt for Tensor {
             axis,
             norm,
         )?;
-        execute_concrete_fft_op(self, &spec, backend)
+        with_fft_exec_session(session, "TensorFftExt::fft", |backend| {
+            execute_concrete_fft_op(self, &spec, backend)
+        })
     }
 
-    fn ifft<B: FftBackend>(
+    fn ifft(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
         let spec = concrete_fft_spec(
             "TensorFftExt::ifft",
@@ -570,15 +566,17 @@ impl TensorFftExt for Tensor {
             axis,
             norm,
         )?;
-        execute_concrete_fft_op(self, &spec, backend)
+        with_fft_exec_session(session, "TensorFftExt::ifft", |backend| {
+            execute_concrete_fft_op(self, &spec, backend)
+        })
     }
 
-    fn rfft<B: FftBackend>(
+    fn rfft(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
         let spec = concrete_fft_spec(
             "TensorFftExt::rfft",
@@ -589,15 +587,17 @@ impl TensorFftExt for Tensor {
             axis,
             norm,
         )?;
-        execute_concrete_fft_op(self, &spec, backend)
+        with_fft_exec_session(session, "TensorFftExt::rfft", |backend| {
+            execute_concrete_fft_op(self, &spec, backend)
+        })
     }
 
-    fn irfft<B: FftBackend>(
+    fn irfft(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
         let spec = concrete_fft_spec(
             "TensorFftExt::irfft",
@@ -608,7 +608,9 @@ impl TensorFftExt for Tensor {
             axis,
             norm,
         )?;
-        execute_concrete_fft_op(self, &spec, backend)
+        with_fft_exec_session(session, "TensorFftExt::irfft", |backend| {
+            execute_concrete_fft_op(self, &spec, backend)
+        })
     }
 }
 
@@ -625,7 +627,7 @@ impl TensorFftExt for Tensor {
 ///
 /// ```
 /// use num_complex::Complex64;
-/// use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+/// use tenferro_cpu::CpuBackend;
 /// use tenferro_fft::{FftNorm, TensorReadFftExt};
 /// use tenferro_tensor::{BackendSessionHost, TensorRead, TensorView};
 ///
@@ -634,12 +636,8 @@ impl TensorFftExt for Tensor {
 /// let input = TensorRead::from_view(TensorView::f64(&shape, &data)?);
 /// let mut backend = CpuBackend::new();
 ///
-/// let spectrum = backend.with_backend_session(|session| {
-///     with_cpu_exec_session(session, |exec_session| {
-///         input.fft_read(None, -1, FftNorm::Backward, exec_session)
-///     })
-///     .expect("CpuBackend must expose a CPU execution session")
-/// })?;
+/// let spectrum = backend
+///     .with_backend_session(|session| input.fft_read(None, -1, FftNorm::Backward, session))?;
 /// assert_eq!(spectrum.as_slice::<Complex64>()?[0], Complex64::new(10.0, 0.0));
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
@@ -650,14 +648,15 @@ pub trait TensorReadFftExt {
     ///
     /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
     /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for an
-    /// integer or boolean input, or a typed backend source for materialization
-    /// or execution.
-    fn fft_read<B: FftBackend>(
+    /// integer or boolean input, a typed capability error when the session
+    /// does not expose an FFT execution capability, or a typed backend source
+    /// for materialization or execution.
+    fn fft_read(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Execute a one-dimensional inverse FFT along `axis`.
@@ -666,13 +665,15 @@ pub trait TensorReadFftExt {
     ///
     /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
     /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for a
-    /// non-complex input, or a typed backend source for materialization.
-    fn ifft_read<B: FftBackend>(
+    /// non-complex input, a typed capability error when the session does not
+    /// expose an FFT execution capability, or a typed backend source for
+    /// materialization.
+    fn ifft_read(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Execute a one-dimensional real FFT along `axis`.
@@ -681,13 +682,15 @@ pub trait TensorReadFftExt {
     ///
     /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
     /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for a
-    /// non-`F32`/`F64` input, or a typed backend source for materialization.
-    fn rfft_read<B: FftBackend>(
+    /// non-`F32`/`F64` input, a typed capability error when the session does
+    /// not expose an FFT execution capability, or a typed backend source for
+    /// materialization.
+    fn rfft_read(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Execute a one-dimensional inverse real FFT along `axis`.
@@ -696,88 +699,97 @@ pub trait TensorReadFftExt {
     ///
     /// Returns `Error::Validation` with `AxisOutOfBounds`, `InvalidArgument`,
     /// or spectrum-length details, `Error::Extension` with
-    /// `ErrorKind::Unsupported` for a non-complex input, or a typed backend
-    /// source for materialization.
-    fn irfft_read<B: FftBackend>(
+    /// `ErrorKind::Unsupported` for a non-complex input, a typed capability
+    /// error when the session does not expose an FFT execution capability, or
+    /// a typed backend source for materialization.
+    fn irfft_read(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
 }
 
 impl TensorReadFftExt for TensorRead<'_> {
-    fn fft_read<B: FftBackend>(
+    fn fft_read(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        execute_concrete_fft_read_op(
-            self,
-            concrete_fft_operation("TensorReadFftExt::fft_read", self.dtype())?,
-            "TensorReadFftExt::fft_read",
-            n,
-            axis,
-            norm,
-            backend,
-        )
+        with_fft_exec_session(session, "TensorReadFftExt::fft_read", |backend| {
+            execute_concrete_fft_read_op(
+                self,
+                concrete_fft_operation("TensorReadFftExt::fft_read", self.dtype())?,
+                "TensorReadFftExt::fft_read",
+                n,
+                axis,
+                norm,
+                backend,
+            )
+        })
     }
 
-    fn ifft_read<B: FftBackend>(
+    fn ifft_read(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        execute_concrete_fft_read_op(
-            self,
-            concrete_ifft_operation("TensorReadFftExt::ifft_read", self.dtype())?,
-            "TensorReadFftExt::ifft_read",
-            n,
-            axis,
-            norm,
-            backend,
-        )
+        with_fft_exec_session(session, "TensorReadFftExt::ifft_read", |backend| {
+            execute_concrete_fft_read_op(
+                self,
+                concrete_ifft_operation("TensorReadFftExt::ifft_read", self.dtype())?,
+                "TensorReadFftExt::ifft_read",
+                n,
+                axis,
+                norm,
+                backend,
+            )
+        })
     }
 
-    fn rfft_read<B: FftBackend>(
+    fn rfft_read(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        execute_concrete_fft_read_op(
-            self,
-            concrete_rfft_operation("TensorReadFftExt::rfft_read", self.dtype())?,
-            "TensorReadFftExt::rfft_read",
-            n,
-            axis,
-            norm,
-            backend,
-        )
+        with_fft_exec_session(session, "TensorReadFftExt::rfft_read", |backend| {
+            execute_concrete_fft_read_op(
+                self,
+                concrete_rfft_operation("TensorReadFftExt::rfft_read", self.dtype())?,
+                "TensorReadFftExt::rfft_read",
+                n,
+                axis,
+                norm,
+                backend,
+            )
+        })
     }
 
-    fn irfft_read<B: FftBackend>(
+    fn irfft_read(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        execute_concrete_fft_read_op(
-            self,
-            concrete_irfft_operation("TensorReadFftExt::irfft_read", self.dtype())?,
-            "TensorReadFftExt::irfft_read",
-            n,
-            axis,
-            norm,
-            backend,
-        )
+        with_fft_exec_session(session, "TensorReadFftExt::irfft_read", |backend| {
+            execute_concrete_fft_read_op(
+                self,
+                concrete_irfft_operation("TensorReadFftExt::irfft_read", self.dtype())?,
+                "TensorReadFftExt::irfft_read",
+                n,
+                axis,
+                norm,
+                backend,
+            )
+        })
     }
 }
 
@@ -959,24 +971,61 @@ impl ExtensionOp for FftOp {
     }
 }
 
-fn execute_concrete_fft_op<B: FftBackend>(
+/// Run a concrete FFT body against the built-in FFT execution sessions
+/// carried by `session` (CPU/CUDA/WebGPU), returning a typed capability error
+/// when the session does not expose an FFT execution capability.
+///
+/// This is the built-in dispatch shared by the concrete FFT surface; callers
+/// never downcast themselves (issue #1680 Phase 3). Third-party
+/// [`FftBackend`] implementations remain supported through the SPI trait, but
+/// the concrete op path is built-in-session only.
+fn with_fft_exec_session<X>(
+    session: &mut dyn BackendSession,
+    op: &'static str,
+    f: impl FnOnce(&mut dyn FftBackend) -> tenferro_tensor::Result<X>,
+) -> tenferro_tensor::Result<X> {
+    // The capability branches are mutually exclusive, so `f` runs exactly
+    // once. Probe the marker first, then re-extract the same exec session and
+    // run the concrete body on it (FnOnce cannot be captured by several
+    // branch closures).
+    if with_cpu_exec_session(session, |_| ()).is_some() {
+        return with_cpu_exec_session(session, |exec| f(exec as &mut dyn FftBackend))
+            .expect("marker probe matched a CPU execution session");
+    }
+    #[cfg(feature = "cuda")]
+    if with_cuda_exec_session(session, |_| ()).is_some() {
+        return with_cuda_exec_session(session, |exec| f(exec as &mut dyn FftBackend))
+            .expect("marker probe matched a CUDA execution session");
+    }
+    #[cfg(feature = "webgpu")]
+    if with_webgpu_exec_session(session, |_| ()).is_some() {
+        return with_webgpu_exec_session(session, |exec| f(exec as &mut dyn FftBackend))
+            .expect("marker probe matched a WebGPU execution session");
+    }
+    Err(tenferro_tensor::Error::unsupported(
+        op,
+        "selected backend session does not expose an FFT execution capability",
+    ))
+}
+
+fn execute_concrete_fft_op(
     input: &Tensor,
     spec: &FftPlanSpec,
-    backend: &mut B,
+    backend: &mut dyn FftBackend,
 ) -> tenferro_tensor::Result<Tensor> {
     let mut plans = FftPlanCache::with_capacity(NonZeroUsize::MIN);
     backend.execute_fft(input, spec, FftExecutionCache::caller_owned(&mut plans))
 }
 
 #[allow(clippy::too_many_arguments)]
-fn execute_concrete_fft_read_op<B: FftBackend>(
+fn execute_concrete_fft_read_op(
     input: &TensorRead<'_>,
     operation: FftOperation,
     op_name: &'static str,
     n: Option<usize>,
     axis: isize,
     norm: FftNorm,
-    backend: &mut B,
+    backend: &mut dyn FftBackend,
 ) -> tenferro_tensor::Result<Tensor> {
     let spec = concrete_fft_spec(
         op_name,

--- a/crates/tenferro-fft/tests/apple_cpu.rs
+++ b/crates/tenferro-fft/tests/apple_cpu.rs
@@ -3,7 +3,7 @@
 use num_complex::{Complex32, Complex64};
 use tenferro_fft::{FftExecutor, FftNorm, TensorFftExt};
 use tenferro_gpu::{apple::AppleContext, webgpu::upload_webgpu_tensor, webgpu::WebGpuRuntime};
-use tenferro_tensor::{HostAccessError, StorageBuffer, Tensor};
+use tenferro_tensor::{BackendSessionHost, HostAccessError, StorageBuffer, Tensor};
 
 fn apple_context() -> Option<AppleContext> {
     match AppleContext::new() {
@@ -32,14 +32,14 @@ fn managed_cpu_fft_preserves_values_domain_and_transfer_counters() {
 
     let host_f32 = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f32, 2.0, 3.0, 4.0]).unwrap();
     let mut reference_cpu = tenferro_cpu::CpuBackend::new();
-    let reference = host_f32
-        .rfft(Some(4), 1, FftNorm::Ortho, &mut reference_cpu)
+    let reference = reference_cpu
+        .with_backend_session(|session| host_f32.rfft(Some(4), 1, FftNorm::Ortho, session))
         .unwrap();
     let managed_f32 = context.upload_tensor(&host_f32).unwrap();
     let before = context.transfer_stats();
     let mut apple_cpu = context.cpu_backend().clone();
-    let output = managed_f32
-        .rfft(Some(4), 1, FftNorm::Ortho, &mut apple_cpu)
+    let output = apple_cpu
+        .with_backend_session(|session| managed_f32.rfft(Some(4), 1, FftNorm::Ortho, session))
         .unwrap();
 
     let Tensor::C32(output) = output else {
@@ -54,20 +54,27 @@ fn managed_cpu_fft_preserves_values_domain_and_transfer_counters() {
     assert_eq!(context.transfer_stats(), before);
 
     let host_f64 = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, -2.0, 0.5]).unwrap();
-    let reference_spectrum = host_f64
-        .rfft(Some(4), 0, FftNorm::Forward, &mut reference_cpu)
-        .unwrap();
-    let reference_round_trip = reference_spectrum
-        .irfft(Some(4), 0, FftNorm::Forward, &mut reference_cpu)
-        .unwrap();
+    let (reference_spectrum, reference_round_trip) =
+        reference_cpu.with_backend_session(|session| {
+            let spectrum = host_f64
+                .rfft(Some(4), 0, FftNorm::Forward, session)
+                .unwrap();
+            let round_trip = spectrum
+                .irfft(Some(4), 0, FftNorm::Forward, session)
+                .unwrap();
+            (spectrum, round_trip)
+        });
     let managed_f64 = context.upload_tensor(&host_f64).unwrap();
     let before = context.transfer_stats();
-    let spectrum = managed_f64
-        .rfft(Some(4), 0, FftNorm::Forward, &mut apple_cpu)
-        .unwrap();
-    let round_trip = spectrum
-        .irfft(Some(4), 0, FftNorm::Forward, &mut apple_cpu)
-        .unwrap();
+    let (spectrum, round_trip) = apple_cpu.with_backend_session(|session| {
+        let spectrum = managed_f64
+            .rfft(Some(4), 0, FftNorm::Forward, session)
+            .unwrap();
+        let round_trip = spectrum
+            .irfft(Some(4), 0, FftNorm::Forward, session)
+            .unwrap();
+        (spectrum, round_trip)
+    });
     let Tensor::F64(round_trip) = round_trip else {
         panic!("expected F64 output")
     };
@@ -87,13 +94,13 @@ fn managed_cpu_fft_preserves_values_domain_and_transfer_counters() {
         ],
     )
     .unwrap();
-    let reference = host_c32
-        .fft(Some(2), 0, FftNorm::Forward, &mut reference_cpu)
+    let reference = reference_cpu
+        .with_backend_session(|session| host_c32.fft(Some(2), 0, FftNorm::Forward, session))
         .unwrap();
     let managed_c32 = context.upload_tensor(&host_c32).unwrap();
     let before = context.transfer_stats();
-    let output = managed_c32
-        .fft(Some(2), 0, FftNorm::Forward, &mut apple_cpu)
+    let output = apple_cpu
+        .with_backend_session(|session| managed_c32.fft(Some(2), 0, FftNorm::Forward, session))
         .unwrap();
     let Tensor::C32(output) = output else {
         panic!("expected C32 output")
@@ -110,20 +117,23 @@ fn managed_cpu_fft_preserves_values_domain_and_transfer_counters() {
         vec![Complex64::new(1.0, -1.0), Complex64::new(2.0, 0.5)],
     )
     .unwrap();
-    let reference = host_c64
-        .fft(None, -1, FftNorm::Backward, &mut reference_cpu)
+    let reference = reference_cpu
+        .with_backend_session(|session| host_c64.fft(None, -1, FftNorm::Backward, session))
         .unwrap();
     let managed_c64 = context.upload_tensor(&host_c64).unwrap();
     let before = context.transfer_stats();
     let mut executor = FftExecutor::default();
-    let output = executor
-        .fft(&managed_c64, None, -1, FftNorm::Backward, &mut apple_cpu)
-        .unwrap();
+    let (output, repeated) = apple_cpu.with_backend_session(|session| {
+        let output = executor
+            .fft(&managed_c64, None, -1, FftNorm::Backward, session)
+            .unwrap();
+        let repeated = executor
+            .fft(&managed_c64, None, -1, FftNorm::Backward, session)
+            .unwrap();
+        (output, repeated)
+    });
     let cached_entries = executor.cache_stats().entries;
     assert!(cached_entries > 0);
-    let repeated = executor
-        .fft(&managed_c64, None, -1, FftNorm::Backward, &mut apple_cpu)
-        .unwrap();
     assert_eq!(executor.cache_stats().entries, cached_entries);
     let Tensor::C64(output) = output else {
         panic!("expected C64 output")

--- a/crates/tenferro-fft/tests/backend_capability.rs
+++ b/crates/tenferro-fft/tests/backend_capability.rs
@@ -1,19 +1,9 @@
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc, Mutex,
-};
-
 use num_complex::{Complex32, Complex64};
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend, CpuExecSession};
-use tenferro_fft::{
-    FftBackend, FftExecutionCache, FftExecutor, FftNorm, FftOperation, FftPlanSpec, TensorFftExt,
-    FFT_EXTENSION_FAMILY_ID,
-};
+use tenferro_cpu::{CpuBackend, CpuExecSession};
+use tenferro_fft::{FftBackend, FftExecutor, FftNorm, TensorFftExt};
 #[cfg(feature = "cuda")]
 use tenferro_gpu::cuda::CudaExecSession;
-use tenferro_runtime::{ExtensionCacheKey, Runtime};
+use tenferro_runtime::Runtime;
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
     BackendStorageHandle, CompareDir, DType, DeviceId, DeviceKind, DotGeneralConfig, ErrorKind,
@@ -159,135 +149,6 @@ impl TensorOnlyBackend {
 struct TensorOnlyBackendSessionMarker;
 impl_minimal_tensor_backend!(TensorOnlyBackend, TensorOnlyBackendSessionMarker);
 
-#[derive(Debug, Default)]
-struct MockNonCpuSession {
-    plan_builds: usize,
-    plan_reuses: usize,
-}
-
-impl MockNonCpuSession {
-    fn record_transfer(&self) {}
-}
-
-#[doc(hidden)]
-struct MockNonCpuSessionMarker;
-impl_minimal_tensor_backend!(MockNonCpuSession, MockNonCpuSessionMarker);
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct MockNonCpuPlanKey {
-    operation: FftOperation,
-    normalized_axis: usize,
-    requested_len: Option<usize>,
-    input_dtype: DType,
-    input_shape: Vec<usize>,
-}
-
-#[derive(Debug)]
-struct MockNonCpuPlan {
-    key: MockNonCpuPlanKey,
-}
-
-impl FftBackend for MockNonCpuSession {
-    fn execute_fft(
-        &mut self,
-        input: &Tensor,
-        spec: &FftPlanSpec,
-        mut cache: FftExecutionCache<'_>,
-    ) -> tenferro_tensor::Result<Tensor> {
-        let plan_key = MockNonCpuPlanKey {
-            operation: spec.operation(),
-            normalized_axis: spec.normalized_axis(),
-            requested_len: spec.requested_len(),
-            input_dtype: spec.input_dtype(),
-            input_shape: spec.input_shape().to_vec(),
-        };
-        let mut hasher = DefaultHasher::new();
-        plan_key.hash(&mut hasher);
-        let cache_key = ExtensionCacheKey::new(
-            FFT_EXTENSION_FAMILY_ID,
-            "mock-non-cpu-plans",
-            hasher.finish(),
-        );
-        let store = cache.store_mut();
-        if store
-            .get::<MockNonCpuPlan>(&cache_key)
-            .is_some_and(|plan| plan.key == plan_key)
-        {
-            self.plan_reuses += 1;
-        } else {
-            self.plan_builds += 1;
-            store.put(cache_key, MockNonCpuPlan { key: plan_key }, 96);
-        }
-        input.duplicate()
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct RecordedSpec {
-    operation: FftOperation,
-    normalized_axis: usize,
-    requested_len: Option<usize>,
-    norm: FftNorm,
-    input_dtype: DType,
-    input_shape: Vec<usize>,
-    requires_compact_column_major: bool,
-}
-
-#[derive(Debug)]
-struct RecordingFftSession {
-    cpu_owner: CpuBackend,
-    specs: Arc<Mutex<Vec<RecordedSpec>>>,
-    transfers: Arc<AtomicUsize>,
-}
-
-impl RecordingFftSession {
-    fn new() -> (Self, Arc<Mutex<Vec<RecordedSpec>>>, Arc<AtomicUsize>) {
-        let specs = Arc::new(Mutex::new(Vec::new()));
-        let transfers = Arc::new(AtomicUsize::new(0));
-        (
-            Self {
-                cpu_owner: CpuBackend::new(),
-                specs: Arc::clone(&specs),
-                transfers: Arc::clone(&transfers),
-            },
-            specs,
-            transfers,
-        )
-    }
-
-    fn record_transfer(&self) {
-        self.transfers.fetch_add(1, Ordering::Relaxed);
-    }
-}
-
-#[doc(hidden)]
-struct RecordingFftSessionMarker;
-impl_minimal_tensor_backend!(RecordingFftSession, RecordingFftSessionMarker);
-
-impl FftBackend for RecordingFftSession {
-    fn execute_fft(
-        &mut self,
-        input: &Tensor,
-        spec: &FftPlanSpec,
-        cache: FftExecutionCache<'_>,
-    ) -> tenferro_tensor::Result<Tensor> {
-        self.specs.lock().unwrap().push(RecordedSpec {
-            operation: spec.operation(),
-            normalized_axis: spec.normalized_axis(),
-            requested_len: spec.requested_len(),
-            norm: spec.norm(),
-            input_dtype: spec.input_dtype(),
-            input_shape: spec.input_shape().to_vec(),
-            requires_compact_column_major: spec.requires_compact_column_major(),
-        });
-        self.cpu_owner
-            .with_backend_session(|session| {
-                with_cpu_exec_session(session, |session| session.execute_fft(input, spec, cache))
-            })
-            .expect("CpuBackend must expose a CPU execution session")
-    }
-}
-
 fn assert_fft_capability<B: FftBackend>() {}
 fn assert_tensor_backend<B: TensorBackend>() {}
 
@@ -295,18 +156,6 @@ fn assert_tensor_backend<B: TensorBackend>() {}
 #[test]
 fn cuda_session_is_fft_capable() {
     assert_fft_capability::<CudaExecSession<'static>>();
-}
-
-fn with_cpu_session<R>(
-    backend: &mut CpuBackend,
-    f: impl for<'a> FnOnce(&'a mut CpuExecSession<'a>) -> R + Send,
-) -> R
-where
-    R: Send,
-{
-    backend.with_backend_session(|session| {
-        with_cpu_exec_session(session, f).expect("CpuBackend must expose a CPU execution session")
-    })
 }
 
 #[test]
@@ -337,12 +186,7 @@ fn cpu_fft_is_invoked_through_the_borrowed_provider_session() {
     let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let mut owner = CpuBackend::new();
     let output = owner
-        .with_backend_session(|session| {
-            with_cpu_exec_session(session, |session: &mut CpuExecSession<'_>| {
-                input.fft(None, -1, FftNorm::Backward, session)
-            })
-        })
-        .expect("CpuBackend must expose a CPU execution session")
+        .with_backend_session(|session| input.fft(None, -1, FftNorm::Backward, session))
         .unwrap();
 
     assert_eq!(
@@ -358,65 +202,71 @@ fn caller_owned_cache_is_backend_neutral_and_reports_reuse_clear_and_stats() {
         vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
     )
     .unwrap();
-    let mut session = MockNonCpuSession::default();
+    let mut owner = CpuBackend::new();
     let mut executor = FftExecutor::default();
 
-    executor
-        .fft(&input, None, -1, FftNorm::Backward, &mut session)
-        .unwrap();
-    executor
-        .fft(&input, None, -1, FftNorm::Backward, &mut session)
-        .unwrap();
+    owner.with_backend_session(|session| {
+        executor
+            .fft(&input, None, -1, FftNorm::Backward, session)
+            .unwrap();
+        executor
+            .fft(&input, None, -1, FftNorm::Backward, session)
+            .unwrap();
+    });
 
-    assert_eq!(session.plan_builds, 1);
-    assert_eq!(session.plan_reuses, 1);
-    assert_eq!(executor.cache_stats().entries, 1);
-    assert_eq!(executor.cache_stats().retained_bytes, 96);
+    let stats = executor.cache_stats();
+    assert_eq!(stats.entries, 1);
+    assert!(stats.hits >= 1, "warm call should hit the retained plan");
+    assert!(stats.retained_bytes > 0);
 
     executor.clear_cache();
     assert_eq!(executor.cache_stats().entries, 0);
     assert_eq!(executor.cache_stats().retained_bytes, 0);
 
-    executor
-        .fft(&input, None, -1, FftNorm::Backward, &mut session)
-        .unwrap();
-    assert_eq!(session.plan_builds, 2);
+    owner.with_backend_session(|session| {
+        executor
+            .fft(&input, None, -1, FftNorm::Backward, session)
+            .unwrap();
+    });
+    assert_eq!(executor.cache_stats().entries, 1);
 }
 
 #[test]
-fn direct_concrete_api_uses_call_local_one_shot_plan_cache() {
+fn direct_concrete_api_returns_typed_capability_error_without_fft_capability() {
+    // The concrete FFT traits dispatch internally to the built-in FFT exec
+    // sessions (CPU/CUDA/WebGPU); a backend session that exposes no FFT
+    // capability must return a typed capability error (issue #1680 Phase 3).
     let input = Tensor::from_vec_col_major(
         vec![2],
         vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
     )
     .unwrap();
-    let mut session = MockNonCpuSession::default();
+    let mut session = TensorOnlyBackend;
 
-    input
+    let error = input
         .fft(None, -1, FftNorm::Backward, &mut session)
-        .unwrap();
-    input
-        .fft(None, -1, FftNorm::Backward, &mut session)
-        .unwrap();
+        .unwrap_err();
 
-    assert_eq!(session.plan_builds, 2);
-    assert_eq!(session.plan_reuses, 0);
+    assert_eq!(error.kind(), ErrorKind::Unsupported);
+    assert!(error
+        .to_string()
+        .contains("does not expose an FFT execution capability"));
 }
 
 #[test]
 fn concrete_cpu_execution_preserves_all_four_scalar_dtypes() {
     let mut backend = CpuBackend::new();
 
-    with_cpu_session(&mut backend, |backend| {
+    backend.with_backend_session(|session| {
         let f32_input = Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap();
-        let f32_output = f32_input.fft(None, -1, FftNorm::Backward, backend).unwrap();
+        let f32_output = f32_input.fft(None, -1, FftNorm::Backward, session).unwrap();
         assert_eq!(
             f32_output.as_slice::<Complex32>().unwrap()[0],
             Complex32::new(3.0, 0.0)
         );
 
         let f64_input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-        let f64_output = f64_input.fft(None, -1, FftNorm::Backward, backend).unwrap();
+        let f64_output = f64_input.fft(None, -1, FftNorm::Backward, session).unwrap();
         assert_eq!(
             f64_output.as_slice::<Complex64>().unwrap()[0],
             Complex64::new(3.0, 0.0)
@@ -427,7 +277,7 @@ fn concrete_cpu_execution_preserves_all_four_scalar_dtypes() {
             vec![Complex32::new(1.0, 0.0), Complex32::new(2.0, 0.0)],
         )
         .unwrap();
-        let c32_output = c32_input.fft(None, -1, FftNorm::Backward, backend).unwrap();
+        let c32_output = c32_input.fft(None, -1, FftNorm::Backward, session).unwrap();
         assert_eq!(
             c32_output.as_slice::<Complex32>().unwrap()[0],
             Complex32::new(3.0, 0.0)
@@ -438,47 +288,12 @@ fn concrete_cpu_execution_preserves_all_four_scalar_dtypes() {
             vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
         )
         .unwrap();
-        let c64_output = c64_input.fft(None, -1, FftNorm::Backward, backend).unwrap();
+        let c64_output = c64_input.fft(None, -1, FftNorm::Backward, session).unwrap();
         assert_eq!(
             c64_output.as_slice::<Complex64>().unwrap()[0],
             Complex64::new(3.0, 0.0)
         );
     });
-}
-
-#[test]
-fn concrete_execution_delegates_the_validated_plan_spec() {
-    let (mut session, specs, _) = RecordingFftSession::new();
-    let input = Tensor::from_vec_col_major(
-        vec![2, 3],
-        vec![
-            Complex64::new(1.0, 0.0),
-            Complex64::new(2.0, 0.0),
-            Complex64::new(3.0, 0.0),
-            Complex64::new(4.0, 0.0),
-            Complex64::new(5.0, 0.0),
-            Complex64::new(6.0, 0.0),
-        ],
-    )
-    .unwrap();
-
-    let output = input
-        .fft(Some(4), -1, FftNorm::Ortho, &mut session)
-        .unwrap();
-    assert_eq!(output.shape(), &[2, 4]);
-
-    assert_eq!(
-        *specs.lock().unwrap(),
-        vec![RecordedSpec {
-            operation: FftOperation::C2cForward,
-            normalized_axis: 1,
-            requested_len: Some(4),
-            norm: FftNorm::Ortho,
-            input_dtype: DType::C64,
-            input_shape: vec![2, 3],
-            requires_compact_column_major: true,
-        }]
-    );
 }
 
 fn cuda_c64_tensor(shape: Vec<usize>) -> Tensor {
@@ -504,13 +319,12 @@ fn cuda_c64_tensor(shape: Vec<usize>) -> Tensor {
 
 #[test]
 fn foreign_placement_is_unsupported_without_transfer() {
-    let (mut session, _, transfers) = RecordingFftSession::new();
     let input = cuda_c64_tensor(vec![2]);
+    let mut owner = CpuBackend::new();
 
-    let error = input
-        .fft(None, -1, FftNorm::Backward, &mut session)
+    let error = owner
+        .with_backend_session(|session| input.fft(None, -1, FftNorm::Backward, session))
         .unwrap_err();
 
     assert_eq!(error.kind(), ErrorKind::Unsupported);
-    assert_eq!(transfers.load(Ordering::Relaxed), 0);
 }

--- a/crates/tenferro-fft/tests/cuda_fft/common.rs
+++ b/crates/tenferro-fft/tests/cuda_fft/common.rs
@@ -24,14 +24,11 @@ impl Operation {
         axis: isize,
         norm: FftNorm,
     ) -> tenferro_tensor::Result<Tensor> {
-        backend.with_backend_session(|session| {
-            with_cpu_exec_session(session, |exec_session| match self {
-                Self::Fft => input.fft(n, axis, norm, exec_session),
-                Self::Ifft => input.ifft(n, axis, norm, exec_session),
-                Self::Rfft => input.rfft(n, axis, norm, exec_session),
-                Self::Irfft => input.irfft(n, axis, norm, exec_session),
-            })
-            .expect("CPU backend session should be available")
+        backend.with_backend_session(|session| match self {
+            Self::Fft => input.fft(n, axis, norm, session),
+            Self::Ifft => input.ifft(n, axis, norm, session),
+            Self::Rfft => input.rfft(n, axis, norm, session),
+            Self::Irfft => input.irfft(n, axis, norm, session),
         })
     }
 

--- a/crates/tenferro-fft/tests/cuda_fft/support.rs
+++ b/crates/tenferro-fft/tests/cuda_fft/support.rs
@@ -1,19 +1,15 @@
-use tenferro_gpu::cuda::{
-    download_tensor, upload_tensor, with_cuda_exec_session, CudaBackend, CudaExecSession,
-};
+use tenferro_gpu::cuda::{download_tensor, upload_tensor, CudaBackend};
 use tenferro_runtime::Tensor;
-use tenferro_tensor::{BackendSessionHost, TensorRead};
+use tenferro_tensor::{BackendSession, BackendSessionHost, TensorRead};
 
 pub fn with_cuda_fft_session<R>(
     backend: &mut CudaBackend,
-    f: impl for<'a> FnOnce(&'a mut CudaExecSession<'a>) -> R + Send,
+    f: impl for<'a> FnOnce(&'a mut (dyn BackendSession + 'a)) -> R + Send,
 ) -> R
 where
     R: Send,
 {
-    backend.with_backend_session(|session| {
-        with_cuda_exec_session(session, f).expect("CUDA backend session should be available")
-    })
+    backend.with_backend_session(f)
 }
 
 pub fn cuda_backend() -> CudaBackend {

--- a/crates/tenferro-fft/tests/prelude.rs
+++ b/crates/tenferro-fft/tests/prelude.rs
@@ -1,5 +1,5 @@
 use num_complex::Complex64;
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_fft::prelude::*;
 
 #[test]
@@ -7,12 +7,7 @@ fn prelude_calls_concrete_fft_operation() {
     let input = Tensor::from_vec_col_major([4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let mut backend = CpuBackend::new();
     let spectrum = backend
-        .with_backend_session(|session| {
-            with_cpu_exec_session(session, |exec_session| {
-                input.fft(None, -1, FftNorm::Backward, exec_session)
-            })
-            .expect("CpuBackend must expose a CPU execution session")
-        })
+        .with_backend_session(|session| input.fft(None, -1, FftNorm::Backward, session))
         .unwrap();
     assert_eq!(
         spectrum.as_slice::<Complex64>().unwrap()[0],

--- a/crates/tenferro-fft/tests/webgpu_metal_fft.rs
+++ b/crates/tenferro-fft/tests/webgpu_metal_fft.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "macos")]
 mod metal {
     use num_complex::{Complex32, Complex64};
-    use tenferro_cpu::{with_cpu_exec_session, CpuBackend, CpuExecSession};
+    use tenferro_cpu::CpuBackend;
     use tenferro_fft::{FftNorm, TensorFftExt};
     use tenferro_gpu::{
         apple::AppleContext, webgpu::interop as webgpu_interop, webgpu::upload_webgpu_tensor,
@@ -10,19 +10,9 @@ mod metal {
     };
     use tenferro_tensor::{BackendSessionHost, Error, StorageBuffer, Tensor};
 
-    fn with_cpu_fft<R>(
-        backend: &mut CpuBackend,
-        f: impl for<'a> FnOnce(&'a mut CpuExecSession<'a>) -> R + Send,
-    ) -> R
-    where
-        R: Send,
-    {
-        backend.with_backend_session(|session| {
-            with_cpu_exec_session(session, f)
-                .expect("CpuBackend must expose a CPU execution session")
-        })
-    }
-
+    /// Visit the concrete WebGPU session for SPI-level behavior only: stream
+    /// synchronization and backend-interop limits. Concrete FFT trait calls
+    /// take `&mut dyn BackendSession` and use `with_backend_session` directly.
     fn with_webgpu_fft<R>(
         backend: &mut WebGpuBackend,
         f: impl for<'a> FnOnce(&'a mut WebGpuExecSession<'a>) -> R + Send,
@@ -107,17 +97,21 @@ mod metal {
 
         for norm in [FftNorm::Backward, FftNorm::Forward, FftNorm::Ortho] {
             let mut cpu = tenferro_cpu::CpuBackend::new();
-            let reference =
-                with_cpu_fft(&mut cpu, |session| input.fft(None, 0, norm, session)).unwrap();
-            let output =
-                with_webgpu_fft(&mut metal, |session| managed.fft(None, 0, norm, session)).unwrap();
+            let reference = cpu
+                .with_backend_session(|session| input.fft(None, 0, norm, session))
+                .unwrap();
+            let output = metal
+                .with_backend_session(|session| managed.fft(None, 0, norm, session))
+                .unwrap();
             with_webgpu_fft(&mut metal, |session| session.runtime().synchronize()).unwrap();
             assert_c32_close(&c32_values(&output), reference.as_slice().unwrap(), 2.0e-5);
 
-            let round_trip =
-                with_webgpu_fft(&mut metal, |session| output.ifft(None, 0, norm, session)).unwrap();
-            let reference_round_trip =
-                with_cpu_fft(&mut cpu, |session| reference.ifft(None, 0, norm, session)).unwrap();
+            let round_trip = metal
+                .with_backend_session(|session| output.ifft(None, 0, norm, session))
+                .unwrap();
+            let reference_round_trip = cpu
+                .with_backend_session(|session| reference.ifft(None, 0, norm, session))
+                .unwrap();
             with_webgpu_fft(&mut metal, |session| session.runtime().synchronize()).unwrap();
             assert_c32_close(
                 &c32_values(&round_trip),
@@ -140,14 +134,12 @@ mod metal {
         .unwrap();
         let managed = context.upload_tensor(&axis_one_input).unwrap();
         let mut cpu = tenferro_cpu::CpuBackend::new();
-        let reference = with_cpu_fft(&mut cpu, |session| {
-            axis_one_input.fft(None, 1, FftNorm::Backward, session)
-        })
-        .unwrap();
-        let output = with_webgpu_fft(&mut metal, |session| {
-            managed.fft(None, 1, FftNorm::Backward, session)
-        })
-        .unwrap();
+        let reference = cpu
+            .with_backend_session(|session| axis_one_input.fft(None, 1, FftNorm::Backward, session))
+            .unwrap();
+        let output = metal
+            .with_backend_session(|session| managed.fft(None, 1, FftNorm::Backward, session))
+            .unwrap();
         with_webgpu_fft(&mut metal, |session| session.runtime().synchronize()).unwrap();
         assert_c32_close(&c32_values(&output), reference.as_slice().unwrap(), 2.0e-5);
         assert_eq!(
@@ -172,28 +164,32 @@ mod metal {
             let managed = context.upload_tensor(&input).unwrap();
             let before = context.transfer_stats();
             let mut cpu = tenferro_cpu::CpuBackend::new();
-            let reference = with_cpu_fft(&mut cpu, |session| {
-                input.rfft(Some(n_fft), axis, FftNorm::Ortho, session)
-            })
-            .unwrap();
-            let spectrum = with_webgpu_fft(&mut metal, |session| {
-                managed.rfft(Some(n_fft), axis, FftNorm::Ortho, session)
-            })
-            .unwrap();
+            let reference = cpu
+                .with_backend_session(|session| {
+                    input.rfft(Some(n_fft), axis, FftNorm::Ortho, session)
+                })
+                .unwrap();
+            let spectrum = metal
+                .with_backend_session(|session| {
+                    managed.rfft(Some(n_fft), axis, FftNorm::Ortho, session)
+                })
+                .unwrap();
             with_webgpu_fft(&mut metal, |session| session.runtime().synchronize()).unwrap();
             assert_c32_close(
                 &c32_values(&spectrum),
                 reference.as_slice().unwrap(),
                 2.0e-5,
             );
-            let round_trip = with_webgpu_fft(&mut metal, |session| {
-                spectrum.irfft(Some(n_fft), axis, FftNorm::Ortho, session)
-            })
-            .unwrap();
-            let reference_round_trip = with_cpu_fft(&mut cpu, |session| {
-                reference.irfft(Some(n_fft), axis, FftNorm::Ortho, session)
-            })
-            .unwrap();
+            let round_trip = metal
+                .with_backend_session(|session| {
+                    spectrum.irfft(Some(n_fft), axis, FftNorm::Ortho, session)
+                })
+                .unwrap();
+            let reference_round_trip = cpu
+                .with_backend_session(|session| {
+                    reference.irfft(Some(n_fft), axis, FftNorm::Ortho, session)
+                })
+                .unwrap();
             metal.synchronize().unwrap();
             assert_f32_close(
                 &f32_values(&round_trip),
@@ -228,14 +224,12 @@ mod metal {
             let complex = Tensor::from_vec_col_major(vec![n_fft], complex_values).unwrap();
             let managed = context.upload_tensor(&complex).unwrap();
             let mut cpu = tenferro_cpu::CpuBackend::new();
-            let reference = with_cpu_fft(&mut cpu, |session| {
-                complex.fft(None, 0, FftNorm::Backward, session)
-            })
-            .unwrap();
-            let output = with_webgpu_fft(&mut metal, |session| {
-                managed.fft(None, 0, FftNorm::Backward, session)
-            })
-            .unwrap();
+            let reference = cpu
+                .with_backend_session(|session| complex.fft(None, 0, FftNorm::Backward, session))
+                .unwrap();
+            let output = metal
+                .with_backend_session(|session| managed.fft(None, 0, FftNorm::Backward, session))
+                .unwrap();
             with_webgpu_fft(&mut metal, |session| session.runtime().synchronize()).unwrap();
             assert_c32_close(&c32_values(&output), reference.as_slice().unwrap(), 2.0e-3);
 
@@ -244,20 +238,19 @@ mod metal {
                 .collect::<Vec<_>>();
             let real = Tensor::from_vec_col_major(vec![n_fft], real_values).unwrap();
             let managed = context.upload_tensor(&real).unwrap();
-            let reference = with_cpu_fft(&mut cpu, |session| {
-                real.rfft(None, 0, FftNorm::Backward, session)
-            })
-            .unwrap();
-            let output = with_webgpu_fft(&mut metal, |session| {
-                managed.rfft(None, 0, FftNorm::Backward, session)
-            })
-            .unwrap();
+            let reference = cpu
+                .with_backend_session(|session| real.rfft(None, 0, FftNorm::Backward, session))
+                .unwrap();
+            let output = metal
+                .with_backend_session(|session| managed.rfft(None, 0, FftNorm::Backward, session))
+                .unwrap();
             with_webgpu_fft(&mut metal, |session| session.runtime().synchronize()).unwrap();
             assert_c32_close(&c32_values(&output), reference.as_slice().unwrap(), 2.0e-3);
-            let round_trip = with_webgpu_fft(&mut metal, |session| {
-                output.irfft(Some(n_fft), 0, FftNorm::Backward, session)
-            })
-            .unwrap();
+            let round_trip = metal
+                .with_backend_session(|session| {
+                    output.irfft(Some(n_fft), 0, FftNorm::Backward, session)
+                })
+                .unwrap();
             with_webgpu_fft(&mut metal, |session| session.runtime().synchronize()).unwrap();
             assert_f32_close(&f32_values(&round_trip), real.as_slice().unwrap(), 2.0e-3);
         }
@@ -279,54 +272,50 @@ mod metal {
             (context.upload_tensor(&c64_input).unwrap(), "fft"),
         ] {
             let error = if transform == "rfft" {
-                with_webgpu_fft(&mut metal, |session| {
-                    input.rfft(None, 0, FftNorm::Backward, session)
-                })
+                metal
+                    .with_backend_session(|session| input.rfft(None, 0, FftNorm::Backward, session))
             } else {
-                with_webgpu_fft(&mut metal, |session| {
-                    input.fft(None, 0, FftNorm::Backward, session)
-                })
+                metal.with_backend_session(|session| input.fft(None, 0, FftNorm::Backward, session))
             }
             .unwrap_err();
             assert!(matches!(error, Error::Unsupported { .. }));
         }
 
         let managed_real = context.upload_tensor(&f32_input).unwrap();
-        let error = with_webgpu_fft(&mut metal, |session| {
-            managed_real.fft(None, 0, FftNorm::Backward, session)
-        })
-        .unwrap_err();
+        let error = metal
+            .with_backend_session(|session| managed_real.fft(None, 0, FftNorm::Backward, session))
+            .unwrap_err();
         assert!(matches!(error, Error::Unsupported { .. }));
         for invalid_n in [1usize, 3usize, 1usize << 40] {
-            let error = with_webgpu_fft(&mut metal, |session| {
-                managed_real.rfft(Some(invalid_n), 0, FftNorm::Backward, session)
-            })
-            .unwrap_err();
+            let error = metal
+                .with_backend_session(|session| {
+                    managed_real.rfft(Some(invalid_n), 0, FftNorm::Backward, session)
+                })
+                .unwrap_err();
             assert!(matches!(error, Error::Unsupported { .. }));
         }
         let managed_complex = context.upload_tensor(&c32_input).unwrap();
-        let error = with_webgpu_fft(&mut metal, |session| {
-            managed_complex.fft(Some(8), 0, FftNorm::Backward, session)
-        })
-        .unwrap_err();
+        let error = metal
+            .with_backend_session(|session| {
+                managed_complex.fft(Some(8), 0, FftNorm::Backward, session)
+            })
+            .unwrap_err();
         assert!(matches!(error, Error::Unsupported { .. }));
 
         let other = AppleContext::new().unwrap();
         let foreign = other.upload_tensor(&c32_input).unwrap();
         let before = context.transfer_stats();
-        let error = with_webgpu_fft(&mut metal, |session| {
-            foreign.fft(None, 0, FftNorm::Backward, session)
-        })
-        .unwrap_err();
+        let error = metal
+            .with_backend_session(|session| foreign.fft(None, 0, FftNorm::Backward, session))
+            .unwrap_err();
         assert!(matches!(error, Error::HostAccess { .. }));
         assert_eq!(context.transfer_stats(), before);
 
         let runtime = WebGpuRuntime::new_default().unwrap();
         let device_local = upload_webgpu_tensor(&runtime, &c32_input).unwrap();
-        let error = with_webgpu_fft(&mut metal, |session| {
-            device_local.fft(None, 0, FftNorm::Backward, session)
-        })
-        .unwrap_err();
+        let error = metal
+            .with_backend_session(|session| device_local.fft(None, 0, FftNorm::Backward, session))
+            .unwrap_err();
         assert!(matches!(error, Error::RuntimeState { .. }));
         assert_eq!(context.transfer_stats(), before);
     }

--- a/crates/tenferro-gpu/src/cubecl/exec_session.rs
+++ b/crates/tenferro-gpu/src/cubecl/exec_session.rs
@@ -11,9 +11,11 @@ use tenferro_tensor::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
 use tenferro_tensor::{
+    with_session_entry_guard, TensorRank, TensorScalar, TensorViewCanonicalization, TypedTensorView,
+};
+use tenferro_tensor::{
     DotGeneralAccumulation, Tensor, TensorRead, TensorValue, TensorWrite, TypedTensor,
 };
-use tenferro_tensor::{TensorRank, TensorScalar, TensorViewCanonicalization, TypedTensorView};
 
 use super::identity::GpuExtensionCapability;
 use super::runtime::RawContextRestore;
@@ -608,6 +610,8 @@ impl BackendSessionHost for CudaBackend {
             backend: self,
             _not_send_sync: PhantomData,
         };
-        f(&mut session)
+        // Nested entry is caught by the portable in-session guard in debug
+        // builds; the CUDA runtime must never re-enter a session closure.
+        with_session_entry_guard(|| f(&mut session))
     }
 }

--- a/crates/tenferro-gpu/src/cubecl/tests/cubecl_session_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/cubecl_session_tests.rs
@@ -193,19 +193,26 @@ fn cubecl_session_flushes_after_error_callback() {
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic(expected = "nested backend session entry")]
 fn cuda_with_backend_session_rejects_nested_entry_in_debug_builds() {
     if !gpu_available() {
+        // Skipped on hosts without a CUDA device: the nested-entry contract
+        // is exercised on the shared helper + default adapter here.
         return;
     }
     let mut backend = first_cuda_backend().expect("CUDA backend should initialize");
-    backend.with_backend_session(|_session| {
-        // The CUDA override wraps its closure in the portable in-session
-        // guard, so re-entering any session-entry point on this thread
-        // (here the shared helper directly) trips the debug assert
-        // (issue #1680 Phase 3).
-        tenferro_tensor::with_session_entry_guard(|| ())
-    });
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.with_backend_session(|_session| {
+            // The CUDA override wraps its closure in the portable in-session
+            // guard, so re-entering any session-entry point on this thread
+            // (here the shared helper directly) trips the debug assert
+            // (issue #1680 Phase 3).
+            tenferro_tensor::with_session_entry_guard(|| ())
+        })
+    }));
+    assert!(
+        outcome.is_err(),
+        "nested session entry must panic in debug builds"
+    );
 }
 
 #[cfg(debug_assertions)]

--- a/crates/tenferro-gpu/src/cubecl/tests/cubecl_session_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/cubecl_session_tests.rs
@@ -190,3 +190,36 @@ fn cubecl_session_flushes_after_error_callback() {
             .unwrap();
     });
 }
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "nested backend session entry")]
+fn cuda_with_backend_session_rejects_nested_entry_in_debug_builds() {
+    if !gpu_available() {
+        return;
+    }
+    let mut backend = first_cuda_backend().expect("CUDA backend should initialize");
+    backend.with_backend_session(|_session| {
+        // The CUDA override wraps its closure in the portable in-session
+        // guard, so re-entering any session-entry point on this thread
+        // (here the shared helper directly) trips the debug assert
+        // (issue #1680 Phase 3).
+        tenferro_tensor::with_session_entry_guard(|| ())
+    });
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn cuda_with_backend_session_restores_the_in_session_flag_after_panic() {
+    if !gpu_available() {
+        return;
+    }
+    let mut backend = first_cuda_backend().expect("CUDA backend should initialize");
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.with_backend_session(|_session| panic!("boom"))
+    }));
+    assert!(outcome.is_err());
+    // The flag is usable again on the same thread.
+    let value = backend.with_backend_session(|_session| 7usize);
+    assert_eq!(value, 7);
+}

--- a/crates/tenferro-gpu/src/webgpu/exec_session.rs
+++ b/crates/tenferro-gpu/src/webgpu/exec_session.rs
@@ -7,7 +7,9 @@ use tenferro_tensor::backend::{
 use tenferro_tensor::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use tenferro_tensor::{DotGeneralAccumulation, Tensor, TensorRead, TensorValue, TensorWrite};
+use tenferro_tensor::{
+    with_session_entry_guard, DotGeneralAccumulation, Tensor, TensorRead, TensorValue, TensorWrite,
+};
 
 use super::{WebGpuBackend, WebGpuRuntime, WebGpuRuntimeIdentity};
 
@@ -265,6 +267,8 @@ impl BackendSessionHost for WebGpuBackend {
         f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
     ) -> R {
         let mut session = WebGpuExecSession { backend: self };
-        f(&mut session)
+        // Nested entry is caught by the portable in-session guard in debug
+        // builds; the WebGPU runtime must never re-enter a session closure.
+        with_session_entry_guard(|| f(&mut session))
     }
 }

--- a/crates/tenferro-gpu/src/webgpu/tests/runtime_adapter.rs
+++ b/crates/tenferro-gpu/src/webgpu/tests/runtime_adapter.rs
@@ -15,7 +15,8 @@ use tenferro_runtime::{
 #[cfg(not(target_family = "wasm"))]
 use tenferro_tensor::TensorStructural;
 use tenferro_tensor::{
-    AllocationId, BackendAllocation, BackendStorage, DeviceId, StorageBuffer, Tensor, TypedTensor,
+    AllocationId, BackendAllocation, BackendSessionHost, BackendStorage, DeviceId, StorageBuffer,
+    Tensor, TypedTensor,
 };
 
 use super::super::WebGpuBuffer;
@@ -411,4 +412,37 @@ fn webgpu_event_domain_tokens_are_repeatable_and_order_native_dependencies() {
         output.as_slice().expect("host slice"),
         &[1.0, 2.0, 3.0, 4.0]
     );
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "nested backend session entry")]
+fn webgpu_with_backend_session_rejects_nested_entry_in_debug_builds() {
+    if !webgpu_available() {
+        return;
+    }
+    let mut backend = WebGpuBackend::new_default().expect("WebGPU backend");
+    backend.with_backend_session(|_session| {
+        // The WebGPU override wraps its closure in the portable in-session
+        // guard, so re-entering any session-entry point on this thread
+        // (here the shared helper directly) trips the debug assert
+        // (issue #1680 Phase 3).
+        tenferro_tensor::with_session_entry_guard(|| ())
+    });
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn webgpu_with_backend_session_restores_the_in_session_flag_after_panic() {
+    if !webgpu_available() {
+        return;
+    }
+    let mut backend = WebGpuBackend::new_default().expect("WebGPU backend");
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.with_backend_session(|_session| panic!("boom"))
+    }));
+    assert!(outcome.is_err());
+    // The flag is usable again on the same thread.
+    let value = backend.with_backend_session(|_session| 7usize);
+    assert_eq!(value, 7);
 }

--- a/crates/tenferro-gpu/src/webgpu/tests/runtime_adapter.rs
+++ b/crates/tenferro-gpu/src/webgpu/tests/runtime_adapter.rs
@@ -416,19 +416,26 @@ fn webgpu_event_domain_tokens_are_repeatable_and_order_native_dependencies() {
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic(expected = "nested backend session entry")]
 fn webgpu_with_backend_session_rejects_nested_entry_in_debug_builds() {
     if !webgpu_available() {
+        // Skipped on hosts without a WebGPU adapter: the nested-entry
+        // contract is exercised on the shared helper + default adapter here.
         return;
     }
     let mut backend = WebGpuBackend::new_default().expect("WebGPU backend");
-    backend.with_backend_session(|_session| {
-        // The WebGPU override wraps its closure in the portable in-session
-        // guard, so re-entering any session-entry point on this thread
-        // (here the shared helper directly) trips the debug assert
-        // (issue #1680 Phase 3).
-        tenferro_tensor::with_session_entry_guard(|| ())
-    });
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.with_backend_session(|_session| {
+            // The WebGPU override wraps its closure in the portable in-session
+            // guard, so re-entering any session-entry point on this thread
+            // (here the shared helper directly) trips the debug assert
+            // (issue #1680 Phase 3).
+            tenferro_tensor::with_session_entry_guard(|| ())
+        })
+    }));
+    assert!(
+        outcome.is_err(),
+        "nested session entry must panic in debug builds"
+    );
 }
 
 #[cfg(debug_assertions)]

--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -2,11 +2,19 @@
 //!
 //! Owned tensors use [`TensorLinalgExt`], borrowed tensors and views use the
 //! `_read` methods on [`TensorReadLinalgExt`], and typed tensors use
-//! [`TypedTensorLinalgExt`]. All methods reuse a caller-owned backend.
+//! [`TypedTensorLinalgExt`]. All methods dispatch internally to the built-in
+//! CPU/CUDA execution sessions through an erased `&mut dyn BackendSession`
+//! (issue #1680 Phase 3); third-party [`LinalgBackend`] implementations
+//! remain supported through the SPI trait, but the concrete op path is
+//! built-in-session only.
 
 use num_complex::{Complex32, Complex64};
+use tenferro_cpu::with_cpu_exec_session;
+#[cfg(feature = "cuda")]
+use tenferro_gpu::cuda::with_cuda_exec_session;
 use tenferro_tensor::{
-    CompareDir, DType, DotGeneralConfig, Tensor, TensorRead, TensorScalar, TensorWrite, TypedTensor,
+    BackendSession, CompareDir, DType, DotGeneralConfig, Tensor, TensorRead, TensorScalar,
+    TensorWrite, TypedTensor,
 };
 
 use crate::extension::{
@@ -107,16 +115,13 @@ pub type TypedEig<T> = (
 /// # Examples
 ///
 /// ```rust
-/// use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+/// use tenferro_cpu::CpuBackend;
 /// use tenferro_linalg::TensorLinalgExt;
 /// use tenferro_tensor::{BackendSessionHost, Tensor};
 ///
 /// let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
 /// let mut host = CpuBackend::new();
-/// let (_u, singular_values, _vt) = host.with_backend_session(|session| {
-///     with_cpu_exec_session(session, |backend| a.svd(backend))
-///         .expect("CpuBackend must expose a CpuExecSession")
-/// })?;
+/// let (_u, singular_values, _vt) = host.with_backend_session(|session| a.svd(session))?;
 /// assert_eq!(singular_values.as_slice::<f64>()?, &[4.0, 2.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
@@ -127,21 +132,18 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (_u, s, _vt) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.svd(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (_u, s, _vt) = host.with_backend_session(|session| a.svd(session))?;
     /// assert_eq!(s.shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn svd<B: LinalgBackend>(
+    fn svd(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -149,24 +151,19 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::{SvdOptions, TensorLinalgExt};
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (_u, s, _vt) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         a.svd_with_options(SvdOptions::default(), backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (_u, s, _vt) = host.with_backend_session(|session| { a.svd_with_options(SvdOptions::default(), session) })?;
     /// assert_eq!(s.shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn svd_with_options<B: LinalgBackend>(
+    fn svd_with_options(
         &self,
         options: SvdOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -174,45 +171,37 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (q, r) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.qr(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (q, r) = host.with_backend_session(|session| a.qr(session))?;
     /// assert_eq!(q.shape(), &[2, 2]);
     /// assert_eq!(r.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn qr<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn qr(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for matrix metadata or options, plus QR backend errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::{QrOptions, TensorLinalgExt};
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (q, r) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         a.qr_with_options(QrOptions::default(), backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (q, r) = host.with_backend_session(|session| { a.qr_with_options(QrOptions::default(), session) })?;
     /// assert_eq!(q.shape(), &[2, 2]);
     /// assert_eq!(r.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn qr_with_options<B: LinalgBackend>(
+    fn qr_with_options(
         &self,
         options: QrOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -220,23 +209,20 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (_p, l, u, parity) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.lu(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (_p, l, u, parity) = host.with_backend_session(|session| a.lu(session))?;
     /// assert_eq!(l.shape(), &[2, 2]);
     /// assert_eq!(u.shape(), &[2, 2]);
     /// assert_eq!(parity.shape(), &[]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn lu<B: LinalgBackend>(
+    fn lu(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -244,23 +230,20 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (p, _l, _u, q, parity) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.full_piv_lu(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (p, _l, _u, q, parity) = host.with_backend_session(|session| a.full_piv_lu(session))?;
     /// assert_eq!(p.shape(), &[2, 2]);
     /// assert_eq!(q.shape(), &[2, 2]);
     /// assert_eq!(parity.shape(), &[]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn full_piv_lu<B: LinalgBackend>(
+    fn full_piv_lu(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -268,23 +251,20 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0])?;
     /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![-1.0_f64, 5.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let x = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.full_piv_lu_solve(&b, backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let x = host.with_backend_session(|session| a.full_piv_lu_solve(&b, session))?;
     /// assert_eq!(x.shape(), &[2, 1]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn full_piv_lu_solve<B: LinalgBackend>(
+    fn full_piv_lu_solve(
         &self,
         b: &Tensor,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -292,23 +272,20 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 8.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let x = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.solve(&b, backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let x = host.with_backend_session(|session| a.solve(&b, session))?;
     /// assert_eq!(x.as_slice::<f64>()?, &[2.0, 2.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn solve<B: LinalgBackend>(
+    fn solve(
         &self,
         b: &Tensor,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -316,64 +293,53 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 2.0, 2.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let l = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.cholesky(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let l = host.with_backend_session(|session| a.cholesky(session))?;
     /// assert_eq!(l.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn cholesky<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn cholesky(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, convergence, or output-contract errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (values, vectors) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.eigh(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (values, vectors) = host.with_backend_session(|session| a.eigh(session))?;
     /// assert_eq!(values.as_slice::<f64>()?, &[1.0, 3.0]);
     /// assert_eq!(vectors.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eigh<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn eigh(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for matrix metadata or options, plus Eigh backend errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::{EighOptions, TensorLinalgExt};
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (values, vectors) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         a.eigh_with_options(EighOptions::default(), backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (values, vectors) = host.with_backend_session(|session| { a.eigh_with_options(EighOptions::default(), session) })?;
     /// assert_eq!(values.shape(), &[2]);
     /// assert_eq!(vectors.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eigh_with_options<B: LinalgBackend>(
+    fn eigh_with_options(
         &self,
         options: EighOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -381,20 +347,17 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (values, vectors) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.eig(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (values, vectors) = host.with_backend_session(|session| a.eig(session))?;
     /// assert_eq!(values.shape(), &[2]);
     /// assert_eq!(vectors.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eig<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn eig(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for incompatible inputs/flags or backend/numerical errors.
@@ -402,29 +365,24 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 1.0, 3.0])?;
     /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 9.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let x = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         a.triangular_solve(&b, true, false, false, false, backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let x = host.with_backend_session(|session| { a.triangular_solve(&b, true, false, false, false, session) })?;
     /// assert_eq!(x.shape(), &[2, 1]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn triangular_solve<B: LinalgBackend>(
+    fn triangular_solve(
         &self,
         b: &Tensor,
         left_side: bool,
         lower: bool,
         transpose_a: bool,
         unit_diagonal: bool,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -432,22 +390,19 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (sign, logabsdet) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.slogdet(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (sign, logabsdet) = host.with_backend_session(|session| a.slogdet(session))?;
     /// assert_eq!(sign.as_slice::<f64>()?, &[1.0]);
     /// assert_eq!(logabsdet.shape(), &[]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn slogdet<B: LinalgBackend>(
+    fn slogdet(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -455,117 +410,99 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let determinant = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.det(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let determinant = host.with_backend_session(|session| a.det(session))?;
     /// assert!((determinant.as_slice::<f64>()?[0] - 8.0).abs() < 1.0e-12);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn det<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn det(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, or singular-solve numerical errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let inverse = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.inv(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let inverse = host.with_backend_session(|session| a.inv(session))?;
     /// assert_eq!(inverse.as_slice::<f64>()?, &[0.5, 0.0, 0.0, 0.25]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn inv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn inv(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns the validation, backend, convergence, or contract errors from [`Self::eigh`].
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let values = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.eigvalsh(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let values = host.with_backend_session(|session| a.eigvalsh(session))?;
     /// assert_eq!(values.as_slice::<f64>()?, &[1.0, 3.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eigvalsh<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn eigvalsh(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns the validation, backend, convergence, or contract errors from [`Self::eig`].
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let values = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.eigvals(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let values = host.with_backend_session(|session| a.eigvals(session))?;
     /// assert_eq!(values.shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eigvals<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn eigvals(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, numerical, or SVD contract errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let pseudoinverse = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.pinv(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let pseudoinverse = host.with_backend_session(|session| a.pinv(session))?;
     /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn pinv(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns a validation error for invalid `rtol`, plus errors from [`Self::pinv`].
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let pseudoinverse = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.pinv_with_rtol(1.0e-12, backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let pseudoinverse = host.with_backend_session(|session| a.pinv_with_rtol(1.0e-12, session))?;
     /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn pinv_with_rtol<B: LinalgBackend>(
+    fn pinv_with_rtol(
         &self,
         rtol: f64,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -573,24 +510,21 @@ pub trait TensorLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let frobenius = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.norm(None, None, false, backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let frobenius = host.with_backend_session(|session| a.norm(None, None, false, session))?;
     /// assert_eq!(frobenius.shape(), &[]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn norm<B: LinalgBackend>(
+    fn norm(
         &self,
         ord: Option<f64>,
         dim: Option<&[usize]>,
         keepdim: bool,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
 }
 
@@ -599,17 +533,14 @@ pub trait TensorLinalgExt {
 /// # Examples
 ///
 /// ```rust
-/// use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+/// use tenferro_cpu::CpuBackend;
 /// use tenferro_linalg::TensorReadLinalgExt;
 /// use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
 ///
 /// let input = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
 /// let mut host = CpuBackend::new();
 /// let (_q, r) = host.with_backend_session(|session| {
-///     with_cpu_exec_session(session, |backend| {
-///         TensorRead::from_tensor(&input).qr_read(backend)
-///     })
-///     .expect("CpuBackend must expose a CpuExecSession")
+///     TensorRead::from_tensor(&input).qr_read(session)
 /// })?;
 /// assert_eq!(r.shape(), &[2, 2]);
 /// # Ok::<(), tenferro_tensor::Error>(())
@@ -621,23 +552,20 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
     /// let (_u, s, _vt) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).svd_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
+    ///     TensorRead::from_tensor(&a).svd_read(session)
     /// })?;
     /// assert_eq!(s.shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn svd_read<B: LinalgBackend>(
+    fn svd_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -645,25 +573,21 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::{SvdOptions, TensorReadLinalgExt};
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
     /// let (_u, s, _vt) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a)
-    ///             .svd_with_options_read(SvdOptions::default(), backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
+    ///     TensorRead::from_tensor(&a).svd_with_options_read(SvdOptions::default(), session)
     /// })?;
     /// assert_eq!(s.shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn svd_with_options_read<B: LinalgBackend>(
+    fn svd_with_options_read(
         self,
         options: SvdOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -671,51 +595,40 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (q, r) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).qr_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (q, r) = host.with_backend_session(|session| { TensorRead::from_tensor(&a).qr_read(session) })?;
     /// assert_eq!(q.shape(), &[2, 2]);
     /// assert_eq!(r.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn qr_read<B: LinalgBackend>(
-        self,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn qr_read(self, session: &mut dyn BackendSession)
+        -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for metadata/options, plus read/materialization or QR errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::{QrOptions, TensorReadLinalgExt};
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0])?;
     /// # let mut host = CpuBackend::new();
     /// let (q, r) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a)
-    ///             .qr_with_options_read(QrOptions::default(), backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
+    ///     TensorRead::from_tensor(&a).qr_with_options_read(QrOptions::default(), session)
     /// })?;
     /// assert_eq!(q.shape(), &[2, 2]);
     /// assert_eq!(r.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn qr_with_options_read<B: LinalgBackend>(
+    fn qr_with_options_read(
         self,
         options: QrOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -723,24 +636,19 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (_p, l, u, _parity) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).lu_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (_p, l, u, _parity) = host.with_backend_session(|session| { TensorRead::from_tensor(&a).lu_read(session) })?;
     /// assert_eq!(l.shape(), &[2, 2]);
     /// assert_eq!(u.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn lu_read<B: LinalgBackend>(
+    fn lu_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -748,24 +656,19 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (p, _l, _u, q, _parity) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).full_piv_lu_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (p, _l, _u, q, _parity) = host.with_backend_session(|session| { TensorRead::from_tensor(&a).full_piv_lu_read(session) })?;
     /// assert_eq!(p.shape(), &[2, 2]);
     /// assert_eq!(q.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn full_piv_lu_read<B: LinalgBackend>(
+    fn full_piv_lu_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -773,26 +676,22 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0])?;
     /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![-1.0_f64, 5.0])?;
     /// # let mut host = CpuBackend::new();
     /// let x = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a)
-    ///             .full_piv_lu_solve_read(TensorRead::from_tensor(&b), backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
+    ///     TensorRead::from_tensor(&a).full_piv_lu_solve_read(TensorRead::from_tensor(&b), session)
     /// })?;
     /// assert_eq!(x.shape(), &[2, 1]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn full_piv_lu_solve_read<B: LinalgBackend>(
+    fn full_piv_lu_solve_read(
         self,
         b: TensorRead<'_>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -800,25 +699,20 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 8.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let x = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).solve_read(TensorRead::from_tensor(&b), backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let x = host.with_backend_session(|session| { TensorRead::from_tensor(&a).solve_read(TensorRead::from_tensor(&b), session) })?;
     /// assert_eq!(x.as_slice::<f64>()?, &[2.0, 2.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn solve_read<B: LinalgBackend>(
+    fn solve_read(
         self,
         b: TensorRead<'_>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Solve into a caller-owned destination without allocating the result at
     /// the public API boundary.
@@ -836,7 +730,7 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead, TensorWrite};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
@@ -844,28 +738,25 @@ pub trait TensorReadLinalgExt {
     /// # let mut out = Tensor::from_vec_col_major(vec![2, 1], vec![0.0_f64; 2])?;
     /// # let mut host = CpuBackend::new();
     /// host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
     ///         TensorRead::from_tensor(&a).solve_read_into(
     ///             TensorRead::from_tensor(&b),
     ///             TensorWrite::from_tensor(&mut out),
-    ///             backend,
+    ///             session,
     ///         )
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    ///     })?;
     /// assert_eq!(out.as_slice::<f64>()?, &[2.0, 2.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn solve_read_into<B: LinalgBackend>(
+    fn solve_read_into(
         self,
         b: TensorRead<'_>,
         out: TensorWrite<'_>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<()>
     where
         Self: Sized,
     {
-        let _ = (self, b, out, backend);
+        let _ = (self, b, out, session);
         Err(tenferro_tensor::Error::unsupported(
             "solve_read_into",
             "this tensor-read extension implementation does not accept borrowed solve targets",
@@ -877,45 +768,35 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 2.0, 2.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let l = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).cholesky_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let l = host.with_backend_session(|session| { TensorRead::from_tensor(&a).cholesky_read(session) })?;
     /// assert_eq!(l.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn cholesky_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn cholesky_read(self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, convergence, or contract errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (values, vectors) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).eigh_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (values, vectors) = host.with_backend_session(|session| { TensorRead::from_tensor(&a).eigh_read(session) })?;
     /// assert_eq!(values.as_slice::<f64>()?, &[1.0, 3.0]);
     /// assert_eq!(vectors.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eigh_read<B: LinalgBackend>(
+    fn eigh_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -923,26 +804,22 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::{EighOptions, TensorReadLinalgExt};
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
     /// let (values, vectors) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a)
-    ///             .eigh_with_options_read(EighOptions::default(), backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
+    ///     TensorRead::from_tensor(&a).eigh_with_options_read(EighOptions::default(), session)
     /// })?;
     /// assert_eq!(values.shape(), &[2]);
     /// assert_eq!(vectors.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eigh_with_options_read<B: LinalgBackend>(
+    fn eigh_with_options_read(
         self,
         options: EighOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -950,24 +827,19 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (values, vectors) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).eig_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (values, vectors) = host.with_backend_session(|session| { TensorRead::from_tensor(&a).eig_read(session) })?;
     /// assert_eq!(values.shape(), &[2]);
     /// assert_eq!(vectors.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eig_read<B: LinalgBackend>(
+    fn eig_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -976,36 +848,33 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 1.0, 3.0])?;
     /// # let b = Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 9.0])?;
     /// # let mut host = CpuBackend::new();
     /// let x = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).triangular_solve_read(
-    ///             TensorRead::from_tensor(&b),
-    ///             true,
-    ///             false,
-    ///             false,
-    ///             false,
-    ///             backend,
-    ///         )
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
+    ///     TensorRead::from_tensor(&a).triangular_solve_read(
+    ///         TensorRead::from_tensor(&b),
+    ///         true,
+    ///         false,
+    ///         false,
+    ///         false,
+    ///         session,
+    ///     )
     /// })?;
     /// assert_eq!(x.shape(), &[2, 1]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn triangular_solve_read<B: LinalgBackend>(
+    fn triangular_solve_read(
         self,
         b: TensorRead<'_>,
         left_side: bool,
         lower: bool,
         transpose_a: bool,
         unit_diagonal: bool,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1013,24 +882,19 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (sign, logabsdet) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).slogdet_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (sign, logabsdet) = host.with_backend_session(|session| { TensorRead::from_tensor(&a).slogdet_read(session) })?;
     /// assert_eq!(sign.as_slice::<f64>()?, &[1.0]);
     /// assert_eq!(logabsdet.shape(), &[]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn slogdet_read<B: LinalgBackend>(
+    fn slogdet_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1038,129 +902,99 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let determinant = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).det_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let determinant = host.with_backend_session(|session| { TensorRead::from_tensor(&a).det_read(session) })?;
     /// assert!((determinant.as_slice::<f64>()?[0] - 8.0).abs() < 1.0e-12);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn det_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn det_read(self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, or singular-solve errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let inverse = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).inv_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let inverse = host.with_backend_session(|session| { TensorRead::from_tensor(&a).inv_read(session) })?;
     /// assert_eq!(inverse.as_slice::<f64>()?, &[0.5, 0.0, 0.0, 0.25]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn inv_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn inv_read(self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, convergence, or contract errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let values = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).eigvalsh_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let values = host.with_backend_session(|session| { TensorRead::from_tensor(&a).eigvalsh_read(session) })?;
     /// assert_eq!(values.as_slice::<f64>()?, &[1.0, 3.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eigvalsh_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn eigvalsh_read(self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, convergence, or contract errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let values = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).eigvals_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let values = host.with_backend_session(|session| { TensorRead::from_tensor(&a).eigvals_read(session) })?;
     /// assert_eq!(values.shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eigvals_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn eigvals_read(self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, read/materialization, backend, numerical, or SVD contract errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let pseudoinverse = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).pinv_read(backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let pseudoinverse = host.with_backend_session(|session| { TensorRead::from_tensor(&a).pinv_read(session) })?;
     /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn pinv_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn pinv_read(self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns a validation error for invalid `rtol`, plus errors from [`Self::pinv_read`].
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let pseudoinverse = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).pinv_with_rtol_read(1.0e-12, backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let pseudoinverse = host.with_backend_session(|session| { TensorRead::from_tensor(&a).pinv_with_rtol_read(1.0e-12, session) })?;
     /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn pinv_with_rtol_read<B: LinalgBackend>(
+    fn pinv_with_rtol_read(
         self,
         rtol: f64,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1168,26 +1002,21 @@ pub trait TensorReadLinalgExt {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TensorReadLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
     /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let frobenius = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         TensorRead::from_tensor(&a).norm_read(None, None, false, backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let frobenius = host.with_backend_session(|session| { TensorRead::from_tensor(&a).norm_read(None, None, false, session) })?;
     /// assert_eq!(frobenius.shape(), &[]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn norm_read<B: LinalgBackend>(
+    fn norm_read(
         self,
         ord: Option<f64>,
         dim: Option<&[usize]>,
         keepdim: bool,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor>;
 }
 
@@ -1199,7 +1028,7 @@ pub trait TensorReadLinalgExt {
 /// # Examples
 ///
 /// ```rust
-/// use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+/// use tenferro_cpu::CpuBackend;
 /// use tenferro_linalg::TypedTensorLinalgExt;
 /// use tenferro_tensor::{BackendSessionHost, TypedTensor};
 ///
@@ -1208,10 +1037,7 @@ pub trait TensorReadLinalgExt {
 ///     vec![2.0, 0.0, 0.0, 4.0],
 /// )?;
 /// let mut host = CpuBackend::new();
-/// let (_u, singular_values, _vt) = host.with_backend_session(|session| {
-///     with_cpu_exec_session(session, |backend| input.svd(backend))
-///         .expect("CpuBackend must expose a CpuExecSession")
-/// })?;
+/// let (_u, singular_values, _vt) = host.with_backend_session(|session| input.svd(session))?;
 /// assert_eq!(singular_values.as_slice()?, &[4.0, 2.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
@@ -1222,43 +1048,35 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (_u, s, _vt) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.svd(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (_u, s, _vt) = host.with_backend_session(|session| a.svd(session))?;
     /// assert_eq!(s.as_slice()?, &[4.0, 2.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn svd<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedSvd<T>>;
+    fn svd(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedSvd<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for metadata/options, plus backend or typed-output errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::{SvdOptions, TypedTensorLinalgExt};
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (_u, s, _vt) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         a.svd_with_options(SvdOptions::default(), backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (_u, s, _vt) = host.with_backend_session(|session| { a.svd_with_options(SvdOptions::default(), session) })?;
     /// assert_eq!(s.as_slice()?, &[4.0, 2.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn svd_with_options<B: LinalgBackend>(
+    fn svd_with_options(
         &self,
         options: SvdOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedSvd<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1266,22 +1084,19 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (q, r) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.qr(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (q, r) = host.with_backend_session(|session| a.qr(session))?;
     /// assert_eq!(q.shape(), &[2, 2]);
     /// assert_eq!(r.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn qr<B: LinalgBackend>(
+    fn qr(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1289,25 +1104,20 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::{QrOptions, TypedTensorLinalgExt};
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (q, r) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         a.qr_with_options(QrOptions::default(), backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (q, r) = host.with_backend_session(|session| { a.qr_with_options(QrOptions::default(), session) })?;
     /// assert_eq!(q.shape(), &[2, 2]);
     /// assert_eq!(r.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn qr_with_options<B: LinalgBackend>(
+    fn qr_with_options(
         &self,
         options: QrOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1315,42 +1125,36 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (_p, l, u, _parity) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.lu(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (_p, l, u, _parity) = host.with_backend_session(|session| a.lu(session))?;
     /// assert_eq!(l.shape(), &[2, 2]);
     /// assert_eq!(u.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn lu<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedLu<T>>;
+    fn lu(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedLu<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (p, _l, _u, q, _parity) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.full_piv_lu(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (p, _l, _u, q, _parity) = host.with_backend_session(|session| a.full_piv_lu(session))?;
     /// assert_eq!(p.shape(), &[2, 2]);
     /// assert_eq!(q.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn full_piv_lu<B: LinalgBackend>(
+    fn full_piv_lu(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedFullPivLu<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1358,23 +1162,20 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![0.0, 2.0, 1.0, 3.0])?;
     /// # let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 1], vec![-1.0, 5.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let x = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.full_piv_lu_solve(&b, backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let x = host.with_backend_session(|session| a.full_piv_lu_solve(&b, session))?;
     /// assert_eq!(x.shape(), &[2, 1]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn full_piv_lu_solve<B: LinalgBackend>(
+    fn full_piv_lu_solve(
         &self,
         b: &TypedTensor<T>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1382,23 +1183,20 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
     /// # let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 1], vec![4.0, 8.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let x = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.solve(&b, backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let x = host.with_backend_session(|session| a.solve(&b, session))?;
     /// assert_eq!(x.as_slice()?, &[2.0, 2.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn solve<B: LinalgBackend>(
+    fn solve(
         &self,
         b: &TypedTensor<T>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1406,44 +1204,36 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![4.0, 2.0, 2.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let l = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.cholesky(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let l = host.with_backend_session(|session| a.cholesky(session))?;
     /// assert_eq!(l.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn cholesky<B: LinalgBackend>(
-        &self,
-        backend: &mut B,
-    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn cholesky(&self, session: &mut dyn BackendSession)
+        -> tenferro_tensor::Result<TypedTensor<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, convergence, output-contract, or typed-downcast errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (values, vectors) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.eigh(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (values, vectors) = host.with_backend_session(|session| a.eigh(session))?;
     /// assert_eq!(values.as_slice()?, &[1.0, 3.0]);
     /// assert_eq!(vectors.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eigh<B: LinalgBackend>(
+    fn eigh(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(TypedTensor<<T as TensorScalar>::Real>, TypedTensor<T>)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1451,25 +1241,20 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::{EighOptions, TypedTensorLinalgExt};
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (values, vectors) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         a.eigh_with_options(EighOptions::default(), backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (values, vectors) = host.with_backend_session(|session| { a.eigh_with_options(EighOptions::default(), session) })?;
     /// assert_eq!(values.shape(), &[2]);
     /// assert_eq!(vectors.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eigh_with_options<B: LinalgBackend>(
+    fn eigh_with_options(
         &self,
         options: EighOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(TypedTensor<<T as TensorScalar>::Real>, TypedTensor<T>)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1477,20 +1262,17 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (values, vectors) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.eig(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (values, vectors) = host.with_backend_session(|session| a.eig(session))?;
     /// assert_eq!(values.shape(), &[2]);
     /// assert_eq!(vectors.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eig<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedEig<T>>;
+    fn eig(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedEig<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns incompatible-input/flag validation, backend, singular, or typed-output errors.
@@ -1498,29 +1280,24 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 1.0, 3.0])?;
     /// # let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 1], vec![4.0, 9.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let x = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         a.triangular_solve(&b, true, false, false, false, backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let x = host.with_backend_session(|session| { a.triangular_solve(&b, true, false, false, false, session) })?;
     /// assert_eq!(x.shape(), &[2, 1]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn triangular_solve<B: LinalgBackend>(
+    fn triangular_solve(
         &self,
         b: &TypedTensor<T>,
         left_side: bool,
         lower: bool,
         transpose_a: bool,
         unit_diagonal: bool,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1528,22 +1305,19 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let (sign, logabsdet) = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.slogdet(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let (sign, logabsdet) = host.with_backend_session(|session| a.slogdet(session))?;
     /// assert_eq!(sign.as_slice()?, &[1.0]);
     /// assert_eq!(logabsdet.shape(), &[]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn slogdet<B: LinalgBackend>(
+    fn slogdet(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<<T as TensorScalar>::Real>)>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1551,59 +1325,50 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let determinant = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.det(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let determinant = host.with_backend_session(|session| a.det(session))?;
     /// assert!((determinant.as_slice()?[0] - 8.0).abs() < 1.0e-12);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn det<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn det(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, singular-solve, or typed-downcast errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let inverse = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.inv(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let inverse = host.with_backend_session(|session| a.inv(session))?;
     /// assert_eq!(inverse.as_slice()?, &[0.5, 0.0, 0.0, 0.25]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn inv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn inv(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, convergence, output-contract, or typed-downcast errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 3.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let values = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.eigvalsh(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let values = host.with_backend_session(|session| a.eigvalsh(session))?;
     /// assert_eq!(values.as_slice()?, &[1.0, 3.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eigvalsh<B: LinalgBackend>(
+    fn eigvalsh(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<<T as TensorScalar>::Real>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1611,21 +1376,18 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let values = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.eigvals(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let values = host.with_backend_session(|session| a.eigvals(session))?;
     /// assert_eq!(values.shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn eigvals<B: LinalgBackend>(
+    fn eigvals(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T::Complex>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1633,43 +1395,35 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let pseudoinverse = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.pinv(backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let pseudoinverse = host.with_backend_session(|session| a.pinv(session))?;
     /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn pinv(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns a validation error for invalid `rtol`, plus backend or typed-output errors.
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let pseudoinverse = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| {
-    ///         a.pinv_with_rtol(1.0e-12, backend)
-    ///     })
-    ///     .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let pseudoinverse = host.with_backend_session(|session| { a.pinv_with_rtol(1.0e-12, session) })?;
     /// assert_eq!(pseudoinverse.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn pinv_with_rtol<B: LinalgBackend>(
+    fn pinv_with_rtol(
         &self,
         rtol: f64,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
@@ -1677,495 +1431,596 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// # use tenferro_cpu::CpuBackend;
     /// # use tenferro_linalg::TypedTensorLinalgExt;
     /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
     /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![3.0, 0.0, 0.0, 4.0])?;
     /// # let mut host = CpuBackend::new();
-    /// let frobenius = host.with_backend_session(|session| {
-    ///     with_cpu_exec_session(session, |backend| a.norm(None, None, false, backend))
-    ///         .expect("CpuBackend must expose a CpuExecSession")
-    /// })?;
+    /// let frobenius = host.with_backend_session(|session| a.norm(None, None, false, session))?;
     /// assert_eq!(frobenius.shape(), &[]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn norm<B: LinalgBackend>(
+    fn norm(
         &self,
         ord: Option<f64>,
         dim: Option<&[usize]>,
         keepdim: bool,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<<T as TensorScalar>::Real>>;
 }
 
 impl TensorLinalgExt for Tensor {
-    fn svd<B: LinalgBackend>(
+    fn svd(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)> {
-        three(backend.svd(self)?, "svd")
+        with_linalg_backend(session, "svd", |backend| three(backend.svd(self)?, "svd"))
     }
-    fn svd_with_options<B: LinalgBackend>(
+    fn svd_with_options(
         &self,
         options: SvdOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)> {
-        three(backend.svd_with_options(self, options)?, "svd_with_options")
+        with_linalg_backend(session, "svd_with_options", |backend| {
+            three(backend.svd_with_options(self, options)?, "svd_with_options")
+        })
     }
-    fn qr<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)> {
-        two(backend.qr(self)?, "qr")
+    fn qr(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        with_linalg_backend(session, "qr", |backend| two(backend.qr(self)?, "qr"))
     }
-    fn qr_with_options<B: LinalgBackend>(
+    fn qr_with_options(
         &self,
         options: QrOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
-        two(backend.qr_with_options(self, options)?, "qr_with_options")
+        with_linalg_backend(session, "qr_with_options", |backend| {
+            two(backend.qr_with_options(self, options)?, "qr_with_options")
+        })
     }
-    fn lu<B: LinalgBackend>(
+    fn lu(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor)> {
-        four(backend.lu(self)?, "lu")
+        with_linalg_backend(session, "lu", |backend| four(backend.lu(self)?, "lu"))
     }
-    fn full_piv_lu<B: LinalgBackend>(
+    fn full_piv_lu(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)> {
-        five(backend.full_piv_lu(self)?, "full_piv_lu")
+        with_linalg_backend(session, "full_piv_lu", |backend| {
+            five(backend.full_piv_lu(self)?, "full_piv_lu")
+        })
     }
-    fn full_piv_lu_solve<B: LinalgBackend>(
+    fn full_piv_lu_solve(
         &self,
         b: &Tensor,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        backend.full_piv_lu_solve(self, b, false)
+        with_linalg_backend(session, "full_piv_lu_solve", |backend| {
+            backend.full_piv_lu_solve(self, b, false)
+        })
     }
-    fn solve<B: LinalgBackend>(
+    fn solve(
         &self,
         b: &Tensor,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        backend.solve(self, b)
+        with_linalg_backend(session, "solve", |backend| backend.solve(self, b))
     }
-    fn cholesky<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        backend.cholesky(self)
+    fn cholesky(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor> {
+        with_linalg_backend(session, "cholesky", |backend| backend.cholesky(self))
     }
-    fn eigh<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)> {
-        two(backend.eigh(self)?, "eigh")
+    fn eigh(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        with_linalg_backend(session, "eigh", |backend| two(backend.eigh(self)?, "eigh"))
     }
-    fn eigh_with_options<B: LinalgBackend>(
+    fn eigh_with_options(
         &self,
         options: EighOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
-        two(
-            backend.eigh_with_options(self, options)?,
-            "eigh_with_options",
-        )
+        with_linalg_backend(session, "eigh_with_options", |backend| {
+            two(
+                backend.eigh_with_options(self, options)?,
+                "eigh_with_options",
+            )
+        })
     }
-    fn eig<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)> {
-        two(backend.eig(self)?, "eig")
+    fn eig(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        with_linalg_backend(session, "eig", |backend| two(backend.eig(self)?, "eig"))
     }
-    fn triangular_solve<B: LinalgBackend>(
+    fn triangular_solve(
         &self,
         b: &Tensor,
         left_side: bool,
         lower: bool,
         transpose_a: bool,
         unit_diagonal: bool,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        backend.triangular_solve(self, b, left_side, lower, transpose_a, unit_diagonal)
+        with_linalg_backend(session, "triangular_solve", |backend| {
+            backend.triangular_solve(self, b, left_side, lower, transpose_a, unit_diagonal)
+        })
     }
-    fn slogdet<B: LinalgBackend>(
+    fn slogdet(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
-        slogdet_from_lu(four(backend.lu(self)?, "slogdet")?, backend)
+        with_linalg_backend(session, "slogdet", |backend| {
+            slogdet_from_lu(four(backend.lu(self)?, "slogdet")?, backend)
+        })
     }
-    fn det<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        det_impl(self.slogdet(backend)?, backend)
+    fn det(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor> {
+        with_linalg_backend(session, "det", |backend| {
+            det_impl(self.slogdet(backend)?, backend)
+        })
     }
-    fn inv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        inv_owned(self, backend)
+    fn inv(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor> {
+        with_linalg_backend(session, "inv", |backend| inv_owned(self, backend))
     }
-    fn eigvalsh<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        Ok(self.eigh(backend)?.0)
+    fn eigvalsh(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor> {
+        with_linalg_backend(session, "eigvalsh", |backend| Ok(self.eigh(backend)?.0))
     }
-    fn eigvals<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        backend.eig_values(self)
+    fn eigvals(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor> {
+        with_linalg_backend(session, "eigvals", |backend| backend.eig_values(self))
     }
-    fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        pinv_owned(self, None, backend)
+    fn pinv(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor> {
+        with_linalg_backend(session, "pinv", |backend| pinv_owned(self, None, backend))
     }
-    fn pinv_with_rtol<B: LinalgBackend>(
+    fn pinv_with_rtol(
         &self,
         rtol: f64,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        pinv_owned(self, Some(rtol), backend)
+        with_linalg_backend(session, "pinv_with_rtol", |backend| {
+            pinv_owned(self, Some(rtol), backend)
+        })
     }
-    fn norm<B: LinalgBackend>(
+    fn norm(
         &self,
         ord: Option<f64>,
         dim: Option<&[usize]>,
         keepdim: bool,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        norm_from_read(TensorRead::from_tensor(self), ord, dim, keepdim, backend)
+        with_linalg_backend(session, "norm", |backend| {
+            norm_from_read(TensorRead::from_tensor(self), ord, dim, keepdim, backend)
+        })
     }
 }
 
 impl TensorReadLinalgExt for TensorRead<'_> {
-    fn svd_read<B: LinalgBackend>(
+    fn svd_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)> {
-        three(backend.svd_read(self)?, "svd_read")
+        with_linalg_backend(session, "svd_read", |backend| {
+            three(backend.svd_read(self)?, "svd_read")
+        })
     }
-    fn svd_with_options_read<B: LinalgBackend>(
+    fn svd_with_options_read(
         self,
         options: SvdOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)> {
-        validate_derivative_eps("svd_with_options_read", options.derivative_eps)?;
-        let mut out = backend.svd_read(self)?;
-        apply_svd_gauge(options.gauge, &mut out)?;
-        three(out, "svd_with_options_read")
+        with_linalg_backend(session, "svd_with_options_read", |backend| {
+            validate_derivative_eps("svd_with_options_read", options.derivative_eps)?;
+            let mut out = backend.svd_read(self)?;
+            apply_svd_gauge(options.gauge, &mut out)?;
+            three(out, "svd_with_options_read")
+        })
     }
-    fn qr_read<B: LinalgBackend>(
+    fn qr_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
-        two(backend.qr_read(self)?, "qr_read")
+        with_linalg_backend(session, "qr_read", |backend| {
+            two(backend.qr_read(self)?, "qr_read")
+        })
     }
-    fn qr_with_options_read<B: LinalgBackend>(
+    fn qr_with_options_read(
         self,
         options: QrOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
-        let mut out = backend.qr_read(self)?;
-        apply_qr_gauge(options.gauge, &mut out)?;
-        two(out, "qr_with_options_read")
+        with_linalg_backend(session, "qr_with_options_read", |backend| {
+            let mut out = backend.qr_read(self)?;
+            apply_qr_gauge(options.gauge, &mut out)?;
+            two(out, "qr_with_options_read")
+        })
     }
-    fn lu_read<B: LinalgBackend>(
+    fn lu_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor)> {
-        four(backend.lu_read(self)?, "lu_read")
+        with_linalg_backend(session, "lu_read", |backend| {
+            four(backend.lu_read(self)?, "lu_read")
+        })
     }
-    fn full_piv_lu_read<B: LinalgBackend>(
+    fn full_piv_lu_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)> {
-        five(backend.full_piv_lu_read(self)?, "full_piv_lu_read")
+        with_linalg_backend(session, "full_piv_lu_read", |backend| {
+            five(backend.full_piv_lu_read(self)?, "full_piv_lu_read")
+        })
     }
-    fn full_piv_lu_solve_read<B: LinalgBackend>(
+    fn full_piv_lu_solve_read(
         self,
         b: TensorRead<'_>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        let b_is_vector = b.shape().len() + 1 == self.shape().len();
-        let original_b_shape = b.shape().to_vec();
-        let vector_as_matrix = if b_is_vector {
-            let mut shape = vec![b.shape()[0], 1];
-            shape.extend_from_slice(&b.shape()[1..]);
-            Some(backend.reshape_read(b.clone(), &shape)?)
-        } else {
-            None
-        };
-        let b = vector_as_matrix.as_ref().map_or(b, TensorRead::from_tensor);
-        let (p, l, u, q, _parity) = self.full_piv_lu_read(backend)?;
-        let pb = linalg_matmul_read(&p, b, false, backend)?;
-        let z = backend.triangular_solve_read(
-            TensorRead::from_tensor(&l),
-            TensorRead::from_tensor(&pb),
-            true,
-            true,
-            false,
-            true,
-        )?;
-        let w = backend.triangular_solve_read(
-            TensorRead::from_tensor(&u),
-            TensorRead::from_tensor(&z),
-            true,
-            false,
-            false,
-            false,
-        )?;
-        let mut perm: Vec<usize> = (0..q.shape().len()).collect();
-        perm.swap(0, 1);
-        let qt = transpose(&q, &perm, backend)?;
-        let solution = linalg_matmul_read(&qt, TensorRead::from_tensor(&w), false, backend)?;
-        if b_is_vector {
-            reshape(&solution, &original_b_shape, backend)
-        } else {
-            Ok(solution)
-        }
+        with_linalg_backend(session, "full_piv_lu_solve_read", |backend| {
+            let b_is_vector = b.shape().len() + 1 == self.shape().len();
+            let original_b_shape = b.shape().to_vec();
+            let vector_as_matrix = if b_is_vector {
+                let mut shape = vec![b.shape()[0], 1];
+                shape.extend_from_slice(&b.shape()[1..]);
+                Some(backend.reshape_read(b.clone(), &shape)?)
+            } else {
+                None
+            };
+            let b = vector_as_matrix.as_ref().map_or(b, TensorRead::from_tensor);
+            let (p, l, u, q, _parity) = self.full_piv_lu_read(backend)?;
+            let pb = linalg_matmul_read(&p, b, false, backend)?;
+            let z = backend.triangular_solve_read(
+                TensorRead::from_tensor(&l),
+                TensorRead::from_tensor(&pb),
+                true,
+                true,
+                false,
+                true,
+            )?;
+            let w = backend.triangular_solve_read(
+                TensorRead::from_tensor(&u),
+                TensorRead::from_tensor(&z),
+                true,
+                false,
+                false,
+                false,
+            )?;
+            let mut perm: Vec<usize> = (0..q.shape().len()).collect();
+            perm.swap(0, 1);
+            let qt = transpose(&q, &perm, backend)?;
+            let solution = linalg_matmul_read(&qt, TensorRead::from_tensor(&w), false, backend)?;
+            if b_is_vector {
+                reshape(&solution, &original_b_shape, backend)
+            } else {
+                Ok(solution)
+            }
+        })
     }
-    fn solve_read<B: LinalgBackend>(
+    fn solve_read(
         self,
         b: TensorRead<'_>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        backend.solve_read(self, b)
+        with_linalg_backend(session, "solve_read", |backend| backend.solve_read(self, b))
     }
-    fn solve_read_into<B: LinalgBackend>(
+    fn solve_read_into(
         self,
         b: TensorRead<'_>,
         out: TensorWrite<'_>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<()> {
-        backend.solve_read_into(self, b, out)
+        with_linalg_backend(session, "solve_read_into", |backend| {
+            backend.solve_read_into(self, b, out)
+        })
     }
-    fn cholesky_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        backend.cholesky_read(self)
+    fn cholesky_read(self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor> {
+        with_linalg_backend(session, "cholesky_read", |backend| {
+            backend.cholesky_read(self)
+        })
     }
-    fn eigh_read<B: LinalgBackend>(
+    fn eigh_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
-        two(backend.eigh_read(self)?, "eigh_read")
+        with_linalg_backend(session, "eigh_read", |backend| {
+            two(backend.eigh_read(self)?, "eigh_read")
+        })
     }
-    fn eigh_with_options_read<B: LinalgBackend>(
+    fn eigh_with_options_read(
         self,
         options: EighOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
-        validate_derivative_eps("eigh_with_options_read", options.derivative_eps)?;
-        let mut out = backend.eigh_read(self)?;
-        apply_eigh_gauge(options.gauge, &mut out)?;
-        two(out, "eigh_with_options_read")
+        with_linalg_backend(session, "eigh_with_options_read", |backend| {
+            validate_derivative_eps("eigh_with_options_read", options.derivative_eps)?;
+            let mut out = backend.eigh_read(self)?;
+            apply_eigh_gauge(options.gauge, &mut out)?;
+            two(out, "eigh_with_options_read")
+        })
     }
-    fn eig_read<B: LinalgBackend>(
+    fn eig_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
-        two(backend.eig_read(self)?, "eig_read")
+        with_linalg_backend(session, "eig_read", |backend| {
+            two(backend.eig_read(self)?, "eig_read")
+        })
     }
-    fn triangular_solve_read<B: LinalgBackend>(
+    fn triangular_solve_read(
         self,
         b: TensorRead<'_>,
         left_side: bool,
         lower: bool,
         transpose_a: bool,
         unit_diagonal: bool,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        backend.triangular_solve_read(self, b, left_side, lower, transpose_a, unit_diagonal)
+        with_linalg_backend(session, "triangular_solve_read", |backend| {
+            backend.triangular_solve_read(self, b, left_side, lower, transpose_a, unit_diagonal)
+        })
     }
-    fn slogdet_read<B: LinalgBackend>(
+    fn slogdet_read(
         self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
-        slogdet_from_lu(four(backend.lu_read(self)?, "slogdet_read")?, backend)
+        with_linalg_backend(session, "slogdet_read", |backend| {
+            slogdet_from_lu(four(backend.lu_read(self)?, "slogdet_read")?, backend)
+        })
     }
-    fn det_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        det_impl(self.slogdet_read(backend)?, backend)
+    fn det_read(self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor> {
+        with_linalg_backend(session, "det_read", |backend| {
+            det_impl(self.slogdet_read(backend)?, backend)
+        })
     }
-    fn inv_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        inv_read(self, backend)
+    fn inv_read(self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor> {
+        with_linalg_backend(session, "inv_read", |backend| inv_read(self, backend))
     }
-    fn eigvalsh_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        Ok(self.eigh_read(backend)?.0)
+    fn eigvalsh_read(self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor> {
+        with_linalg_backend(session, "eigvalsh_read", |backend| {
+            Ok(self.eigh_read(backend)?.0)
+        })
     }
-    fn eigvals_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        Ok(self.eig_read(backend)?.0)
+    fn eigvals_read(self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor> {
+        with_linalg_backend(session, "eigvals_read", |backend| {
+            Ok(self.eig_read(backend)?.0)
+        })
     }
-    fn pinv_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
-        pinv_read(self, None, backend)
+    fn pinv_read(self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<Tensor> {
+        with_linalg_backend(session, "pinv_read", |backend| {
+            pinv_read(self, None, backend)
+        })
     }
-    fn pinv_with_rtol_read<B: LinalgBackend>(
+    fn pinv_with_rtol_read(
         self,
         rtol: f64,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        pinv_read(self, Some(rtol), backend)
+        with_linalg_backend(session, "pinv_with_rtol_read", |backend| {
+            pinv_read(self, Some(rtol), backend)
+        })
     }
-    fn norm_read<B: LinalgBackend>(
+    fn norm_read(
         self,
         ord: Option<f64>,
         dim: Option<&[usize]>,
         keepdim: bool,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<Tensor> {
-        norm_from_read(self, ord, dim, keepdim, backend)
+        with_linalg_backend(session, "norm_read", |backend| {
+            norm_from_read(self, ord, dim, keepdim, backend)
+        })
     }
 }
 
 impl<T: LinalgScalar> TypedTensorLinalgExt<T> for TypedTensor<T> {
-    fn svd<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedSvd<T>> {
-        typed_svd(T::tensor_read(self).svd_read(backend)?)
+    fn svd(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedSvd<T>> {
+        with_linalg_backend(session, "svd", |backend| {
+            typed_svd(T::tensor_read(self).svd_read(backend)?)
+        })
     }
 
-    fn svd_with_options<B: LinalgBackend>(
+    fn svd_with_options(
         &self,
         options: SvdOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedSvd<T>> {
-        typed_svd(T::tensor_read(self).svd_with_options_read(options, backend)?)
+        with_linalg_backend(session, "svd_with_options", |backend| {
+            typed_svd(T::tensor_read(self).svd_with_options_read(options, backend)?)
+        })
     }
 
-    fn qr<B: LinalgBackend>(
+    fn qr(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)> {
-        typed_pair_same(T::tensor_read(self).qr_read(backend)?)
+        with_linalg_backend(session, "qr", |backend| {
+            typed_pair_same(T::tensor_read(self).qr_read(backend)?)
+        })
     }
 
-    fn qr_with_options<B: LinalgBackend>(
+    fn qr_with_options(
         &self,
         options: QrOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)> {
-        typed_pair_same(T::tensor_read(self).qr_with_options_read(options, backend)?)
+        with_linalg_backend(session, "qr_with_options", |backend| {
+            typed_pair_same(T::tensor_read(self).qr_with_options_read(options, backend)?)
+        })
     }
 
-    fn lu<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedLu<T>> {
-        let (p, l, u, parity) = T::tensor_read(self).lu_read(backend)?;
-        Ok((
-            typed_output::<T>(p)?,
-            typed_output::<T>(l)?,
-            typed_output::<T>(u)?,
-            typed_output::<<T as TensorScalar>::Real>(parity)?,
-        ))
+    fn lu(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedLu<T>> {
+        with_linalg_backend(session, "lu", |backend| {
+            let (p, l, u, parity) = T::tensor_read(self).lu_read(backend)?;
+            Ok((
+                typed_output::<T>(p)?,
+                typed_output::<T>(l)?,
+                typed_output::<T>(u)?,
+                typed_output::<<T as TensorScalar>::Real>(parity)?,
+            ))
+        })
     }
 
-    fn full_piv_lu_solve<B: LinalgBackend>(
+    fn full_piv_lu_solve(
         &self,
         b: &TypedTensor<T>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T>> {
-        typed_output::<T>(T::tensor_read(self).full_piv_lu_solve_read(T::tensor_read(b), backend)?)
+        with_linalg_backend(session, "full_piv_lu_solve", |backend| {
+            typed_output::<T>(
+                T::tensor_read(self).full_piv_lu_solve_read(T::tensor_read(b), backend)?,
+            )
+        })
     }
 
-    fn full_piv_lu<B: LinalgBackend>(
+    fn full_piv_lu(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedFullPivLu<T>> {
-        let (p, l, u, q, parity) = T::tensor_read(self).full_piv_lu_read(backend)?;
-        Ok((
-            typed_output::<T>(p)?,
-            typed_output::<T>(l)?,
-            typed_output::<T>(u)?,
-            typed_output::<T>(q)?,
-            typed_output::<<T as TensorScalar>::Real>(parity)?,
-        ))
+        with_linalg_backend(session, "full_piv_lu", |backend| {
+            let (p, l, u, q, parity) = T::tensor_read(self).full_piv_lu_read(backend)?;
+            Ok((
+                typed_output::<T>(p)?,
+                typed_output::<T>(l)?,
+                typed_output::<T>(u)?,
+                typed_output::<T>(q)?,
+                typed_output::<<T as TensorScalar>::Real>(parity)?,
+            ))
+        })
     }
 
-    fn solve<B: LinalgBackend>(
+    fn solve(
         &self,
         b: &TypedTensor<T>,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T>> {
-        typed_output::<T>(T::tensor_read(self).solve_read(T::tensor_read(b), backend)?)
+        with_linalg_backend(session, "solve", |backend| {
+            typed_output::<T>(T::tensor_read(self).solve_read(T::tensor_read(b), backend)?)
+        })
     }
 
-    fn cholesky<B: LinalgBackend>(
+    fn cholesky(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T>> {
-        typed_output::<T>(T::tensor_read(self).cholesky_read(backend)?)
+        with_linalg_backend(session, "cholesky", |backend| {
+            typed_output::<T>(T::tensor_read(self).cholesky_read(backend)?)
+        })
     }
 
-    fn eigh<B: LinalgBackend>(
+    fn eigh(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(TypedTensor<<T as TensorScalar>::Real>, TypedTensor<T>)> {
-        typed_eigh(T::tensor_read(self).eigh_read(backend)?)
+        with_linalg_backend(session, "eigh", |backend| {
+            typed_eigh(T::tensor_read(self).eigh_read(backend)?)
+        })
     }
 
-    fn eigh_with_options<B: LinalgBackend>(
+    fn eigh_with_options(
         &self,
         options: EighOptions,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(TypedTensor<<T as TensorScalar>::Real>, TypedTensor<T>)> {
-        typed_eigh(T::tensor_read(self).eigh_with_options_read(options, backend)?)
+        with_linalg_backend(session, "eigh_with_options", |backend| {
+            typed_eigh(T::tensor_read(self).eigh_with_options_read(options, backend)?)
+        })
     }
 
-    fn eig<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedEig<T>> {
-        let (values, vectors) = T::tensor_read(self).eig_read(backend)?;
-        Ok((
-            typed_output::<T::Complex>(values)?,
-            typed_output::<T::Complex>(vectors)?,
-        ))
+    fn eig(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedEig<T>> {
+        with_linalg_backend(session, "eig", |backend| {
+            let (values, vectors) = T::tensor_read(self).eig_read(backend)?;
+            Ok((
+                typed_output::<T::Complex>(values)?,
+                typed_output::<T::Complex>(vectors)?,
+            ))
+        })
     }
 
-    fn triangular_solve<B: LinalgBackend>(
+    fn triangular_solve(
         &self,
         b: &TypedTensor<T>,
         left_side: bool,
         lower: bool,
         transpose_a: bool,
         unit_diagonal: bool,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T>> {
-        typed_output::<T>(T::tensor_read(self).triangular_solve_read(
-            T::tensor_read(b),
-            left_side,
-            lower,
-            transpose_a,
-            unit_diagonal,
-            backend,
-        )?)
+        with_linalg_backend(session, "triangular_solve", |backend| {
+            typed_output::<T>(T::tensor_read(self).triangular_solve_read(
+                T::tensor_read(b),
+                left_side,
+                lower,
+                transpose_a,
+                unit_diagonal,
+                backend,
+            )?)
+        })
     }
 
-    fn slogdet<B: LinalgBackend>(
+    fn slogdet(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<<T as TensorScalar>::Real>)> {
-        let (sign, logabsdet) = T::tensor_read(self).slogdet_read(backend)?;
-        Ok((
-            typed_output::<T>(sign)?,
-            typed_output::<<T as TensorScalar>::Real>(logabsdet)?,
-        ))
+        with_linalg_backend(session, "slogdet", |backend| {
+            let (sign, logabsdet) = T::tensor_read(self).slogdet_read(backend)?;
+            Ok((
+                typed_output::<T>(sign)?,
+                typed_output::<<T as TensorScalar>::Real>(logabsdet)?,
+            ))
+        })
     }
 
-    fn det<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>> {
-        typed_output::<T>(T::tensor_read(self).det_read(backend)?)
+    fn det(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>> {
+        with_linalg_backend(session, "det", |backend| {
+            typed_output::<T>(T::tensor_read(self).det_read(backend)?)
+        })
     }
 
-    fn inv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>> {
-        typed_output::<T>(T::tensor_read(self).inv_read(backend)?)
+    fn inv(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>> {
+        with_linalg_backend(session, "inv", |backend| {
+            typed_output::<T>(T::tensor_read(self).inv_read(backend)?)
+        })
     }
 
-    fn eigvalsh<B: LinalgBackend>(
+    fn eigvalsh(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<<T as TensorScalar>::Real>> {
-        typed_output::<<T as TensorScalar>::Real>(T::tensor_read(self).eigvalsh_read(backend)?)
+        with_linalg_backend(session, "eigvalsh", |backend| {
+            typed_output::<<T as TensorScalar>::Real>(T::tensor_read(self).eigvalsh_read(backend)?)
+        })
     }
 
-    fn eigvals<B: LinalgBackend>(
+    fn eigvals(
         &self,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T::Complex>> {
-        typed_output::<T::Complex>(T::tensor_read(self).eigvals_read(backend)?)
+        with_linalg_backend(session, "eigvals", |backend| {
+            typed_output::<T::Complex>(T::tensor_read(self).eigvals_read(backend)?)
+        })
     }
 
-    fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>> {
-        typed_output::<T>(T::tensor_read(self).pinv_read(backend)?)
+    fn pinv(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedTensor<T>> {
+        with_linalg_backend(session, "pinv", |backend| {
+            typed_output::<T>(T::tensor_read(self).pinv_read(backend)?)
+        })
     }
 
-    fn pinv_with_rtol<B: LinalgBackend>(
+    fn pinv_with_rtol(
         &self,
         rtol: f64,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<T>> {
-        typed_output::<T>(T::tensor_read(self).pinv_with_rtol_read(rtol, backend)?)
+        with_linalg_backend(session, "pinv_with_rtol", |backend| {
+            typed_output::<T>(T::tensor_read(self).pinv_with_rtol_read(rtol, backend)?)
+        })
     }
 
-    fn norm<B: LinalgBackend>(
+    fn norm(
         &self,
         ord: Option<f64>,
         dim: Option<&[usize]>,
         keepdim: bool,
-        backend: &mut B,
+        session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<TypedTensor<<T as TensorScalar>::Real>> {
-        typed_output::<<T as TensorScalar>::Real>(
-            T::tensor_read(self).norm_read(ord, dim, keepdim, backend)?,
-        )
+        with_linalg_backend(session, "norm", |backend| {
+            typed_output::<<T as TensorScalar>::Real>(
+                T::tensor_read(self).norm_read(ord, dim, keepdim, backend)?,
+            )
+        })
     }
 }
 
@@ -2191,6 +2046,39 @@ fn typed_eigh<T: LinalgScalar>(
     Ok((
         typed_output::<<T as TensorScalar>::Real>(values)?,
         typed_output::<T>(vectors)?,
+    ))
+}
+
+/// Run a concrete linalg body against the built-in linalg execution sessions
+/// (CPU/CUDA) carried by `session`, returning a typed capability error when
+/// the session does not expose a linalg execution capability.
+///
+/// This is the built-in dispatch shared by the concrete linalg surface;
+/// callers never downcast themselves (issue #1680 Phase 3). Third-party
+/// [`LinalgBackend`] implementations remain supported through the SPI trait,
+/// but the concrete op path is built-in-session only. The composite bodies
+/// run on the borrowed `&mut dyn LinalgBackend` exactly as before.
+fn with_linalg_backend<X>(
+    session: &mut dyn BackendSession,
+    op: &'static str,
+    f: impl FnOnce(&mut dyn LinalgBackend) -> tenferro_tensor::Result<X>,
+) -> tenferro_tensor::Result<X> {
+    // The capability branches are mutually exclusive, so `f` runs exactly
+    // once. Probe the marker first, then re-extract the same exec session and
+    // run the composite body on it (FnOnce cannot be captured by several
+    // branch closures).
+    if with_cpu_exec_session(session, |_| ()).is_some() {
+        return with_cpu_exec_session(session, |exec| f(exec as &mut dyn LinalgBackend))
+            .expect("marker probe matched a CPU execution session");
+    }
+    #[cfg(feature = "cuda")]
+    if with_cuda_exec_session(session, |_| ()).is_some() {
+        return with_cuda_exec_session(session, |exec| f(exec as &mut dyn LinalgBackend))
+            .expect("marker probe matched a CUDA execution session");
+    }
+    Err(tenferro_tensor::Error::unsupported(
+        op,
+        "selected backend session does not expose a linalg execution capability",
     ))
 }
 
@@ -2260,7 +2148,7 @@ fn five(
 
 // Composite implementations are kept below the surface adapters so every
 // backend-visible operation remains explicit and testable.
-fn slogdet_from_lu<B: LinalgBackend>(
+fn slogdet_from_lu<B: LinalgBackend + ?Sized>(
     (_p, _l, u, parity): (Tensor, Tensor, Tensor, Tensor),
     backend: &mut B,
 ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
@@ -2276,7 +2164,7 @@ fn slogdet_from_lu<B: LinalgBackend>(
     let logabsdet = backend.reduce_sum_read(TensorRead::from_tensor(&log), &[0])?;
     Ok((sign, logabsdet))
 }
-fn det_impl<B: LinalgBackend>(
+fn det_impl<B: LinalgBackend + ?Sized>(
     (sign, logabsdet): (Tensor, Tensor),
     backend: &mut B,
 ) -> tenferro_tensor::Result<Tensor> {
@@ -2286,18 +2174,21 @@ fn det_impl<B: LinalgBackend>(
         TensorRead::from_tensor(&magnitude),
     )
 }
-fn inv_owned<B: LinalgBackend>(a: &Tensor, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+fn inv_owned<B: LinalgBackend + ?Sized>(
+    a: &Tensor,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
     let eye = eye_like(a.dtype(), a.shape(), backend)?;
     backend.solve(a, &eye)
 }
-fn inv_read<B: LinalgBackend>(
+fn inv_read<B: LinalgBackend + ?Sized>(
     a: TensorRead<'_>,
     backend: &mut B,
 ) -> tenferro_tensor::Result<Tensor> {
     let eye = eye_like(a.dtype(), a.shape(), backend)?;
     backend.solve_read(a, TensorRead::from_tensor(&eye))
 }
-fn pinv_owned<B: LinalgBackend>(
+fn pinv_owned<B: LinalgBackend + ?Sized>(
     a: &Tensor,
     rtol: Option<f64>,
     backend: &mut B,
@@ -2310,7 +2201,7 @@ fn pinv_owned<B: LinalgBackend>(
         backend,
     )
 }
-fn pinv_read<B: LinalgBackend>(
+fn pinv_read<B: LinalgBackend + ?Sized>(
     a: TensorRead<'_>,
     rtol: Option<f64>,
     backend: &mut B,
@@ -2320,7 +2211,7 @@ fn pinv_read<B: LinalgBackend>(
     let outputs = three(backend.svd_read(a)?, "pinv_read")?;
     pinv_from_svd(outputs, rtol.unwrap_or(default_rtol), backend)
 }
-fn norm_from_read<B: LinalgBackend>(
+fn norm_from_read<B: LinalgBackend + ?Sized>(
     input: TensorRead<'_>,
     ord: Option<f64>,
     dim: Option<&[usize]>,
@@ -2367,7 +2258,7 @@ fn scalar_real(dtype: DType, value: f64) -> tenferro_tensor::Result<Tensor> {
     }
 }
 
-fn broadcast<B: LinalgBackend>(
+fn broadcast<B: LinalgBackend + ?Sized>(
     input: &Tensor,
     shape: &[usize],
     dims: &[usize],
@@ -2379,7 +2270,7 @@ fn broadcast<B: LinalgBackend>(
     backend.broadcast_in_dim_read(TensorRead::from_tensor(input), shape, dims)
 }
 
-fn eye_like<B: LinalgBackend>(
+fn eye_like<B: LinalgBackend + ?Sized>(
     dtype: DType,
     shape: &[usize],
     backend: &mut B,
@@ -2434,7 +2325,7 @@ fn default_pinv_rtol(dtype: DType, shape: &[usize]) -> f64 {
     eps * max_dim as f64
 }
 
-fn pinv_from_svd<B: LinalgBackend>(
+fn pinv_from_svd<B: LinalgBackend + ?Sized>(
     (u, s, vt): (Tensor, Tensor, Tensor),
     rtol: f64,
     backend: &mut B,
@@ -2466,12 +2357,15 @@ fn pinv_from_svd<B: LinalgBackend>(
     matmul_preserve_trailing_batch(&vs, &uh, backend)
 }
 
-fn ones_like<B: LinalgBackend>(input: &Tensor, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+fn ones_like<B: LinalgBackend + ?Sized>(
+    input: &Tensor,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
     let one = scalar_real(input.dtype(), 1.0)?;
     broadcast(&one, input.shape(), &[], backend)
 }
 
-fn binary_add<B: LinalgBackend>(
+fn binary_add<B: LinalgBackend + ?Sized>(
     lhs: &Tensor,
     rhs: &Tensor,
     backend: &mut B,
@@ -2479,7 +2373,7 @@ fn binary_add<B: LinalgBackend>(
     backend.add_read(TensorRead::from_tensor(lhs), TensorRead::from_tensor(rhs))
 }
 
-fn binary_mul<B: LinalgBackend>(
+fn binary_mul<B: LinalgBackend + ?Sized>(
     lhs: &Tensor,
     rhs: &Tensor,
     backend: &mut B,
@@ -2487,7 +2381,7 @@ fn binary_mul<B: LinalgBackend>(
     backend.mul_read(TensorRead::from_tensor(lhs), TensorRead::from_tensor(rhs))
 }
 
-fn reduce_max<B: LinalgBackend>(
+fn reduce_max<B: LinalgBackend + ?Sized>(
     input: &Tensor,
     axes: &[usize],
     backend: &mut B,
@@ -2495,7 +2389,7 @@ fn reduce_max<B: LinalgBackend>(
     backend.reduce_max_read(TensorRead::from_tensor(input), axes)
 }
 
-fn reduce_sum<B: LinalgBackend>(
+fn reduce_sum<B: LinalgBackend + ?Sized>(
     input: &Tensor,
     axes: &[usize],
     backend: &mut B,
@@ -2503,7 +2397,7 @@ fn reduce_sum<B: LinalgBackend>(
     backend.reduce_sum_read(TensorRead::from_tensor(input), axes)
 }
 
-fn reduce_min<B: LinalgBackend>(
+fn reduce_min<B: LinalgBackend + ?Sized>(
     input: &Tensor,
     axes: &[usize],
     backend: &mut B,
@@ -2511,7 +2405,7 @@ fn reduce_min<B: LinalgBackend>(
     backend.reduce_min_read(TensorRead::from_tensor(input), axes)
 }
 
-fn reshape<B: LinalgBackend>(
+fn reshape<B: LinalgBackend + ?Sized>(
     input: &Tensor,
     shape: &[usize],
     backend: &mut B,
@@ -2519,7 +2413,7 @@ fn reshape<B: LinalgBackend>(
     backend.reshape_read(TensorRead::from_tensor(input), shape)
 }
 
-fn transpose<B: LinalgBackend>(
+fn transpose<B: LinalgBackend + ?Sized>(
     input: &Tensor,
     perm: &[usize],
     backend: &mut B,
@@ -2527,7 +2421,7 @@ fn transpose<B: LinalgBackend>(
     backend.transpose_read(TensorRead::from_tensor(input), perm)
 }
 
-fn broadcast_batch_scalar_to_leading_axis<B: LinalgBackend>(
+fn broadcast_batch_scalar_to_leading_axis<B: LinalgBackend + ?Sized>(
     input: &Tensor,
     shape: &[usize],
     backend: &mut B,
@@ -2536,7 +2430,7 @@ fn broadcast_batch_scalar_to_leading_axis<B: LinalgBackend>(
     broadcast(input, shape, &dims, backend)
 }
 
-fn conjugate_transpose<B: LinalgBackend>(
+fn conjugate_transpose<B: LinalgBackend + ?Sized>(
     input: &Tensor,
     backend: &mut B,
 ) -> tenferro_tensor::Result<Tensor> {
@@ -2546,7 +2440,7 @@ fn conjugate_transpose<B: LinalgBackend>(
     transpose(&conj, &perm, backend)
 }
 
-fn scale_matrix_columns<B: LinalgBackend>(
+fn scale_matrix_columns<B: LinalgBackend + ?Sized>(
     matrix: &Tensor,
     scale: &Tensor,
     backend: &mut B,
@@ -2559,7 +2453,7 @@ fn scale_matrix_columns<B: LinalgBackend>(
     binary_mul(matrix, &expanded, backend)
 }
 
-fn matmul_preserve_trailing_batch<B: LinalgBackend>(
+fn matmul_preserve_trailing_batch<B: LinalgBackend + ?Sized>(
     lhs: &Tensor,
     rhs: &Tensor,
     backend: &mut B,
@@ -2578,7 +2472,7 @@ fn matmul_preserve_trailing_batch<B: LinalgBackend>(
     )
 }
 
-fn linalg_matmul_read<B: LinalgBackend>(
+fn linalg_matmul_read<B: LinalgBackend + ?Sized>(
     lhs: &Tensor,
     rhs: TensorRead<'_>,
     rhs_is_vector: bool,
@@ -2596,7 +2490,7 @@ fn linalg_matmul_read<B: LinalgBackend>(
     backend.dot_general_read(TensorRead::from_tensor(lhs), rhs, &config)
 }
 
-fn frobenius_norm<B: LinalgBackend>(
+fn frobenius_norm<B: LinalgBackend + ?Sized>(
     abs: &Tensor,
     axes: &[usize],
     backend: &mut B,
@@ -2605,7 +2499,7 @@ fn frobenius_norm<B: LinalgBackend>(
     backend.sqrt_read(TensorRead::from_tensor(&sum))
 }
 
-fn frobenius_norm_read<B: LinalgBackend>(
+fn frobenius_norm_read<B: LinalgBackend + ?Sized>(
     input: TensorRead<'_>,
     axes: &[usize],
     backend: &mut B,
@@ -2614,7 +2508,7 @@ fn frobenius_norm_read<B: LinalgBackend>(
     backend.sqrt_read(TensorRead::from_tensor(&sum))
 }
 
-fn p_norm<B: LinalgBackend>(
+fn p_norm<B: LinalgBackend + ?Sized>(
     abs: &Tensor,
     axes: &[usize],
     p: f64,
@@ -2643,7 +2537,7 @@ fn p_norm<B: LinalgBackend>(
     )
 }
 
-fn count_nonzero<B: LinalgBackend>(
+fn count_nonzero<B: LinalgBackend + ?Sized>(
     abs: &Tensor,
     axes: &[usize],
     backend: &mut B,
@@ -2659,7 +2553,7 @@ fn count_nonzero<B: LinalgBackend>(
     reduce_sum(&mask, axes, backend)
 }
 
-fn norm_over_axes<B: LinalgBackend>(
+fn norm_over_axes<B: LinalgBackend + ?Sized>(
     abs: &Tensor,
     axes: &[usize],
     ord: Option<f64>,
@@ -2674,7 +2568,7 @@ fn norm_over_axes<B: LinalgBackend>(
     }
 }
 
-fn matrix_norm<B: LinalgBackend>(
+fn matrix_norm<B: LinalgBackend + ?Sized>(
     abs: &Tensor,
     axes: &[usize],
     ord: Option<f64>,
@@ -2700,7 +2594,7 @@ fn matrix_norm<B: LinalgBackend>(
     }
 }
 
-fn row_sum_norm<B: LinalgBackend>(
+fn row_sum_norm<B: LinalgBackend + ?Sized>(
     input: &Tensor,
     take_max: bool,
     backend: &mut B,
@@ -2713,7 +2607,7 @@ fn row_sum_norm<B: LinalgBackend>(
     }
 }
 
-fn col_sum_norm<B: LinalgBackend>(
+fn col_sum_norm<B: LinalgBackend + ?Sized>(
     input: &Tensor,
     take_max: bool,
     backend: &mut B,
@@ -2726,7 +2620,7 @@ fn col_sum_norm<B: LinalgBackend>(
     }
 }
 
-fn move_axes_to_front<B: LinalgBackend>(
+fn move_axes_to_front<B: LinalgBackend + ?Sized>(
     input: &Tensor,
     axes: &[usize],
     backend: &mut B,

--- a/crates/tenferro-linalg/tests/integration/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/integration/backend_errors.rs
@@ -281,26 +281,26 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
 
     let input =
         TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0]).unwrap();
-    let expected_eig_values = Tensor::C64(
-        TypedTensor::from_vec_col_major(
-            vec![2],
-            vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
-        )
-        .unwrap(),
-    );
     let mut backend = DefaultOnlyLinalgBackend {
-        eig_values_result: Some(expected_eig_values),
+        eig_values_result: None,
         eig_values_calls: 0,
     };
 
-    let eig_values = Tensor::F64(input.duplicate().unwrap())
+    // The concrete linalg traits dispatch internally to the built-in
+    // CPU/CUDA execution sessions; a session without a linalg capability
+    // returns a typed capability error instead of accepting the arbitrary
+    // backend (issue #1680 Phase 3). The custom backend here is SPI-only.
+    let error = Tensor::F64(input.duplicate().unwrap())
         .eigvals(&mut backend)
-        .unwrap();
-    assert_eq!(backend.eig_values_calls, 1);
-    assert_eq!(
-        c64_values(&eig_values),
-        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)]
-    );
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::Unsupported {
+            op: "eigvals",
+            ref message,
+        } if message.contains("does not expose a linalg execution capability")
+    ));
+    assert_eq!(backend.eig_values_calls, 0);
 
     let err = backend
         .lu_factor(&Tensor::F64(input.duplicate().unwrap()))

--- a/crates/tenferro-linalg/tests/integration/concrete_surface.rs
+++ b/crates/tenferro-linalg/tests/integration/concrete_surface.rs
@@ -4,9 +4,7 @@ use tenferro_linalg::{
     EighOptions, LinalgBackend, QrOptions, SvdOptions, TensorLinalgExt, TensorReadLinalgExt,
     TypedTensorLinalgExt,
 };
-use tenferro_tensor::{Tensor, TensorRead, TensorScalar, TypedTensor};
-
-use super::support;
+use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead, TensorScalar, TypedTensor};
 
 #[test]
 fn cpu_execution_session_implements_linalg_backend() {
@@ -18,12 +16,12 @@ fn cpu_execution_session_implements_linalg_backend() {
 #[test]
 fn dynamic_and_read_surfaces_return_fixed_tuples() {
     let input = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap();
-    let mut backend = CpuBackend::new();
+    let mut host = CpuBackend::new();
 
-    support::with_cpu_linalg(&mut backend, |backend| {
-        let (_u, s, _vt) = input.svd(backend).unwrap();
-        let (_q, r) = TensorRead::from_tensor(&input).qr_read(backend).unwrap();
-        let (sign, logabsdet) = input.slogdet(backend).unwrap();
+    host.with_backend_session(|session| {
+        let (_u, s, _vt) = input.svd(session).unwrap();
+        let (_q, r) = TensorRead::from_tensor(&input).qr_read(session).unwrap();
+        let (sign, logabsdet) = input.slogdet(session).unwrap();
 
         assert_eq!(s.as_slice::<f64>().unwrap(), &[4.0, 2.0]);
         assert_eq!(r.shape(), &[2, 2]);
@@ -46,18 +44,18 @@ fn typed_surface_exposes_associated_real_and_complex_outputs() {
         ],
     )
     .unwrap();
-    let mut backend = CpuBackend::new();
+    let mut host = CpuBackend::new();
 
-    support::with_cpu_linalg(&mut backend, |backend| {
+    host.with_backend_session(|session| {
         let (_u, singular_values, _vt): (TypedTensor<f64>, TypedTensor<f64>, TypedTensor<f64>) =
-            real.svd(backend).unwrap();
+            real.svd(session).unwrap();
         let (eigenvalues, _vectors): (TypedTensor<Complex64>, TypedTensor<Complex64>) =
-            real.eig(backend).unwrap();
+            real.eig(session).unwrap();
         let (_cu, complex_singular_values, _cvt): (
             TypedTensor<Complex64>,
             TypedTensor<f64>,
             TypedTensor<Complex64>,
-        ) = complex.svd(backend).unwrap();
+        ) = complex.svd(session).unwrap();
 
         assert_eq!(singular_values.as_slice().unwrap(), &[4.0, 2.0]);
         assert_eq!(complex_singular_values.as_slice().unwrap(), &[4.0, 2.0]);
@@ -70,10 +68,10 @@ fn typed_input_is_erased_as_a_borrowed_read() {
     let input =
         TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![4.0_f64, 2.0, 2.0, 3.0]).unwrap();
     let read = f64::tensor_read(&input);
-    let mut backend = CpuBackend::new();
+    let mut host = CpuBackend::new();
 
-    support::with_cpu_linalg(&mut backend, |backend| {
-        let factor = read.cholesky_read(backend).unwrap();
+    host.with_backend_session(|session| {
+        let factor = read.cholesky_read(session).unwrap();
         assert_eq!(factor.shape(), &[2, 2]);
     });
 }
@@ -81,15 +79,15 @@ fn typed_input_is_erased_as_a_borrowed_read() {
 #[test]
 fn dynamic_composites_cover_inverse_pseudoinverse_eigenvalues_and_norm() {
     let input = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap();
-    let mut backend = CpuBackend::new();
+    let mut host = CpuBackend::new();
 
-    support::with_cpu_linalg(&mut backend, |backend| {
-        let det = input.det(backend).unwrap();
-        let inv = input.inv(backend).unwrap();
-        let pinv = input.pinv(backend).unwrap();
-        let eigvalsh = input.eigvalsh(backend).unwrap();
-        let eigvals = input.eigvals(backend).unwrap();
-        let norm = input.norm(None, Some(&[0, 1]), true, backend).unwrap();
+    host.with_backend_session(|session| {
+        let det = input.det(session).unwrap();
+        let inv = input.inv(session).unwrap();
+        let pinv = input.pinv(session).unwrap();
+        let eigvalsh = input.eigvalsh(session).unwrap();
+        let eigvals = input.eigvals(session).unwrap();
+        let norm = input.norm(None, Some(&[0, 1]), true, session).unwrap();
 
         assert!((det.as_slice::<f64>().unwrap()[0] - 8.0).abs() < 1.0e-12);
         assert_eq!(inv.as_slice::<f64>().unwrap(), &[0.5, 0.0, 0.0, 0.25]);
@@ -108,10 +106,10 @@ fn read_surface_accepts_a_strided_view_without_an_input_clone() {
             .unwrap();
     let transposed = input.as_view().transpose_view([1, 0]).unwrap();
     let read = TensorRead::from_view(f64::tensor_view(transposed));
-    let mut backend = CpuBackend::new();
+    let mut host = CpuBackend::new();
 
-    support::with_cpu_linalg(&mut backend, |backend| {
-        let (_u, singular_values, _vt) = read.svd_read(backend).unwrap();
+    host.with_backend_session(|session| {
+        let (_u, singular_values, _vt) = read.svd_read(session).unwrap();
         assert_eq!(singular_values.as_slice::<f64>().unwrap(), &[2.0, 1.0]);
     });
 }
@@ -128,12 +126,12 @@ fn typed_complex_composites_return_real_outputs_where_required() {
         ],
     )
     .unwrap();
-    let mut backend = CpuBackend::new();
+    let mut host = CpuBackend::new();
 
-    support::with_cpu_linalg(&mut backend, |backend| {
+    host.with_backend_session(|session| {
         let (_sign, logabsdet): (TypedTensor<Complex64>, TypedTensor<f64>) =
-            input.slogdet(backend).unwrap();
-        let norm: TypedTensor<f64> = input.norm(None, Some(&[0, 1]), false, backend).unwrap();
+            input.slogdet(session).unwrap();
+        let norm: TypedTensor<f64> = input.norm(None, Some(&[0, 1]), false, session).unwrap();
 
         assert!((logabsdet.as_slice().unwrap()[0] - 8.0_f64.ln()).abs() < 1.0e-12);
         assert!((norm.as_slice().unwrap()[0] - 20.0_f64.sqrt()).abs() < 1.0e-12);
@@ -146,13 +144,13 @@ fn typed_solve_surfaces_accept_vector_and_matrix_rhs() {
         TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap();
     let vector = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![4.0, 8.0]).unwrap();
     let matrix = TypedTensor::<f64>::from_vec_col_major(vec![2, 1], vec![4.0, 8.0]).unwrap();
-    let mut backend = CpuBackend::new();
+    let mut host = CpuBackend::new();
 
-    support::with_cpu_linalg(&mut backend, |backend| {
-        let vector_x = a.full_piv_lu_solve(&vector, backend).unwrap();
-        let matrix_x = a.full_piv_lu_solve(&matrix, backend).unwrap();
+    host.with_backend_session(|session| {
+        let vector_x = a.full_piv_lu_solve(&vector, session).unwrap();
+        let matrix_x = a.full_piv_lu_solve(&matrix, session).unwrap();
         let triangular_x = a
-            .triangular_solve(&matrix, true, false, false, false, backend)
+            .triangular_solve(&matrix, true, false, false, false, session)
             .unwrap();
 
         assert_eq!(vector_x.as_slice().unwrap(), &[2.0, 2.0]);
@@ -164,12 +162,12 @@ fn typed_solve_surfaces_accept_vector_and_matrix_rhs() {
 #[test]
 fn concrete_norm_distinguishes_empty_axes_and_rejects_invalid_axes() {
     let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
-    let mut backend = CpuBackend::new();
+    let mut host = CpuBackend::new();
 
-    support::with_cpu_linalg(&mut backend, |backend| {
-        let identity = input.norm(Some(2.0), Some(&[]), false, backend).unwrap();
+    host.with_backend_session(|session| {
+        let identity = input.norm(Some(2.0), Some(&[]), false, session).unwrap();
         let error = input
-            .norm(Some(2.0), Some(&[1]), false, backend)
+            .norm(Some(2.0), Some(&[1]), false, session)
             .unwrap_err();
 
         assert_eq!(identity.as_slice::<f64>().unwrap(), &[3.0, 4.0]);
@@ -181,40 +179,40 @@ fn concrete_norm_distinguishes_empty_axes_and_rejects_invalid_axes() {
 fn read_surface_covers_factorizations_and_composites() {
     let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]).unwrap();
     let b = Tensor::from_vec_col_major(vec![2], vec![9.0_f64, 7.0]).unwrap();
-    let mut backend = CpuBackend::new();
+    let mut host = CpuBackend::new();
 
-    support::with_cpu_linalg(&mut backend, |backend| {
+    host.with_backend_session(|session| {
         TensorRead::from_tensor(&a)
-            .svd_with_options_read(SvdOptions::default(), backend)
+            .svd_with_options_read(SvdOptions::default(), session)
             .unwrap();
         TensorRead::from_tensor(&a)
-            .qr_with_options_read(QrOptions::default(), backend)
+            .qr_with_options_read(QrOptions::default(), session)
             .unwrap();
-        TensorRead::from_tensor(&a).lu_read(backend).unwrap();
+        TensorRead::from_tensor(&a).lu_read(session).unwrap();
         TensorRead::from_tensor(&a)
-            .full_piv_lu_read(backend)
+            .full_piv_lu_read(session)
             .unwrap();
         let x = TensorRead::from_tensor(&a)
-            .full_piv_lu_solve_read(TensorRead::from_tensor(&b), backend)
+            .full_piv_lu_solve_read(TensorRead::from_tensor(&b), session)
             .unwrap();
         TensorRead::from_tensor(&a)
-            .solve_read(TensorRead::from_tensor(&b), backend)
+            .solve_read(TensorRead::from_tensor(&b), session)
             .unwrap();
         TensorRead::from_tensor(&a)
-            .eigh_with_options_read(EighOptions::default(), backend)
+            .eigh_with_options_read(EighOptions::default(), session)
             .unwrap();
-        TensorRead::from_tensor(&a).eig_read(backend).unwrap();
-        TensorRead::from_tensor(&a).slogdet_read(backend).unwrap();
-        TensorRead::from_tensor(&a).det_read(backend).unwrap();
-        TensorRead::from_tensor(&a).inv_read(backend).unwrap();
-        TensorRead::from_tensor(&a).eigvalsh_read(backend).unwrap();
-        TensorRead::from_tensor(&a).eigvals_read(backend).unwrap();
-        TensorRead::from_tensor(&a).pinv_read(backend).unwrap();
+        TensorRead::from_tensor(&a).eig_read(session).unwrap();
+        TensorRead::from_tensor(&a).slogdet_read(session).unwrap();
+        TensorRead::from_tensor(&a).det_read(session).unwrap();
+        TensorRead::from_tensor(&a).inv_read(session).unwrap();
+        TensorRead::from_tensor(&a).eigvalsh_read(session).unwrap();
+        TensorRead::from_tensor(&a).eigvals_read(session).unwrap();
+        TensorRead::from_tensor(&a).pinv_read(session).unwrap();
         TensorRead::from_tensor(&a)
-            .pinv_with_rtol_read(1.0e-12, backend)
+            .pinv_with_rtol_read(1.0e-12, session)
             .unwrap();
         TensorRead::from_tensor(&a)
-            .norm_read(Some(2.0), Some(&[0, 1]), false, backend)
+            .norm_read(Some(2.0), Some(&[0, 1]), false, session)
             .unwrap();
 
         let actual = x.as_slice::<f64>().unwrap();
@@ -224,30 +222,70 @@ fn read_surface_covers_factorizations_and_composites() {
 }
 
 #[test]
+fn read_surface_solve_read_into_writes_the_caller_buffer_directly() {
+    // The concrete `solve_read_into` keeps the direct write path: the CPU
+    // exec session solves into the caller's buffer without an allocate-then-
+    // copy round trip (issue #1680 Phase 3).
+    let a = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 1.0, 0.0, 2.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2, 1], vec![7.0_f64, 4.0]).unwrap();
+    let mut host = CpuBackend::new();
+
+    let mut owned = Tensor::from_vec_col_major([2, 1], vec![-9.0_f64; 2]).unwrap();
+    host.with_backend_session(|session| {
+        TensorRead::from_tensor(&a).solve_read_into(
+            TensorRead::from_tensor(&b),
+            tenferro_tensor::TensorWrite::from_tensor(&mut owned),
+            session,
+        )
+    })
+    .unwrap();
+    let solved = owned.as_slice::<f64>().unwrap();
+    assert!((solved[0] - 7.0 / 3.0).abs() < 1.0e-12);
+    assert!((solved[1] - 5.0 / 6.0).abs() < 1.0e-12);
+
+    // Strided output: only the destination entries are touched.
+    let mut storage = vec![-17.0_f64; 8];
+    let view =
+        tenferro_tensor::TypedTensorViewMut::from_slice([2, 1], [1, 4], 1, &mut storage).unwrap();
+    host.with_backend_session(|session| {
+        TensorRead::from_tensor(&a).solve_read_into(
+            TensorRead::from_tensor(&b),
+            tenferro_tensor::TensorWrite::from_view(tenferro_tensor::TensorViewMut::F64(view)),
+            session,
+        )
+    })
+    .unwrap();
+    assert_eq!(storage[0], -17.0);
+    assert!((storage[1] - 7.0 / 3.0).abs() < 1.0e-12);
+    assert!((storage[2] - 5.0 / 6.0).abs() < 1.0e-12);
+    assert_eq!(storage[3], -17.0);
+}
+
+#[test]
 fn typed_surface_covers_all_receiver_adapters() {
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![4.0, 1.0, 1.0, 3.0]).unwrap();
     let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 1], vec![9.0, 7.0]).unwrap();
-    let mut backend = CpuBackend::new();
+    let mut host = CpuBackend::new();
 
-    support::with_cpu_linalg(&mut backend, |backend| {
-        a.svd_with_options(SvdOptions::default(), backend).unwrap();
-        a.qr(backend).unwrap();
-        a.qr_with_options(QrOptions::default(), backend).unwrap();
-        a.lu(backend).unwrap();
-        a.full_piv_lu(backend).unwrap();
-        a.solve(&b, backend).unwrap();
-        a.cholesky(backend).unwrap();
-        a.eigh(backend).unwrap();
-        a.eigh_with_options(EighOptions::default(), backend)
+    host.with_backend_session(|session| {
+        a.svd_with_options(SvdOptions::default(), session).unwrap();
+        a.qr(session).unwrap();
+        a.qr_with_options(QrOptions::default(), session).unwrap();
+        a.lu(session).unwrap();
+        a.full_piv_lu(session).unwrap();
+        a.solve(&b, session).unwrap();
+        a.cholesky(session).unwrap();
+        a.eigh(session).unwrap();
+        a.eigh_with_options(EighOptions::default(), session)
             .unwrap();
-        a.det(backend).unwrap();
-        a.inv(backend).unwrap();
-        a.eigvalsh(backend).unwrap();
-        a.eigvals(backend).unwrap();
-        a.pinv(backend).unwrap();
-        a.pinv_with_rtol(1.0e-12, backend).unwrap();
+        a.det(session).unwrap();
+        a.inv(session).unwrap();
+        a.eigvalsh(session).unwrap();
+        a.eigvals(session).unwrap();
+        a.pinv(session).unwrap();
+        a.pinv_with_rtol(1.0e-12, session).unwrap();
         let norm = a
-            .norm(Some(f64::INFINITY), Some(&[0, 1]), false, backend)
+            .norm(Some(f64::INFINITY), Some(&[0, 1]), false, session)
             .unwrap();
 
         assert_eq!(norm.as_slice().unwrap(), &[5.0]);
@@ -262,9 +300,9 @@ fn concrete_norm_covers_orders_axis_permutation_and_validation() {
         vec![1.0_f64, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0],
     )
     .unwrap();
-    let mut backend = CpuBackend::new();
+    let mut host = CpuBackend::new();
 
-    support::with_cpu_linalg(&mut backend, |backend| {
+    host.with_backend_session(|session| {
         for order in [
             Some(0.0),
             Some(1.0),
@@ -274,12 +312,12 @@ fn concrete_norm_covers_orders_axis_permutation_and_validation() {
             Some(f64::INFINITY),
             Some(f64::NEG_INFINITY),
         ] {
-            matrix.norm(order, Some(&[0, 1]), false, backend).unwrap();
+            matrix.norm(order, Some(&[0, 1]), false, session).unwrap();
         }
-        tensor.norm(None, Some(&[2, 0]), true, backend).unwrap();
-        tensor.norm(Some(3.0), None, false, backend).unwrap();
+        tensor.norm(None, Some(&[2, 0]), true, session).unwrap();
+        tensor.norm(Some(3.0), None, false, session).unwrap();
 
-        assert!(tensor.norm(None, Some(&[0, 0]), false, backend).is_err());
-        assert!(tensor.norm(Some(0.0), None, false, backend).is_ok());
+        assert!(tensor.norm(None, Some(&[0, 0]), false, session).is_err());
+        assert!(tensor.norm(Some(0.0), None, false, session).is_ok());
     });
 }

--- a/crates/tenferro-linalg/tests/integration/linalg_internal_path_contract.rs
+++ b/crates/tenferro-linalg/tests/integration/linalg_internal_path_contract.rs
@@ -99,12 +99,12 @@ fn norm_fro_and_p2_norm_use_fused_backend_hook_without_generic_pow() {
     let concrete_source = crate_source("src/tensor_ext.rs");
     let concrete_frobenius = source_section(
         &concrete_source,
-        "fn frobenius_norm<B: LinalgBackend>",
-        "fn p_norm<B: LinalgBackend>",
+        "fn frobenius_norm<B: LinalgBackend + ?Sized>",
+        "fn p_norm<B: LinalgBackend + ?Sized>",
     );
     let concrete_p_norm = source_section(
         &concrete_source,
-        "fn p_norm<B: LinalgBackend>",
+        "fn p_norm<B: LinalgBackend + ?Sized>",
         "fn count_nonzero<B: LinalgBackend>",
     );
     assert!(
@@ -156,7 +156,7 @@ fn real_sum_of_squares_norm_skips_abs_materialization_before_square() {
     let concrete_source = crate_source("src/tensor_ext.rs");
     let concrete_norm = source_section(
         &concrete_source,
-        "fn norm_from_read<B: LinalgBackend>",
+        "fn norm_from_read<B: LinalgBackend + ?Sized>",
         "fn scalar_real(dtype: DType",
     );
     assert!(
@@ -501,5 +501,62 @@ fn traced_lstsq_validates_once_without_symbolic_shape_probe_allocation() {
             && validation.contains("ensure_float_or_complex(op, dtype)?")
             && validation.contains("ensure_min_rank(op, a_rank, 2)?"),
         "shared lstsq validation must keep dtype/rank checks ahead of lazy shape extraction"
+    );
+}
+
+#[test]
+fn cpu_solve_read_into_reaches_direct_write_for_eligible_outputs() {
+    // The public solve_read_into surface must dispatch eligible calls to the
+    // direct in-place write (`solve_read_into_entered`) and reserve the
+    // allocate-then-copy fallback (`solve_read_into_default`) for ineligible
+    // destinations. `concrete_surface.rs` exercises the eligible runtime path
+    // (contiguous host output, matching shape/dtype/placement), so this source
+    // contract closes the gap: the direct path is provably taken, not just
+    // value-identical.
+    let source = crate_source("src/cpu/backend.rs");
+    let solve_read_into = source_section(
+        &source,
+        "fn solve_read_into(",
+        "fn solve_read_into_direct_eligible",
+    );
+
+    assert!(
+        solve_read_into.contains("solve_read_into_entered(provider, context, buffers, a, b, out)"),
+        "eligible solve_read_into should reach the direct in-place solver"
+    );
+    assert_eq!(
+        solve_read_into.matches("solve_read_into_default").count(),
+        1,
+        "the allocate+copy fallback should appear exactly once, behind the eligibility guard"
+    );
+    let guarded_fallback = source_section(
+        solve_read_into,
+        "if has_zero_dim(a.shape())",
+        "}\n\n        let a = a.tensor_view();",
+    );
+    assert!(
+        guarded_fallback.contains("solve_read_into_default(self, a, b, out)"),
+        "the allocate+copy fallback must be the guarded ineligible branch, not the main path"
+    );
+}
+
+#[test]
+fn cpu_solve_read_into_entered_writes_into_the_caller_buffer() {
+    // The direct path must solve into the caller's destination buffer without
+    // an allocate-then-copy round trip.
+    let source = crate_source("src/cpu/backend.rs");
+    let entered = source_section(
+        &source,
+        "fn solve_read_into_entered(",
+        "fn tensor_write_view(out: TensorWrite<'_>) -> TensorViewMut<'_> {",
+    );
+
+    assert!(
+        entered.contains("&mut out") && entered.contains("solve_into("),
+        "the direct path should solve straight into the caller's out buffer"
+    );
+    assert!(
+        !entered.contains("copy_read_into"),
+        "the direct path should not allocate-then-copy"
     );
 }

--- a/crates/tenferro-linalg/tests/prelude.rs
+++ b/crates/tenferro-linalg/tests/prelude.rs
@@ -1,4 +1,4 @@
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_linalg::prelude::*;
 
 #[test]
@@ -6,10 +6,7 @@ fn prelude_calls_concrete_linalg_operation() {
     let input = Tensor::from_vec_col_major([2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap();
     let mut backend = CpuBackend::new();
     let (_u, singular_values, _vt) = backend
-        .with_backend_session(|session| {
-            with_cpu_exec_session(session, |exec_session| input.svd(exec_session))
-                .expect("CpuBackend must expose a CPU execution session")
-        })
+        .with_backend_session(|session| input.svd(session))
         .unwrap();
     assert_eq!(singular_values.shape(), &[2]);
 }

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -4168,9 +4168,9 @@ pub trait TensorBackend:
 impl<T> SessionCachedDot for T where T: TensorBackend + ?Sized {}
 
 thread_local! {
-    /// Tracks whether a [`default_backend_session`] closure is currently
-    /// running on this thread, so nested session entry is caught in debug
-    /// builds even for backends that do not override
+    /// Tracks whether a session-entry closure is currently running on this
+    /// thread, so nested session entry is caught in debug builds even for
+    /// backends that do not override
     /// [`BackendSessionHost::with_backend_session`].
     static IN_SESSION: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
@@ -4197,6 +4197,20 @@ impl Drop for InSessionGuard {
     }
 }
 
+/// Run `f` with the thread-local in-session flag set, restoring it on exit
+/// including on panic, and asserting (in debug builds) that the caller is not
+/// already inside a session closure.
+///
+/// This is the portable nested-entry guard shared by every backend-session
+/// entry point: [`default_backend_session`] and the GPU
+/// `BackendSessionHost::with_backend_session` overrides. CPU keeps its own
+/// release-mode `EXECUTION_OWNER` panic on top of this debug check.
+#[doc(hidden)]
+pub fn with_session_entry_guard<R>(f: impl FnOnce() -> R) -> R {
+    let _guard = InSessionGuard::enter();
+    f()
+}
+
 /// Run a closure using the backend itself as a default execution session.
 ///
 /// This is suitable for backends whose individual ops already manage their own
@@ -4215,6 +4229,5 @@ pub fn default_backend_session<B: TensorBackend, R: Send>(
     backend: &mut B,
     f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
 ) -> R {
-    let _guard = InSessionGuard::enter();
-    f(backend)
+    with_session_entry_guard(|| f(backend))
 }

--- a/crates/tenferro-tensor/src/backend/tests.rs
+++ b/crates/tenferro-tensor/src/backend/tests.rs
@@ -120,3 +120,26 @@ fn default_backend_session_clears_the_in_session_flag_after_panic() {
     assert_eq!(again, 3);
     assert!(!IN_SESSION.get());
 }
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "nested backend session entry")]
+fn with_session_entry_guard_rejects_nested_entry_in_debug_builds() {
+    with_session_entry_guard(|| with_session_entry_guard(|| ()))
+}
+
+#[test]
+fn with_session_entry_guard_sets_and_restores_the_flag() {
+    let value = with_session_entry_guard(|| 1usize);
+    assert_eq!(value, 1);
+    assert!(!IN_SESSION.get());
+
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        with_session_entry_guard(|| panic!("boom"))
+    }));
+    assert!(outcome.is_err());
+    assert!(!IN_SESSION.get());
+
+    let again = with_session_entry_guard(|| 2usize);
+    assert_eq!(again, 2);
+}

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -63,10 +63,10 @@ pub mod types;
 pub mod validate;
 
 pub use backend::{
-    default_backend_session, BackendCachedDot, BackendRuntimeCache, BackendSession,
-    BackendSessionHost, ContractionScalar, DotGeneralAccumulation, ElementwiseReadOp,
-    SessionCachedDot, TensorAnalytic, TensorBackend, TensorBackendOps, TensorBuffer,
-    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    default_backend_session, with_session_entry_guard, BackendCachedDot, BackendRuntimeCache,
+    BackendSession, BackendSessionHost, ContractionScalar, DotGeneralAccumulation,
+    ElementwiseReadOp, SessionCachedDot, TensorAnalytic, TensorBackend, TensorBackendOps,
+    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorReduction, TensorStructural, TensorViewCanonicalization,
 };
 pub use cache::{CacheStats, RuntimeCacheControl};

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -1548,7 +1548,9 @@ fn tensor_index_select_builds_gather_config_and_validates_inputs() {
     let input = Tensor::from_vec_col_major(vec![2, 3], vec![0.0_f64; 6]).unwrap();
     let mut backend = DefaultReadBackend::default();
 
-    input.index_select(-1, &[2, 0], &mut backend).unwrap();
+    backend
+        .with_backend_session(|session| input.index_select(-1, &[2, 0], session))
+        .unwrap();
 
     let indices = backend.gather_indices.as_ref().unwrap();
     assert_eq!(indices.shape(), &[2, 1]);
@@ -1561,10 +1563,14 @@ fn tensor_index_select_builds_gather_config_and_validates_inputs() {
     assert_eq!(config.index_vector_dim, 1);
     assert_eq!(config.slice_sizes, vec![2, 1]);
 
-    let axis_err = input.index_select(2, &[0], &mut backend).unwrap_err();
+    let axis_err = backend
+        .with_backend_session(|session| input.index_select(2, &[0], session))
+        .unwrap_err();
     assert!(axis_err.to_string().contains("axis 2"));
 
-    let position_err = input.index_select(1, &[3], &mut backend).unwrap_err();
+    let position_err = backend
+        .with_backend_session(|session| input.index_select(1, &[3], session))
+        .unwrap_err();
     assert!(position_err
         .to_string()
         .contains("position 3 out of bounds"));
@@ -1576,17 +1582,23 @@ fn tensor_stack_reshapes_then_concatenates_and_validates_inputs() {
     let b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
     let mut backend = DefaultReadBackend::default();
 
-    Tensor::stack(&[&a, &b], -1, &mut backend).unwrap();
+    backend
+        .with_backend_session(|session| Tensor::stack(&[&a, &b], -1, session))
+        .unwrap();
 
     assert_eq!(backend.reshape_shapes, vec![vec![2, 1], vec![2, 1]]);
     assert_eq!(backend.concatenate_axis, Some(1));
 
     let empty: [&Tensor; 0] = [];
-    let empty_err = Tensor::stack(&empty, 0, &mut backend).unwrap_err();
+    let empty_err = backend
+        .with_backend_session(|session| Tensor::stack(&empty, 0, session))
+        .unwrap_err();
     assert!(empty_err.to_string().contains("at least one input"));
 
     let c = Tensor::from_vec_col_major(vec![3], vec![0.0_f64; 3]).unwrap();
-    let shape_err = Tensor::stack(&[&a, &c], 0, &mut backend).unwrap_err();
+    let shape_err = backend
+        .with_backend_session(|session| Tensor::stack(&[&a, &c], 0, session))
+        .unwrap_err();
     assert!(matches!(
         shape_err,
         crate::Error::Validation {
@@ -1595,7 +1607,9 @@ fn tensor_stack_reshapes_then_concatenates_and_validates_inputs() {
         }
     ));
 
-    let axis_err = Tensor::stack(&[&a], 2, &mut backend).unwrap_err();
+    let axis_err = backend
+        .with_backend_session(|session| Tensor::stack(&[&a], 2, session))
+        .unwrap_err();
     assert!(axis_err.to_string().contains("axis 2"));
 }
 

--- a/crates/tenferro-tensor/src/types/shape_packing.rs
+++ b/crates/tenferro-tensor/src/types/shape_packing.rs
@@ -1,4 +1,4 @@
-use crate::{GatherConfig, ShapeMismatch, TensorBackend, ValidationError};
+use crate::{GatherConfig, ShapeMismatch, ValidationError};
 
 use super::{Tensor, TypedTensor};
 
@@ -122,13 +122,13 @@ impl Tensor {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_tensor::{Tensor, TensorBackend};
+    /// use tenferro_tensor::{BackendSession, Tensor};
     ///
-    /// fn select_last_axis<B: TensorBackend>(
-    ///     backend: &mut B,
+    /// fn select_last_axis(
+    ///     session: &mut dyn BackendSession,
     ///     x: &Tensor,
     /// ) -> tenferro_tensor::Result<Tensor> {
-    ///     x.index_select(-1, &[2, 0], backend)
+    ///     x.index_select(-1, &[2, 0], session)
     /// }
     /// ```
     /// # Errors
@@ -139,10 +139,10 @@ impl Tensor {
         &self,
         axis: isize,
         positions: &[usize],
-        ctx: &mut impl TensorBackend,
+        session: &mut dyn crate::BackendSession,
     ) -> crate::Result<Self> {
         let (indices, config) = index_select_parts(self.shape(), axis, positions)?;
-        ctx.with_backend_session(|exec| exec.gather(self, &indices, &config))
+        session.gather(self, &indices, &config)
     }
 
     /// Stack tensors along a newly inserted axis.
@@ -150,14 +150,14 @@ impl Tensor {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_tensor::{Tensor, TensorBackend};
+    /// use tenferro_tensor::{BackendSession, Tensor};
     ///
-    /// fn stack_scalars<B: TensorBackend>(
-    ///     backend: &mut B,
+    /// fn stack_scalars(
+    ///     session: &mut dyn BackendSession,
     ///     a: &Tensor,
     ///     b: &Tensor,
     /// ) -> tenferro_tensor::Result<Tensor> {
-    ///     Tensor::stack(&[a, b], -1, backend)
+    ///     Tensor::stack(&[a, b], -1, session)
     /// }
     /// ```
     /// # Errors
@@ -167,7 +167,7 @@ impl Tensor {
     pub fn stack(
         tensors: &[&Self],
         dim: isize,
-        ctx: &mut impl TensorBackend,
+        session: &mut dyn crate::BackendSession,
     ) -> crate::Result<Self> {
         let first = tensors.first().copied().ok_or_else(|| {
             crate::Error::invalid_argument("stack", "tensors", "requires at least one input")
@@ -190,14 +190,12 @@ impl Tensor {
         let mut expanded_shape = first.shape().to_vec();
         expanded_shape.insert(axis, 1);
 
-        ctx.with_backend_session(|exec| {
-            let mut expanded = Vec::with_capacity(tensors.len());
-            for tensor in tensors {
-                expanded.push(exec.reshape(tensor, &expanded_shape)?);
-            }
-            let refs = expanded.iter().collect::<Vec<_>>();
-            exec.concatenate(&refs, axis)
-        })
+        let mut expanded = Vec::with_capacity(tensors.len());
+        for tensor in tensors {
+            expanded.push(session.reshape(tensor, &expanded_shape)?);
+        }
+        let refs = expanded.iter().collect::<Vec<_>>();
+        session.concatenate(&refs, axis)
     }
 }
 

--- a/docs/design/session-oriented-concrete-apis.md
+++ b/docs/design/session-oriented-concrete-apis.md
@@ -576,3 +576,111 @@ expected values (drops the one-shot comparison arm).
 - Einsum top-level traits, FFT, linalg, shape-packing one-shot surfaces.
 - GPU (CUDA/WebGPU) nested-entry enforcement.
 - Behavioral changes to any op (rename/removal only).
+
+## Migration specification (issue #1680, Phase 3: extension surfaces + GPU guard)
+
+Completes the single-API end state for the remaining backend-taking concrete
+surfaces and wires the GPU nested-entry guard. All five areas in ONE
+designed-and-gated PR.
+
+**Capability decision (option b — built-in session dispatch)**: the concrete
+op methods take `&mut dyn BackendSession` and dispatch **internally** to the
+built-in exec sessions (the existing `execute_linalg_extension_reads_on_session`
+/ `execute_fft_extension_reads_session` downcast patterns). This removes the
+caller's manual `with_cpu_exec_session`/`with_cuda_exec_session` wrappers
+(the current linalg/fft doctests require them). A session that cannot run the
+op returns a typed capability error; callers never downcast themselves.
+**Documented breaking restriction**: the concrete op traits no longer accept
+arbitrary third-party `LinalgBackend`/`FftBackend` implementations — the
+public SPI traits stay (backend implementers still implement them), but the
+concrete op path is built-in-session only. The test-only custom backends
+(tenferro-linalg backend_errors.rs, tenferro-fft backend_capability.rs)
+migrate to the built-in sessions or are removed, and the extensibility
+claims in their docs are updated to the SPI-only scope.
+
+### 1. einsum top-level traits (10 traits) + tensordot
+
+Methods take `&mut dyn BackendSession`. Einsum-family internals already route
+through `ConcreteEinsumPlan::execute*` (Phase-2 finding-3 fix); **tensordot**
+is not a plan path — `TensorTensordotExt`/`TypedTensorTensordotExt` call
+`session.dot_general`/`dot_general_read` directly (concrete.rs:47-57, 79-91),
+the correct session form. Remove the backend-taking forms. Call sites (6
+files) migrate per the Phase-2 rule.
+
+### 2. FFT (TensorFftExt / TensorReadFftExt)
+
+Methods take `&mut dyn BackendSession`; internal dispatch to the built-in
+FFT exec sessions (CPU/CUDA/WebGPU — all implement FftBackend); typed
+capability error otherwise. Inventory: 4 executor methods (fft/ifft/rfft/
+irfft, lib.rs:236-333) + the 8 trait methods. The executor calls
+`backend.execute_fft` directly (no internal session entry); the manual
+external downcasts in callers/tests/benches (backend_capability.rs:335-345,
+fft_plan_cache.rs:51-70) are removed. Plan cache stays executor-owned. Call
+sites: 5 files + the test/bench downcast sites.
+
+### 3. linalg concrete traits (TensorLinalgExt / TensorReadLinalgExt / TypedTensorLinalgExt — 64 methods)
+
+Methods take `&mut dyn BackendSession`; internal dispatch downcasts once to
+the concrete exec session and runs the EXISTING generic composite bodies on
+it (they already operate on the borrowed LinalgBackend — tensor_ext.rs
+1702-1817; base session ops via reshape_read/transpose_read/dot_general_read
+at 2514-2589). **Preserve the direct `solve_read_into` write path**
+(tensor_ext.rs:1914-1920 → cpu/backend.rs:718-741; do NOT replace with
+allocate+copy). Typed contract via `typed_output` (tensor_ext.rs:2197-2205),
+not `into_typed_result`. The caller's `with_cpu_exec_session` wrappers are
+removed (internal dispatch replaces them). Validation, dtype promotion,
+error payloads unchanged. Call sites: 5 files.
+
+### 4. shape_packing (Tensor::index_select / Tensor::stack)
+
+Methods take `&mut dyn BackendSession`. Both already run inside a session
+closure (shape_packing.rs:138-145, 167-193) — replace the host parameter and
+remove the closure. Migration gate: scoped grep for `.index_select(`/
+`.stack(` on the concrete surface; traced/eager APIs and historical
+docs/plans are explicitly excluded.
+
+### 5. GPU nested-entry guard (CUDA / WebGPU)
+
+Extract the portable guard (thread-local in-session flag + panic-safe
+restore + debug assert) into a **`#[doc(hidden)] pub` shared helper** in
+tenferro-tensor (e.g. `with_session_entry_guard`). CUDA
+(cubecl/exec_session.rs:603) and WebGPU (webgpu/exec_session.rs:263)
+`with_backend_session` overrides wrap their closure in it — nested entry is
+detected in debug builds on every backend family. CPU keeps its release
+`EXECUTION_OWNER` panic; `Send` bounds untouched. **Verification**:
+package-targeted checks (`cargo check -p tenferro-gpu --features cuda`,
+`--features webgpu`) + new cfg-gated nested-entry tests for BOTH overrides;
+the shared helper's own tests cover the flag semantics.
+
+### Baselines (recorded BEFORE implementation — required for the gate)
+
+Pre-change pinned baselines recorded in the worklog:
+- FFT: `crates/tenferro-fft/benches/fft_plan_cache.rs` arms
+  (direct_one_shot / executor_warm_cache, 1024 f64, 1 thread, pinned core 40)
+  — measured: ~15.0/11.3 µs (small) and ~88.3/73.1 µs (large) pre-change.
+- Linalg: representative ops via the current caller pattern
+  (`with_backend_session` + `with_cpu_exec_session`), 8×8 f64 diagonal
+  (diag 2..=9), 1 thread, pinned core 40 — measured pre-change:
+  **solve 14.4 µs** (incl. the direct `solve_read_into` path) and
+  **svd 18.6 µs** (2000 iters, release). matmul shares the same session
+  path as solve and is not a separate baseline.
+- Post-migration: same arms re-run; no-regression threshold = within the
+  machine's interleaved noise band (±1% on interleaved runs); recorded in
+  the Phase-3 worklog.
+
+### Migration rules (reuse Phase-2), tests, doctests
+
+Phase-2 rule (single-op wrap / group / session-typed helpers / already-in-
+session direct / closure result types; docs/spec/tutorials/skills/snippet
+generators migrate). Runnable doctests on every changed public method.
+Parity/error tests per area (values + structured errors; linalg typed
+conversion via typed_output; solve_read_into direct-path test). The runtime/
+einsum chain benches are untouched (core API unchanged).
+
+### Out of scope
+
+- Low-level backend SPI traits (TensorBackend capability traits, the
+  LinalgBackend/FftBackend trait definitions) — backend contracts, not
+  concrete op surfaces; third-party backend implementers still implement
+  them, but the concrete op path is built-in-session only (documented above).
+- GPU runtime execution (needs a CUDA host; CI gate item).

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -133,10 +133,9 @@ tenferro-linalg = { path = "/path/to/tenferro-rs/crates/tenferro-linalg", featur
 
 <!-- snippet-source: docs/tutorial-code/src/bin/direct_linalg_quickstart.rs -->
 ```rust
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_linalg::prelude::*;
 use tenferro_runtime::prelude::*;
-use tenferro_runtime::{TensorRead, TensorView};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -159,17 +158,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(product.shape(), &[2, 2]);
     assert_close(product.host_data()?, &[3.0, 0.0, 0.0, 1.0]);
 
-    let svd = backend.with_backend_session(|session| {
-        with_cpu_exec_session(session, |exec_session| {
-            exec_session.svd_read(TensorRead::from_view(TensorView::F64(product.as_view())))
-        })
-        .expect("CpuBackend must expose a CPU execution session")
-    })?;
-    assert_eq!(svd.len(), 3);
-    assert_eq!(svd[0].shape(), &[2, 2]);
-    assert_eq!(svd[1].shape(), &[2]);
-    assert_eq!(svd[2].shape(), &[2, 2]);
-    assert_close(svd[1].as_slice::<f64>().unwrap(), &[3.0, 1.0]);
+    let (u, s, vt) = backend.with_backend_session(|session| product.svd(session))?;
+    assert_eq!(u.shape(), &[2, 2]);
+    assert_eq!(s.shape(), &[2]);
+    assert_eq!(vt.shape(), &[2, 2]);
+    assert_close(s.as_slice()?, &[3.0, 1.0]);
 
     Ok(())
 }

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -6,7 +6,7 @@ This page is a translation guide for readers who already know `torch` or `jax.nu
 
 A focused module can keep its dependencies explicit with direct imports such as
 `use tenferro_runtime::{Tensor, TensorSessionOpsExt};` and
-`use tenferro_linalg::{LinalgBackend, TensorLinalgExt};`. A tutorial or a
+`use tenferro_linalg::TensorLinalgExt;`. A tutorial or a
 module that uses several operation families can use the equivalent crate-local
 preludes: `use tenferro_runtime::prelude::*;` and
 `use tenferro_linalg::prelude::*;`. These imports only affect name lookup;
@@ -39,10 +39,10 @@ backend and device choices remain explicit.
 | Broadcast | `x.expand(...)` / implicit broadcast | implicit broadcast in many ops | backend-level op | `x.broadcast_in_dim(&shape, &dims)` |
 | Reduce sum | `x.sum(dim=...)` | `jnp.sum(x, axis=...)` | `ctx.with_backend_session(\|s\| x.reduce_sum(&axes, s))` via `TensorSessionOpsExt` | `x.reduce_sum(Some(&axes))` |
 | Einsum | `torch.einsum(spec, ...)` | `jnp.einsum(spec, ...)` | `[&a, &b].einsum(...)` via `EagerEinsumExt` | `trace.einsum(...)` via `TraceContextEinsumExt` plus extension module installation |
-| SVD | `torch.linalg.svd(x)` | `jnp.linalg.svd(x)` | `tenferro_linalg::LinalgBackend::svd(&mut ctx, &x)?` | `x.svd()?` via `TracedTensorLinalgExt` |
-| QR | `torch.linalg.qr(x)` | `jnp.linalg.qr(x)` | `tenferro_linalg::LinalgBackend::qr(&mut ctx, &x)?` | `x.qr()?` via `TracedTensorLinalgExt` |
-| Cholesky | `torch.linalg.cholesky(x)` | `jnp.linalg.cholesky(x)` | `tenferro_linalg::LinalgBackend::cholesky(&mut ctx, &x)?` | `x.cholesky()?` via `TracedTensorLinalgExt` |
-| Solve | `torch.linalg.solve(a, b)` | `jnp.linalg.solve(a, b)` | `tenferro_linalg::LinalgBackend::solve(&mut ctx, &a, &b)?` | `a.solve(&b)?` via `TracedTensorLinalgExt` |
+| SVD | `torch.linalg.svd(x)` | `jnp.linalg.svd(x)` | `ctx.with_backend_session(\|s\| x.svd(s))` via `TensorLinalgExt` | `x.svd()?` via `TracedTensorLinalgExt` |
+| QR | `torch.linalg.qr(x)` | `jnp.linalg.qr(x)` | `ctx.with_backend_session(\|s\| x.qr(s))` via `TensorLinalgExt` | `x.qr()?` via `TracedTensorLinalgExt` |
+| Cholesky | `torch.linalg.cholesky(x)` | `jnp.linalg.cholesky(x)` | `ctx.with_backend_session(\|s\| x.cholesky(s))` via `TensorLinalgExt` | `x.cholesky()?` via `TracedTensorLinalgExt` |
+| Solve | `torch.linalg.solve(a, b)` | `jnp.linalg.solve(a, b)` | `ctx.with_backend_session(\|s\| a.solve(&b, s))` via `TensorLinalgExt` | `a.solve(&b)?` via `TracedTensorLinalgExt` |
 | Scalar-loss backward | `loss.backward()` | — | `loss.backward()` on `EagerTensor` | — |
 | Reverse-mode grad | `torch.autograd.grad(loss, x)` | `jax.grad(f)(x)` | `ctx.grad(&loss, &x)?` | `loss.grad(&x)` |
 | VJP | `torch.autograd.grad(..., grad_outputs=...)` | `jax.vjp` | `ctx.vjp(&y, &x, &cotangent)?` | `y.vjp(&x, &cotangent)?` |

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -28,7 +28,7 @@ Quick reference:
 
 Use direct imports when a small module should make its dependencies explicit:
 `use tenferro_runtime::{Tensor, TensorSessionOpsExt};` and
-`use tenferro_linalg::{LinalgBackend, TensorLinalgExt};`. For tutorials or
+`use tenferro_linalg::TensorLinalgExt;`. For tutorials or
 modules using several operation traits, the equivalent crate-local preludes are
 `use tenferro_runtime::prelude::*;` and `use tenferro_linalg::prelude::*;`.
 There is no facade prelude: keep each operation family imported from its own
@@ -103,7 +103,7 @@ operations.
 | Einsum | `[&a, &b].einsum(...)` via `TensorEinsumExt` / `TypedTensorEinsumExt`; `TensorReadEinsumExt` / `TypedTensorReadEinsumExt` for views; `ConcreteEinsumPlan` for repeated fixed metadata | `[&a, &b].einsum(...)` via `EagerEinsumExt` | `trace.einsum(...)` via `TraceContextEinsumExt` plus `extension_module` |
 | FFT | `x.fft(...)` via `TensorFftExt`; `read.fft_read(...)` via `TensorReadFftExt` | `x.fft(...)` via `EagerTensorFftExt` with `autodiff` | `x.fft(...)` via `TracedTensorFftExt` plus `extension_module` |
 | Tensordot sugar | Use `matmul` or `dot_general` directly | `a.tensordot(&b, axes)` via `EagerTensorEinsumExt` | `a.tensordot(&b, axes)` via `TracedTensorEinsumExt` |
-| Linear algebra | `tenferro_linalg::LinalgBackend` methods on a backend | `EagerTensorLinalgExt` methods with `autodiff` | `TracedTensorLinalgExt` methods |
+| Linear algebra | `TensorLinalgExt` session methods via `with_backend_session` | `EagerTensorLinalgExt` methods with `autodiff` | `TracedTensorLinalgExt` methods |
 | Automatic differentiation | Not applicable | `backward()` plus `EagerRuntime` functional `grad`, `vjp`, `jvp`, HVP via composition | `grad`, `vjp`, `jvp`, HVP via composition |
 | External operations | Extension-defined concrete hooks | Extension-defined eager hooks and optional AD rules | Extension-defined graph hooks and optional AD rules |
 

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -187,8 +187,8 @@ assert_eq!(negated.as_slice::<f64>().unwrap(), &[-1.0, -2.0, -3.0]);
 
 <!-- snippet-source: docs/tutorial-code/src/bin/core_tensor_snippets.rs#eager_operations_5 -->
 ```rust
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
-use tenferro_linalg::LinalgBackend;
+use tenferro_cpu::CpuBackend;
+use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{BackendSessionHost, Tensor};
 
 let mut backend = CpuBackend::new();
@@ -199,19 +199,17 @@ let a = Tensor::from_vec_col_major(vec![3, 3], vec![
 ])?;
 let b = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0])?;
 backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec| {
-        let svd = LinalgBackend::svd(exec, &a).unwrap();
-        let qr = LinalgBackend::qr(exec, &a).unwrap();
-        let chol = LinalgBackend::cholesky(exec, &a).unwrap();
-        let eigh = LinalgBackend::eigh(exec, &a).unwrap();
-        let x = LinalgBackend::solve(exec, &a, &b).unwrap();
-        assert_eq!(svd[1].shape(), &[3]);
-        assert_eq!(qr[0].shape(), &[3, 3]);
-        assert_eq!(chol.shape(), &[3, 3]);
-        assert_eq!(eigh[0].shape(), &[3]);
-        assert_eq!(eigh[1].shape(), &[3, 3]);
-        assert_eq!(x.shape(), &[3]);
-    }).expect("CPU execution session is available")
+    let svd = a.svd(session).unwrap();
+    let qr = a.qr(session).unwrap();
+    let chol = a.cholesky(session).unwrap();
+    let eigh = a.eigh(session).unwrap();
+    let x = a.solve(&b, session).unwrap();
+    assert_eq!(svd.1.shape(), &[3]);
+    assert_eq!(qr.0.shape(), &[3, 3]);
+    assert_eq!(chol.shape(), &[3, 3]);
+    assert_eq!(eigh.0.shape(), &[3]);
+    assert_eq!(eigh.1.shape(), &[3, 3]);
+    assert_eq!(x.shape(), &[3]);
 });
 ```
 <!-- end-snippet-source -->

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -70,8 +70,8 @@ use tenferro_einsum::{
     TypedTensorEinsumIntoExt, TypedTensorReadEinsumIntoExt,
 };
 use tenferro_tensor::{
-    Tensor, TensorWrite, TypedTensor, TypedTensorView, TypedTensorViewMut,
-    TypedTensorWrite,
+    BackendSessionHost, Tensor, TensorWrite, TypedTensor, TypedTensorView,
+    TypedTensorViewMut, TypedTensorWrite,
 };
 
 let lhs = Tensor::from_vec_col_major(
@@ -83,15 +83,19 @@ let rhs = Tensor::from_vec_col_major(
     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
 )?;
 let mut backend = CpuBackend::new();
-let product = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend)?;
+let product = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum("ij,jk->ik", session)
+})?;
 assert_eq!(product.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
 
 let mut product_out = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4])?;
-[&lhs, &rhs].einsum_into(
-    "ij,jk->ik",
-    &mut backend,
-    TensorWrite::from_tensor(&mut product_out),
-)?;
+backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum_into(
+        "ij,jk->ik",
+        session,
+        TensorWrite::from_tensor(&mut product_out),
+    )
+})?;
 assert_eq!(product_out.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
 
 let complex_lhs = TypedTensor::<Complex64>::from_vec_col_major(
@@ -107,7 +111,9 @@ let complex_rhs = TypedTensor::<Complex64>::from_vec_col_major(
     vec![2, 1],
     vec![Complex64::new(5.0, 0.0), Complex64::new(6.0, -1.0)],
 )?;
-let complex = [&complex_lhs, &complex_rhs].einsum("ij,jk->ik", &mut backend)?;
+let complex = backend.with_backend_session(|session| {
+    [&complex_lhs, &complex_rhs].einsum("ij,jk->ik", session)
+})?;
 assert_eq!(
     complex.as_slice()?,
     &[Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)],
@@ -118,11 +124,13 @@ let borrowed_rhs = complex_rhs.as_view();
 let mut borrowed_storage = [Complex64::new(0.0, 0.0); 4];
 let borrowed_out =
     TypedTensorViewMut::from_slice([2, 1], [2, 4], 1, &mut borrowed_storage)?;
-[borrowed, borrowed_rhs].einsum_read_into(
-    "ij,jk->ik",
-    &mut backend,
-    TypedTensorWrite::from_view(borrowed_out),
-)?;
+backend.with_backend_session(|session| {
+    [borrowed, borrowed_rhs].einsum_read_into(
+        "ij,jk->ik",
+        session,
+        TypedTensorWrite::from_view(borrowed_out),
+    )
+})?;
 assert_eq!(
     [borrowed_storage[1], borrowed_storage[3]],
     [Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)],
@@ -159,7 +167,9 @@ let inputs = [
 ];
 
 let mut backend = CpuBackend::new();
-let result = inputs.einsum_read("ij,j->i", &mut backend)?;
+let result = backend.with_backend_session(|session| {
+    inputs.einsum_read("ij,j->i", session)
+})?;
 assert_eq!(result.as_slice::<f64>()?, &[140.0, 320.0]);
 
 let plan = ConcreteEinsumPlan::prepare_read(inputs.clone(), "ij,j->i")?;
@@ -173,11 +183,13 @@ let inputs = [
     TensorRead::from_view(TensorView::F64(matrix)),
     TensorRead::from_tensor(&vector),
 ];
-plan.execute_read_into(
-    inputs,
-    &mut backend,
-    TensorWrite::from_tensor(&mut planned_out),
-)?;
+backend.with_backend_session(|session| {
+    plan.execute_read_into(
+        inputs,
+        session,
+        TensorWrite::from_tensor(&mut planned_out),
+    )
+})?;
 assert_eq!(planned_out.as_slice::<f64>()?, &[140.0, 320.0]);
 ```
 <!-- end-snippet-source -->

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -47,7 +47,7 @@ Box<dyn std::error::Error>>` for a standalone binary.
 
 | Layer | Linear algebra style |
 | --- | --- |
-| Concrete `Tensor` / `TensorRead` / `TypedTensor<T>` | crate-root linalg extension traits; methods take `&mut impl LinalgBackend` |
+| Concrete `Tensor` / `TensorRead` / `TypedTensor<T>` | crate-root linalg extension traits; methods take `&mut dyn BackendSession` obtained via `BackendSessionHost::with_backend_session` |
 | `EagerTensor` | `EagerTensorLinalgExt` methods behind `autodiff`; tracked variables support `backward()` and `EagerRuntime` functional transforms where AD rules support the operation |
 | `TracedTensor` | `TracedTensorLinalgExt` methods for graph execution and `grad`/`vjp`/`jvp` workflows |
 
@@ -74,7 +74,10 @@ CUDA is a backend/device choice for supported `Tensor`, `EagerTensor`, and
 | Norms | `norm` | `norm` | `norm` |
 
 Concrete, read, typed, eager, and traced tensor APIs are crate-root extension
-traits. `LinalgBackend` remains the provider contract passed to concrete methods.
+traits. Concrete methods take `&mut dyn BackendSession` obtained through
+`BackendSessionHost::with_backend_session`. `LinalgBackend` is the SPI provider
+contract used by backend implementations and lower-level session tests, not by
+ordinary callers.
 
 ## Batch And Inner Parallelism
 
@@ -100,7 +103,7 @@ than silently changing the algorithm or execution backend.
 
 <!-- snippet-source: docs/tutorial-code/src/bin/math_snippets.rs#linear_algebra_1 -->
 ```rust
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::Tensor;
@@ -108,13 +111,7 @@ use tenferro_runtime::Tensor;
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 0.0, 0.0, 9.0])?;
 let b = Tensor::from_vec_col_major(vec![2, 1], vec![8.0_f64, 27.0])?;
 let mut backend = CpuBackend::new();
-let x = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| a.solve(&b, exec_session))
-        .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "CPU execution session is unavailable".to_owned(),
-            })?
-})?;
+let x = backend.with_backend_session(|session| a.solve(&b, session))?;
 
 assert_eq!(x.shape(), &[2, 1]);
 assert_eq!(x.as_slice::<f64>()?, &[2.0, 3.0]);
@@ -125,7 +122,7 @@ assert_eq!(x.as_slice::<f64>()?, &[2.0, 3.0]);
 
 <!-- snippet-source: docs/tutorial-code/src/bin/math_snippets.rs#linear_algebra_2 -->
 ```rust
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{Tensor, TensorSessionOpsExt};
@@ -142,13 +139,7 @@ fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Erro
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0])?;
 let mut backend = CpuBackend::new();
 let (factor, reconstructed) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor, Tensor)> {
-    // Double `?`: `with_cpu_exec_session` yields `Option<Result<..>>`; the
-    // first `?` surfaces the session, the second unwraps the op result.
-    let factor = with_cpu_exec_session(session, |exec_session| a.cholesky(exec_session))
-        .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "CPU execution session is unavailable".to_owned(),
-            })??;
+    let factor = a.cholesky(session)?;
     let factor_t = factor.transpose(&[1, 0], session)?;
     let reconstructed = factor.matmul(&factor_t, session)?;
     Ok((factor, reconstructed))
@@ -188,7 +179,7 @@ let ad = AdContext::builder()
 
 <!-- snippet-source: docs/tutorial-code/src/bin/math_snippets.rs#linear_algebra_4 -->
 ```rust
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{Tensor, TensorSessionOpsExt};
@@ -204,13 +195,7 @@ fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Erro
 }
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])?;
 let mut backend = CpuBackend::new();
-let (u, s, vt) = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| a.svd(exec_session))
-        .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "CPU execution session is unavailable".to_owned(),
-            })?
-})?;
+let (u, s, vt) = backend.with_backend_session(|session| a.svd(session))?;
 
 assert_eq!(u.shape(), &[2, 2]);
 assert_eq!(vt.shape(), &[2, 2]);
@@ -298,7 +283,7 @@ assert_eq!(repeated.concrete_shape()?, vec![3]);
 
 <!-- snippet-source: docs/tutorial-code/src/bin/math_snippets.rs#linear_algebra_7 -->
 ```rust
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::{QrGauge, QrOptions, TensorLinalgExt};
 use tenferro_runtime::{Tensor, TensorSessionOpsExt};
@@ -322,16 +307,10 @@ let a = Tensor::from_vec_col_major(
 )?;
 let mut backend = CpuBackend::new();
 let (q, r) = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| {
-        a.qr_with_options(
-            QrOptions::default().gauge(QrGauge::PositiveDiagonal),
-            exec_session,
-        )
-    })
-        .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "CPU execution session is unavailable".to_owned(),
-            })?
+    a.qr_with_options(
+        QrOptions::default().gauge(QrGauge::PositiveDiagonal),
+        session,
+    )
 })?;
 
 let identity = Tensor::from_vec_col_major(
@@ -357,7 +336,7 @@ assert!(max_abs_diff(&qtq, &identity)? < 1.0e-12);
 
 <!-- snippet-source: docs/tutorial-code/src/bin/math_snippets.rs#linear_algebra_8 -->
 ```rust
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{Tensor, TensorSessionOpsExt};
@@ -373,13 +352,7 @@ fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Erro
 }
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 1.0, 1.0, 2.0])?;
 let mut backend = CpuBackend::new();
-let (values, vectors) = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| a.eigh(exec_session))
-        .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "CPU execution session is unavailable".to_owned(),
-            })?
-})?;
+let (values, vectors) = backend.with_backend_session(|session| a.eigh(session))?;
 
 assert_eq!(values.shape(), &[2]);
 assert_eq!(vectors.shape(), &[2, 2]);
@@ -473,9 +446,9 @@ exposes an explicit transpose flag.
 
 <!-- snippet-source: docs/tutorial-code/src/bin/math_snippets.rs#linear_algebra_11 -->
 ```rust
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::BackendSessionHost;
-use tenferro_linalg::LinalgBackend;
+use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Error> {
@@ -499,37 +472,15 @@ let a = Tensor::from_vec_col_major(
 )?;
 let b = Tensor::from_vec_col_major(vec![4, 1], vec![1.0_f64, 2.0, 3.0, 4.0])?;
 
-let outputs = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| {
-        LinalgBackend::full_piv_lu(exec_session, &a)
-    })
-    .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-        op: "full_piv_lu",
-        message: "CPU execution session is unavailable".to_owned(),
-    })?
-})?;
-assert_eq!(outputs.len(), 5);
-let p = &outputs[0];
-let l = &outputs[1];
-let u = &outputs[2];
-let q = &outputs[3];
-let parity = &outputs[4];
+let (p, l, u, q, parity) = backend.with_backend_session(|session| a.full_piv_lu(session))?;
 let (reconstructed,) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor,)> {
     let pt = p.transpose(&[1, 0], session)?;
-    let pt_l = pt.matmul(l, session)?;
-    let pt_lu = pt_l.matmul(u, session)?;
-    let reconstructed = pt_lu.matmul(q, session)?;
+    let pt_l = pt.matmul(&l, session)?;
+    let pt_lu = pt_l.matmul(&u, session)?;
+    let reconstructed = pt_lu.matmul(&q, session)?;
     Ok((reconstructed,))
 })?;
-let x = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| {
-        LinalgBackend::full_piv_lu_solve(exec_session, &a, &b, false)
-    })
-    .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-        op: "full_piv_lu_solve",
-        message: "CPU execution session is unavailable".to_owned(),
-    })?
-})?;
+let x = backend.with_backend_session(|session| a.full_piv_lu_solve(&b, session))?;
 
 assert_eq!(p.shape(), &[4, 4]);
 assert_eq!(a.shape(), &[4, 4]);

--- a/docs/guides/tenferro-fft.md
+++ b/docs/guides/tenferro-fft.md
@@ -128,8 +128,7 @@ example is the source of truth for this guide:
 use num_complex::Complex32;
 use tenferro_fft::{FftNorm, TensorFftExt};
 use tenferro_gpu::cuda::{
-    cuda_devices, download_tensor, gpu_available, upload_tensor, with_cuda_exec_session,
-    CudaBackend,
+    cuda_devices, download_tensor, gpu_available, upload_tensor, CudaBackend,
 };
 use tenferro_runtime::BackendSessionHost;
 use tenferro_tensor::{DType, MemoryKind, Tensor, TensorRead};
@@ -189,15 +188,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or("uploaded tensor has no CUDA allocation domain")?;
 
     // FFT execution consumes the already uploaded tensor; it does not transfer it.
-    let spectrum = backend.with_backend_session(|session| {
-        with_cuda_exec_session(session, |exec_session| {
-            gpu_input.rfft(None, 0, FftNorm::Backward, exec_session)
-        })
-        .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-            op: "cuda_fft_tutorial",
-            message: "CUDA backend session is unavailable".to_owned(),
-        })?
-    })?;
+    let spectrum = backend
+        .with_backend_session(|session| gpu_input.rfft(None, 0, FftNorm::Backward, session))?;
 
     // Check residency before crossing the explicit device-to-host boundary.
     let spectrum_read = TensorRead::from_tensor(&spectrum);
@@ -297,34 +289,28 @@ names.
 <!-- snippet-source: docs/tutorial-code/src/bin/math_snippets.rs#tenferro_fft_22 -->
 ```rust
 use num_complex::Complex64;
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_fft::{FftNorm, TensorFftExt, TensorReadFftExt};
 use tenferro_runtime::BackendSessionHost;
 use tenferro_tensor::{Tensor, TensorRead, TensorView, TypedTensorView};
 
 let mut backend = CpuBackend::new();
-backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |backend| -> Result<(), tenferro_tensor::Error> {
-        let x = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0])?;
-        let full = x.fft(None, -1, FftNorm::Backward, backend)?;
-        let one_sided = x.rfft(None, -1, FftNorm::Backward, backend)?;
-        assert_eq!(full.as_slice::<Complex64>()?[0], Complex64::new(10.0, 0.0));
-        assert_eq!(one_sided.shape(), &[3]);
+backend.with_backend_session(|session| -> Result<(), tenferro_tensor::Error> {
+    let x = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0])?;
+    let full = x.fft(None, -1, FftNorm::Backward, session)?;
+    let one_sided = x.rfft(None, -1, FftNorm::Backward, session)?;
+    assert_eq!(full.as_slice::<Complex64>()?[0], Complex64::new(10.0, 0.0));
+    assert_eq!(one_sided.shape(), &[3]);
 
-        let data = [1.0_f64, 99.0, 2.0, 99.0, 3.0, 99.0, 4.0];
-        let view = TypedTensorView::from_slice([4], [2], 0, &data)?;
-        let read = TensorRead::from_view(TensorView::F64(view));
-        let read_full = read.fft_read(None, -1, FftNorm::Backward, backend)?;
-        assert_eq!(
-            read_full.as_slice::<Complex64>()?[0],
-            Complex64::new(10.0, 0.0),
-        );
-        Ok(())
-    })
-    .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-        op: "documentation",
-        message: "CPU execution session is unavailable".to_owned(),
-    })?
+    let data = [1.0_f64, 99.0, 2.0, 99.0, 3.0, 99.0, 4.0];
+    let view = TypedTensorView::from_slice([4], [2], 0, &data)?;
+    let read = TensorRead::from_view(TensorView::F64(view));
+    let read_full = read.fft_read(None, -1, FftNorm::Backward, session)?;
+    assert_eq!(
+        read_full.as_slice::<Complex64>()?[0],
+        Complex64::new(10.0, 0.0),
+    );
+    Ok(())
 })?;
 ```
 <!-- end-snippet-source -->
@@ -366,12 +352,9 @@ each FFT call:
 
 <!-- snippet-source: docs/tutorial-code/src/bin/math_snippets.rs#tenferro_fft_24 -->
 ```rust
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_fft::{FftNorm, TensorFftExt};
-use tenferro_gpu::{
-    apple::AppleContext,
-    webgpu::with_webgpu_exec_session,
-};
+use tenferro_gpu::apple::AppleContext;
 use tenferro_runtime::BackendSessionHost;
 use tenferro_tensor::Tensor;
 
@@ -383,27 +366,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut cpu = context.cpu_backend().clone();
     let cpu_spectrum = cpu
-        .with_backend_session(|session| {
-            with_cpu_exec_session(session, |exec_session| {
-                managed.rfft(None, 0, FftNorm::Backward, exec_session)
-            })
-            .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "CPU execution session is unavailable".to_owned(),
-            })?
-        })?;
+        .with_backend_session(|session| managed.rfft(None, 0, FftNorm::Backward, session))?;
 
     let mut metal = context.metal_backend().clone();
     let metal_spectrum = metal
-        .with_backend_session(|session| {
-            with_webgpu_exec_session(session, |exec_session| {
-                managed.rfft(None, 0, FftNorm::Backward, exec_session)
-            })
-            .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "WebGPU execution session is unavailable".to_owned(),
-            })?
-        })?;
+        .with_backend_session(|session| managed.rfft(None, 0, FftNorm::Backward, session))?;
     metal.synchronize()?;
 
     assert_eq!(cpu_spectrum.shape(), metal_spectrum.shape());

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,10 +33,9 @@ compilation, CUDA, or experimental WebGPU only when the workflow needs them.
 
 <!-- snippet-source: docs/tutorial-code/src/bin/direct_linalg_quickstart.rs -->
 ```rust
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_linalg::prelude::*;
 use tenferro_runtime::prelude::*;
-use tenferro_runtime::{TensorRead, TensorView};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -59,17 +58,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(product.shape(), &[2, 2]);
     assert_close(product.host_data()?, &[3.0, 0.0, 0.0, 1.0]);
 
-    let svd = backend.with_backend_session(|session| {
-        with_cpu_exec_session(session, |exec_session| {
-            exec_session.svd_read(TensorRead::from_view(TensorView::F64(product.as_view())))
-        })
-        .expect("CpuBackend must expose a CPU execution session")
-    })?;
-    assert_eq!(svd.len(), 3);
-    assert_eq!(svd[0].shape(), &[2, 2]);
-    assert_eq!(svd[1].shape(), &[2]);
-    assert_eq!(svd[2].shape(), &[2, 2]);
-    assert_close(svd[1].as_slice::<f64>().unwrap(), &[3.0, 1.0]);
+    let (u, s, vt) = backend.with_backend_session(|session| product.svd(session))?;
+    assert_eq!(u.shape(), &[2, 2]);
+    assert_eq!(s.shape(), &[2]);
+    assert_eq!(vt.shape(), &[2, 2]);
+    assert_close(s.as_slice()?, &[3.0, 1.0]);
 
     Ok(())
 }

--- a/docs/tutorial-code/src/bin/apple_shared_fft.rs
+++ b/docs/tutorial-code/src/bin/apple_shared_fft.rs
@@ -8,7 +8,7 @@ use tenferro_fft::{FftNorm, TensorFftExt};
 use tenferro_gpu::apple::AppleContext;
 #[cfg(target_os = "macos")]
 use tenferro_tensor::{
-    AllocationDomainId, AllocationId, Error, StorageBuffer, Tensor, TypedTensor,
+    AllocationDomainId, AllocationId, BackendSessionHost, Error, StorageBuffer, Tensor, TypedTensor,
 };
 
 #[cfg(target_os = "macos")]
@@ -42,16 +42,19 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let after_creation = context.transfer_stats();
 
     let mut cpu = context.cpu_backend().clone();
-    let cpu_first = unified.rfft(None, 0, FftNorm::Backward, &mut cpu)?;
+    let cpu_first =
+        cpu.with_backend_session(|session| unified.rfft(None, 0, FftNorm::Backward, session))?;
     assert_eq!(f32_identity(&unified), input_identity);
 
     let mut metal = context.metal_backend().clone();
-    let metal_result = unified.rfft(None, 0, FftNorm::Backward, &mut metal)?;
+    let metal_result =
+        metal.with_backend_session(|session| unified.rfft(None, 0, FftNorm::Backward, session))?;
     metal.synchronize()?;
     assert_eq!(f32_identity(&unified), input_identity);
 
     let mut cpu = context.cpu_backend().clone();
-    let cpu_again = unified.rfft(None, 0, FftNorm::Backward, &mut cpu)?;
+    let cpu_again =
+        cpu.with_backend_session(|session| unified.rfft(None, 0, FftNorm::Backward, session))?;
     assert_eq!(f32_identity(&unified), input_identity);
 
     let (Tensor::C32(cpu_first), Tensor::C32(metal_result), Tensor::C32(cpu_again)) =
@@ -96,15 +99,16 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let c64 = context.upload_tensor(&c64_host)?;
     let after_c64_creation = context.transfer_stats();
     let mut cpu = context.cpu_backend().clone();
-    let cpu_c64 = c64.fft(None, 0, FftNorm::Backward, &mut cpu)?;
+    let cpu_c64 =
+        cpu.with_backend_session(|session| c64.fft(None, 0, FftNorm::Backward, session))?;
     let Tensor::C64(cpu_c64) = cpu_c64 else {
         panic!("C64 FFT must return C64")
     };
     assert_eq!(cpu_c64.allocation_domain(), Some(context.domain_id()));
 
     let mut metal = context.metal_backend().clone();
-    let error = c64
-        .fft(None, 0, FftNorm::Backward, &mut metal)
+    let error = metal
+        .with_backend_session(|session| c64.fft(None, 0, FftNorm::Backward, session))
         .expect_err("Metal must reject C64");
     assert!(matches!(error, Error::Unsupported { .. }));
     assert_eq!(context.transfer_stats(), after_c64_creation);

--- a/docs/tutorial-code/src/bin/core_tensor_snippets.rs
+++ b/docs/tutorial-code/src/bin/core_tensor_snippets.rs
@@ -103,8 +103,8 @@ assert_eq!(negated.as_slice::<f64>().unwrap(), &[-1.0, -2.0, -3.0]);
     // snippet source: docs/guides/eager-operations.md:173
     fn snippet_eager_operations_5() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:eager_operations_5
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
-use tenferro_linalg::LinalgBackend;
+use tenferro_cpu::CpuBackend;
+use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{BackendSessionHost, Tensor};
 
 let mut backend = CpuBackend::new();
@@ -115,19 +115,17 @@ let a = Tensor::from_vec_col_major(vec![3, 3], vec![
 ])?;
 let b = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0])?;
 backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec| {
-        let svd = LinalgBackend::svd(exec, &a).unwrap();
-        let qr = LinalgBackend::qr(exec, &a).unwrap();
-        let chol = LinalgBackend::cholesky(exec, &a).unwrap();
-        let eigh = LinalgBackend::eigh(exec, &a).unwrap();
-        let x = LinalgBackend::solve(exec, &a, &b).unwrap();
-        assert_eq!(svd[1].shape(), &[3]);
-        assert_eq!(qr[0].shape(), &[3, 3]);
-        assert_eq!(chol.shape(), &[3, 3]);
-        assert_eq!(eigh[0].shape(), &[3]);
-        assert_eq!(eigh[1].shape(), &[3, 3]);
-        assert_eq!(x.shape(), &[3]);
-    }).expect("CPU execution session is available")
+    let svd = a.svd(session).unwrap();
+    let qr = a.qr(session).unwrap();
+    let chol = a.cholesky(session).unwrap();
+    let eigh = a.eigh(session).unwrap();
+    let x = a.solve(&b, session).unwrap();
+    assert_eq!(svd.1.shape(), &[3]);
+    assert_eq!(qr.0.shape(), &[3, 3]);
+    assert_eq!(chol.shape(), &[3, 3]);
+    assert_eq!(eigh.0.shape(), &[3]);
+    assert_eq!(eigh.1.shape(), &[3, 3]);
+    assert_eq!(x.shape(), &[3]);
 });
         // snippet-end:eager_operations_5
         Ok(())

--- a/docs/tutorial-code/src/bin/cuda_fft.rs
+++ b/docs/tutorial-code/src/bin/cuda_fft.rs
@@ -3,8 +3,7 @@
 use num_complex::Complex32;
 use tenferro_fft::{FftNorm, TensorFftExt};
 use tenferro_gpu::cuda::{
-    cuda_devices, download_tensor, gpu_available, upload_tensor, with_cuda_exec_session,
-    CudaBackend,
+    cuda_devices, download_tensor, gpu_available, upload_tensor, CudaBackend,
 };
 use tenferro_runtime::BackendSessionHost;
 use tenferro_tensor::{DType, MemoryKind, Tensor, TensorRead};
@@ -64,15 +63,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or("uploaded tensor has no CUDA allocation domain")?;
 
     // FFT execution consumes the already uploaded tensor; it does not transfer it.
-    let spectrum = backend.with_backend_session(|session| {
-        with_cuda_exec_session(session, |exec_session| {
-            gpu_input.rfft(None, 0, FftNorm::Backward, exec_session)
-        })
-        .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-            op: "cuda_fft_tutorial",
-            message: "CUDA backend session is unavailable".to_owned(),
-        })?
-    })?;
+    let spectrum = backend
+        .with_backend_session(|session| gpu_input.rfft(None, 0, FftNorm::Backward, session))?;
 
     // Check residency before crossing the explicit device-to-host boundary.
     let spectrum_read = TensorRead::from_tensor(&spectrum);

--- a/docs/tutorial-code/src/bin/direct_linalg_quickstart.rs
+++ b/docs/tutorial-code/src/bin/direct_linalg_quickstart.rs
@@ -1,7 +1,6 @@
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_linalg::prelude::*;
 use tenferro_runtime::prelude::*;
-use tenferro_runtime::{TensorRead, TensorView};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -24,17 +23,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(product.shape(), &[2, 2]);
     assert_close(product.host_data()?, &[3.0, 0.0, 0.0, 1.0]);
 
-    let svd = backend.with_backend_session(|session| {
-        with_cpu_exec_session(session, |exec_session| {
-            exec_session.svd_read(TensorRead::from_view(TensorView::F64(product.as_view())))
-        })
-        .expect("CpuBackend must expose a CPU execution session")
-    })?;
-    assert_eq!(svd.len(), 3);
-    assert_eq!(svd[0].shape(), &[2, 2]);
-    assert_eq!(svd[1].shape(), &[2]);
-    assert_eq!(svd[2].shape(), &[2, 2]);
-    assert_close(svd[1].as_slice::<f64>().unwrap(), &[3.0, 1.0]);
+    let (u, s, vt) = backend.with_backend_session(|session| product.svd(session))?;
+    assert_eq!(u.shape(), &[2, 2]);
+    assert_eq!(s.shape(), &[2]);
+    assert_eq!(vt.shape(), &[2, 2]);
+    assert_close(s.as_slice()?, &[3.0, 1.0]);
 
     Ok(())
 }

--- a/docs/tutorial-code/src/bin/math_snippets.rs
+++ b/docs/tutorial-code/src/bin/math_snippets.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // snippet source: docs/guides/linear-algebra.md:101
     fn snippet_linear_algebra_1() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:linear_algebra_1
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::Tensor;
@@ -25,13 +25,7 @@ use tenferro_runtime::Tensor;
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 0.0, 0.0, 9.0])?;
 let b = Tensor::from_vec_col_major(vec![2, 1], vec![8.0_f64, 27.0])?;
 let mut backend = CpuBackend::new();
-let x = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| a.solve(&b, exec_session))
-        .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "CPU execution session is unavailable".to_owned(),
-            })?
-})?;
+let x = backend.with_backend_session(|session| a.solve(&b, session))?;
 
 assert_eq!(x.shape(), &[2, 1]);
 assert_eq!(x.as_slice::<f64>()?, &[2.0, 3.0]);
@@ -44,7 +38,7 @@ assert_eq!(x.as_slice::<f64>()?, &[2.0, 3.0]);
     // snippet source: docs/guides/linear-algebra.md:118
     fn snippet_linear_algebra_2() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:linear_algebra_2
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{Tensor, TensorSessionOpsExt};
@@ -61,13 +55,7 @@ fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Erro
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0])?;
 let mut backend = CpuBackend::new();
 let (factor, reconstructed) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor, Tensor)> {
-    // Double `?`: `with_cpu_exec_session` yields `Option<Result<..>>`; the
-    // first `?` surfaces the session, the second unwraps the op result.
-    let factor = with_cpu_exec_session(session, |exec_session| a.cholesky(exec_session))
-        .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "CPU execution session is unavailable".to_owned(),
-            })??;
+    let factor = a.cholesky(session)?;
     let factor_t = factor.transpose(&[1, 0], session)?;
     let reconstructed = factor.matmul(&factor_t, session)?;
     Ok((factor, reconstructed))
@@ -99,7 +87,7 @@ let ad = AdContext::builder()
     // snippet source: docs/guides/linear-algebra.md:169
     fn snippet_linear_algebra_4() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:linear_algebra_4
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{Tensor, TensorSessionOpsExt};
@@ -115,13 +103,7 @@ fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Erro
 }
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])?;
 let mut backend = CpuBackend::new();
-let (u, s, vt) = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| a.svd(exec_session))
-        .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "CPU execution session is unavailable".to_owned(),
-            })?
-})?;
+let (u, s, vt) = backend.with_backend_session(|session| a.svd(session))?;
 
 assert_eq!(u.shape(), &[2, 2]);
 assert_eq!(vt.shape(), &[2, 2]);
@@ -207,7 +189,7 @@ assert_eq!(repeated.concrete_shape()?, vec![3]);
     // snippet source: docs/guides/linear-algebra.md:265
     fn snippet_linear_algebra_7() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:linear_algebra_7
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::{QrGauge, QrOptions, TensorLinalgExt};
 use tenferro_runtime::{Tensor, TensorSessionOpsExt};
@@ -231,16 +213,10 @@ let a = Tensor::from_vec_col_major(
 )?;
 let mut backend = CpuBackend::new();
 let (q, r) = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| {
-        a.qr_with_options(
-            QrOptions::default().gauge(QrGauge::PositiveDiagonal),
-            exec_session,
-        )
-    })
-        .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "CPU execution session is unavailable".to_owned(),
-            })?
+    a.qr_with_options(
+        QrOptions::default().gauge(QrGauge::PositiveDiagonal),
+        session,
+    )
 })?;
 
 let identity = Tensor::from_vec_col_major(
@@ -268,7 +244,7 @@ assert!(max_abs_diff(&qtq, &identity)? < 1.0e-12);
     // snippet source: docs/guides/linear-algebra.md:312
     fn snippet_linear_algebra_8() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:linear_algebra_8
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::BackendSessionHost;
 use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{Tensor, TensorSessionOpsExt};
@@ -284,13 +260,7 @@ fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Erro
 }
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 1.0, 1.0, 2.0])?;
 let mut backend = CpuBackend::new();
-let (values, vectors) = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| a.eigh(exec_session))
-        .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "CPU execution session is unavailable".to_owned(),
-            })?
-})?;
+let (values, vectors) = backend.with_backend_session(|session| a.eigh(session))?;
 
 assert_eq!(values.shape(), &[2]);
 assert_eq!(vectors.shape(), &[2, 2]);
@@ -383,9 +353,9 @@ assert_eq!(result.as_slice::<f64>()?, &[2.0, 3.0]);
     // snippet source: docs/guides/linear-algebra.md:415
     fn snippet_linear_algebra_11() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:linear_algebra_11
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_runtime::BackendSessionHost;
-use tenferro_linalg::LinalgBackend;
+use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<f64, tenferro_tensor::Error> {
@@ -409,37 +379,15 @@ let a = Tensor::from_vec_col_major(
 )?;
 let b = Tensor::from_vec_col_major(vec![4, 1], vec![1.0_f64, 2.0, 3.0, 4.0])?;
 
-let outputs = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| {
-        LinalgBackend::full_piv_lu(exec_session, &a)
-    })
-    .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-        op: "full_piv_lu",
-        message: "CPU execution session is unavailable".to_owned(),
-    })?
-})?;
-assert_eq!(outputs.len(), 5);
-let p = &outputs[0];
-let l = &outputs[1];
-let u = &outputs[2];
-let q = &outputs[3];
-let parity = &outputs[4];
+let (p, l, u, q, parity) = backend.with_backend_session(|session| a.full_piv_lu(session))?;
 let (reconstructed,) = backend.with_backend_session(|session| -> tenferro_tensor::Result<(Tensor,)> {
     let pt = p.transpose(&[1, 0], session)?;
-    let pt_l = pt.matmul(l, session)?;
-    let pt_lu = pt_l.matmul(u, session)?;
-    let reconstructed = pt_lu.matmul(q, session)?;
+    let pt_l = pt.matmul(&l, session)?;
+    let pt_lu = pt_l.matmul(&u, session)?;
+    let reconstructed = pt_lu.matmul(&q, session)?;
     Ok((reconstructed,))
 })?;
-let x = backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |exec_session| {
-        LinalgBackend::full_piv_lu_solve(exec_session, &a, &b, false)
-    })
-    .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-        op: "full_piv_lu_solve",
-        message: "CPU execution session is unavailable".to_owned(),
-    })?
-})?;
+let x = backend.with_backend_session(|session| a.full_piv_lu_solve(&b, session))?;
 
 assert_eq!(p.shape(), &[4, 4]);
 assert_eq!(a.shape(), &[4, 4]);
@@ -468,8 +416,8 @@ use tenferro_einsum::{
     TypedTensorEinsumIntoExt, TypedTensorReadEinsumIntoExt,
 };
 use tenferro_tensor::{
-    Tensor, TensorWrite, TypedTensor, TypedTensorView, TypedTensorViewMut,
-    TypedTensorWrite,
+    BackendSessionHost, Tensor, TensorWrite, TypedTensor, TypedTensorView,
+    TypedTensorViewMut, TypedTensorWrite,
 };
 
 let lhs = Tensor::from_vec_col_major(
@@ -481,15 +429,19 @@ let rhs = Tensor::from_vec_col_major(
     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
 )?;
 let mut backend = CpuBackend::new();
-let product = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend)?;
+let product = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum("ij,jk->ik", session)
+})?;
 assert_eq!(product.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
 
 let mut product_out = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4])?;
-[&lhs, &rhs].einsum_into(
-    "ij,jk->ik",
-    &mut backend,
-    TensorWrite::from_tensor(&mut product_out),
-)?;
+backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum_into(
+        "ij,jk->ik",
+        session,
+        TensorWrite::from_tensor(&mut product_out),
+    )
+})?;
 assert_eq!(product_out.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
 
 let complex_lhs = TypedTensor::<Complex64>::from_vec_col_major(
@@ -505,7 +457,9 @@ let complex_rhs = TypedTensor::<Complex64>::from_vec_col_major(
     vec![2, 1],
     vec![Complex64::new(5.0, 0.0), Complex64::new(6.0, -1.0)],
 )?;
-let complex = [&complex_lhs, &complex_rhs].einsum("ij,jk->ik", &mut backend)?;
+let complex = backend.with_backend_session(|session| {
+    [&complex_lhs, &complex_rhs].einsum("ij,jk->ik", session)
+})?;
 assert_eq!(
     complex.as_slice()?,
     &[Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)],
@@ -516,11 +470,13 @@ let borrowed_rhs = complex_rhs.as_view();
 let mut borrowed_storage = [Complex64::new(0.0, 0.0); 4];
 let borrowed_out =
     TypedTensorViewMut::from_slice([2, 1], [2, 4], 1, &mut borrowed_storage)?;
-[borrowed, borrowed_rhs].einsum_read_into(
-    "ij,jk->ik",
-    &mut backend,
-    TypedTensorWrite::from_view(borrowed_out),
-)?;
+backend.with_backend_session(|session| {
+    [borrowed, borrowed_rhs].einsum_read_into(
+        "ij,jk->ik",
+        session,
+        TypedTensorWrite::from_view(borrowed_out),
+    )
+})?;
 assert_eq!(
     [borrowed_storage[1], borrowed_storage[3]],
     [Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)],
@@ -547,7 +503,9 @@ let inputs = [
 ];
 
 let mut backend = CpuBackend::new();
-let result = inputs.einsum_read("ij,j->i", &mut backend)?;
+let result = backend.with_backend_session(|session| {
+    inputs.einsum_read("ij,j->i", session)
+})?;
 assert_eq!(result.as_slice::<f64>()?, &[140.0, 320.0]);
 
 let plan = ConcreteEinsumPlan::prepare_read(inputs.clone(), "ij,j->i")?;
@@ -561,11 +519,13 @@ let inputs = [
     TensorRead::from_view(TensorView::F64(matrix)),
     TensorRead::from_tensor(&vector),
 ];
-plan.execute_read_into(
-    inputs,
-    &mut backend,
-    TensorWrite::from_tensor(&mut planned_out),
-)?;
+backend.with_backend_session(|session| {
+    plan.execute_read_into(
+        inputs,
+        session,
+        TensorWrite::from_tensor(&mut planned_out),
+    )
+})?;
 assert_eq!(planned_out.as_slice::<f64>()?, &[140.0, 320.0]);
         // snippet-end:einsum_13
         Ok(())
@@ -885,34 +845,28 @@ assert_eq!(
     fn snippet_tenferro_fft_22() -> Result<(), Box<dyn std::error::Error>> {
 // snippet-start:tenferro_fft_22
 use num_complex::Complex64;
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_fft::{FftNorm, TensorFftExt, TensorReadFftExt};
 use tenferro_runtime::BackendSessionHost;
 use tenferro_tensor::{Tensor, TensorRead, TensorView, TypedTensorView};
 
 let mut backend = CpuBackend::new();
-backend.with_backend_session(|session| {
-    with_cpu_exec_session(session, |backend| -> Result<(), tenferro_tensor::Error> {
-        let x = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0])?;
-        let full = x.fft(None, -1, FftNorm::Backward, backend)?;
-        let one_sided = x.rfft(None, -1, FftNorm::Backward, backend)?;
-        assert_eq!(full.as_slice::<Complex64>()?[0], Complex64::new(10.0, 0.0));
-        assert_eq!(one_sided.shape(), &[3]);
+backend.with_backend_session(|session| -> Result<(), tenferro_tensor::Error> {
+    let x = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0])?;
+    let full = x.fft(None, -1, FftNorm::Backward, session)?;
+    let one_sided = x.rfft(None, -1, FftNorm::Backward, session)?;
+    assert_eq!(full.as_slice::<Complex64>()?[0], Complex64::new(10.0, 0.0));
+    assert_eq!(one_sided.shape(), &[3]);
 
-        let data = [1.0_f64, 99.0, 2.0, 99.0, 3.0, 99.0, 4.0];
-        let view = TypedTensorView::from_slice([4], [2], 0, &data)?;
-        let read = TensorRead::from_view(TensorView::F64(view));
-        let read_full = read.fft_read(None, -1, FftNorm::Backward, backend)?;
-        assert_eq!(
-            read_full.as_slice::<Complex64>()?[0],
-            Complex64::new(10.0, 0.0),
-        );
-        Ok(())
-    })
-    .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-        op: "documentation",
-        message: "CPU execution session is unavailable".to_owned(),
-    })?
+    let data = [1.0_f64, 99.0, 2.0, 99.0, 3.0, 99.0, 4.0];
+    let view = TypedTensorView::from_slice([4], [2], 0, &data)?;
+    let read = TensorRead::from_view(TensorView::F64(view));
+    let read_full = read.fft_read(None, -1, FftNorm::Backward, session)?;
+    assert_eq!(
+        read_full.as_slice::<Complex64>()?[0],
+        Complex64::new(10.0, 0.0),
+    );
+    Ok(())
 })?;
 // snippet-end:tenferro_fft_22
 
@@ -950,12 +904,9 @@ assert_eq!(restored.to_tensor()?.as_slice::<f64>()?, &[1.0, 2.0, 3.0, 4.0]);
     #[cfg(all(feature = "apple-shared", target_os = "macos"))]
     fn snippet_tenferro_fft_24() -> Result<(), Box<dyn std::error::Error>> {
         // snippet-start:tenferro_fft_24
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+use tenferro_cpu::CpuBackend;
 use tenferro_fft::{FftNorm, TensorFftExt};
-use tenferro_gpu::{
-    apple::AppleContext,
-    webgpu::with_webgpu_exec_session,
-};
+use tenferro_gpu::apple::AppleContext;
 use tenferro_runtime::BackendSessionHost;
 use tenferro_tensor::Tensor;
 
@@ -967,27 +918,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut cpu = context.cpu_backend().clone();
     let cpu_spectrum = cpu
-        .with_backend_session(|session| {
-            with_cpu_exec_session(session, |exec_session| {
-                managed.rfft(None, 0, FftNorm::Backward, exec_session)
-            })
-            .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "CPU execution session is unavailable".to_owned(),
-            })?
-        })?;
+        .with_backend_session(|session| managed.rfft(None, 0, FftNorm::Backward, session))?;
 
     let mut metal = context.metal_backend().clone();
     let metal_spectrum = metal
-        .with_backend_session(|session| {
-            with_webgpu_exec_session(session, |exec_session| {
-                managed.rfft(None, 0, FftNorm::Backward, exec_session)
-            })
-            .ok_or_else(|| tenferro_tensor::Error::Unsupported {
-                op: "documentation",
-                message: "WebGPU execution session is unavailable".to_owned(),
-            })?
-        })?;
+        .with_backend_session(|session| managed.rfft(None, 0, FftNorm::Backward, session))?;
     metal.synchronize()?;
 
     assert_eq!(cpu_spectrum.shape(), metal_spectrum.shape());

--- a/docs/worklogs/2026-08-14-phase3-extension-surfaces.md
+++ b/docs/worklogs/2026-08-14-phase3-extension-surfaces.md
@@ -1,0 +1,90 @@
+# 2026-08-14 — #1680 Phase 3: extension surfaces + GPU guard (single API complete)
+
+## Session summary
+
+Completed the single-API end state for the remaining backend-taking concrete
+surfaces and wired the GPU nested-entry guard, in one designed-and-gated PR
+(39 files, net −11 lines: 1949+ / 1960−). After this phase, **no concrete op
+takes a non-session `&mut B`** in the migrated areas; every concrete op runs
+on a borrowed session (core, einsum, fft, linalg, shape-packing), and
+CUDA/WebGPU enforce the nested-entry contract like CPU and the default
+adapter.
+
+## Gate record (frontier review, per AGENTS.md)
+
+- **Pre-implementation design gate** (reviewer-gpt on
+  `docs/design/session-oriented-concrete-apis.md` §"Phase 3"): 3 rounds →
+  **approved**. Round 1: 4 blocking (custom-capability compatibility →
+  chose option (b) built-in dispatch with documented breaking restriction;
+  linalg dispatch completeness incl. solve_read_into + typed_output; GPU
+  verification commands; missing FFT/linalg baselines) + 3 minor (tensordot
+  not a plan path; FFT inventory; shape-packing grep gate). Rounds 2-3:
+  baseline values + wording.
+- **Post-implementation diff gate** (reviewer-gpt on the full ~7.8k-line
+  diff): 2 rounds → **Correct-to-merge**. Round 1: 3 blocking (docs/guides
+  still taught the retired `&mut impl LinalgBackend` contract;
+  caller-downcasts remained in concrete tests; worklog + verification
+  evidence missing) + 1 minor (direct solve_read_into path not provably
+  taken). All fixed; Round 2 confirmed.
+
+## Design decisions
+
+- **Option (b) capability decision**: concrete ops take `&mut dyn
+  BackendSession` with internal built-in dispatch (reusing the existing
+  linalg/fft extension-session downcast patterns). Documented breaking
+  restriction: the concrete op traits no longer accept third-party
+  LinalgBackend/FftBackend impls; the SPI traits stay for backend
+  implementers; test-only custom backends migrated (assert typed capability
+  errors) or removed.
+- **solve_read_into direct path preserved** (no allocate+copy); typed
+  contract via `typed_output` (not into_typed_result).
+- **GPU guard**: `with_session_entry_guard` (`#[doc(hidden)] pub`, thread-
+  local flag + panic-safe Drop restore + debug assert) extracted and used by
+  `default_backend_session` + both GPU `with_backend_session` overrides; CPU
+  EXECUTION_OWNER release panic and Send soundness bounds untouched.
+- tensordot calls `session.dot_general` directly (not a plan path); FFT plan
+  cache stays executor-owned; einsum top-level internals keep routing
+  through ConcreteEinsumPlan.
+
+## Measurements (release, pinned core 40; pre = main, post = Phase-3)
+
+| arm | pre | post |
+|---|---|---|
+| FFT 256×1 direct_one_shot | 15.0 µs | 14.5 µs |
+| FFT 256×1 executor_warm | 11.3 µs | 10.9 µs |
+| FFT 1024×16 direct_one_shot | 88.3 µs | 84.2 µs |
+| FFT 1024×16 executor_warm | 73.1 µs | 71.5 µs |
+| linalg solve 8×8 (session form) | 14.4 µs | **14.3 µs** (orchestrator-verified) |
+| linalg svd 8×8 (session form) | 18.6 µs | **18.8 µs** (orchestrator-verified) |
+
+All within the interleaved noise band — **no regression** (the internal
+dispatch replaced the caller's manual `with_cpu_exec_session` wrapper with
+no measurable cost; FFT arms slightly improved).
+
+## Verification
+
+- Workspace build; test suites: runtime 402+146+1+413, einsum 161+24+1+87,
+  fft 18+6+20+1+18, linalg 124+134+1+126, ad 86+337+1+147, cpu
+  512+1+46+2+185, tensor 260+…+326 — all pass (incl. doctests)
+- Doc scripts: guide-dependency-snippets-ok, test-doc-consistency exit 0,
+  doc-snippets-ok; fmt clean; clippy workspace 0 findings
+- GPU: `cargo check -p tenferro-gpu --features cuda` and
+  `--features webgpu` (both --all-targets) pass; the cfg-gated nested-entry
+  tests for CUDA/WebGPU compile but **execute only on a GPU host** (CI gate
+  item); the shared helper's panic-restore/nested tests run on CPU
+- Source-contract tests: `cpu_solve_read_into_reaches_direct_write_for_eligible_outputs`
+  and `cpu_solve_read_into_entered_writes_into_the_caller_buffer` prove the
+  direct write path is taken (not allocate+copy)
+- Grep: no `&mut B` in the 5 areas' public concrete methods; no
+  `with_cpu_exec_session`/`with_cuda_exec_session` at migrated call sites
+  (remaining uses are SPI-level: runtime() access, provider-contract tests);
+  `with_session_entry_guard` used by default adapter + CUDA + WebGPU
+
+## Residual risks
+
+- GPU nested-entry tests are compile-verified locally; runtime execution
+  requires a CUDA host (CI gate).
+- The option-(b) breaking restriction (concrete op traits are
+  built-in-session only) narrows third-party extensibility of the concrete
+  path; the SPI traits remain for backend implementers. Documented in the
+  design doc + PR body.

--- a/scripts/check-guide-dependency-snippets.py
+++ b/scripts/check-guide-dependency-snippets.py
@@ -73,8 +73,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 LINALG_SOURCE = r"""
 use tenferro_ad::AdContext;
-use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
-use tenferro_linalg::LinalgBackend;
+use tenferro_cpu::CpuBackend;
+use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{BackendSessionHost, Tensor, TensorSessionOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
@@ -96,23 +96,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         vec![2, 2],
         vec![0.0_f64, 2.0, 1.0, 3.0],
     )?;
-    let outputs = backend.with_backend_session(|session| {
-        with_cpu_exec_session(session, |exec_session| {
-            LinalgBackend::full_piv_lu(exec_session, &a)
-        })
-        .expect("CpuBackend must expose a CPU execution session")
-    })?;
-    let p = &outputs[0];
-    let l = &outputs[1];
-    let u = &outputs[2];
-    let q = &outputs[3];
-    let parity = &outputs[4];
+    let (p, l, u, q, parity) = backend.with_backend_session(|session| a.full_piv_lu(session))?;
 
     let reconstructed = backend.with_backend_session(|session| {
         let pt = p.transpose(&[1, 0], session)?;
-        let pt_l = pt.matmul(l, session)?;
-        let pt_lu = pt_l.matmul(u, session)?;
-        pt_lu.matmul(q, session)
+        let pt_l = pt.matmul(&l, session)?;
+        let pt_lu = pt_l.matmul(&u, session)?;
+        pt_lu.matmul(&q, session)
     })?;
     assert!(max_abs_diff(&reconstructed, &a) < 1.0e-12);
 
@@ -121,12 +111,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert!(parity_value == 1.0 || parity_value == -1.0);
 
     let b = Tensor::from_vec_col_major(vec![2, 1], vec![-1.0_f64, 5.0])?;
-    let x = backend.with_backend_session(|session| {
-        with_cpu_exec_session(session, |exec_session| {
-            LinalgBackend::full_piv_lu_solve(exec_session, &a, &b, false)
-        })
-        .expect("CpuBackend must expose a CPU execution session")
-    })?;
+    let x = backend.with_backend_session(|session| a.full_piv_lu_solve(&b, session))?;
     assert_eq!(x.shape(), &[2, 1]);
 
     Ok(())


### PR DESCRIPTION
## Summary

Issue #1680 **Phase 3** — completes the single session-explicit API end state:
the remaining backend-taking concrete surfaces migrate to `&mut dyn
BackendSession`, and the GPU nested-entry guard is wired into CUDA/WebGPU.

## What changed

- **einsum top-level (10 traits)**: einsum-family methods take `&mut dyn
  BackendSession` (internals keep routing through `ConcreteEinsumPlan`);
  tensordot calls `session.dot_general` directly.
- **FFT (4 executor + 8 trait methods)**: session receiver with internal
  built-in dispatch (CPU/CUDA/WebGPU); typed capability error otherwise;
  plan cache stays executor-owned; manual caller downcasts removed.
- **linalg (64 methods)**: session receiver; existing composite bodies run on
  the concrete exec session after one internal downcast; **direct
  `solve_read_into` write path preserved** (source-contract-tested, no
  allocate+copy); typed contract via `typed_output`.
- **shape_packing**: `Tensor::index_select`/`stack` take the session.
- **GPU nested-entry**: `with_session_entry_guard` (`#[doc(hidden)] pub`)
  extracted and wired into the default adapter + CUDA + WebGPU
  `with_backend_session` overrides — nested entry detected in debug builds on
  every backend family. CPU's release `EXECUTION_OWNER` panic and the `Send`
  soundness bounds are untouched.
- **Documented breaking restriction** (option b): the concrete op traits are
  built-in-session only; the `LinalgBackend`/`FftBackend` SPI traits remain
  for backend implementers; test-only custom backends migrated to assert
  typed capability errors.

## Measurements (release, pinned core 40)

| arm | pre | post |
|---|---|---|
| FFT 256×1 direct / executor | 15.0 / 11.3 µs | 14.5 / 10.9 µs |
| FFT 1024×16 direct / executor | 88.3 / 73.1 µs | 84.2 / 71.5 µs |
| linalg solve 8×8 | 14.4 µs | 14.3 µs |
| linalg svd 8×8 | 18.6 µs | 18.8 µs |

**No regression** (internal dispatch replaced the caller's manual downcast at
no measurable cost; orchestrator-verified).

## Gate record (frontier review, per AGENTS.md)

- **Pre-implementation design gate** (reviewer-gpt): 3 rounds → **approved**
  (capability decision option b, linalg dispatch completeness incl.
  solve_read_into/typed_output, GPU verification, FFT/linalg baselines,
  tensordot, FFT inventory, shape-packing gate).
- **Post-implementation diff gate** (reviewer-gpt): 2 rounds →
  **Correct-to-merge** (docs/guides retired-contract migration, concrete-test
  downcast removal, worklog + verification, solve_read_into source-contract
  test).

## Verification

check-pr-fast green (runtime/einsum/fft/linalg/ad/cpu/tensor suites +
doctests), repository-rules pass, fmt/clippy clean, doc scripts pass, GPU
package-targeted checks (`--features cuda`, `--features webgpu`) pass, grep
evidence clean. GPU nested-entry tests compile-verified; execution needs a
CUDA host (CI gate).

Worklog: `docs/worklogs/2026-08-14-phase3-extension-surfaces.md`.
