### PR TITLE
Fix eager concatenate AD with mixed activity

### DIFF
--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -4091,7 +4091,7 @@ fn record_semantic_eager_outputs(
         }
     }
     let mut constants = owned_constants.iter();
-    let semantic_inputs: Vec<&TracedTensor> = inputs
+    let mut semantic_inputs: Vec<&TracedTensor> = inputs
         .iter()
         .map(|input| {
             input
@@ -4100,6 +4100,26 @@ fn record_semantic_eager_outputs(
                 .unwrap_or_else(|| constants.next().expect("materialized constant"))
         })
         .collect();
+    let exact_semantic_inputs = if matches!(op, StdTensorOp::Concatenate { .. }) {
+        Some(
+            semantic_inputs
+                .iter()
+                .zip(inputs)
+                .map(|(&semantic, input)| {
+                    if semantic.is_concrete_shape() {
+                        Ok(semantic.clone())
+                    } else {
+                        semantic.reshape(input.shape())
+                    }
+                })
+                .collect::<Result<Vec<_>>>()?,
+        )
+    } else {
+        None
+    };
+    if let Some(exact_semantic_inputs) = &exact_semantic_inputs {
+        semantic_inputs = exact_semantic_inputs.iter().collect();
+    }
     // Deferred materialization (issue #1665 steps 6-7): append the op to the
     // raw `Graph<StdTensorOp>` carrier only. Metadata inference, registry
     // registration, and constraint discovery run once at the first AD request

--- a/crates/tenferro-ad/tests/integration/ad_structural_primitives.rs
+++ b/crates/tenferro-ad/tests/integration/ad_structural_primitives.rs
@@ -1,8 +1,10 @@
+use std::fmt::Debug;
 use std::sync::Arc;
-use tenferro_ad::{EagerRuntime, EagerTensor};
 
+use num_complex::Complex64;
+use tenferro_ad::{EagerRuntime, EagerTensor};
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::Tensor;
+use tenferro_runtime::{Tensor, TensorScalar};
 
 const FD_H: f64 = 1.0e-6;
 const TOL: f64 = 1.0e-5;
@@ -23,6 +25,28 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
 
 fn test_ctx() -> Arc<EagerRuntime> {
     EagerRuntime::with_cpu_backend(CpuBackend::new()).unwrap()
+}
+
+fn eager_input<T: TensorScalar>(
+    ctx: &Arc<EagerRuntime>,
+    shape: Vec<usize>,
+    data: &[T],
+    tracked: bool,
+) -> EagerTensor {
+    let tensor = Tensor::from_vec_col_major(shape, data.to_vec()).unwrap();
+    if tracked {
+        EagerTensor::requires_grad_in(tensor, Arc::clone(ctx)).unwrap()
+    } else {
+        EagerTensor::from_tensor_in(tensor, Arc::clone(ctx)).unwrap()
+    }
+}
+
+fn assert_values<T>(tensor: &EagerTensor, expected: &[T])
+where
+    T: TensorScalar + Debug + PartialEq,
+{
+    let actual = tensor.to_tensor().unwrap();
+    assert_eq!(actual.as_slice::<T>().unwrap(), expected);
 }
 
 fn finite_diff_unary(f: impl Fn(&[f64]) -> f64, base: &[f64]) -> Vec<f64> {
@@ -437,4 +461,301 @@ fn eager_concatenate_gradients_match_finite_diff() {
         f64_data(&right.grad().unwrap().unwrap().to_tensor().unwrap()),
         &finite_diff_unary(loss_for_right, &right_data),
     );
+}
+
+// INVARIANT: Explicit input and oracle slices keep both dtype cases independently auditable.
+#[allow(clippy::too_many_arguments)]
+fn run_exact_concatenate_case<T>(
+    left_data: &[T],
+    middle_data: &[T],
+    right_data: &[T],
+    cotangent_data: &[T],
+    middle_tangent_data: &[T],
+    expected_output: &[T],
+    expected_left_vjp: &[T],
+    expected_middle_vjp: &[T],
+    expected_right_vjp: &[T],
+    expected_jvp: &[T],
+) where
+    T: TensorScalar + Debug + PartialEq,
+{
+    let ctx = test_ctx();
+    let left = eager_input(&ctx, vec![2, 1], left_data, true);
+    let middle = eager_input(&ctx, vec![2, 2], middle_data, true);
+    let right = eager_input(&ctx, vec![2, 1], right_data, true);
+    let cotangent = eager_input(&ctx, vec![2, 4], cotangent_data, false);
+
+    let output = EagerTensor::concatenate(&[&left, &middle, &right], 1).unwrap();
+    assert_values(&output, expected_output);
+    assert_values(
+        &ctx.vjp(&output, &left, &cotangent).unwrap(),
+        expected_left_vjp,
+    );
+    assert_values(
+        &ctx.vjp(&output, &middle, &cotangent).unwrap(),
+        expected_middle_vjp,
+    );
+    assert_values(
+        &ctx.vjp(&output, &right, &cotangent).unwrap(),
+        expected_right_vjp,
+    );
+
+    let middle_tangent = eager_input(&ctx, vec![2, 2], middle_tangent_data, false);
+    assert_values(
+        &ctx.jvp(&output, &middle, &middle_tangent).unwrap(),
+        expected_jvp,
+    );
+}
+
+#[test]
+fn eager_concatenate_semantic_vjp_accepts_distinct_tracked_shapes() {
+    run_exact_concatenate_case(
+        &[1.0_f64, 2.0],
+        &[3.0, 4.0, 5.0, 6.0],
+        &[7.0, 8.0],
+        &[0.5, -1.25, 2.0, 1.5, -0.25, 0.75, 3.0, -2.0],
+        &[0.25, -0.5, 1.25, -1.5],
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        &[0.5, -1.25],
+        &[2.0, 1.5, -0.25, 0.75],
+        &[3.0, -2.0],
+        &[0.0, 0.0, 0.25, -0.5, 1.25, -1.5, 0.0, 0.0],
+    );
+}
+
+#[test]
+fn eager_concatenate_semantic_vjp_supports_complex64_exact_weights() {
+    let c = Complex64::new;
+    run_exact_concatenate_case(
+        &[c(1.0, 0.5), c(2.0, -0.25)],
+        &[c(3.0, 1.0), c(4.0, -1.0), c(5.0, 0.5), c(6.0, -0.5)],
+        &[c(7.0, 0.25), c(8.0, -0.75)],
+        &[
+            c(0.5, -1.0),
+            c(-1.25, 0.25),
+            c(2.0, 0.5),
+            c(1.5, -0.75),
+            c(-0.25, 1.0),
+            c(0.75, -0.5),
+            c(3.0, 1.25),
+            c(-2.0, 0.25),
+        ],
+        &[c(0.25, 0.5), c(-0.5, -0.25), c(1.25, 1.0), c(-1.5, 0.75)],
+        &[
+            c(1.0, 0.5),
+            c(2.0, -0.25),
+            c(3.0, 1.0),
+            c(4.0, -1.0),
+            c(5.0, 0.5),
+            c(6.0, -0.5),
+            c(7.0, 0.25),
+            c(8.0, -0.75),
+        ],
+        &[c(0.5, -1.0), c(-1.25, 0.25)],
+        &[c(2.0, 0.5), c(1.5, -0.75), c(-0.25, 1.0), c(0.75, -0.5)],
+        &[c(3.0, 1.25), c(-2.0, 0.25)],
+        &[
+            c(0.0, 0.0),
+            c(0.0, 0.0),
+            c(0.25, 0.5),
+            c(-0.5, -0.25),
+            c(1.25, 1.0),
+            c(-1.5, 0.75),
+            c(0.0, 0.0),
+            c(0.0, 0.0),
+        ],
+    );
+}
+
+fn run_mixed_concatenate_case(tracked_first: bool) {
+    let ctx = test_ctx();
+    let tracked = eager_input(&ctx, vec![2, 1], &[10.0_f64, 20.0], true);
+    let inactive = eager_input(&ctx, vec![2, 2], &[30.0_f64, 40.0, 50.0, 60.0], false);
+    let cotangent = eager_input(
+        &ctx,
+        vec![2, 3],
+        &[0.5_f64, -1.0, 2.0, 1.5, -0.25, 0.75],
+        false,
+    );
+    let output = if tracked_first {
+        EagerTensor::concatenate(&[&tracked, &inactive], 1).unwrap()
+    } else {
+        EagerTensor::concatenate(&[&inactive, &tracked], 1).unwrap()
+    };
+
+    let expected_output = if tracked_first {
+        &[10.0, 20.0, 30.0, 40.0, 50.0, 60.0][..]
+    } else {
+        &[30.0, 40.0, 50.0, 60.0, 10.0, 20.0][..]
+    };
+    let expected_vjp = if tracked_first {
+        &[0.5, -1.0][..]
+    } else {
+        &[-0.25, 0.75][..]
+    };
+    assert_values(&output, expected_output);
+    assert_values(
+        &ctx.vjp(&output, &tracked, &cotangent).unwrap(),
+        expected_vjp,
+    );
+}
+
+#[test]
+fn eager_concatenate_mixed_activity_preserves_tracked_gradients_and_offsets() {
+    for tracked_first in [true, false] {
+        run_mixed_concatenate_case(tracked_first);
+    }
+}
+
+// INVARIANT: Explicit inputs and oracles cover the bounded order/axis test matrix without duplication.
+#[allow(clippy::too_many_arguments)]
+fn run_mixed_stack_case<T>(
+    dim: isize,
+    tracked_first: bool,
+    tracked_data: &[T],
+    inactive_data: &[T],
+    cotangent_data: &[T],
+    tangent_data: &[T],
+    expected_output: Vec<T>,
+    expected_vjp: Vec<T>,
+    expected_jvp: Vec<T>,
+) where
+    T: TensorScalar + Debug + PartialEq,
+{
+    let ctx = test_ctx();
+    let tracked = eager_input(&ctx, vec![2], tracked_data, true);
+    let inactive = eager_input(&ctx, vec![2], inactive_data, false);
+    let output = if tracked_first {
+        EagerTensor::stack(&[&tracked, &inactive], dim).unwrap()
+    } else {
+        EagerTensor::stack(&[&inactive, &tracked], dim).unwrap()
+    };
+    let cotangent = eager_input(&ctx, vec![2, 2], cotangent_data, false);
+    let tangent = eager_input(&ctx, vec![2], tangent_data, false);
+
+    assert_values(&output, &expected_output);
+    assert_values(
+        &ctx.vjp(&output, &tracked, &cotangent).unwrap(),
+        &expected_vjp,
+    );
+    assert!(ctx
+        .vjp_optional(&output, &inactive, &cotangent)
+        .unwrap()
+        .is_none());
+    assert_values(
+        &ctx.jvp(&output, &tracked, &tangent).unwrap(),
+        &expected_jvp,
+    );
+}
+
+#[test]
+fn eager_mixed_stack_vjp_and_jvp_cover_orders_and_axes() {
+    for &(dim, tracked_first) in &[(0, true), (0, false), (-1, true), (-1, false)] {
+        let (expected_output, expected_vjp, expected_jvp) = match (dim, tracked_first) {
+            (0, true) => (
+                vec![10.0, 30.0, 20.0, 40.0],
+                vec![0.5, 2.0],
+                vec![0.25, 0.0, -1.5, 0.0],
+            ),
+            (0, false) => (
+                vec![30.0, 10.0, 40.0, 20.0],
+                vec![-1.25, 1.5],
+                vec![0.0, 0.25, 0.0, -1.5],
+            ),
+            (-1, true) => (
+                vec![10.0, 20.0, 30.0, 40.0],
+                vec![0.5, -1.25],
+                vec![0.25, -1.5, 0.0, 0.0],
+            ),
+            (-1, false) => (
+                vec![30.0, 40.0, 10.0, 20.0],
+                vec![2.0, 1.5],
+                vec![0.0, 0.0, 0.25, -1.5],
+            ),
+            _ => unreachable!(),
+        };
+        run_mixed_stack_case(
+            dim,
+            tracked_first,
+            &[10.0_f64, 20.0],
+            &[30.0_f64, 40.0],
+            &[0.5_f64, -1.25, 2.0, 1.5],
+            &[0.25_f64, -1.5],
+            expected_output,
+            expected_vjp,
+            expected_jvp,
+        );
+    }
+
+    let c = Complex64::new;
+    run_mixed_stack_case(
+        -1,
+        false,
+        &[c(10.0, 1.0), c(20.0, -2.0)],
+        &[c(30.0, 3.0), c(40.0, -4.0)],
+        &[c(0.5, -0.5), c(-1.25, 0.25), c(2.0, 1.0), c(1.5, -1.5)],
+        &[c(0.25, 0.75), c(-1.5, -0.25)],
+        vec![c(30.0, 3.0), c(40.0, -4.0), c(10.0, 1.0), c(20.0, -2.0)],
+        vec![c(2.0, 1.0), c(1.5, -1.5)],
+        vec![c(0.0, 0.0), c(0.0, 0.0), c(0.25, 0.75), c(-1.5, -0.25)],
+    );
+}
+
+#[test]
+fn eager_mixed_stack_vjp_then_jvp_remains_composable() {
+    let ctx = test_ctx();
+    let tracked = eager_input(&ctx, vec![2], &[2.0_f64, 3.0], true);
+    let inactive = eager_input(&ctx, vec![2], &[5.0_f64, 7.0], false);
+    let stacked = EagerTensor::stack(&[&tracked, &inactive], -1).unwrap();
+    let loss = stacked
+        .mul(&stacked)
+        .unwrap()
+        .reduce_sum(Some(&[0, 1]))
+        .unwrap();
+    let seed = eager_input(&ctx, vec![], &[1.0_f64], false);
+
+    let gradient = ctx.vjp(&loss, &tracked, &seed).unwrap();
+    assert_values(&gradient, &[4.0, 6.0]);
+
+    let tangent = eager_input(&ctx, vec![2], &[0.5_f64, -1.25], false);
+    let hvp = ctx.jvp(&gradient, &tracked, &tangent).unwrap();
+    assert_values(&hvp, &[1.0, -2.5]);
+}
+
+#[test]
+fn eager_concatenate_cache_isolated_for_compatible_shapes() {
+    let ctx = test_ctx();
+    ctx.clear_caches().unwrap();
+
+    let first_left = eager_input(&ctx, vec![2, 1], &[1.0_f64, 2.0], true);
+    let first_right = eager_input(&ctx, vec![2, 2], &[3.0_f64, 4.0, 5.0, 6.0], true);
+    let first_output = EagerTensor::concatenate(&[&first_left, &first_right], 1).unwrap();
+    let first_cotangent = eager_input(
+        &ctx,
+        vec![2, 3],
+        &[0.5_f64, -1.0, 2.0, 1.5, -0.25, 0.75],
+        false,
+    );
+    assert_values(
+        &ctx.vjp(&first_output, &first_right, &first_cotangent)
+            .unwrap(),
+        &[2.0, 1.5, -0.25, 0.75],
+    );
+    assert_eq!(ctx.cache_stats().unwrap().prepared_derivatives.entries, 1);
+
+    let second_left = eager_input(&ctx, vec![2, 2], &[7.0_f64, 8.0, 9.0, 10.0], true);
+    let second_right = eager_input(&ctx, vec![2, 1], &[11.0_f64, 12.0], true);
+    let second_output = EagerTensor::concatenate(&[&second_left, &second_right], 1).unwrap();
+    let second_cotangent = eager_input(
+        &ctx,
+        vec![2, 3],
+        &[1.25_f64, -0.5, 2.5, -1.75, 3.0, 0.25],
+        false,
+    );
+    assert_values(
+        &ctx.vjp(&second_output, &second_right, &second_cotangent)
+            .unwrap(),
+        &[3.0, 0.25],
+    );
+    assert_eq!(ctx.cache_stats().unwrap().prepared_derivatives.entries, 2);
 }

--- a/crates/tenferro-runtime/src/ad_support.rs
+++ b/crates/tenferro-runtime/src/ad_support.rs
@@ -356,7 +356,8 @@ pub fn merge_traced_leaf_metas<'a>(
 /// feeding tracked ops) stay analyzable even after their leaf scopes are
 /// dropped. Seeding from the retained symbolic leaf metas keeps the compiled
 /// program's semantic fingerprint symbolic-consistent with the traced path
-/// (concrete extents are binding data, not part of the fingerprint). The
+/// (concrete leaf extents are binding data, not part of the fingerprint;
+/// explicit operation parameters remain part of semantic identity). The
 /// seeded registrations live in the scopes attached to the returned trace,
 /// keeping them alive through `compile_ad_source`.
 ///
@@ -378,8 +379,9 @@ pub fn analyze_deferred_semantic_trace(raw: &TracedTensor) -> Result<TracedTenso
     // Canonical symbolic leaves: seed each bound input key from the leaf's
     // retained construction-time metadata (the same `symbolic_input_meta`
     // registered at leaf construction), not from concrete extents derived from
-    // the bound value. Concrete extents are binding data and must not leak
-    // into the semantic fingerprint.
+    // the bound value. Concrete leaf extents remain binding data, while explicit
+    // operation parameters such as eager shape-specializing reshapes are part of
+    // semantic identity.
     let mut leaf_keys = HashSet::new();
     for graph in &graphs {
         if !graph.operations().is_empty() {

--- a/docs/design/eager-concatenate-shape-recording.md
+++ b/docs/design/eager-concatenate-shape-recording.md
@@ -1,0 +1,104 @@
+# Eager Concatenate Exact-Shape Recording
+
+## Status
+
+Implementation design for [#1692](https://github.com/tensor4all/tenferro-rs/issues/1692).
+This is a bug fix to existing eager AD behavior. It adds no public API, changes
+no AD formula, and does not expand traced symbolic-shape support.
+
+## Problem
+
+Eager tensor values always have concrete runtime shapes, but their semantic AD
+leaves intentionally use symbolic shape metadata so derivative programs can be
+reused. `Concatenate` requires equal non-concatenated dimensions and currently
+checks those dimensions by structural `DimExpr` equality. Distinct symbolic
+leaves therefore fail semantic AD compilation even when their concrete eager
+shapes are compatible.
+
+The failure affects:
+
+- direct eager concatenate of separately tracked inputs; and
+- eager stack with mixed tracked and untracked rows, because stack lowers to
+  reshape plus concatenate and active-edge recording lazily creates a symbolic
+  constant leaf for the untracked row.
+
+Forward execution has already validated the concrete shapes and produced the
+correct value. VJP/JVP compilation later fails with `input ... dimension ...
+does not match the first input`.
+
+## Design
+
+Shape-specialize only the deferred eager semantic carrier at the concatenate
+boundary.
+
+1. Keep active-edge recording and lazy untracked constants unchanged.
+2. In `record_semantic_eager_outputs`, after collecting each semantic input and
+   before appending a `Concatenate` op, ensure every semantic input has the
+   current eager input's exact concrete shape.
+3. If a semantic input is already concrete-shaped, reuse it. Otherwise append a
+   semantic `Reshape` to `EagerTensor::shape()` and feed that result to the
+   concatenate op.
+4. The reshape exists only in the deferred semantic graph. It adds no
+   additional eager tensor copy, upload, materialization, or execution kernel.
+   Existing tracked n-ary forward execution still obtains owned tensors through
+   `to_tensor()`, and lazy untracked semantic constants still retain an owned
+   tensor value; removing those existing boundaries is outside this bug fix.
+
+This is valid because an `EagerTensor` value has a fixed concrete shape for its
+lifetime. The exact reshape extents intentionally enter the semantic program
+fingerprint, while both transform and prepared-derivative cache keys also carry
+bound metadata. Concatenate VJP needs concrete concatenated-axis extents to
+slice the cotangent, so the eager derivative graph is inherently
+shape-specialized at that operation. The implementation must update the stale
+`analyze_deferred_semantic_trace` comment: concrete leaf extents remain binding
+data, but explicit operation parameters such as this reshape are valid semantic
+identity.
+
+## Scope boundary
+
+Public traced symbolic behavior is unchanged. In particular, this PR does not:
+
+- make rank-known symbolic `TracedTensor::concatenate` accept unresolved
+  equality obligations;
+- change symbolic stack's current concrete-shape requirement;
+- add core shape constraints, guard namespaces, import remapping, or compiler
+  staging behavior.
+
+Those changes require a separate accepted design because they affect reusable
+traced-program contracts. The current fix is owned by eager semantic recording,
+where concrete shapes are already known and validated.
+
+## Rejected alternatives
+
+- **Core symbolic concatenate constraints.** Correct as a broader traced feature,
+  but it requires changes across metadata analysis, semantic builders, graph
+  import guard remapping, staging, and strict inference callers. It exceeds
+  #1692's eager regression scope.
+- **Concrete lazy constants only.** Fixes mixed stack but leaves direct eager
+  concatenate of distinct tracked symbolic leaves broken.
+- **Downstream tensor4all workaround.** Temporary tracked leaves or pad/add
+  substitutes add copies or kernels and repair the wrong abstraction layer.
+- **Skip equality validation.** This would weaken reusable traced-program shape
+  safety.
+
+## Verification ownership matrix
+
+| Owner | Coverage |
+|---|---|
+| `tenferro-ad` eager recording | Direct concatenate with distinct tracked leaves; mixed tracked/untracked inputs in both orders; unequal concatenate-axis extents |
+| `tenferro-ad` shape packing | Mixed stack in both orders and insertion axes `0` and `-1` |
+| Reverse AD | Direct concatenate and mixed stack exact weighted f64 and Complex64 cotangents, including offsets across inactive inputs |
+| Forward AD | Direct concatenate and mixed stack JVPs with exact tangent oracles |
+| Higher-order composition | One concatenate or mixed-stack VJP→JVP or JVP→VJP regression proves derivative traces remain composable |
+| Cache identity | Same runtime, different compatible concatenate shapes do not reuse an incorrect transform or prepared derivative |
+| Existing active-edge contract | Existing untracked-constant-feeds-tracked-AD and all-tracked tests remain green |
+| Scope boundary | Existing symbolic traced stack rejection remains unchanged |
+| Source contract | `analyze_deferred_semantic_trace` distinguishes symbolic leaf metadata from explicit shape-bearing operation semantics |
+
+The implementation must add a curated work log under `docs/worklogs/` with the
+source/architecture review, the rejected core-constraint expansion, focused
+commands, coverage review, and residual traced-symbolic limitation.
+
+No tolerance changes are involved. The new metadata work is
+`O(input_count)` for concatenate and adds no additional tensor-sized copy or
+execution kernel.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -23,6 +23,7 @@ migration notes live under [Plans](../plans/), not this active design index.
 | [contraction-pipeline.md](./contraction-pipeline.md) | Binary contraction pipeline, copy elision |
 | [dot-general-overhead.md](./dot-general-overhead.md) | Fixed-cost analysis for many small `dot_general` contractions |
 | [dynamic-symbolic-shapes.md](./dynamic-symbolic-shapes.md) | Dynamic and symbolic shape architecture. Covers `DynamicTruncate`, `transpose_scatter`, symbolic `slice_sizes`, the `Exact`/`UpperBound`/`Unknown` extent model, and extension equalities from graph-owned scopes through compiled guards. This is the key design doc for understanding how tenferro differs from XLA-style shape-specialized compilation. |
+| [eager-concatenate-shape-recording.md](./eager-concatenate-shape-recording.md) | Exact-shape semantic recording for eager concatenate and mixed-activity stack AD (#1692) |
 | [gpu-backend-design.md](./gpu-backend-design.md) | GPU backend architecture |
 | [xla-backend.md](./xla-backend.md) | Experimental StableHLO lowering and PJRT plugin-loading peer executor over static `CompiledGraph` values |
 | [inplace-indexing.md](./inplace-indexing.md) | Partial in-place updates design |

--- a/docs/worklogs/2026-08-15-issue-1692-eager-concatenate-tests.md
+++ b/docs/worklogs/2026-08-15-issue-1692-eager-concatenate-tests.md
@@ -1,0 +1,118 @@
+# Issue #1692: eager concatenate and mixed stack verification
+
+## Scope
+
+This change implements the approved eager-only fix, integration coverage, and
+this curated worklog. No dependency, tolerance, branch, commit, or push was
+changed here.
+
+## Source and design review
+
+Reviewed:
+
+- issue [#1692](https://github.com/tensor4all/tenferro-rs/issues/1692) and
+  `docs/design/eager-concatenate-shape-recording.md`;
+- eager recording in `crates/tenferro-ad/src/eager.rs`, including
+  `record_semantic_eager_outputs`, the semantic VJP/JVP execution path, and
+  prepared-derivative cache keys;
+- `crates/tenferro-ad/src/shape_packing.rs` (`stack` lowers reshape plus
+  concatenate);
+- `crates/tenferro-ad/src/semantic_transform/core_structural.rs` (concatenate
+  zero-tangent and VJP slice/offset rules);
+- `crates/tenferro-ad/src/transform_cache.rs` (bound-shape cache metadata);
+- the existing eager structural tests and
+  `primitive_ops::traced_stack_rejects_empty_mismatched_invalid_axis_and_symbolic_shapes`.
+
+The production path shape-specializes only deferred eager concatenate inputs:
+non-concrete semantic carriers receive an exact-shape semantic reshape before
+concatenate. Concrete eager values are unchanged, and the reshape adds no
+runtime tensor copy or kernel. Stack consequently receives the same behavior
+through its existing reshape/concatenate composition.
+
+## Review gates and rejected scope
+
+The reviewer-gpt pre-implementation gate ran in three rounds. Round 1 rejected
+a broad core-constraint design because it omitted traced/import/staging owners.
+Round 2 required accurate existing-materialization wording, cache-identity
+coverage, direct JVP, and higher-order coverage. Round 3 returned
+**Correct-to-merge**, authorizing implementation of the narrowed eager-only
+design.
+
+Post-implementation reviewer-gpt round 1 found the implementation and
+numerical/AD behavior sound, but returned **Not Correct-to-merge** because this
+worklog described only the test-file coverage impact and had not recorded the
+post-implementation round. The coverage record below was corrected.
+Post-implementation round 2 returned **Correct-to-merge** on the corrected full
+diff.
+
+Rejected or deferred alternatives were:
+
+- broad core symbolic concatenate constraints, which would require changes to
+  shape analysis, graph import/remapping, staging, and strict inference;
+- concrete lazy constants only, which would not repair direct concatenate of
+  distinct tracked leaves;
+- downstream tensor4all workarounds using temporary tracked leaves or pad/add
+  substitutes, which add copies/kernels at the wrong layer; and
+- skipping concatenate equality validation, which would weaken reusable traced
+  shape safety.
+
+## Test coverage added
+
+`crates/tenferro-ad/tests/integration/ad_structural_primitives.rs` now uses a
+small generic exact-value helper to cover:
+
+- direct concatenate of separately tracked `[2, 1]`, `[2, 2]`, and `[2, 1]`
+  inputs with unequal concatenate-axis extents, exact weighted VJPs for every
+  input, and an exact JVP oracle;
+- the same direct concatenate VJP/JVP contract for `f64` and `Complex64`;
+- mixed tracked/untracked direct concatenate in both operand orders, checking
+  the tracked cotangent slice after the inactive operand's offset;
+- mixed stack in both operand orders and insertion axes `0` and `-1`, with
+  exact primal, tracked VJP, inactive-edge, and JVP assertions; one complex
+  stack case also checks exact complex cotangent placement;
+- one mixed-stack VJP-to-JVP higher-order composition (`2*x` then `2*tangent`);
+- one shared-runtime cache-isolation case with compatible output shapes but
+  swapped concatenate-axis extents, checking both exact second-shape values and
+  two prepared derivative entries.
+
+The existing traced symbolic rejection test was not rewritten.
+
+## Verification
+
+- `cargo fmt --all` — passed.
+- `git diff --check` — passed.
+- `cargo test --release -p tenferro-ad --test integration eager_concatenate_semantic_vjp_accepts_distinct_tracked_shapes` — passed (1 test, 342 filtered).
+- `cargo test --release -p tenferro-ad --test integration eager_concatenate_semantic_vjp` — passed (2 tests, 341 filtered).
+- `cargo test --release -p tenferro-ad --test integration eager_concatenate_mixed_activity_preserves_tracked_gradients_and_offsets` — passed (1 test, 342 filtered).
+- `cargo test --release -p tenferro-ad --test integration eager_mixed_stack_vjp_and_jvp_cover_orders_and_axes` — passed (1 test, 342 filtered).
+- `cargo test --release -p tenferro-ad --test integration eager_mixed_stack_vjp_then_jvp_remains_composable` — passed (1 test, 342 filtered).
+- `cargo test --release -p tenferro-ad --test integration eager_concatenate_cache_isolated_for_compatible_shapes` — passed (1 test, 342 filtered).
+- `cargo test --release -p tenferro-ad --test integration traced_stack_rejects_empty_mismatched_invalid_axis_and_symbolic_shapes` — passed (1 test, 342 filtered).
+- `cargo test --release -p tenferro-ad --test integration` — passed (343 tests).
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-ad --test integration eager_concatenate_semantic_vjp_accepts_distinct_tracked_shapes'` — passed, including root and standalone-extension formatting/clippy gates.
+- `cargo test --doc --release --workspace` — passed (1,677 tests).
+- `cargo doc --workspace --no-deps` — passed with four pre-existing broken-link warnings outside this diff.
+- `python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run` and `python3 scripts/test-repository-rules-review.py` — passed.
+- `cargo nextest run --release --workspace -E 'not test(residual_mask_detector_rejects_undeclared_input_access)' --no-fail-fast` — passed (3,042 tests; 131 skipped).
+- The unfiltered release workspace command is blocked on the unchanged `origin/main` test tracked as [#1694](https://github.com/tensor4all/tenferro-rs/issues/1694): a `#[should_panic]` release test expects a debug-only assertion. Its isolated release reproduction fails, while its debug build passes.
+
+## Coverage impact and residual risk
+
+Production coverage was reviewed for both changed Rust source files:
+
+- `crates/tenferro-ad/src/eager.rs`: the new concatenate-only branch is covered
+  by direct concatenate and stack, tracked-only and mixed-activity operands,
+  both inactive operand orders, axes `0`/`-1`, f64/Complex64, VJP/JVP,
+  higher-order composition, and cross-shape cache isolation. The full 343-test
+  integration target also exercises existing non-concatenate recording.
+- `crates/tenferro-runtime/src/ad_support.rs`: only explanatory comments changed;
+  deferred semantic analysis behavior is unchanged.
+
+No production coverage threshold, tolerance, or coverage configuration was
+changed. The new tests use numerical whole-value assertions rather than
+shape-only smoke checks, and existing eager and traced tests remain in the same
+integration target.
+
+The residual limitation is intentional: unresolved symbolic traced
+`concatenate`/`stack` behavior remains rejected and is not expanded by #1692.
+A future core symbolic-shape design must address that separately.


### PR DESCRIPTION
## Summary

- shape-specialize deferred eager semantic inputs only at `Concatenate` by adding exact semantic reshapes when needed
- preserve active-edge pruning, lazy untracked constants, and existing public traced symbolic-shape behavior
- cover direct concatenate and mixed stack VJP/JVP behavior across operand order, axes, f64/Complex64, higher-order composition, and cache isolation

Closes #1692.

## Design and review gates

- Design: `docs/design/eager-concatenate-shape-recording.md`
- Pre-implementation reviewer-gpt: three rounds; final verdict **Correct-to-merge**
- Post-implementation reviewer-gpt: full-diff review, findings fixed, final exact-diff verdict **Correct-to-merge**
- Worklog: `docs/worklogs/2026-08-15-issue-1692-eager-concatenate-tests.md`

## Verification

- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-ad --test integration eager_concatenate_semantic_vjp_accepts_distinct_tracked_shapes'`
- `cargo test --release -p tenferro-ad --test integration` — 343 passed
- `cargo test --doc --release --workspace` — 1,677 passed
- `cargo nextest run --release --workspace -E 'not test(residual_mask_detector_rejects_undeclared_input_access)' --no-fail-fast` — 3,042 passed, 131 skipped
- committed-head repository-rules deterministic review — pass

The unfiltered release workspace command reaches an unchanged `origin/main` failure tracked in #1694: a `#[should_panic]` release test expects a debug-only assertion. The isolated debug test passes, the isolated release test reproduces the baseline failure, and every other release workspace test passes.

## Coverage impact

Reviewed the changed eager recording branch against direct concatenate, mixed activity, stack lowering, both operand orders, axes `0`/`-1`, f64/Complex64, VJP/JVP, higher-order composition, and cross-shape cache identity. `ad_support.rs` changes comments only. No threshold or tolerance changed.
