### PR TITLE
feat(cpu): uninitialized full-overwrite provider destinations (#1690)

### DIFF
--- a/crates/tenferro-cpu/src/dot_runtime.rs
+++ b/crates/tenferro-cpu/src/dot_runtime.rs
@@ -3,7 +3,9 @@ use tenferro_tensor::{
     TensorViewMut, TensorWrite, TypedTensor, ValidationError,
 };
 
+use num_complex::{Complex32, Complex64};
 use smallvec::SmallVec;
+use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -13,11 +15,11 @@ use crate::provider::{
     builtin_gemm_provider, builtin_layout_provider, CpuContractionAxes, CpuDotGeneralRequest,
     CpuExecutionContext, CpuGemmProvider, CpuGeneralContractionProvider, CpuGroupedGemmRequest,
     CpuLayoutTransformIntent, CpuLayoutTransformProvider, CpuLayoutTransformRequest,
-    CpuOperationEntry, CpuProviderOutcome, CpuProviderUnsupported,
+    CpuOperationEntry, CpuProviderOutcome, CpuProviderUnsupported, CpuUninitGemmProvider,
 };
 use crate::{
     gemm::GemmAnalysisCache, CpuDomainExecutorError, CpuDomainId, CpuPlacementGuarantee,
-    CpuProviderDomainError, CpuSet, Error, ParallelMode, Result,
+    CpuProviderDomainError, CpuSet, Error, ParallelMode, PooledUninitOutput, Result,
 };
 
 const OP: &str = "dot_general";
@@ -696,6 +698,74 @@ impl DotGeneralRuntime {
         result
     }
 
+    /// Execute a `beta == 0` allocated dot into uninitialized pooled bytes.
+    ///
+    /// Returns [`CpuProviderOutcome::Executed`] after every destination
+    /// element is initialized, or [`CpuProviderOutcome::Unsupported`] when the
+    /// GEMM provider cannot execute the planned contraction into
+    /// uninitialized storage (the caller discards the checkout and retries on
+    /// the zeroed path). Errors propagate; a provider error may follow a
+    /// partial write, so it is never silently retried.
+    ///
+    /// Only the direct GEMM plan is attempted here: the uninit checkout holds
+    /// the scratch pool exclusively, so the canonical fallback (which
+    /// materializes operands from the pool) is left to the zeroed path.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn execute_dot_into_uninit(
+        &self,
+        bundle_identity: &Arc<CpuProviderBundleInner>,
+        entry: &CpuOperationEntry<'_>,
+        entered: Option<&CpuExecutionContext<'_>>,
+        cache: &mut GemmAnalysisCache,
+        cache_slot: Option<usize>,
+        lhs: &TensorRead<'_>,
+        rhs: &TensorRead<'_>,
+        config: &DotGeneralConfig,
+        accumulation: DotGeneralAccumulation,
+        output_shape: &[usize],
+        output_bytes: &mut [MaybeUninit<u8>],
+    ) -> Result<CpuProviderOutcome> {
+        let Some(witness) = self.gemm.uninit_provider() else {
+            return Err(Error::unsupported(
+                OP,
+                "configured CPU GEMM provider does not expose the uninitialized-output contract",
+            ));
+        };
+        let mode = self
+            .dot_general_mode(entry)
+            .map_err(|error| Error::backend_source(OP, error))?;
+        cache.bind_provider_bundle(bundle_identity);
+        entry
+            .enter_or_reuse(entered, mode, |provider_context| {
+                let Some(plan) = crate::gemm::prepare_provider_gemm_into_uninit(
+                    cache,
+                    cache_slot,
+                    lhs,
+                    rhs,
+                    output_shape,
+                    config,
+                )?
+                else {
+                    // No direct plan; the canonical path needs the scratch
+                    // pool, which is exclusively held by the uninit checkout.
+                    // The caller falls back to the zeroed path.
+                    return Ok(CpuProviderOutcome::Unsupported(
+                        CpuProviderUnsupported::Layout(crate::provider::CpuOperand::Output),
+                    ));
+                };
+                execute_gemm_plan_into_uninit(
+                    witness,
+                    provider_context,
+                    plan,
+                    lhs,
+                    rhs,
+                    accumulation,
+                    output_bytes,
+                )
+            })
+            .map_err(|error| Error::backend_source(OP, error))?
+    }
+
     #[allow(clippy::redundant_closure)]
     fn execute_grouped(
         &self,
@@ -870,6 +940,23 @@ fn execute_gemm_plan(
     Ok(outcome)
 }
 
+fn execute_gemm_plan_into_uninit(
+    witness: &dyn CpuUninitGemmProvider,
+    context: &CpuExecutionContext<'_>,
+    plan: crate::gemm::ProviderGemmPlan,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
+    accumulation: DotGeneralAccumulation,
+    output_bytes: &mut [MaybeUninit<u8>],
+) -> Result<CpuProviderOutcome> {
+    let request = plan.uninit_request(lhs, rhs, accumulation);
+    // SAFETY: the witness is structural proof the provider asserted the
+    // full-overwrite contract via `unsafe impl`; the caller guarantees
+    // beta == 0, so every destination element is written before `Executed`
+    // and never read.
+    unsafe { witness.gemm_into_uninit(context, request, output_bytes) }
+}
+
 fn canonical_gemm_fallback_supported(reason: CpuProviderUnsupported) -> bool {
     matches!(
         reason,
@@ -942,13 +1029,56 @@ fn materialize_canonical_operand(
     conjugate: bool,
 ) -> Result<Tensor> {
     let input_view = transposed_read_view(input, permutation)?;
-    let mut output =
-        allocate_canonical_operand(buffers, input_view.dtype(), input_view.shape().to_vec())?;
+    let dtype = input_view.dtype();
+    let shape = input_view.shape().to_vec();
     let input = TensorRead::from_view(input_view);
+    if let Some(witness) = provider.uninit_provider() {
+        let mut output = UninitTensor::acquire(buffers, dtype, shape.clone())?;
+        let outcome = {
+            let output_bytes = output.as_uninit_bytes_mut();
+            // SAFETY: `witness` is structural proof the provider asserted the
+            // full-overwrite contract via `unsafe impl`; `Executed` means
+            // every element of `output_bytes` was written by
+            // `materialize_into_uninit` (never read).
+            unsafe {
+                witness.materialize_into_uninit(
+                    context,
+                    &input,
+                    CpuLayoutTransformIntent::CanonicalColumnMajor,
+                    conjugate,
+                    output_bytes,
+                )
+            }
+        };
+        match outcome {
+            Ok(CpuProviderOutcome::Executed) => {
+                // SAFETY: the unsafe provider contract guarantees the
+                // destination is fully initialized before `Executed`.
+                return unsafe { output.assume_init() };
+            }
+            Ok(CpuProviderOutcome::Unsupported(_)) => {
+                // Discard the uninit checkout (drop frees via
+                // `pool_discard_uninit`) and fall back to the zeroed path.
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    materialize_canonical_operand_zeroed(provider, context, buffers, &input, shape, conjugate)
+}
+
+fn materialize_canonical_operand_zeroed(
+    provider: &dyn CpuLayoutTransformProvider,
+    context: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    input: &TensorRead<'_>,
+    shape: Vec<usize>,
+    conjugate: bool,
+) -> Result<Tensor> {
+    let mut output = allocate_canonical_operand(buffers, input.dtype(), shape)?;
     let outcome = {
         let mut output_write = TensorWrite::from_tensor(&mut output);
         let request = CpuLayoutTransformRequest::new(
-            &input,
+            input,
             &mut output_write,
             CpuLayoutTransformIntent::CanonicalColumnMajor,
             conjugate,
@@ -964,6 +1094,66 @@ fn materialize_canonical_operand(
         Err(error) => {
             reclaim_temporary(buffers, output);
             Err(error)
+        }
+    }
+}
+
+/// Dtype-dispatched pooled full-overwrite destination for the uninitialized
+/// dot paths.
+///
+/// The destination travels only as `MaybeUninit` bytes until an unsafe
+/// `assume_init` completes the handoff; no `TensorWrite` is ever fabricated
+/// over uninitialized storage.
+pub(crate) enum UninitTensor<'pool> {
+    F32(PooledUninitOutput<'pool, f32>),
+    F64(PooledUninitOutput<'pool, f64>),
+    C32(PooledUninitOutput<'pool, Complex32>),
+    C64(PooledUninitOutput<'pool, Complex64>),
+}
+
+impl<'pool> UninitTensor<'pool> {
+    pub(crate) fn acquire(
+        buffers: &'pool mut BufferPool,
+        dtype: DType,
+        shape: Vec<usize>,
+    ) -> Result<Self> {
+        match dtype {
+            DType::F32 => Ok(Self::F32(PooledUninitOutput::new(buffers, shape)?)),
+            DType::F64 => Ok(Self::F64(PooledUninitOutput::new(buffers, shape)?)),
+            DType::C32 => Ok(Self::C32(PooledUninitOutput::new(buffers, shape)?)),
+            DType::C64 => Ok(Self::C64(PooledUninitOutput::new(buffers, shape)?)),
+            dtype => Err(Error::unsupported_dtype(
+                OP,
+                dtype,
+                crate::cpu_contraction_unsupported_dtype_message(dtype),
+            )),
+        }
+    }
+
+    pub(crate) fn as_uninit_bytes_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        match self {
+            Self::F32(output) => output.as_uninit_bytes_mut(),
+            Self::F64(output) => output.as_uninit_bytes_mut(),
+            Self::C32(output) => output.as_uninit_bytes_mut(),
+            Self::C64(output) => output.as_uninit_bytes_mut(),
+        }
+    }
+
+    /// # Safety
+    ///
+    /// Every logical destination element must have been initialized by the
+    /// completed unsafe provider call before this handoff; otherwise reading
+    /// or dropping the returned tensor is undefined behavior.
+    pub(crate) unsafe fn assume_init(self) -> Result<Tensor> {
+        // SAFETY: the caller proves every logical destination element was
+        // written before `Executed` by the unsafe provider impl.
+        unsafe {
+            match self {
+                Self::F32(output) => output.assume_init().map(Tensor::F32),
+                Self::F64(output) => output.assume_init().map(Tensor::F64),
+                Self::C32(output) => output.assume_init().map(Tensor::C32),
+                Self::C64(output) => output.assume_init().map(Tensor::C64),
+            }
         }
     }
 }

--- a/crates/tenferro-cpu/src/dot_runtime/tests.rs
+++ b/crates/tenferro-cpu/src/dot_runtime/tests.rs
@@ -7,8 +7,9 @@ use crate::gemm::GemmAnalysisCache;
 use crate::provider::tests::{execution_context_fixture, external_execution_context_fixture};
 use crate::provider::{
     CpuExecutionContext, CpuGemmProvider, CpuGemmRequest, CpuGeneralContractionProvider,
-    CpuGroupedGemmRequest, CpuLayoutTransformProvider, CpuLayoutTransformRequest, CpuOperand,
-    CpuProviderOutcome, CpuProviderUnsupported, ParallelMode, StridedLayoutTransformProvider,
+    CpuGroupedGemmRequest, CpuLayoutTransformIntent, CpuLayoutTransformProvider,
+    CpuLayoutTransformRequest, CpuOperand, CpuProviderOutcome, CpuProviderUnsupported,
+    CpuUninitLayoutTransformProvider, ParallelMode, StridedLayoutTransformProvider,
 };
 use crate::{
     CpuBackendKind, CpuDomainExecutor, CpuDomainExecutorCapabilities, CpuDomainExecutorError,
@@ -2175,4 +2176,130 @@ fn engine_outer_real_faer_writes_only_nonzero_base_output_view_jobs() {
     );
     assert_eq!(submits.load(Ordering::Relaxed), 1);
     assert_eq!(installs.load(Ordering::Relaxed), 0);
+}
+
+/// Layout provider without the uninitialized-output witness (default opt-out).
+#[derive(Debug)]
+struct OptOutLayoutProvider;
+
+impl CpuLayoutTransformProvider for OptOutLayoutProvider {
+    fn execution_capabilities(&self) -> crate::CpuProviderExecutionCapabilities {
+        crate::provider_capability::engine_worker_capabilities()
+    }
+
+    fn materialize(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuLayoutTransformRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        StridedLayoutTransformProvider.materialize(context, request)
+    }
+}
+
+/// Layout provider that opts into the uninitialized-output contract but always
+/// reports [`CpuProviderOutcome::Unsupported`], forcing the caller's
+/// discard-and-reallocate fallback onto the zeroed path.
+#[derive(Debug)]
+struct UnsupportedUninitLayoutProvider {
+    uninit_calls: Arc<Mutex<usize>>,
+}
+
+impl CpuLayoutTransformProvider for UnsupportedUninitLayoutProvider {
+    fn execution_capabilities(&self) -> crate::CpuProviderExecutionCapabilities {
+        crate::provider_capability::engine_worker_capabilities()
+    }
+
+    fn materialize(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuLayoutTransformRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        StridedLayoutTransformProvider.materialize(context, request)
+    }
+
+    fn uninit_provider(&self) -> Option<&dyn CpuUninitLayoutTransformProvider> {
+        Some(self)
+    }
+}
+
+// SAFETY: this test provider asserts the unsafe trait only to exercise the
+// caller's `Unsupported` fallback; it never writes the destination, so it must
+// always return `Unsupported` (never `Executed`).
+unsafe impl CpuUninitLayoutTransformProvider for UnsupportedUninitLayoutProvider {
+    unsafe fn materialize_into_uninit(
+        &self,
+        _context: &CpuExecutionContext<'_>,
+        _input: &TensorRead<'_>,
+        _intent: CpuLayoutTransformIntent,
+        _conjugate: bool,
+        _output_bytes: &mut [std::mem::MaybeUninit<u8>],
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        *self.uninit_calls.lock().unwrap() += 1;
+        Ok(CpuProviderOutcome::Unsupported(
+            CpuProviderUnsupported::DType(DType::F64),
+        ))
+    }
+}
+
+fn assert_canonical_operand_materialization_with_layout(
+    layout: Arc<dyn CpuLayoutTransformProvider>,
+) {
+    let gemm = Arc::new(CanonicalFallbackSpy::new(
+        CpuProviderUnsupported::Conjugation,
+        CanonicalFallbackBehavior::ConjugatedComplex,
+    ));
+    let bundle = CpuProviderBundle::custom_builder()
+        .gemm_provider(gemm.clone())
+        .engine_outer_grouped_gemm()
+        .layout_transform_provider(layout)
+        .build()
+        .unwrap();
+    let lhs = Tensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 2.0)]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(3.0, 4.0)]).unwrap();
+    let mut output =
+        Tensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(5.0, 1.0)]).unwrap();
+    let mut accumulation = DotGeneralAccumulation::scaled(
+        ContractionScalar::C64(Complex64::new(2.0, 0.0)),
+        ContractionScalar::C64(Complex64::new(3.0, 0.0)),
+    )
+    .unwrap();
+    accumulation.lhs_conj = true;
+    let fixture = execution_context_fixture(1);
+
+    bundle
+        .execute_dot_general_into(
+            &fixture.entry(),
+            &mut BufferPool::new(),
+            &mut GemmAnalysisCache::default(),
+            None,
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config(&[1], &[0], &[], &[]),
+            accumulation,
+            TensorWrite::from_tensor(&mut output),
+        )
+        .unwrap();
+
+    assert_eq!(*gemm.calls.lock().unwrap(), 2);
+    assert_eq!(
+        output.as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(37.0, -1.0)],
+    );
+}
+
+#[test]
+fn opted_out_layout_provider_keeps_zeroed_canonical_operand_values() {
+    assert_canonical_operand_materialization_with_layout(Arc::new(OptOutLayoutProvider));
+}
+
+#[test]
+fn opted_in_layout_provider_unsupported_falls_back_to_zeroed_materialization() {
+    let layout = Arc::new(UnsupportedUninitLayoutProvider {
+        uninit_calls: Arc::new(Mutex::new(0)),
+    });
+    let uninit_calls = Arc::clone(&layout.uninit_calls);
+    assert_canonical_operand_materialization_with_layout(layout);
+    // Both canonical operands (lhs and rhs) attempted the uninit path before
+    // falling back to the zeroed materialization.
+    assert_eq!(*uninit_calls.lock().unwrap(), 2);
 }

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -16,7 +16,7 @@ use super::backend::{
     elementwise_read_into_fallback_with_pool, reclaim_typed, tag_fresh_output, FreshCpuOutput,
 };
 use super::indexed_plan_cache::IndexedPlanCache;
-use super::provider::{CpuExecutionContext, CpuOperationEntry};
+use super::provider::{CpuExecutionContext, CpuOperationEntry, CpuProviderOutcome};
 use super::CpuProviderBundle;
 use super::{
     analytic, copy_tensor_read_into, elementwise, gemm, indexing, materialize_tensor_read,
@@ -468,13 +468,56 @@ impl CpuExecSession<'_> {
             "dot_general",
         )?;
         self.providers.preflight_dot_general(&self.entry)?;
-        let mut output = allocate_dot_output(self.buffers, dtype, output_shape)?;
         let accumulation = DotGeneralAccumulation {
             lhs_conj,
             rhs_conj,
             alpha: ContractionScalar::one(dtype)?,
             beta: ContractionScalar::zero(dtype)?,
         };
+
+        // Uninitialized fast path: beta == 0 here by construction, so the
+        // dot output is fully overwritten. Take it only when the GEMM
+        // provider is the guaranteed consumer (no general-contraction
+        // provider) and exposes the full-overwrite witness. The uninit
+        // checkout holds the scratch pool exclusively, so only the direct
+        // GEMM plan is attempted; anything else falls back below.
+        let providers = self.providers;
+        let runtime = providers.dot_general();
+        if runtime.general.is_none() && runtime.gemm.uninit_provider().is_some() {
+            let mut output = crate::dot_runtime::UninitTensor::acquire(
+                self.buffers,
+                dtype,
+                output_shape.clone(),
+            )?;
+            let outcome = runtime.execute_dot_into_uninit(
+                providers.inner(),
+                &self.entry,
+                self.entered.as_ref(),
+                self.gemm_analysis_cache,
+                cache_slot,
+                &lhs,
+                &rhs,
+                config,
+                accumulation,
+                &output_shape,
+                output.as_uninit_bytes_mut(),
+            );
+            match outcome {
+                Ok(CpuProviderOutcome::Executed) => {
+                    // SAFETY: the GEMM provider's unsafe impl guarantees every
+                    // destination element is initialized before `Executed`.
+                    let mut output = unsafe { output.assume_init()? };
+                    tag_fresh_output(&mut output, self.entry.domain_id());
+                    return Ok(output);
+                }
+                Ok(CpuProviderOutcome::Unsupported(_)) => {
+                    // Discard the uninit checkout; fall back to the zeroed path.
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        let mut output = allocate_dot_output(self.buffers, dtype, output_shape)?;
         self.providers.execute_dot_general_into_scoped(
             &self.entry,
             self.entered.as_ref(),

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -2,6 +2,8 @@ use num_traits::Zero;
 use smallvec::{Array, SmallVec};
 use std::fmt;
 use std::mem::size_of;
+#[cfg(feature = "cpu-faer")]
+use std::mem::{align_of, MaybeUninit};
 use std::sync::{Arc, Weak};
 
 use crate::dot_runtime::CpuProviderBundleInner;
@@ -962,6 +964,26 @@ impl ProviderGemmPlan {
             accumulation,
         )
     }
+
+    pub(crate) fn uninit_request<'request, 'input>(
+        self,
+        lhs: &'request TensorRead<'input>,
+        rhs: &'request TensorRead<'input>,
+        accumulation: DotGeneralAccumulation,
+    ) -> crate::provider::CpuGemmUninitRequest<'request, 'input> {
+        crate::provider::CpuGemmUninitRequest::new(
+            lhs,
+            rhs,
+            self.rows,
+            self.columns,
+            self.contracted,
+            self.batch_count,
+            self.lhs_layout,
+            self.rhs_layout,
+            self.output_layout,
+            accumulation,
+        )
+    }
 }
 
 fn provider_output_strides(output: &TensorWrite<'_>) -> Result<SmallVec<[isize; 8]>> {
@@ -972,7 +994,7 @@ fn provider_output_strides(output: &TensorWrite<'_>) -> Result<SmallVec<[isize; 
 }
 
 #[allow(clippy::too_many_arguments)]
-fn prepare_provider_gemm_typed<L, R, T>(
+fn prepare_provider_gemm_typed_with_output<L, R, T>(
     cache: &mut GemmAnalysisCache,
     cache_slot: Option<usize>,
     cache_kind: GemmAnalysisCacheKind,
@@ -980,7 +1002,9 @@ fn prepare_provider_gemm_typed<L, R, T>(
     rhs: &R,
     lhs_offset: isize,
     rhs_offset: isize,
-    output: &TensorWrite<'_>,
+    output_shape: &[usize],
+    output_strides: &[isize],
+    output_offset: isize,
     config: &DotGeneralConfig,
 ) -> Result<Option<ProviderGemmPlan>>
 where
@@ -990,10 +1014,9 @@ where
     let Some(dims) = analyse_gemm_cached(cache, cache_slot, cache_kind, lhs, rhs, config)? else {
         return Ok(None);
     };
-    let output_strides = provider_output_strides(output)?;
     let Some((output_row_stride, output_column_stride, output_batch_stride)) = output_gemm_strides(
-        output.shape(),
-        &output_strides,
+        output_shape,
+        output_strides,
         lhs.shape().len(),
         rhs.shape().len(),
         config,
@@ -1025,7 +1048,7 @@ where
             dims.b_bs,
         ),
         output_layout: crate::provider::CpuBatchedMatrixLayout::new(
-            output.offset(),
+            output_offset,
             output_row_stride,
             output_column_stride,
             output_batch_stride,
@@ -1051,6 +1074,32 @@ fn prepare_provider_gemm_kind(
     output: &TensorWrite<'_>,
     config: &DotGeneralConfig,
 ) -> Result<Option<ProviderGemmPlan>> {
+    let output_strides = provider_output_strides(output)?;
+    prepare_provider_gemm_kind_with_output(
+        cache,
+        cache_slot,
+        cache_kind,
+        lhs,
+        rhs,
+        output.shape(),
+        &output_strides,
+        output.offset(),
+        config,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_provider_gemm_kind_with_output(
+    cache: &mut GemmAnalysisCache,
+    cache_slot: Option<usize>,
+    cache_kind: GemmAnalysisCacheKind,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
+    output_shape: &[usize],
+    output_strides: &[isize],
+    output_offset: isize,
+    config: &DotGeneralConfig,
+) -> Result<Option<ProviderGemmPlan>> {
     macro_rules! dispatch {
         ($owned:ident, $view:ident) => {
             match (lhs, rhs) {
@@ -1058,7 +1107,7 @@ fn prepare_provider_gemm_kind(
                     TensorRead::Tensor(crate::Tensor::$owned(lhs)),
                     TensorRead::Tensor(crate::Tensor::$owned(rhs)),
                 ) => {
-                    return prepare_provider_gemm_typed(
+                    return prepare_provider_gemm_typed_with_output(
                         cache,
                         cache_slot,
                         cache_kind,
@@ -1066,7 +1115,9 @@ fn prepare_provider_gemm_kind(
                         rhs,
                         lhs.offset(),
                         rhs.offset(),
-                        output,
+                        output_shape,
+                        output_strides,
+                        output_offset,
                         config,
                     );
                 }
@@ -1074,7 +1125,7 @@ fn prepare_provider_gemm_kind(
                     TensorRead::Tensor(crate::Tensor::$owned(lhs)),
                     TensorRead::View(TensorView::$view(rhs)),
                 ) => {
-                    return prepare_provider_gemm_typed(
+                    return prepare_provider_gemm_typed_with_output(
                         cache,
                         cache_slot,
                         cache_kind,
@@ -1082,7 +1133,9 @@ fn prepare_provider_gemm_kind(
                         rhs,
                         lhs.offset(),
                         rhs.offset(),
-                        output,
+                        output_shape,
+                        output_strides,
+                        output_offset,
                         config,
                     );
                 }
@@ -1090,7 +1143,7 @@ fn prepare_provider_gemm_kind(
                     TensorRead::View(TensorView::$view(lhs)),
                     TensorRead::Tensor(crate::Tensor::$owned(rhs)),
                 ) => {
-                    return prepare_provider_gemm_typed(
+                    return prepare_provider_gemm_typed_with_output(
                         cache,
                         cache_slot,
                         cache_kind,
@@ -1098,7 +1151,9 @@ fn prepare_provider_gemm_kind(
                         rhs,
                         lhs.offset(),
                         rhs.offset(),
-                        output,
+                        output_shape,
+                        output_strides,
+                        output_offset,
                         config,
                     );
                 }
@@ -1106,7 +1161,7 @@ fn prepare_provider_gemm_kind(
                     TensorRead::View(TensorView::$view(lhs)),
                     TensorRead::View(TensorView::$view(rhs)),
                 ) => {
-                    return prepare_provider_gemm_typed(
+                    return prepare_provider_gemm_typed_with_output(
                         cache,
                         cache_slot,
                         cache_kind,
@@ -1114,7 +1169,9 @@ fn prepare_provider_gemm_kind(
                         rhs,
                         lhs.offset(),
                         rhs.offset(),
-                        output,
+                        output_shape,
+                        output_strides,
+                        output_offset,
                         config,
                     );
                 }
@@ -1127,6 +1184,30 @@ fn prepare_provider_gemm_kind(
     dispatch!(C32, C32);
     dispatch!(C64, C64);
     Ok(None)
+}
+
+/// Plan a GEMM into a fresh compact column-major output of `output_shape` at
+/// element offset zero (an uninitialized pooled destination).
+pub(crate) fn prepare_provider_gemm_into_uninit(
+    cache: &mut GemmAnalysisCache,
+    cache_slot: Option<usize>,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
+    output_shape: &[usize],
+    config: &DotGeneralConfig,
+) -> Result<Option<ProviderGemmPlan>> {
+    let output_strides = col_major_strides(output_shape)?;
+    prepare_provider_gemm_kind_with_output(
+        cache,
+        cache_slot,
+        GemmAnalysisCacheKind::Direct,
+        lhs,
+        rhs,
+        output_shape,
+        &output_strides,
+        0,
+        config,
+    )
 }
 
 pub(crate) fn prepare_provider_gemm(
@@ -1547,6 +1628,20 @@ impl ProviderGemmDescriptor {
             accumulation: parts.accumulation,
         }
     }
+
+    #[cfg(feature = "cpu-faer")]
+    fn from_uninit_parts(parts: &crate::provider::CpuGemmUninitRequestParts<'_, '_>) -> Self {
+        Self {
+            rows: parts.rows,
+            columns: parts.columns,
+            contracted: parts.contracted,
+            batch_count: parts.batch_count,
+            lhs_layout: parts.lhs_layout,
+            rhs_layout: parts.rhs_layout,
+            output_layout: parts.output_layout,
+            accumulation: parts.accumulation,
+        }
+    }
 }
 
 #[cfg(feature = "cpu-faer")]
@@ -1571,13 +1666,33 @@ where
     {
         return scale_empty_contract_output(output, beta);
     }
+    let output_data = output.host_storage_mut()?.as_mut_ptr();
+    execute_faer_request_typed_with_output(context, descriptor, lhs, rhs, output_data, alpha, beta)
+}
+
+#[cfg(feature = "cpu-faer")]
+fn execute_faer_request_typed_with_output<L, R, T>(
+    context: &CpuExecutionContext<'_>,
+    descriptor: ProviderGemmDescriptor,
+    lhs: &L,
+    rhs: &R,
+    output_data: *mut T,
+    alpha: T,
+    beta: T,
+) -> Result<()>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+    T: FaerGemm + Copy + Zero + PartialEq + std::ops::Mul<Output = T> + 'static,
+{
+    // INVARIANT: callers reach this helper only for non-empty GEMMs (rows,
+    // columns, contracted, and batch count are all non-zero).
     let Some(lhs_data) = lhs.host_data_opt()?.map(<[T]>::as_ptr) else {
         return Err(crate::cpu_backend_buffer_error(OP));
     };
     let Some(rhs_data) = rhs.host_data_opt()?.map(<[T]>::as_ptr) else {
         return Err(crate::cpu_backend_buffer_error(OP));
     };
-    let output_data = output.host_storage_mut()?.as_mut_ptr();
     let par = context.faer_parallelism();
     for batch in 0..descriptor.batch_count {
         checked_view_batch_offset(
@@ -1765,6 +1880,224 @@ pub(crate) fn execute_faer_gemm_request(
                             context, descriptor, lhs, rhs, output, alpha, beta,
                         )?;
                         return Ok(CpuProviderOutcome::Executed);
+                    }
+                    _ => {}
+                }
+            }
+        };
+    }
+    dispatch!(F32, F32);
+    dispatch!(F64, F64);
+    dispatch!(C32, C32);
+    dispatch!(C64, C64);
+    Ok(CpuProviderOutcome::Unsupported(
+        CpuProviderUnsupported::DType(dtype),
+    ))
+}
+
+/// Validate that `output_bytes` is exactly the byte representation of
+/// `element_count` `T`-sized elements, aligned for `T`, and return the
+/// destination pointer.
+#[cfg(feature = "cpu-faer")]
+fn checked_uninit_output_ptr<T>(
+    output_bytes: &mut [MaybeUninit<u8>],
+    element_count: usize,
+    op: &'static str,
+) -> Result<*mut T> {
+    let byte_len = element_count.checked_mul(size_of::<T>()).ok_or_else(|| {
+        Error::invalid_argument(
+            op,
+            "output",
+            "uninitialized destination byte length overflow",
+        )
+    })?;
+    if output_bytes.len() != byte_len {
+        return Err(Error::invalid_argument(
+            op,
+            "output",
+            format!(
+                "uninitialized destination has {} bytes but requires {byte_len}",
+                output_bytes.len()
+            ),
+        ));
+    }
+    if !(output_bytes.as_mut_ptr() as usize).is_multiple_of(align_of::<T>()) {
+        return Err(Error::invalid_argument(
+            op,
+            "output",
+            format!(
+                "uninitialized destination is misaligned for {}",
+                std::any::type_name::<T>()
+            ),
+        ));
+    }
+    Ok(output_bytes.as_mut_ptr().cast::<T>())
+}
+
+/// Write zero into every destination element for an empty-contraction GEMM
+/// (beta == 0 semantics overwrite without reading). Zero-element destinations
+/// (rows, columns, or batch count zero) write nothing and are satisfied.
+#[cfg(feature = "cpu-faer")]
+fn write_empty_contract_zeros_into_uninit<T>(
+    output_data: *mut T,
+    descriptor: &ProviderGemmDescriptor,
+) -> Result<()>
+where
+    T: Copy + Zero,
+{
+    if descriptor.rows == 0 || descriptor.columns == 0 || descriptor.batch_count == 0 {
+        return Ok(());
+    }
+    for batch in 0..descriptor.batch_count {
+        let output_offset = checked_view_batch_offset(
+            descriptor.output_layout.offset(),
+            batch,
+            descriptor.output_layout.batch_stride(),
+        )?;
+        let mut column_offset = 0isize;
+        for _ in 0..descriptor.columns {
+            let mut offset = column_offset;
+            for _ in 0..descriptor.rows {
+                // SAFETY: `output_data` points at the validated rows*columns*
+                // batch destination; every index lies inside the span described
+                // by the engine-validated output layout.
+                unsafe {
+                    output_data.offset(output_offset + offset).write(T::zero());
+                }
+                offset += descriptor.output_layout.row_stride();
+            }
+            column_offset += descriptor.output_layout.column_stride();
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "cpu-faer")]
+fn execute_faer_request_typed_into_uninit<L, R, T>(
+    context: &CpuExecutionContext<'_>,
+    descriptor: ProviderGemmDescriptor,
+    lhs: &L,
+    rhs: &R,
+    output_bytes: &mut [MaybeUninit<u8>],
+    alpha: T,
+    beta: T,
+) -> Result<CpuProviderOutcome>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+    T: FaerGemm + Copy + Zero + PartialEq + std::ops::Mul<Output = T> + 'static,
+{
+    if beta != T::zero() {
+        // The uninit destination contract only holds for full-overwrite
+        // (beta == 0) accumulations; refuse rather than read uninitialized C.
+        return Ok(CpuProviderOutcome::Unsupported(
+            CpuProviderUnsupported::Accumulation,
+        ));
+    }
+    let element_count = descriptor
+        .rows
+        .checked_mul(descriptor.columns)
+        .and_then(|count| count.checked_mul(descriptor.batch_count))
+        .ok_or_else(|| {
+            Error::invalid_argument(OP, "output", "uninitialized output element count overflow")
+        })?;
+    let output_data = checked_uninit_output_ptr::<T>(output_bytes, element_count, OP)?;
+    if descriptor.rows == 0
+        || descriptor.columns == 0
+        || descriptor.contracted == 0
+        || descriptor.batch_count == 0
+    {
+        write_empty_contract_zeros_into_uninit(output_data, &descriptor)?;
+        return Ok(CpuProviderOutcome::Executed);
+    }
+    execute_faer_request_typed_with_output(
+        context,
+        descriptor,
+        lhs,
+        rhs,
+        output_data,
+        alpha,
+        beta,
+    )?;
+    Ok(CpuProviderOutcome::Executed)
+}
+
+/// Execute one validated full-overwrite GEMM (beta == 0) into uninitialized
+/// bytes. The destination is written through `MaybeUninit` storage only; every
+/// logical element is initialized before `Executed` (faer `Accum::Replace`;
+/// empty contractions write zeros).
+#[cfg(feature = "cpu-faer")]
+pub(crate) fn execute_faer_gemm_request_into_uninit(
+    context: &CpuExecutionContext<'_>,
+    request: crate::provider::CpuGemmUninitRequest<'_, '_>,
+    output_bytes: &mut [MaybeUninit<u8>],
+) -> Result<CpuProviderOutcome> {
+    let parts = request.into_parts();
+    let descriptor = ProviderGemmDescriptor::from_uninit_parts(&parts);
+    let lhs = parts.lhs;
+    let rhs = parts.rhs;
+    let dtype = lhs.dtype();
+    macro_rules! dispatch {
+        ($owned:ident, $view:ident) => {
+            if let (ContractionScalar::$owned(alpha), ContractionScalar::$owned(beta)) =
+                (descriptor.accumulation.alpha, descriptor.accumulation.beta)
+            {
+                match (lhs, rhs) {
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(lhs)),
+                        TensorRead::Tensor(crate::Tensor::$owned(rhs)),
+                    ) => {
+                        return execute_faer_request_typed_into_uninit(
+                            context,
+                            descriptor,
+                            lhs,
+                            rhs,
+                            output_bytes,
+                            alpha,
+                            beta,
+                        );
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(lhs)),
+                        TensorRead::View(TensorView::$view(rhs)),
+                    ) => {
+                        return execute_faer_request_typed_into_uninit(
+                            context,
+                            descriptor,
+                            lhs,
+                            rhs,
+                            output_bytes,
+                            alpha,
+                            beta,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(lhs)),
+                        TensorRead::Tensor(crate::Tensor::$owned(rhs)),
+                    ) => {
+                        return execute_faer_request_typed_into_uninit(
+                            context,
+                            descriptor,
+                            lhs,
+                            rhs,
+                            output_bytes,
+                            alpha,
+                            beta,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(lhs)),
+                        TensorRead::View(TensorView::$view(rhs)),
+                    ) => {
+                        return execute_faer_request_typed_into_uninit(
+                            context,
+                            descriptor,
+                            lhs,
+                            rhs,
+                            output_bytes,
+                            alpha,
+                            beta,
+                        );
                     }
                     _ => {}
                 }

--- a/crates/tenferro-cpu/src/provider.rs
+++ b/crates/tenferro-cpu/src/provider.rs
@@ -5,6 +5,7 @@
 //! tensor metadata and reachable ranges have already been validated.
 
 use core::fmt;
+use std::mem::MaybeUninit;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -747,11 +748,29 @@ impl<'request, 'input, 'output> CpuGemmRequest<'request, 'input, 'output> {
     }
 
     /// Return the borrowed left input.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.lhs();
+    /// # }
+    /// ```
     pub fn lhs(&self) -> &TensorRead<'input> {
         self.lhs
     }
 
     /// Return the borrowed right input.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.rhs();
+    /// # }
+    /// ```
     pub fn rhs(&self) -> &TensorRead<'input> {
         self.rhs
     }
@@ -762,11 +781,29 @@ impl<'request, 'input, 'output> CpuGemmRequest<'request, 'input, 'output> {
     }
 
     /// Return the number of output rows.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.rows();
+    /// # }
+    /// ```
     pub fn rows(&self) -> usize {
         self.rows
     }
 
     /// Return the number of output columns.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.columns();
+    /// # }
+    /// ```
     pub fn columns(&self) -> usize {
         self.columns
     }
@@ -806,6 +843,247 @@ impl<'request, 'input, 'output> CpuGemmRequest<'request, 'input, 'output> {
             lhs: self.lhs,
             rhs: self.rhs,
             output: self.output,
+            rows: self.rows,
+            columns: self.columns,
+            contracted: self.contracted,
+            batch_count: self.batch_count,
+            lhs_layout: self.lhs_layout,
+            rhs_layout: self.rhs_layout,
+            output_layout: self.output_layout,
+            accumulation: self.accumulation,
+        }
+    }
+}
+
+/// Validated output-free borrowed GEMM request for full-overwrite destinations.
+///
+/// Mirrors [`CpuGemmRequest`] minus the writable output: the destination is
+/// provided separately as `&mut [MaybeUninit<u8>]` to [`CpuUninitGemmProvider`]
+/// callers. This request is only used for `beta == 0` (full-overwrite)
+/// accumulations, where the destination is never read.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::provider::CpuGemmUninitRequest;
+/// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+/// assert!(request.batch_count() >= 1);
+/// # }
+/// ```
+#[derive(Debug)]
+/// Output-free prepared GEMM request for uninitialized full-overwrite
+/// execution (see `CpuUninitGemmProvider::gemm_into_uninit`).
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::provider::CpuGemmUninitRequest;
+/// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+/// #     let _ = request.rows();
+/// #     let _ = request.columns();
+/// #     let _ = request.contracted();
+/// # }
+/// ```
+pub struct CpuGemmUninitRequest<'request, 'input> {
+    lhs: &'request TensorRead<'input>,
+    rhs: &'request TensorRead<'input>,
+    rows: usize,
+    columns: usize,
+    contracted: usize,
+    batch_count: usize,
+    lhs_layout: CpuBatchedMatrixLayout,
+    rhs_layout: CpuBatchedMatrixLayout,
+    output_layout: CpuBatchedMatrixLayout,
+    accumulation: DotGeneralAccumulation,
+}
+
+#[cfg(feature = "cpu-faer")]
+pub(crate) struct CpuGemmUninitRequestParts<'request, 'input> {
+    pub(crate) lhs: &'request TensorRead<'input>,
+    pub(crate) rhs: &'request TensorRead<'input>,
+    pub(crate) rows: usize,
+    pub(crate) columns: usize,
+    pub(crate) contracted: usize,
+    pub(crate) batch_count: usize,
+    pub(crate) lhs_layout: CpuBatchedMatrixLayout,
+    pub(crate) rhs_layout: CpuBatchedMatrixLayout,
+    pub(crate) output_layout: CpuBatchedMatrixLayout,
+    pub(crate) accumulation: DotGeneralAccumulation,
+}
+
+impl<'request, 'input> CpuGemmUninitRequest<'request, 'input> {
+    #[allow(clippy::too_many_arguments, dead_code)]
+    pub(crate) fn new(
+        lhs: &'request TensorRead<'input>,
+        rhs: &'request TensorRead<'input>,
+        rows: usize,
+        columns: usize,
+        contracted: usize,
+        batch_count: usize,
+        lhs_layout: CpuBatchedMatrixLayout,
+        rhs_layout: CpuBatchedMatrixLayout,
+        output_layout: CpuBatchedMatrixLayout,
+        accumulation: DotGeneralAccumulation,
+    ) -> Self {
+        Self {
+            lhs,
+            rhs,
+            rows,
+            columns,
+            contracted,
+            batch_count,
+            lhs_layout,
+            rhs_layout,
+            output_layout,
+            accumulation,
+        }
+    }
+
+    /// Return the `lhs` of this output-free request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.lhs();
+    /// # }
+    /// ```
+    pub fn lhs(&self) -> &TensorRead<'input> {
+        self.lhs
+    }
+
+    /// Return the `rhs` of this output-free request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.rhs();
+    /// # }
+    /// ```
+    pub fn rhs(&self) -> &TensorRead<'input> {
+        self.rhs
+    }
+
+    /// Return the `rows` of this output-free request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.rows();
+    /// # }
+    /// ```
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    /// Return the `columns` of this output-free request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.columns();
+    /// # }
+    /// ```
+    pub fn columns(&self) -> usize {
+        self.columns
+    }
+
+    /// Return the `contracted` of this output-free request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.contracted();
+    /// # }
+    /// ```
+    pub fn contracted(&self) -> usize {
+        self.contracted
+    }
+
+    /// Return the `batch_count` of this output-free request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.batch_count();
+    /// # }
+    /// ```
+    pub fn batch_count(&self) -> usize {
+        self.batch_count
+    }
+
+    /// Return the `lhs_layout` of this output-free request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.lhs_layout();
+    /// # }
+    /// ```
+    pub fn lhs_layout(&self) -> CpuBatchedMatrixLayout {
+        self.lhs_layout
+    }
+
+    /// Return the `rhs_layout` of this output-free request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.rhs_layout();
+    /// # }
+    /// ```
+    pub fn rhs_layout(&self) -> CpuBatchedMatrixLayout {
+        self.rhs_layout
+    }
+
+    /// Return the `output_layout` of this output-free request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.output_layout();
+    /// # }
+    /// ```
+    pub fn output_layout(&self) -> CpuBatchedMatrixLayout {
+        self.output_layout
+    }
+
+    /// Return the `accumulation` of this output-free request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmUninitRequest;
+    /// # fn inspect(request: &CpuGemmUninitRequest<'_, '_>) {
+    /// #     let _ = request.accumulation();
+    /// # }
+    /// ```
+    pub fn accumulation(&self) -> DotGeneralAccumulation {
+        self.accumulation
+    }
+
+    #[cfg(feature = "cpu-faer")]
+    pub(crate) fn into_parts(self) -> CpuGemmUninitRequestParts<'request, 'input> {
+        CpuGemmUninitRequestParts {
+            lhs: self.lhs,
+            rhs: self.rhs,
             rows: self.rows,
             columns: self.columns,
             contracted: self.contracted,
@@ -1238,6 +1516,84 @@ pub trait CpuGemmProvider: fmt::Debug + Send + Sync + 'static {
         context: &CpuExecutionContext<'_>,
         request: CpuGroupedGemmRequest<'_, '_, '_>,
     ) -> tenferro_tensor::Result<CpuProviderOutcome>;
+
+    /// Return the structural full-overwrite witness for this provider.
+    ///
+    /// Returns `Some(self)` only for types that implement
+    /// [`CpuUninitGemmProvider`] via an `unsafe impl`, so a `Some` witness is
+    /// structural proof that the provider asserted the full-overwrite
+    /// destination contract. Defaults to `None` (opted out).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuGemmProvider;
+    /// # fn inspect(provider: &dyn CpuGemmProvider) {
+    /// #     let _ = provider.uninit_provider();
+    /// # }
+    /// ```
+    fn uninit_provider(&self) -> Option<&dyn CpuUninitGemmProvider> {
+        None
+    }
+}
+
+/// Provider for validated GEMM-family requests that fully overwrite their
+/// destination (only `beta == 0` accumulations).
+///
+/// # Safety
+///
+/// Implementors assert that [`CpuUninitGemmProvider::gemm_into_uninit`] writes
+/// every logical output element before returning
+/// [`CpuProviderOutcome::Executed`]; partial writes make the caller's
+/// `assume_init` undefined behavior. Implementations must never read the
+/// destination. This trait is only invoked for `beta == 0` accumulations.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::provider::CpuUninitGemmProvider;
+/// # fn accepts_provider(_: &dyn CpuUninitGemmProvider) {}
+/// ```
+pub unsafe trait CpuUninitGemmProvider: CpuGemmProvider {
+    /// Execute one validated full-overwrite GEMM into uninitialized bytes.
+    ///
+    /// # Safety
+    ///
+    /// Must write every element of the destination represented by
+    /// `output_bytes` (per `request.output_layout()`) before returning
+    /// `Executed`; partial writes are UB at the caller's `assume_init`. The
+    /// destination is never read. Invoked only for `beta == 0` accumulations.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::BackendSource`] or
+    /// [`tenferro_tensor::Error::BackendFailure`] when the provider runtime
+    /// fails. A detected inconsistency in engine-attested request metadata is
+    /// returned as [`tenferro_tensor::Error::Validation`]. Unsupported
+    /// capabilities use [`CpuProviderOutcome::Unsupported`] instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::{CpuGemmUninitRequest, CpuProviderOutcome, CpuUninitGemmProvider};
+    /// use tenferro_cpu::CpuExecutionContext;
+    /// use std::mem::MaybeUninit;
+    /// # fn inspect(
+    /// #     provider: &dyn CpuUninitGemmProvider,
+    /// #     context: &CpuExecutionContext<'_>,
+    /// #     request: CpuGemmUninitRequest<'_, '_>,
+    /// #     output_bytes: &mut [MaybeUninit<u8>],
+    /// # ) -> Option<tenferro_tensor::Result<CpuProviderOutcome>> {
+    /// #     let _ = (provider, context, request, output_bytes);
+    /// #     None
+    /// # }
+    /// ```
+    unsafe fn gemm_into_uninit(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuGemmUninitRequest<'_, '_>,
+        output_bytes: &mut [MaybeUninit<u8>],
+    ) -> tenferro_tensor::Result<CpuProviderOutcome>;
 }
 
 /// Provider for engine-owned tensor materialization.
@@ -1268,6 +1624,88 @@ pub trait CpuLayoutTransformProvider: fmt::Debug + Send + Sync + 'static {
         &self,
         context: &CpuExecutionContext<'_>,
         request: CpuLayoutTransformRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome>;
+
+    /// Return the structural full-overwrite witness for this provider.
+    ///
+    /// Returns `Some(self)` only for types that implement
+    /// [`CpuUninitLayoutTransformProvider`] via an `unsafe impl`, so a `Some`
+    /// witness is structural proof that the provider asserted the
+    /// full-overwrite destination contract. Defaults to `None` (opted out).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::CpuLayoutTransformProvider;
+    /// # fn inspect(provider: &dyn CpuLayoutTransformProvider) {
+    /// #     let _ = provider.uninit_provider();
+    /// # }
+    /// ```
+    fn uninit_provider(&self) -> Option<&dyn CpuUninitLayoutTransformProvider> {
+        None
+    }
+}
+
+/// Provider for engine-owned tensor materialization into uninitialized bytes.
+///
+/// # Safety
+///
+/// Implementors assert that [`CpuUninitLayoutTransformProvider::materialize_into_uninit`]
+/// writes every element of `output_bytes` before returning
+/// [`CpuProviderOutcome::Executed`]; partial writes make the caller's
+/// `assume_init` undefined behavior. Implementations must never read the
+/// destination.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::provider::CpuUninitLayoutTransformProvider;
+/// # fn accepts_provider(_: &dyn CpuUninitLayoutTransformProvider) {}
+/// ```
+pub unsafe trait CpuUninitLayoutTransformProvider: CpuLayoutTransformProvider {
+    /// Materialize one validated input into uninitialized bytes.
+    ///
+    /// # Safety
+    ///
+    /// Must write every element of `output_bytes` (a compact column-major
+    /// destination of the input shape for
+    /// [`CpuLayoutTransformIntent::CanonicalColumnMajor`]) before returning
+    /// `Executed`; partial writes are UB at the caller's `assume_init`. The
+    /// destination is never read.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::BackendSource`] or
+    /// [`tenferro_tensor::Error::BackendFailure`] when execution fails. A
+    /// detected inconsistency in engine-attested layout or range metadata is
+    /// returned as [`tenferro_tensor::Error::Validation`]. Unsupported layouts
+    /// use [`CpuProviderOutcome::Unsupported`] instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::provider::{CpuLayoutTransformIntent, CpuProviderOutcome, CpuUninitLayoutTransformProvider};
+    /// use tenferro_cpu::CpuExecutionContext;
+    /// use tenferro_tensor::TensorRead;
+    /// use std::mem::MaybeUninit;
+    /// # fn inspect(
+    /// #     provider: &dyn CpuUninitLayoutTransformProvider,
+    /// #     context: &CpuExecutionContext<'_>,
+    /// #     input: &TensorRead<'_>,
+    /// #     intent: CpuLayoutTransformIntent,
+    /// #     output_bytes: &mut [MaybeUninit<u8>],
+    /// # ) -> Option<tenferro_tensor::Result<CpuProviderOutcome>> {
+    /// #     let _ = (provider, context, input, intent, output_bytes);
+    /// #     None
+    /// # }
+    /// ```
+    unsafe fn materialize_into_uninit(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        input: &TensorRead<'_>,
+        intent: CpuLayoutTransformIntent,
+        conjugate: bool,
+        output_bytes: &mut [MaybeUninit<u8>],
     ) -> tenferro_tensor::Result<CpuProviderOutcome>;
 }
 
@@ -1358,6 +1796,35 @@ impl CpuGemmProvider for FaerGemmProvider {
         #[cfg(not(feature = "cpu-faer"))]
         {
             let _ = (context, request);
+            Ok(CpuProviderOutcome::Unsupported(
+                CpuProviderUnsupported::RuntimeUnavailable,
+            ))
+        }
+    }
+
+    fn uninit_provider(&self) -> Option<&dyn CpuUninitGemmProvider> {
+        Some(self)
+    }
+}
+
+// SAFETY: `gemm_into_uninit` runs the faer GEMM with `Accum::Replace` semantics
+// (beta == 0 never reads the destination) and writes zeros for empty
+// contractions, so every logical output element is written before `Executed`.
+// See `crate::gemm::execute_faer_gemm_request_into_uninit`.
+unsafe impl CpuUninitGemmProvider for FaerGemmProvider {
+    unsafe fn gemm_into_uninit(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuGemmUninitRequest<'_, '_>,
+        output_bytes: &mut [MaybeUninit<u8>],
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        #[cfg(feature = "cpu-faer")]
+        {
+            crate::gemm::execute_faer_gemm_request_into_uninit(context, request, output_bytes)
+        }
+        #[cfg(not(feature = "cpu-faer"))]
+        {
+            let _ = (context, request, output_bytes);
             Ok(CpuProviderOutcome::Unsupported(
                 CpuProviderUnsupported::RuntimeUnavailable,
             ))
@@ -1458,6 +1925,28 @@ impl CpuLayoutTransformProvider for StridedLayoutTransformProvider {
         request: CpuLayoutTransformRequest<'_, '_, '_>,
     ) -> tenferro_tensor::Result<CpuProviderOutcome> {
         context.with_native_parallelism(|| materialize_strided_layout(request))
+    }
+
+    fn uninit_provider(&self) -> Option<&dyn CpuUninitLayoutTransformProvider> {
+        Some(self)
+    }
+}
+
+// SAFETY: `materialize_into_uninit` replays the layout-transform copy over the
+// full destination (every element written via `MaybeUninit` writes from the
+// source); zero-element destinations are trivially satisfied.
+unsafe impl CpuUninitLayoutTransformProvider for StridedLayoutTransformProvider {
+    unsafe fn materialize_into_uninit(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        input: &TensorRead<'_>,
+        intent: CpuLayoutTransformIntent,
+        conjugate: bool,
+        output_bytes: &mut [MaybeUninit<u8>],
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        context.with_native_parallelism(|| {
+            materialize_strided_layout_into_uninit(input, intent, conjugate, output_bytes)
+        })
     }
 }
 
@@ -1589,6 +2078,56 @@ fn materialize_strided_layout(
     dispatch!(I32, I32);
     dispatch!(I64, I64);
     dispatch!(Bool, Bool);
+    dispatch!(C32, C32);
+    dispatch!(C64, C64);
+    Ok(CpuProviderOutcome::Unsupported(
+        CpuProviderUnsupported::DType(input.dtype()),
+    ))
+}
+
+/// Full-overwrite layout transform into an uninitialized compact column-major
+/// destination. Only [`CpuLayoutTransformIntent::CanonicalColumnMajor`] is
+/// implemented; the destination must be exactly `element_count * size_of::<T>()`
+/// bytes of the input dtype `T`, aligned for `T`.
+fn materialize_strided_layout_into_uninit(
+    input: &TensorRead<'_>,
+    intent: CpuLayoutTransformIntent,
+    conjugate: bool,
+    output_bytes: &mut [MaybeUninit<u8>],
+) -> tenferro_tensor::Result<CpuProviderOutcome> {
+    if intent != CpuLayoutTransformIntent::CanonicalColumnMajor {
+        return Ok(CpuProviderOutcome::Unsupported(
+            CpuProviderUnsupported::Layout(CpuOperand::Output),
+        ));
+    }
+    macro_rules! dispatch {
+        ($owned:ident, $view:ident) => {
+            match input {
+                TensorRead::Tensor(Tensor::$owned(input)) => {
+                    let input = input.as_view();
+                    crate::structural::typed_copy_into_uninit(
+                        &input,
+                        conjugate,
+                        output_bytes,
+                        "cpu layout materialization",
+                    )?;
+                    return Ok(CpuProviderOutcome::Executed);
+                }
+                TensorRead::View(TensorView::$view(input)) => {
+                    crate::structural::typed_copy_into_uninit(
+                        input,
+                        conjugate,
+                        output_bytes,
+                        "cpu layout materialization",
+                    )?;
+                    return Ok(CpuProviderOutcome::Executed);
+                }
+                _ => {}
+            }
+        };
+    }
+    dispatch!(F32, F32);
+    dispatch!(F64, F64);
     dispatch!(C32, C32);
     dispatch!(C64, C64);
     Ok(CpuProviderOutcome::Unsupported(

--- a/crates/tenferro-cpu/src/provider/tests.rs
+++ b/crates/tenferro-cpu/src/provider/tests.rs
@@ -1,14 +1,13 @@
-#[cfg(any(
-    not(feature = "cpu-blas"),
-    all(feature = "cpu-blas", not(feature = "provider-inject"))
-))]
 use super::BlasGemmProvider;
 #[cfg(all(feature = "cpu-blas", not(feature = "provider-inject")))]
 use super::CpuOperand;
+#[cfg(feature = "cpu-faer")]
+use super::CpuUninitGemmProvider;
 use super::{
     CpuBatchedMatrixLayout, CpuExecutionContext, CpuGemmProvider, CpuGemmRequest,
     CpuGeneralContractionProvider, CpuLayoutTransformProvider, CpuOperationEntry,
-    CpuProviderOutcome, CpuProviderUnsupported, ParallelMode, StridedLayoutTransformProvider,
+    CpuProviderOutcome, CpuProviderUnsupported, CpuUninitLayoutTransformProvider, ParallelMode,
+    StridedLayoutTransformProvider,
 };
 use crate::{
     CpuDomainExecutor, CpuDomainExecutorCapabilities, CpuDomainExecutorError, CpuDomainId,
@@ -171,11 +170,15 @@ fn parallel_mode_exposes_the_complete_execution_contract() {
 #[cfg(feature = "cpu-faer")]
 use super::{CpuGroupedGemmRequest, FaerGemmProvider};
 #[cfg(feature = "cpu-faer")]
-use num_complex::{Complex32, Complex64};
+use num_complex::Complex32;
+// `Complex64` and `TensorView` are also used by the feature-neutral
+// `materialize_into_uninit` layout test, so they are imported ungated.
+use num_complex::Complex64;
 #[cfg(feature = "cpu-faer")]
 use tenferro_tensor::backend::GroupedGemmJob;
+use tenferro_tensor::TensorView;
 #[cfg(feature = "cpu-faer")]
-use tenferro_tensor::{ContractionScalar, TensorView, TypedTensorView};
+use tenferro_tensor::{ContractionScalar, TypedTensorView};
 use tenferro_tensor::{DType, DotGeneralAccumulation, Tensor, TensorRead, TensorWrite};
 #[cfg(any(feature = "cpu-faer", feature = "cpu-blas"))]
 use tenferro_tensor::{TensorViewMut, TypedTensorViewMut};
@@ -1293,4 +1296,392 @@ fn layout_provider_fuses_conjugation_into_materialization() {
         output.as_slice::<Complex64>().unwrap(),
         &[Complex64::new(2.0, -3.0), Complex64::new(-1.0, -4.0)],
     );
+}
+
+#[derive(Debug)]
+struct OptOutProvider;
+
+impl CpuGemmProvider for OptOutProvider {
+    fn execution_capabilities(&self) -> crate::CpuProviderExecutionCapabilities {
+        crate::provider_capability::engine_worker_capabilities()
+    }
+
+    fn gemm(
+        &self,
+        _context: &CpuExecutionContext<'_>,
+        _request: CpuGemmRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        unreachable!("opt-out witness test never executes GEMM")
+    }
+
+    fn strided_batched_gemm(
+        &self,
+        _context: &CpuExecutionContext<'_>,
+        _request: CpuGemmRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        unreachable!("opt-out witness test never executes GEMM")
+    }
+
+    fn grouped_gemm(
+        &self,
+        _context: &CpuExecutionContext<'_>,
+        _request: super::CpuGroupedGemmRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        unreachable!("opt-out witness test never executes grouped GEMM")
+    }
+}
+
+impl CpuLayoutTransformProvider for OptOutProvider {
+    fn execution_capabilities(&self) -> crate::CpuProviderExecutionCapabilities {
+        crate::provider_capability::engine_worker_capabilities()
+    }
+
+    fn materialize(
+        &self,
+        _context: &CpuExecutionContext<'_>,
+        _request: super::CpuLayoutTransformRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        unreachable!("opt-out witness test never executes materialization")
+    }
+}
+
+#[test]
+fn uninit_witness_is_exposed_only_by_the_builtin_providers() {
+    // SAFETY assertions are structural: only a type that implements the
+    // unsafe trait via `unsafe impl` can return `Some(self)`.
+    #[cfg(feature = "cpu-faer")]
+    assert!(FaerGemmProvider.uninit_provider().is_some());
+    assert!(StridedLayoutTransformProvider.uninit_provider().is_some());
+    assert!(BlasGemmProvider.uninit_provider().is_none());
+    let opt_out_gemm: &dyn CpuGemmProvider = &OptOutProvider;
+    assert!(opt_out_gemm.uninit_provider().is_none());
+    let opt_out_layout: &dyn CpuLayoutTransformProvider = &OptOutProvider;
+    assert!(opt_out_layout.uninit_provider().is_none());
+}
+
+/// `f64`-aligned uninitialized destination mirroring
+/// `PooledUninitOutput::as_uninit_bytes_mut` provenance (the caller's contract
+/// for the built-in providers).
+struct UninitF64(Vec<std::mem::MaybeUninit<f64>>);
+
+impl UninitF64 {
+    fn new(slots: usize) -> Self {
+        Self(vec![std::mem::MaybeUninit::<f64>::uninit(); slots])
+    }
+
+    fn bytes_mut(&mut self) -> &mut [std::mem::MaybeUninit<u8>] {
+        // SAFETY: `Vec<MaybeUninit<f64>>` is `f64`-aligned; the byte view
+        // reuses the same allocation, matching the real caller's provenance.
+        unsafe {
+            std::slice::from_raw_parts_mut(
+                self.0.as_mut_ptr().cast::<std::mem::MaybeUninit<u8>>(),
+                self.0.len() * 8,
+            )
+        }
+    }
+
+    fn values(&self) -> &[f64] {
+        // SAFETY: the provider wrote every element before `Executed`.
+        unsafe { std::slice::from_raw_parts(self.0.as_ptr().cast::<f64>(), self.0.len()) }
+    }
+}
+
+/// `Complex64`-aligned uninitialized destination (see [`UninitF64`]).
+struct UninitC64(Vec<std::mem::MaybeUninit<num_complex::Complex64>>);
+
+impl UninitC64 {
+    fn new(slots: usize) -> Self {
+        Self(vec![
+            std::mem::MaybeUninit::<num_complex::Complex64>::uninit(
+            );
+            slots
+        ])
+    }
+
+    fn bytes_mut(&mut self) -> &mut [std::mem::MaybeUninit<u8>] {
+        // SAFETY: `Vec<MaybeUninit<Complex64>>` is `Complex64`-aligned.
+        unsafe {
+            std::slice::from_raw_parts_mut(
+                self.0.as_mut_ptr().cast::<std::mem::MaybeUninit<u8>>(),
+                self.0.len() * 16,
+            )
+        }
+    }
+
+    fn values(&self) -> &[num_complex::Complex64] {
+        // SAFETY: the provider wrote every element before `Executed`.
+        unsafe {
+            std::slice::from_raw_parts(
+                self.0.as_ptr().cast::<num_complex::Complex64>(),
+                self.0.len(),
+            )
+        }
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn faer_gemm_into_uninit_matches_initialized_gemm() {
+    use super::{CpuBatchedMatrixLayout as Layout, CpuGemmUninitRequest};
+    use tenferro_tensor::DotGeneralAccumulation;
+
+    let fixture = execution_context_fixture(1);
+    fixture.with_context(ParallelMode::Sequential, |context| {
+        let lhs = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]).unwrap();
+        let rhs = Tensor::from_vec_col_major(vec![2, 2], vec![5.0_f64, 7.0, 6.0, 8.0]).unwrap();
+        let lhs_read = TensorRead::from_tensor(&lhs);
+        let rhs_read = TensorRead::from_tensor(&rhs);
+
+        // Single GEMM: 2x2 x 2x2.
+        let mut output = UninitF64::new(4);
+        let request = CpuGemmUninitRequest::new(
+            &lhs_read,
+            &rhs_read,
+            2,
+            2,
+            2,
+            1,
+            Layout::new(0, 1, 2, 4),
+            Layout::new(0, 1, 2, 4),
+            Layout::new(0, 1, 2, 4),
+            DotGeneralAccumulation::overwrite(DType::F64).unwrap(),
+        );
+        // SAFETY: FaerGemmProvider's unsafe impl writes every destination
+        // element before `Executed` (faer Accum::Replace, beta == 0).
+        let outcome =
+            unsafe { FaerGemmProvider.gemm_into_uninit(context, request, output.bytes_mut()) }
+                .unwrap();
+        assert_eq!(outcome, CpuProviderOutcome::Executed);
+        assert_eq!(output.values(), &[19.0, 43.0, 22.0, 50.0]);
+
+        // Strided batch of two 2x2 GEMMs.
+        let lhs = Tensor::from_vec_col_major(vec![2, 2, 2], vec![1.0_f64; 8]).unwrap();
+        let rhs = Tensor::from_vec_col_major(vec![2, 2, 2], vec![2.0_f64; 8]).unwrap();
+        let lhs_read = TensorRead::from_tensor(&lhs);
+        let rhs_read = TensorRead::from_tensor(&rhs);
+        let mut output = UninitF64::new(8);
+        let request = CpuGemmUninitRequest::new(
+            &lhs_read,
+            &rhs_read,
+            2,
+            2,
+            2,
+            2,
+            Layout::new(0, 1, 2, 4),
+            Layout::new(0, 1, 2, 4),
+            Layout::new(0, 1, 2, 4),
+            DotGeneralAccumulation::overwrite(DType::F64).unwrap(),
+        );
+        // SAFETY: same full-overwrite contract; the uninit GEMM covers all
+        // batches internally.
+        let outcome =
+            unsafe { FaerGemmProvider.gemm_into_uninit(context, request, output.bytes_mut()) }
+                .unwrap();
+        assert_eq!(outcome, CpuProviderOutcome::Executed);
+        assert_eq!(output.values(), &[4.0; 8]);
+
+        // Empty contraction (k == 0) writes zeros without reading.
+        let mut output = UninitF64::new(4);
+        let request = CpuGemmUninitRequest::new(
+            &lhs_read,
+            &rhs_read,
+            2,
+            2,
+            0,
+            1,
+            Layout::new(0, 1, 2, 4),
+            Layout::new(0, 1, 2, 4),
+            Layout::new(0, 1, 2, 4),
+            DotGeneralAccumulation::overwrite(DType::F64).unwrap(),
+        );
+        let outcome =
+            unsafe { FaerGemmProvider.gemm_into_uninit(context, request, output.bytes_mut()) }
+                .unwrap();
+        assert_eq!(outcome, CpuProviderOutcome::Executed);
+        assert_eq!(output.values(), &[0.0; 4]);
+
+        // Empty output (zero rows) is trivially satisfied.
+        let mut output = UninitF64::new(0);
+        let request = CpuGemmUninitRequest::new(
+            &lhs_read,
+            &rhs_read,
+            0,
+            2,
+            2,
+            1,
+            Layout::new(0, 1, 2, 4),
+            Layout::new(0, 1, 2, 4),
+            Layout::new(0, 1, 2, 4),
+            DotGeneralAccumulation::overwrite(DType::F64).unwrap(),
+        );
+        let outcome =
+            unsafe { FaerGemmProvider.gemm_into_uninit(context, request, output.bytes_mut()) }
+                .unwrap();
+        assert_eq!(outcome, CpuProviderOutcome::Executed);
+
+        // A non-zero beta accumulation is refused rather than reading uninit.
+        let mut accumulation = DotGeneralAccumulation::overwrite(DType::F64).unwrap();
+        accumulation.beta = tenferro_tensor::ContractionScalar::F64(1.0);
+        let mut output = UninitF64::new(4);
+        let request = CpuGemmUninitRequest::new(
+            &lhs_read,
+            &rhs_read,
+            2,
+            2,
+            2,
+            1,
+            Layout::new(0, 1, 2, 4),
+            Layout::new(0, 1, 2, 4),
+            Layout::new(0, 1, 2, 4),
+            accumulation,
+        );
+        let outcome =
+            unsafe { FaerGemmProvider.gemm_into_uninit(context, request, output.bytes_mut()) }
+                .unwrap();
+        assert_eq!(
+            outcome,
+            CpuProviderOutcome::Unsupported(CpuProviderUnsupported::Accumulation)
+        );
+    });
+}
+
+#[test]
+fn layout_materialize_into_uninit_matches_initialized_materialization() {
+    use super::CpuLayoutTransformIntent;
+
+    let fixture = execution_context_fixture(1);
+    fixture.with_context(ParallelMode::Sequential, |context| {
+        let input =
+            Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap();
+        let mut output = UninitF64::new(6);
+        let input_read = TensorRead::from_tensor(&input);
+        // SAFETY: StridedLayoutTransformProvider's unsafe impl writes every
+        // destination element before `Executed`.
+        let outcome = unsafe {
+            StridedLayoutTransformProvider.materialize_into_uninit(
+                context,
+                &input_read,
+                CpuLayoutTransformIntent::CanonicalColumnMajor,
+                false,
+                output.bytes_mut(),
+            )
+        }
+        .unwrap();
+        assert_eq!(outcome, CpuProviderOutcome::Executed);
+        assert_eq!(output.values(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+
+        // Conjugated materialization of a transposed view input.
+        let input = Tensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex64::new(1.0, 2.0),
+                Complex64::new(3.0, -1.0),
+                Complex64::new(-2.0, 0.5),
+                Complex64::new(4.0, 1.0),
+            ],
+        )
+        .unwrap();
+        let transposed = match TensorRead::from_tensor(&input).tensor_view() {
+            TensorView::C64(view) => TensorView::C64(view.transpose_view([1, 0]).unwrap()),
+            other => panic!("expected C64 view, got {:?}", other.dtype()),
+        };
+        let mut output = UninitC64::new(4);
+        let input_view = TensorRead::from_view(transposed);
+        let outcome = unsafe {
+            StridedLayoutTransformProvider.materialize_into_uninit(
+                context,
+                &input_view,
+                CpuLayoutTransformIntent::CanonicalColumnMajor,
+                true,
+                output.bytes_mut(),
+            )
+        }
+        .unwrap();
+        assert_eq!(outcome, CpuProviderOutcome::Executed);
+        assert_eq!(
+            output.values(),
+            &[
+                Complex64::new(1.0, -2.0),
+                Complex64::new(-2.0, -0.5),
+                Complex64::new(3.0, 1.0),
+                Complex64::new(4.0, -1.0),
+            ]
+        );
+
+        // Zero-element destination is trivially satisfied.
+        let empty = Tensor::from_vec_col_major(vec![0, 2], Vec::<f64>::new()).unwrap();
+        let empty_read = TensorRead::from_tensor(&empty);
+        let mut output = UninitF64::new(0);
+        let outcome = unsafe {
+            StridedLayoutTransformProvider.materialize_into_uninit(
+                context,
+                &empty_read,
+                CpuLayoutTransformIntent::CanonicalColumnMajor,
+                false,
+                output.bytes_mut(),
+            )
+        }
+        .unwrap();
+        assert_eq!(outcome, CpuProviderOutcome::Executed);
+    });
+}
+
+#[test]
+fn cpu_execution_context_debug_format_is_runnable() {
+    // Cover the CpuExecutionContext Debug impl (field formatting).
+    let fixture = execution_context_fixture(1);
+    fixture.with_context(ParallelMode::Inner, |provider_context| {
+        let rendered = format!("{provider_context:?}");
+        assert!(rendered.contains("CpuExecutionContext"));
+        assert!(rendered.contains("parallel_mode"));
+    });
+}
+
+#[test]
+fn cross_domain_enter_or_reuse_reports_scheduling_error() {
+    // Cover the domain-mismatch branch of CpuOperationEntry::enter_or_reuse.
+    let fixture_a = execution_context_fixture(1); // domain id 9
+    let cpus = crate::CpuSet::singleton(crate::CpuId::new(0));
+    let placement = crate::ResolvedCpuPlacement::AllAllowed { cpus: cpus.clone() };
+    let context = Arc::new(crate::CpuContext::with_threads(1).unwrap());
+    let engine = crate::engine::CpuEngine::from_context(CpuDomainId::new(8), placement, context, 0);
+    let permit = crate::arbiter::ResourceArbiter::new()
+        .acquire(cpus)
+        .unwrap();
+    let fixture_b = CpuExecutionContextFixture { engine, permit };
+
+    fixture_a.with_context(ParallelMode::Sequential, |entered| {
+        let error = fixture_b
+            .entry()
+            .enter_or_reuse(Some(entered), ParallelMode::Sequential, |_| ())
+            .unwrap_err();
+        assert!(matches!(error, CpuDomainExecutorError::Scheduling { .. }));
+    });
+}
+
+#[test]
+#[cfg(feature = "cpu-faer")]
+fn grouped_gemm_request_into_parts_is_covered() {
+    // Cover CpuGroupedGemmRequest::into_parts (tuple destructuring).
+    let lhs = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![2], vec![4.0_f64, 5.0]).unwrap();
+    let mut output = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let jobs = [GroupedGemmJob::new(0, 0, 0, 1, 1, 1)];
+    let lhs_read = TensorRead::from_tensor(&lhs);
+    let rhs_read = TensorRead::from_tensor(&rhs);
+    let mut output_write = TensorWrite::from_tensor(&mut output);
+    let request = CpuGroupedGemmRequest::new(
+        &lhs_read,
+        &rhs_read,
+        &mut output_write,
+        &jobs,
+        DotGeneralAccumulation::overwrite(DType::F64).unwrap(),
+    );
+    let (lhs_p, rhs_p, output_p, jobs_p, accumulation_p) = request.into_parts();
+    assert_eq!(lhs_p.shape(), &[2]);
+    assert_eq!(rhs_p.shape(), &[2]);
+    assert_eq!(output_p.as_read().shape(), &[2]);
+    assert_eq!(jobs_p.len(), 1);
+    // The accumulation config round-trips (overwrite alpha=1, beta=0).
+    let _ = accumulation_p;
 }

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -287,6 +287,85 @@ where
         .map_err(|err| crate::Error::backend_source(op, err))
 }
 
+/// Replay a (possibly conjugating) full-overwrite copy of `src` into a compact
+/// column-major uninitialized destination, writing every destination element.
+///
+/// The destination `output_bytes` must be exactly
+/// `element_count * size_of::<T>()` bytes, aligned for `T`; both are validated
+/// here before any write. The strided kernel replay traverses every
+/// destination element (identical shapes), so zero-element destinations are
+/// trivially satisfied.
+pub(crate) fn typed_copy_into_uninit<T, R>(
+    src: &TypedTensorView<'_, T, R>,
+    conjugate: bool,
+    output_bytes: &mut [MaybeUninit<u8>],
+    op: &'static str,
+) -> crate::Result<()>
+where
+    T: Copy + Send + Sync + ConjElem + 'static,
+    R: TensorRank,
+{
+    if src.backend_buffer().is_some() {
+        return Err(cpu_backend_buffer_error(op));
+    }
+    validate_cpu_host_placement(op, "source", src.placement())?;
+
+    let element_count =
+        tenferro_tensor::validate::checked_shape_product(op, "output", src.shape())?;
+    let byte_len = element_count
+        .checked_mul(std::mem::size_of::<T>())
+        .ok_or_else(|| {
+            crate::Error::invalid_argument(op, "output", "destination byte length overflow")
+        })?;
+    if output_bytes.len() != byte_len {
+        return Err(crate::Error::invalid_argument(
+            op,
+            "output",
+            format!(
+                "uninitialized destination has {} bytes but {} elements require {byte_len}",
+                output_bytes.len(),
+                element_count
+            ),
+        ));
+    }
+    if !(output_bytes.as_ptr() as usize).is_multiple_of(std::mem::align_of::<T>()) {
+        return Err(crate::Error::invalid_argument(
+            op,
+            "output",
+            format!(
+                "uninitialized destination is misaligned for {}",
+                std::any::type_name::<T>()
+            ),
+        ));
+    }
+
+    let src_view: StridedView<'_, T, Identity> = StridedView::new(
+        src.host_storage()?,
+        src.shape(),
+        src.strides(),
+        src.offset(),
+    )
+    .map_err(|err| crate::Error::backend_source(op, err))?;
+    let strides = col_major_strides(src.shape());
+    // SAFETY: the caller provides a validated compact column-major destination
+    // of exactly `element_count` `T`-sized slots; alignment and length are
+    // checked above. This view is used only as a `MaybeUninit<T>` write target.
+    let dst_ptr = output_bytes.as_mut_ptr().cast::<MaybeUninit<T>>();
+    let dst = unsafe { std::slice::from_raw_parts_mut(dst_ptr, element_count) };
+    let mut dst_view = StridedViewMut::new(dst, src.shape(), &strides, 0)
+        .map_err(|err| crate::Error::backend_source(op, err))?;
+    if conjugate {
+        map_into(&mut dst_view, &src_view, |value| {
+            MaybeUninit::new(value.conj_elem())
+        })
+        .map_err(|err| crate::Error::backend_source(op, err))?;
+    } else {
+        map_into(&mut dst_view, &src_view, MaybeUninit::new)
+            .map_err(|err| crate::Error::backend_source(op, err))?;
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_cpu_host_placement(
     op: &'static str,
     role: &'static str,

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -694,3 +694,6 @@ mod elementwise_reduction_helpers;
 mod indexing;
 #[path = "tests/cpu_indexing_coverage_tests.rs"]
 mod indexing_coverage;
+#[cfg(feature = "cpu-faer")]
+#[path = "tests/cpu_tests/uninit_dot_output.rs"]
+mod uninit_dot_output;

--- a/crates/tenferro-cpu/src/tests/cpu_tests/uninit_dot_output.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/uninit_dot_output.rs
@@ -1,0 +1,387 @@
+//! Session-level behavioral tests for the uninitialized allocated-dot output
+//! path (issue #1690): the GEMM provider witness gating in
+//! `execute_dot_allocated`, the `Unsupported` fallback, and values parity
+//! between the uninit and zeroed paths.
+
+use super::*;
+use num_complex::Complex64;
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use crate::provider::{
+    CpuExecutionContext, CpuGemmProvider, CpuGemmRequest, CpuGroupedGemmRequest,
+    CpuProviderOutcome, CpuUninitGemmProvider,
+};
+use crate::{
+    CpuDomainId, CpuPlacementGuarantee, CpuProviderBundle, ExternalCpuDomain, ResolvedCpuPlacement,
+};
+use tenferro_tensor::{DType, DotGeneralConfig};
+
+/// Build a CPU backend that runs a custom provider bundle on one managed
+/// thread, mirroring `from_external_managed_domains_with_provider_bundle`
+/// semantics with the real process topology.
+fn backend_with_bundle(bundle: CpuProviderBundle) -> CpuBackend {
+    let topology = crate::discover_cpu_topology().unwrap();
+    let cpus = topology.allowed_cpus().clone();
+    CpuBackend::from_external_managed_domains_with_provider_bundle(
+        CpuDomainId::new(31337),
+        [ExternalCpuDomain::new(
+            CpuDomainId::new(31337),
+            ResolvedCpuPlacement::AllAllowed { cpus },
+            Arc::new(CpuContext::with_threads(1).unwrap()),
+            NonZeroUsize::new(1).unwrap(),
+            CpuPlacementGuarantee::AdvisoryDeclared,
+        )
+        .unwrap()],
+        bundle,
+    )
+    .unwrap()
+}
+
+/// GEMM provider that delegates to the built-in faer provider without exposing
+/// the uninitialized-output witness (default opt-out).
+#[derive(Debug)]
+struct OptOutGemmProvider {
+    gemm_calls: Arc<AtomicUsize>,
+}
+
+impl CpuGemmProvider for OptOutGemmProvider {
+    fn execution_capabilities(&self) -> crate::CpuProviderExecutionCapabilities {
+        crate::provider_capability::engine_worker_capabilities()
+    }
+
+    fn gemm(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuGemmRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        self.gemm_calls.fetch_add(1, Ordering::Relaxed);
+        crate::provider::FaerGemmProvider.gemm(context, request)
+    }
+
+    fn strided_batched_gemm(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuGemmRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        self.gemm_calls.fetch_add(1, Ordering::Relaxed);
+        crate::provider::FaerGemmProvider.strided_batched_gemm(context, request)
+    }
+
+    fn grouped_gemm(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuGroupedGemmRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        crate::provider::FaerGemmProvider.grouped_gemm(context, request)
+    }
+}
+
+/// GEMM provider that opts into the uninitialized-output contract and executes
+/// it by delegating to the built-in faer provider.
+#[derive(Debug)]
+struct ExecutingUninitGemmProvider {
+    gemm_calls: Arc<AtomicUsize>,
+    uninit_calls: Arc<AtomicUsize>,
+}
+
+impl CpuGemmProvider for ExecutingUninitGemmProvider {
+    fn execution_capabilities(&self) -> crate::CpuProviderExecutionCapabilities {
+        crate::provider_capability::engine_worker_capabilities()
+    }
+
+    fn gemm(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuGemmRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        self.gemm_calls.fetch_add(1, Ordering::Relaxed);
+        crate::provider::FaerGemmProvider.gemm(context, request)
+    }
+
+    fn strided_batched_gemm(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuGemmRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        self.gemm_calls.fetch_add(1, Ordering::Relaxed);
+        crate::provider::FaerGemmProvider.strided_batched_gemm(context, request)
+    }
+
+    fn grouped_gemm(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuGroupedGemmRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        crate::provider::FaerGemmProvider.grouped_gemm(context, request)
+    }
+
+    fn uninit_provider(&self) -> Option<&dyn CpuUninitGemmProvider> {
+        Some(self)
+    }
+}
+
+// SAFETY: the delegated faer implementation writes every destination element
+// before `Executed` (Accum::Replace for beta == 0; zeros for empty
+// contractions), so this wrapper inherits the full-overwrite contract.
+unsafe impl CpuUninitGemmProvider for ExecutingUninitGemmProvider {
+    unsafe fn gemm_into_uninit(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: crate::provider::CpuGemmUninitRequest<'_, '_>,
+        output_bytes: &mut [std::mem::MaybeUninit<u8>],
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        self.uninit_calls.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: delegation preserves the caller's beta == 0 full-overwrite
+        // precondition and the destination-write guarantee.
+        unsafe {
+            crate::provider::FaerGemmProvider.gemm_into_uninit(context, request, output_bytes)
+        }
+    }
+}
+
+/// GEMM provider that opts into the uninitialized-output contract but always
+/// reports `Unsupported`, forcing the caller's discard-and-reallocate fallback
+/// onto the zeroed path.
+#[derive(Debug)]
+struct UnsupportedUninitGemmProvider {
+    gemm_calls: Arc<AtomicUsize>,
+    uninit_calls: Arc<AtomicUsize>,
+}
+
+impl CpuGemmProvider for UnsupportedUninitGemmProvider {
+    fn execution_capabilities(&self) -> crate::CpuProviderExecutionCapabilities {
+        crate::provider_capability::engine_worker_capabilities()
+    }
+
+    fn gemm(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuGemmRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        self.gemm_calls.fetch_add(1, Ordering::Relaxed);
+        crate::provider::FaerGemmProvider.gemm(context, request)
+    }
+
+    fn strided_batched_gemm(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuGemmRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        self.gemm_calls.fetch_add(1, Ordering::Relaxed);
+        crate::provider::FaerGemmProvider.strided_batched_gemm(context, request)
+    }
+
+    fn grouped_gemm(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuGroupedGemmRequest<'_, '_, '_>,
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        crate::provider::FaerGemmProvider.grouped_gemm(context, request)
+    }
+
+    fn uninit_provider(&self) -> Option<&dyn CpuUninitGemmProvider> {
+        Some(self)
+    }
+}
+
+// SAFETY: this test provider asserts the unsafe trait only to exercise the
+// caller's `Unsupported` fallback; it never writes the destination, so it must
+// always return `Unsupported` (never `Executed`).
+unsafe impl CpuUninitGemmProvider for UnsupportedUninitGemmProvider {
+    unsafe fn gemm_into_uninit(
+        &self,
+        _context: &CpuExecutionContext<'_>,
+        _request: crate::provider::CpuGemmUninitRequest<'_, '_>,
+        _output_bytes: &mut [std::mem::MaybeUninit<u8>],
+    ) -> tenferro_tensor::Result<CpuProviderOutcome> {
+        self.uninit_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(CpuProviderOutcome::Unsupported(
+            crate::provider::CpuProviderUnsupported::DType(DType::F64),
+        ))
+    }
+}
+
+fn matmul_config() -> DotGeneralConfig {
+    DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    }
+}
+
+fn dot_bundle(gemm: Arc<dyn CpuGemmProvider>) -> CpuProviderBundle {
+    CpuProviderBundle::custom_builder()
+        .gemm_provider(gemm)
+        .layout_transform_provider(Arc::new(crate::provider::StridedLayoutTransformProvider))
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn opted_out_gemm_provider_keeps_zeroed_dot_output_values() {
+    let gemm = Arc::new(OptOutGemmProvider {
+        gemm_calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let gemm_calls = Arc::clone(&gemm.gemm_calls);
+    let mut backend = backend_with_bundle(dot_bundle(gemm));
+
+    let lhs = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap(),
+    );
+    let rhs = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![3, 2], vec![1.0, 5.0, 2.0, 6.0, 3.0, 7.0]).unwrap(),
+    );
+    let output = backend.dot_general(&lhs, &rhs, &matmul_config()).unwrap();
+
+    assert_eq!(output.as_slice::<f64>().unwrap(), &[17.0, 41.0, 33.0, 81.0]);
+    // Without the witness the uninit path is never attempted; the zeroed path
+    // executed the GEMM exactly once.
+    assert_eq!(gemm_calls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn opted_in_gemm_provider_unsupported_falls_back_to_zeroed_dot() {
+    let gemm = Arc::new(UnsupportedUninitGemmProvider {
+        gemm_calls: Arc::new(AtomicUsize::new(0)),
+        uninit_calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let gemm_calls = Arc::clone(&gemm.gemm_calls);
+    let uninit_calls = Arc::clone(&gemm.uninit_calls);
+    let mut backend = backend_with_bundle(dot_bundle(gemm));
+
+    let lhs = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap(),
+    );
+    let rhs = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![3, 2], vec![1.0, 5.0, 2.0, 6.0, 3.0, 7.0]).unwrap(),
+    );
+    let output = backend.dot_general(&lhs, &rhs, &matmul_config()).unwrap();
+
+    assert_eq!(output.as_slice::<f64>().unwrap(), &[17.0, 41.0, 33.0, 81.0]);
+    // The uninit attempt fired once and was discarded; the zeroed fallback
+    // then executed the GEMM once.
+    assert_eq!(uninit_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(gemm_calls.load(Ordering::Relaxed), 1);
+}
+
+/// Compare every allocated-dot case between the uninit path (executing
+/// witness) and the zeroed path (opt-out provider).
+#[test]
+fn uninit_dot_path_values_match_zeroed_path_for_allocated_dots() {
+    let executing = Arc::new(ExecutingUninitGemmProvider {
+        gemm_calls: Arc::new(AtomicUsize::new(0)),
+        uninit_calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let uninit_calls = Arc::clone(&executing.uninit_calls);
+    let mut uninit_backend = backend_with_bundle(dot_bundle(executing));
+    let mut zeroed_backend = backend_with_bundle(dot_bundle(Arc::new(OptOutGemmProvider {
+        gemm_calls: Arc::new(AtomicUsize::new(0)),
+    })));
+
+    let cases: Vec<(Tensor, Tensor, DotGeneralConfig)> = vec![
+        // Plain matmul.
+        (
+            Tensor::F64(
+                TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0])
+                    .unwrap(),
+            ),
+            Tensor::F64(
+                TypedTensor::from_vec_col_major(vec![3, 2], vec![1.0, 5.0, 2.0, 6.0, 3.0, 7.0])
+                    .unwrap(),
+            ),
+            matmul_config(),
+        ),
+        // Batched matmul: batch dim 0 on both operands.
+        (
+            Tensor::F64(
+                TypedTensor::from_vec_col_major(
+                    vec![2, 2, 3],
+                    vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0, 2.0, 1.0, 1.0, 2.0, 1.0, 1.0],
+                )
+                .unwrap(),
+            ),
+            Tensor::F64(
+                TypedTensor::from_vec_col_major(
+                    vec![2, 3, 2],
+                    vec![1.0, 5.0, 2.0, 6.0, 3.0, 7.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0],
+                )
+                .unwrap(),
+            ),
+            DotGeneralConfig {
+                lhs_contracting_dims: vec![2],
+                rhs_contracting_dims: vec![1],
+                lhs_batch_dims: vec![0],
+                rhs_batch_dims: vec![0],
+            },
+        ),
+        // Empty contraction (k == 0): output must be zeros.
+        (
+            Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 0], Vec::<f64>::new()).unwrap()),
+            Tensor::F64(TypedTensor::from_vec_col_major(vec![0, 2], Vec::<f64>::new()).unwrap()),
+            matmul_config(),
+        ),
+        // Empty output (zero rows).
+        (
+            Tensor::F64(TypedTensor::from_vec_col_major(vec![0, 3], Vec::<f64>::new()).unwrap()),
+            Tensor::F64(
+                TypedTensor::from_vec_col_major(vec![3, 2], vec![1.0, 5.0, 2.0, 6.0, 3.0, 7.0])
+                    .unwrap(),
+            ),
+            matmul_config(),
+        ),
+    ];
+
+    for (lhs, rhs, config) in cases {
+        let uninit_output = uninit_backend.dot_general(&lhs, &rhs, &config).unwrap();
+        let zeroed_output = zeroed_backend.dot_general(&lhs, &rhs, &config).unwrap();
+        assert_eq!(uninit_output.shape(), zeroed_output.shape());
+        assert_eq!(
+            uninit_output.as_slice::<f64>().unwrap(),
+            zeroed_output.as_slice::<f64>().unwrap(),
+        );
+    }
+
+    // Conjugated complex dot (direct faer conjugation) also matches.
+    let lhs = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex64::new(1.0, 2.0),
+                Complex64::new(-3.0, 0.5),
+                Complex64::new(2.0, -1.0),
+                Complex64::new(0.25, 4.0),
+            ],
+        )
+        .unwrap(),
+    );
+    let rhs = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex64::new(-2.0, 1.0),
+                Complex64::new(1.5, -0.25),
+                Complex64::new(0.5, 3.0),
+                Complex64::new(-1.0, -2.0),
+            ],
+        )
+        .unwrap(),
+    );
+    let config = matmul_config();
+    let uninit_output = uninit_backend
+        .dot_general_with_conj(&lhs, &rhs, &config, true, true)
+        .unwrap();
+    let zeroed_output = zeroed_backend
+        .dot_general_with_conj(&lhs, &rhs, &config, true, true)
+        .unwrap();
+    assert_eq!(
+        uninit_output.as_slice::<Complex64>().unwrap(),
+        zeroed_output.as_slice::<Complex64>().unwrap(),
+    );
+
+    // The executing witness handled every direct case above (the conjugated
+    // complex dot included); only the zeroed fallback never fires.
+    assert_eq!(uninit_calls.load(Ordering::Relaxed), 5);
+}

--- a/docs/design/uninitialized-output-contract.md
+++ b/docs/design/uninitialized-output-contract.md
@@ -1,0 +1,121 @@
+# Uninitialized Full-Overwrite Provider Destinations (issue #1690)
+
+Status: design (pre-implementation review target, revision 3).
+
+## Problem
+
+`dot_runtime.rs` canonical-operand allocation and `exec_session.rs` dot-output
+allocation acquire **zeroed** pooled buffers, but both destinations are then
+**fully overwritten** by the consumer (canonical-operand layout transform;
+dot output with `beta == 0` via `Accum::Replace`, empty contractions write
+zeros). The zero-fill is a wasted full pass (≈ 2× memory traffic on those
+paths). Issue #1640 fixed the `structural.rs` sites; these two are the
+deferred follow-up (#1690).
+
+## Design (revision 3)
+
+### 1. Uninitialized-destination traits (unsafe to implement) + structural witness
+
+Two new **`unsafe trait`s** express the full-overwrite contract; implementing
+requires an `unsafe impl` asserting it, so safe third-party code cannot
+manufacture initialization proof:
+
+```rust
+unsafe trait CpuUninitLayoutTransformProvider: CpuLayoutTransformProvider {
+    /// # Safety
+    /// Must write every element of `output_bytes` before returning `Executed`;
+    /// partial writes are UB at the caller's `assume_init`.
+    unsafe fn materialize_into_uninit(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        input: &TensorRead<'_>,
+        intent: CpuLayoutTransformIntent,
+        conjugate: bool,
+        output_bytes: &mut [MaybeUninit<u8>],
+    ) -> tenferro_tensor::Result<CpuProviderOutcome>;
+}
+
+unsafe trait CpuUninitGemmProvider: CpuGemmProvider {
+    /// # Safety
+    /// Must write every logical output element before `Executed`; invoked only
+    /// for `beta == 0` (full-overwrite) accumulations.
+    unsafe fn gemm_into_uninit(
+        &self,
+        context: &CpuExecutionContext<'_>,
+        request: CpuGemmUninitRequest<'_, '_>,      // output-free prepared request
+        output_bytes: &mut [MaybeUninit<u8>],
+    ) -> tenferro_tensor::Result<CpuProviderOutcome>;
+}
+```
+
+**Enablement is a structural witness, not a boolean**: the base provider
+traits gain one object-safe method whose default is `None`:
+
+```rust
+// on CpuLayoutTransformProvider and CpuGemmProvider respectively
+fn uninit_provider(&self) -> Option<&dyn CpuUninitLayoutTransformProvider> { None }
+fn uninit_provider(&self) -> Option<&dyn CpuUninitGemmProvider> { None }
+```
+
+Only a type that actually implements the `unsafe trait` (via `unsafe impl`)
+can return `Some(self)` — a safe impl cannot construct a `&dyn
+CpuUninit*Provider` it does not implement, so a `Some` witness is structural
+proof the full-write contract was asserted. No boolean is used as proof.
+
+`CpuGemmUninitRequest<'request, 'input>` is a public output-free prepared
+request mirroring `CpuGemmRequest` (lhs/rhs/rows/columns/contracted/
+batch_count/layouts/accumulation, no output — two lifetimes, since removing
+`TensorWrite<'output>` removes the only use of `'output`), built by the
+`DotGeneralRuntime` planner from the validated request. The GEMM seam's
+uninit method sits beside the existing
+`CpuGemmProvider::gemm(context, request: CpuGemmRequest)` and takes the same
+`context: &CpuExecutionContext<'_>` (provider.rs:1187+, 1206-1210).
+
+### 2. Caller pattern
+
+At each site:
+
+1. Resolve the executing provider (layout provider for the canonical operand;
+   GEMM provider for the dot when `beta == 0`).
+2. Get the witness: `provider.uninit_provider()`.
+3. `Some(w)` → acquire `PooledUninitOutput`, call the `unsafe fn` in an
+   `unsafe` block (precondition = the unsafe-impl contract), on `Executed`
+   complete via `unsafe assume_init`.
+4. `None` (provider opted out) → **go directly to the zeroed path** (no uninit
+   checkout is acquired or discarded).
+5. Opted-in but the method returns `Unsupported` → discard the uninit checkout
+   (drop frees via `pool_discard_uninit`) and fall back to the zeroed path.
+6. On `Err` → propagate the original error; never silently retry (an error may
+   follow a partial write; matches current provider-error semantics).
+7. `beta != 0` dot accumulations keep the zeroed path (the seed matters).
+
+The discard-and-reallocate fallback fires only for opted-in providers that
+return `Unsupported` for a given layout — never on the built-in hot path.
+
+### 3. Safety argument
+
+- Only `unsafe impl`s can appear as `Some` witnesses; a safe third-party
+  provider is structurally unable to enable the uninit path.
+- The destination travels only as `&mut [MaybeUninit<u8>]` until the `unsafe
+  assume_init` handoff, whose precondition is exactly the unsafe-impl
+  full-write guarantee. No `&mut [T]`/`TensorWrite` is fabricated over
+  uninitialized storage.
+- Built-in full-write guarantees are kernel-verified: layout transform
+  traverses the destination; faer `Accum::Replace` for beta zero; empty
+  contractions write zeros.
+
+## Bench evidence (expected)
+
+Before/after (pinned, release): mid-size dot (128×128 f64, 1 thread) where
+the operand/output zero-fills are measurable, and a tiny 2×2 case. Report the
+memset share removed honestly (a few % mid-size; negligible tiny/large). Add
+a behavioral test: an opted-out provider still gets the zeroed path; an
+opted-in provider returning `Unsupported` falls back correctly.
+
+## Non-goals
+
+- No change to the initialized-output provider methods or their callers.
+- No change to `beta != 0` (accumulate) dot paths.
+- No new public Tensor/backend API beyond the two `unsafe trait`s, the
+  witness methods (default `None`), and `CpuGemmUninitRequest`; existing
+  third-party providers are unaffected (default opt-out).

--- a/docs/worklogs/2026-08-15-uninit-output-contract.md
+++ b/docs/worklogs/2026-08-15-uninit-output-contract.md
@@ -1,0 +1,86 @@
+# 2026-08-15 — #1690: uninitialized full-overwrite provider destinations
+
+## Session summary
+
+Removed the wasted zero-fill on the two deferred sites from #1640: the
+dot_runtime canonical-operand allocation and the exec_session dot-output
+allocation (both fully overwritten by their consumers). Introduced a sound
+opt-in unsafe-contract mechanism: two `unsafe trait`s
+(`CpuUninitLayoutTransformProvider`, `CpuUninitGemmProvider`) whose
+implementation asserts the full-write guarantee, enabled structurally via
+`uninit_provider() -> Option<&dyn ...>` witnesses (default `None`; only an
+`unsafe impl` can return `Some`), a public output-free
+`CpuGemmUninitRequest`, and `PooledUninitOutput::assume_init` handoffs.
+
+## Gate record (frontier review, per AGENTS.md)
+
+- **Pre-implementation design gate** (reviewer-gpt on
+  `docs/design/uninitialized-output-contract.md`): 3 rounds → **approved**.
+  Round 1: 1 Critical (safe provider code could manufacture initialization
+  proof) + 4 Important (request types didn't match; dot seam was the wrong
+  provider; errors must not silently retry; reclaim didn't exist) → revision
+  2 (unsafe traits + capability boolean). Round 2: 1 Critical (the boolean
+  isn't structural proof → witness) + 2 Important (CpuDotGeneralRequest
+  can't represent the call → output-free CpuGemmUninitRequest; the GEMM
+  seam needs context + prepared request) → revision 3 (structural witness,
+  CpuGemmUninitRequest with 2 lifetimes, context param). Round 3 →
+  approved.
+- **Post-implementation diff gate** (reviewer-gpt on the ~2340-line diff,
+  SAFETY-CRITICAL): 3 rounds → **Correct-to-merge**. Round 1: unsafe
+  contract sound (witness structural, destination stays MaybeUninit, full
+  write before Executed verified incl. empty/batched/conj) but 1 blocking
+  (tests not faer-gated for cpu-blas-only) + 1 later (BlasGemmProvider
+  import under provider-inject). Both gating fixes verified.
+
+## Design decisions
+
+- Sound opt-in: the witness method returns `Option<&dyn CpuUninit*Provider>`;
+  only an `unsafe impl` can construct that trait object, so a safe
+  third-party provider is structurally unable to enable the uninit path. The
+  destination travels only as `&mut [MaybeUninit<u8>]` until the `unsafe
+  assume_init` handoff (dtype-agnostic byte carrier; alignment + length
+  validated).
+- Built-in impls satisfy the contract: layout transform replays every
+  destination slot (incl. conj); faer `Accum::Replace` for beta == 0,
+  `beta != 0` defensively refused, empty contractions write zeros.
+- Fallback: `None` witness → zeroed path directly (no uninit checkout);
+  opted-in `Unsupported` → drop checkout (frees) + zeroed fallback; `Err` →
+  propagate (never silently retry). `beta != 0` dot paths untouched.
+- Direct-plan-only routing: the uninit checkout holds the pool exclusively,
+  so the canonical-operand path falls back to zeroed when a plan is needed
+  (per the design's discard-and-retry pattern).
+
+## Measurements (release, pinned core 40, 1 thread)
+
+| op | before (zeroed) | after (uninit) | Δ |
+|---|---|---|---|
+| 128×128 f64 dot | 96.7–99.5 µs | 97.2–98.9 µs | ~0% (memcpy-bound, noise) |
+| 2×2 f64 dot | 3.08–3.19 µs | 2.37 µs | ~24% faster |
+
+Honest reading: mid-size is dominated by the GEMM memory traffic (the
+zero-fill is ~2% of 128 KB); tiny cases win because the uninit branch also
+skips the zeroed pool `resize`/`fill` and the redundant full re-validation of
+the fresh compact output. The win is real but concentrated at small sizes.
+
+## Verification
+
+- `cargo test -p tenferro-cpu` (faer default): 520+1+46+2+188 passed
+- `RUSTFLAGS="-l dylib=openblas -l dylib=lapack" cargo test -p tenferro-cpu
+  --no-default-features --features cpu-blas`: 503+46+2+187 passed (the bare
+  cpu-blas link failure reproduces on origin/main — pre-existing)
+- `cargo check -p tenferro-cpu --features provider-inject`: clean
+- `cargo build --workspace`, `cargo test -p tenferro-ad`: pass; fmt clean;
+  clippy workspace 0 warnings
+- 8 new tests: witness source-contract, provider-level parity (batched /
+  empty-contraction / empty-output / nonzero-beta / layout+conj),
+  opt-out and opted-in-Unsupported fallbacks with call counts, full
+  dot/output value parity
+- PR gates (`check-pr-fast.sh`, `repository-rules-review.py`) run at PR time
+
+## Residual risks
+
+- The unsafe contract relies on the built-in impls' full-write guarantee;
+  future built-in provider changes must preserve it (the safety docs on the
+  unsafe traits name the invariant).
+- Third-party providers keep the zeroed path (default opt-out) — no behavior
+  change for them.


### PR DESCRIPTION
## Summary

Issue #1690 (deferred follow-up from #1640): remove the wasted zero-fill on
the two pooled-buffer sites that are **fully overwritten** by their consumers
(the dot_runtime canonical-operand allocation and the exec_session dot-output
allocation with `beta == 0`).

## Design (reviewer-gpt-gated, `docs/design/uninitialized-output-contract.md`)

A sound opt-in unsafe contract:

- `unsafe trait CpuUninitLayoutTransformProvider` /
  `CpuUninitGemmProvider` — implementing asserts the **full-write-before-
  Executed** destination contract.
- **Structural witness**: `uninit_provider() -> Option<&dyn ...>` (default
  `None`) — only an `unsafe impl` can return `Some`, so a safe third-party
  provider is structurally unable to manufacture initialization proof.
- Output-free `CpuGemmUninitRequest`; destinations travel only as
  `&mut [MaybeUninit<u8>]` until the `unsafe assume_init` handoff (alignment +
  length validated; no `&mut [T]`/`TensorWrite` fabricated over uninit).
- **Fallback**: `None` witness → zeroed path directly; opted-in `Unsupported`
  → drop checkout + zeroed fallback; `Err` propagates (no silent retry);
  `beta != 0` dot paths untouched.
- Built-in impls satisfy the contract: layout transform replays every
  destination slot (incl. conj); faer `Accum::Replace` for beta == 0,
  `beta != 0` refused, empty contractions write zeros.

## Measurements (release, pinned core 40, 1 thread)

| op | before | after | Δ |
|---|---|---|---|
| 2×2 f64 dot | 3.08–3.19 µs | 2.37 µs | ~24% faster |
| 128×128 f64 dot | 96.7–99.5 µs | 97.2–98.9 µs | ~0% (memcpy-bound) |

Honest reading: the win concentrates at small sizes (the uninit branch also
skips the zeroed pool `resize`/`fill` and redundant re-validation); mid-size
is GEMM-bound.

## Gate record (frontier review, per AGENTS.md)

- **Pre-implementation design gate**: 3 rounds → **approved** (round 1: safe-
  provider UB + request/seam/fallback flaws; round 2: structural witness +
  output-free request + GEMM-seam context; round 3 approved).
- **Post-implementation diff gate** (safety-critical): 3 rounds →
  **Correct-to-merge** (unsafe contract sound; faer/`provider-inject` test
  gating fixed).

## Verification

check-pr-fast green (cpu 520+1+46+2+188), cpu-blas-only matrix green with
CI-matching flags (503+46+2+187), provider-inject check clean, repository-
rules review pass (all new public items carry runnable doctests), fmt/clippy
clean, workspace builds, ad tests pass. 8 new tests: witness source-contract,
provider-level parity (batched/empty/nonzero-beta/layout+conj), opt-out and
opted-in-Unsupported fallbacks, full dot/output value parity.

Worklog: `docs/worklogs/2026-08-15-uninit-output-contract.md`.
