### PR TITLE
Record eager dtype promotion for AD replay

### DIFF
--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::cmp::Reverse;
 use std::collections::HashMap;
@@ -55,7 +56,10 @@ use crate::eager_backend::{
 };
 #[cfg(test)]
 use crate::eager_exec::exec_standard_op_on_tensor_reads_in_session;
-use crate::eager_exec::{exec_op_on_tensor_reads_with_runtime, exec_op_on_tensors_with_runtime};
+use crate::eager_exec::{
+    eager_input_promotion_plan, exec_op_on_tensor_reads_with_runtime,
+    exec_op_on_tensors_with_runtime,
+};
 use crate::error::{ContextId, Error, Result};
 use crate::metadata::tensor_meta_from_tensor;
 use crate::semantic_extension::SemanticExtensionRuleSet;
@@ -4100,6 +4104,34 @@ fn record_semantic_eager_outputs(
                 .unwrap_or_else(|| constants.next().expect("materialized constant"))
         })
         .collect();
+    let promotion_plan =
+        eager_input_promotion_plan(op, inputs.len(), |index| inputs[index].dtype());
+    // Mirror eager execution in the deferred carrier only. The concrete
+    // tensors have already been promoted at the execution boundary, so these
+    // casts add semantic graph nodes without an eager copy or backend kernel.
+    let promoted_semantic_inputs = if semantic_inputs.iter().enumerate().any(|(index, semantic)| {
+        semantic.dtype != promotion_plan.target_dtype(index, semantic.dtype)
+    }) {
+        Some(
+            semantic_inputs
+                .iter()
+                .enumerate()
+                .map(|(index, &semantic)| {
+                    let target = promotion_plan.target_dtype(index, semantic.dtype);
+                    if semantic.dtype == target {
+                        Ok(Cow::Borrowed(semantic))
+                    } else {
+                        semantic.cast(target).map(Cow::Owned)
+                    }
+                })
+                .collect::<Result<Vec<Cow<'_, TracedTensor>>>>()?,
+        )
+    } else {
+        None
+    };
+    if let Some(promoted_semantic_inputs) = &promoted_semantic_inputs {
+        semantic_inputs = promoted_semantic_inputs.iter().map(Cow::as_ref).collect();
+    }
     let exact_semantic_inputs = if matches!(op, StdTensorOp::Concatenate { .. }) {
         Some(
             semantic_inputs

--- a/crates/tenferro-ad/src/eager_exec.rs
+++ b/crates/tenferro-ad/src/eager_exec.rs
@@ -13,7 +13,7 @@ use tenferro_tensor::{
 
 use crate::error::{Error, Result};
 use crate::scalar_semantics::dynamic_truncate_size;
-use crate::shape_infer::promote_dtype_for_binary_op;
+use crate::shape_infer::{promote_dtype, promote_dtype_for_binary_op, promote_dtypes};
 
 enum PromotedTensor<'a> {
     Borrowed(&'a Tensor),
@@ -28,6 +28,74 @@ enum PromotedTensorRead<'a> {
 enum ConcreteTensorRead<'a> {
     Borrowed(&'a Tensor),
     Owned(Box<Tensor>),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EagerInputPromotionPlan {
+    Unchanged,
+    All(DType),
+    Pair {
+        first: usize,
+        second: usize,
+        dtype: DType,
+    },
+}
+
+impl EagerInputPromotionPlan {
+    pub(crate) fn target_dtype(self, index: usize, original: DType) -> DType {
+        match self {
+            Self::Unchanged => original,
+            Self::All(dtype) => dtype,
+            Self::Pair {
+                first,
+                second,
+                dtype,
+            } if index == first || index == second => dtype,
+            Self::Pair { .. } => original,
+        }
+    }
+}
+
+pub(crate) fn eager_input_promotion_plan(
+    op: &StdTensorOp,
+    input_count: usize,
+    mut dtype_at: impl FnMut(usize) -> DType,
+) -> EagerInputPromotionPlan {
+    match op {
+        StdTensorOp::Add
+        | StdTensorOp::Sub
+        | StdTensorOp::Mul
+        | StdTensorOp::Div
+        | StdTensorOp::Rem
+        | StdTensorOp::Pow
+        | StdTensorOp::Maximum
+        | StdTensorOp::Minimum
+        | StdTensorOp::Compare(_)
+        | StdTensorOp::DotGeneral { .. } => EagerInputPromotionPlan::Pair {
+            first: 0,
+            second: 1,
+            dtype: promote_dtype_for_binary_op(op, dtype_at(0), dtype_at(1)),
+        },
+        StdTensorOp::Select => EagerInputPromotionPlan::Pair {
+            first: 1,
+            second: 2,
+            dtype: promote_dtype(dtype_at(1), dtype_at(2)),
+        },
+        StdTensorOp::Clamp | StdTensorOp::Concatenate { .. } => {
+            EagerInputPromotionPlan::All(promote_dtypes((0..input_count).map(dtype_at)))
+        }
+        StdTensorOp::Scatter(_) => EagerInputPromotionPlan::Pair {
+            first: 0,
+            second: 2,
+            dtype: promote_dtype(dtype_at(0), dtype_at(2)),
+        },
+        StdTensorOp::DynamicUpdateSlice => EagerInputPromotionPlan::Pair {
+            first: 0,
+            second: 1,
+            dtype: promote_dtype(dtype_at(0), dtype_at(1)),
+        },
+        _ => EagerInputPromotionPlan::Unchanged,
+    }
 }
 
 impl<'a> PromotedTensor<'a> {
@@ -91,8 +159,8 @@ fn promote_binary<'a>(
     b: &'a Tensor,
     op: &StdTensorOp,
 ) -> Result<(PromotedTensor<'a>, PromotedTensor<'a>)> {
-    let promoted = promote_dtype_for_binary_op(op, a.dtype(), b.dtype());
-    promote_binary_to_dtype(exec, a, b, promoted)
+    let plan = eager_input_promotion_plan(op, 2, |index| [a.dtype(), b.dtype()][index]);
+    promote_binary_to_dtype(exec, a, b, plan.target_dtype(0, a.dtype()))
 }
 
 fn materialize_tensor_read(exec: &mut dyn BackendSession, input: TensorRead<'_>) -> Result<Tensor> {
@@ -172,7 +240,8 @@ fn promote_binary_reads<'a>(
     b: TensorRead<'a>,
     op: &StdTensorOp,
 ) -> Result<(PromotedTensorRead<'a>, PromotedTensorRead<'a>)> {
-    let promoted = promote_dtype_for_binary_op(op, a.dtype(), b.dtype());
+    let plan = eager_input_promotion_plan(op, 2, |index| [a.dtype(), b.dtype()][index]);
+    let promoted = plan.target_dtype(0, a.dtype());
     promote_binary_reads_to_dtype(exec, a, b, promoted)
 }
 
@@ -184,7 +253,11 @@ pub(crate) fn exec_dot_general_with_conj_on_tensor_reads<B: TensorBackend>(
     rhs_conj: bool,
     backend: &mut B,
 ) -> Result<Tensor> {
-    let promoted = crate::shape_infer::promote_dtype(lhs.dtype(), rhs.dtype());
+    let op = StdTensorOp::DotGeneral {
+        config: config.clone(),
+    };
+    let plan = eager_input_promotion_plan(&op, 2, |index| [lhs.dtype(), rhs.dtype()][index]);
+    let promoted = plan.target_dtype(0, lhs.dtype());
     backend.with_backend_session(|exec| {
         let (lhs, rhs) = promote_binary_reads_to_dtype(exec, lhs, rhs, promoted)?;
         exec.dot_general_with_conj_read(
@@ -402,6 +475,9 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
         .iter()
         .map(|input| TensorRead::from_tensor(input.tensor()))
         .collect();
+    let promotion_plan =
+        eager_input_promotion_plan(op, inputs.len(), |index| inputs[index].dtype());
+    let target_dtype = |index| promotion_plan.target_dtype(index, inputs[index].dtype());
     let result = match op {
         StdTensorOp::Add => {
             let (a, b) = promote_binary_reads(exec, inputs[0].clone(), inputs[1].clone(), op)?;
@@ -519,17 +595,14 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
                 ));
         }
         StdTensorOp::Select => {
-            let value_dtype =
-                crate::shape_infer::promote_dtype(inputs[1].dtype(), inputs[2].dtype());
-            let b = promote_read_to_dtype(exec, inputs[1].clone(), value_dtype)?;
-            let c = promote_read_to_dtype(exec, inputs[2].clone(), value_dtype)?;
+            let b = promote_read_to_dtype(exec, inputs[1].clone(), target_dtype(1))?;
+            let c = promote_read_to_dtype(exec, inputs[2].clone(), target_dtype(2))?;
             vec![exec.select_read(inputs[0].clone(), b.tensor_read(), c.tensor_read())?]
         }
         StdTensorOp::Clamp => {
-            let value_dtype = crate::shape_infer::promote_dtypes(inputs.iter().map(|t| t.dtype()));
-            let input = promote_read_to_dtype(exec, inputs[0].clone(), value_dtype)?;
-            let lower = promote_read_to_dtype(exec, inputs[1].clone(), value_dtype)?;
-            let upper = promote_read_to_dtype(exec, inputs[2].clone(), value_dtype)?;
+            let input = promote_read_to_dtype(exec, inputs[0].clone(), target_dtype(0))?;
+            let lower = promote_read_to_dtype(exec, inputs[1].clone(), target_dtype(1))?;
+            let upper = promote_read_to_dtype(exec, inputs[2].clone(), target_dtype(2))?;
             vec![exec.clamp_read(
                 input.tensor_read(),
                 lower.tensor_read(),
@@ -537,13 +610,12 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
             )?]
         }
         StdTensorOp::Concatenate { axis, .. } => {
-            let promoted = crate::shape_infer::promote_dtypes(inputs.iter().map(|t| t.dtype()));
             let mut tensors = Vec::with_capacity(inputs.len());
-            for input in inputs {
+            for (index, input) in inputs.iter().enumerate() {
                 tensors.push(concrete_promoted_read_to_dtype(
                     exec,
                     input.clone(),
-                    promoted,
+                    target_dtype(index),
                 )?);
             }
             let refs: Vec<&Tensor> = tensors.iter().map(ConcreteTensorRead::tensor).collect();
@@ -572,10 +644,10 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
             vec![exec.gather(tensors[0].tensor(), tensors[1].tensor(), &config)?]
         }
         StdTensorOp::Scatter(config) => {
-            let operand_dtype =
-                crate::shape_infer::promote_dtype(inputs[0].dtype(), inputs[2].dtype());
-            let operand = concrete_promoted_read_to_dtype(exec, inputs[0].clone(), operand_dtype)?;
-            let updates = concrete_promoted_read_to_dtype(exec, inputs[2].clone(), operand_dtype)?;
+            let operand =
+                concrete_promoted_read_to_dtype(exec, inputs[0].clone(), target_dtype(0))?;
+            let updates =
+                concrete_promoted_read_to_dtype(exec, inputs[2].clone(), target_dtype(2))?;
             let indices = concrete_tensor_read(exec, inputs[1].clone())?;
             vec![exec.scatter(operand.tensor(), indices.tensor(), updates.tensor(), config)?]
         }
@@ -584,10 +656,9 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
             vec![exec.dynamic_slice(tensors[0].tensor(), tensors[1].tensor(), slice_sizes)?]
         }
         StdTensorOp::DynamicUpdateSlice => {
-            let operand_dtype =
-                crate::shape_infer::promote_dtype(inputs[0].dtype(), inputs[1].dtype());
-            let operand = concrete_promoted_read_to_dtype(exec, inputs[0].clone(), operand_dtype)?;
-            let update = concrete_promoted_read_to_dtype(exec, inputs[1].clone(), operand_dtype)?;
+            let operand =
+                concrete_promoted_read_to_dtype(exec, inputs[0].clone(), target_dtype(0))?;
+            let update = concrete_promoted_read_to_dtype(exec, inputs[1].clone(), target_dtype(1))?;
             let starts = concrete_tensor_read(exec, inputs[2].clone())?;
             vec![exec.dynamic_update_slice(operand.tensor(), update.tensor(), starts.tensor())?]
         }
@@ -667,6 +738,9 @@ fn exec_standard_op_on_tensors<B: TensorBackend>(
     }
 
     backend.with_backend_session(|exec| {
+        let promotion_plan =
+            eager_input_promotion_plan(op, inputs.len(), |index| inputs[index].dtype());
+        let target_dtype = |index| promotion_plan.target_dtype(index, inputs[index].dtype());
         let result = match op {
             StdTensorOp::Add => {
                 let (a, b) = promote_binary(exec, inputs[0], inputs[1], op)?;
@@ -758,25 +832,20 @@ fn exec_standard_op_on_tensors<B: TensorBackend>(
                 ));
             }
             StdTensorOp::Select => {
-                let value_dtype =
-                    crate::shape_infer::promote_dtype(inputs[1].dtype(), inputs[2].dtype());
-                let b = promote_to_dtype(exec, inputs[1], value_dtype)?;
-                let c = promote_to_dtype(exec, inputs[2], value_dtype)?;
+                let b = promote_to_dtype(exec, inputs[1], target_dtype(1))?;
+                let c = promote_to_dtype(exec, inputs[2], target_dtype(2))?;
                 vec![exec.select(inputs[0], b.tensor(), c.tensor())?]
             }
             StdTensorOp::Clamp => {
-                let value_dtype =
-                    crate::shape_infer::promote_dtypes(inputs.iter().map(|t| t.dtype()));
-                let input = promote_to_dtype(exec, inputs[0], value_dtype)?;
-                let lower = promote_to_dtype(exec, inputs[1], value_dtype)?;
-                let upper = promote_to_dtype(exec, inputs[2], value_dtype)?;
+                let input = promote_to_dtype(exec, inputs[0], target_dtype(0))?;
+                let lower = promote_to_dtype(exec, inputs[1], target_dtype(1))?;
+                let upper = promote_to_dtype(exec, inputs[2], target_dtype(2))?;
                 vec![exec.clamp(input.tensor(), lower.tensor(), upper.tensor())?]
             }
             StdTensorOp::Concatenate { axis, .. } => {
-                let promoted = crate::shape_infer::promote_dtypes(inputs.iter().map(|t| t.dtype()));
                 let mut promoted_inputs = Vec::with_capacity(inputs.len());
-                for t in inputs {
-                    promoted_inputs.push(promote_to_dtype(exec, t, promoted)?);
+                for (index, input) in inputs.iter().enumerate() {
+                    promoted_inputs.push(promote_to_dtype(exec, input, target_dtype(index))?);
                 }
                 let promoted_refs: Vec<&Tensor> =
                     promoted_inputs.iter().map(PromotedTensor::tensor).collect();
@@ -803,14 +872,16 @@ fn exec_standard_op_on_tensors<B: TensorBackend>(
                 vec![exec.gather(inputs[0], inputs[1], &config)?]
             }
             StdTensorOp::Scatter(config) => {
-                let (operand, updates) = promote_binary(exec, inputs[0], inputs[2], op)?;
+                let operand = promote_to_dtype(exec, inputs[0], target_dtype(0))?;
+                let updates = promote_to_dtype(exec, inputs[2], target_dtype(2))?;
                 vec![exec.scatter(operand.tensor(), inputs[1], updates.tensor(), config)?]
             }
             StdTensorOp::DynamicSlice { slice_sizes } => {
                 vec![exec.dynamic_slice(inputs[0], inputs[1], slice_sizes)?]
             }
             StdTensorOp::DynamicUpdateSlice => {
-                let (operand, update) = promote_binary(exec, inputs[0], inputs[1], op)?;
+                let operand = promote_to_dtype(exec, inputs[0], target_dtype(0))?;
+                let update = promote_to_dtype(exec, inputs[1], target_dtype(1))?;
                 vec![exec.dynamic_update_slice(operand.tensor(), update.tensor(), inputs[2])?]
             }
             StdTensorOp::ShapeOf { .. } => {

--- a/crates/tenferro-ad/src/eager_exec/tests.rs
+++ b/crates/tenferro-ad/src/eager_exec/tests.rs
@@ -4,7 +4,7 @@
 //! via EagerTensor AD tests. These tests target branches with real logic:
 //! edge-case handling, byte parsing, multi-output unpacking, etc.
 
-use super::exec_op_on_tensors;
+use super::{eager_input_promotion_plan, exec_op_on_tensors};
 use std::any::Any;
 use std::hash::Hasher;
 use std::sync::Arc;
@@ -13,7 +13,10 @@ use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::SymDim;
-use tenferro_tensor::{DType, ErrorKind, Tensor, TypedTensor, ValidationKind};
+use tenferro_tensor::{
+    CompareDir, DType, DotGeneralConfig, ErrorKind, ScatterConfig, Tensor, TypedTensor,
+    ValidationKind,
+};
 
 fn f64t(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
@@ -25,6 +28,90 @@ fn scalar(v: f64) -> Tensor {
 
 fn i64_scalar(v: i64) -> Tensor {
     Tensor::I64(TypedTensor::from_vec_col_major(vec![], vec![v]).unwrap())
+}
+
+fn planned_input_dtypes(op: &StdTensorOp, input_dtypes: &[DType]) -> Vec<DType> {
+    let plan = eager_input_promotion_plan(op, input_dtypes.len(), |index| input_dtypes[index]);
+    input_dtypes
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, dtype)| plan.target_dtype(index, dtype))
+        .collect()
+}
+
+#[test]
+fn eager_input_promotion_plan_covers_all_promoted_families() {
+    let binary_ops = [
+        StdTensorOp::Add,
+        StdTensorOp::Sub,
+        StdTensorOp::Mul,
+        StdTensorOp::Div,
+        StdTensorOp::Rem,
+        StdTensorOp::Pow,
+        StdTensorOp::Maximum,
+        StdTensorOp::Minimum,
+        StdTensorOp::Compare(CompareDir::Eq),
+        StdTensorOp::DotGeneral {
+            config: DotGeneralConfig {
+                lhs_contracting_dims: vec![],
+                rhs_contracting_dims: vec![],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+        },
+    ];
+    for op in binary_ops {
+        assert_eq!(
+            planned_input_dtypes(&op, &[DType::F64, DType::C32]),
+            vec![DType::C64, DType::C64],
+            "binary promotion plan for {op:?}"
+        );
+    }
+
+    let cases = [
+        (
+            StdTensorOp::Select,
+            vec![DType::Bool, DType::F64, DType::C32],
+            vec![DType::Bool, DType::C64, DType::C64],
+        ),
+        (
+            StdTensorOp::Clamp,
+            vec![DType::F32, DType::F64, DType::C32],
+            vec![DType::C64, DType::C64, DType::C64],
+        ),
+        (
+            StdTensorOp::Concatenate {
+                axis: 0,
+                input_count: 3,
+            },
+            vec![DType::F32, DType::F64, DType::C32],
+            vec![DType::C64, DType::C64, DType::C64],
+        ),
+        (
+            StdTensorOp::Scatter(ScatterConfig {
+                update_window_dims: vec![],
+                inserted_window_dims: vec![],
+                scatter_dims_to_operand_dims: vec![],
+                index_vector_dim: 0,
+            }),
+            vec![DType::F32, DType::I64, DType::C32],
+            vec![DType::C32, DType::I64, DType::C32],
+        ),
+        (
+            StdTensorOp::DynamicUpdateSlice,
+            vec![DType::F32, DType::C64, DType::I64],
+            vec![DType::C64, DType::C64, DType::I64],
+        ),
+        (StdTensorOp::Neg, vec![DType::C32], vec![DType::C32]),
+    ];
+    for (op, input_dtypes, expected) in cases {
+        assert_eq!(
+            planned_input_dtypes(&op, &input_dtypes),
+            expected,
+            "promotion plan for {op:?}"
+        );
+    }
 }
 
 fn data(t: &Tensor) -> Vec<f64> {

--- a/crates/tenferro-ad/tests/integration/eager_tensor/context_and_promotion.rs
+++ b/crates/tenferro-ad/tests/integration/eager_tensor/context_and_promotion.rs
@@ -1,3 +1,8 @@
+use std::fmt::Debug;
+
+use num_complex::{Complex32, Complex64};
+use tenferro_runtime::TensorScalar;
+
 use super::*;
 
 #[test]
@@ -289,4 +294,191 @@ fn promote_same_dtype_no_conversion_penalty() {
     let z = a.add(&b).unwrap();
     assert_eq!(z.dtype(), DType::F64);
     assert_eq!(z.value().unwrap().as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+}
+
+fn assert_exact_values<T>(tensor: &EagerTensor, expected: &[T])
+where
+    T: TensorScalar + Debug + PartialEq,
+{
+    assert_eq!(
+        tensor.to_tensor().unwrap().as_slice::<T>().unwrap(),
+        expected
+    );
+}
+
+fn eager_input<T: TensorScalar>(ctx: &Arc<EagerRuntime>, data: &[T], tracked: bool) -> EagerTensor {
+    let tensor = Tensor::from_vec_col_major(vec![data.len()], data.to_vec()).unwrap();
+    if tracked {
+        EagerTensor::requires_grad_in(tensor, Arc::clone(ctx)).unwrap()
+    } else {
+        // Keep inactive operands on the active-edge path as lazy constants.
+        EagerTensor::from_tensor_in(tensor, Arc::clone(ctx))
+            .unwrap()
+            .reshape(&[data.len()])
+            .unwrap()
+    }
+}
+
+// INVARIANT: Explicit inputs and exact oracles keep both dtype pairs independently auditable.
+#[allow(clippy::too_many_arguments)]
+fn run_mixed_add_case<R, C>(
+    real_data: &[R],
+    complex_data: &[C],
+    real_tangent: &[R],
+    complex_tangent: &[C],
+    cotangent: &[C],
+    expected_sum: &[C],
+    expected_real_vjp: &[R],
+    expected_complex_vjp: &[C],
+    expected_real_jvp: &[C],
+    expected_complex_jvp: &[C],
+    output_dtype: DType,
+) where
+    R: TensorScalar + Debug + PartialEq,
+    C: TensorScalar + Debug + PartialEq,
+{
+    for active_real in [true, false] {
+        for real_first in [true, false] {
+            let ctx = test_ctx();
+            let real = eager_input(&ctx, real_data, active_real);
+            let complex = eager_input(&ctx, complex_data, !active_real);
+            let output = if real_first {
+                real.add(&complex).unwrap()
+            } else {
+                complex.add(&real).unwrap()
+            };
+            assert_eq!(output.dtype(), output_dtype);
+            assert_exact_values(&output, expected_sum);
+
+            let cotangent = eager_input(&ctx, cotangent, false);
+            if active_real {
+                let real_tangent = eager_input(&ctx, real_tangent, false);
+                assert_exact_values(
+                    &ctx.vjp(&output, &real, &cotangent).unwrap(),
+                    expected_real_vjp,
+                );
+                assert!(ctx
+                    .vjp_optional(&output, &complex, &cotangent)
+                    .unwrap()
+                    .is_none());
+                assert_exact_values(
+                    &ctx.jvp(&output, &real, &real_tangent).unwrap(),
+                    expected_real_jvp,
+                );
+                let complex_tangent = eager_input(&ctx, complex_tangent, false);
+                assert!(ctx
+                    .jvp_optional(&output, &complex, &complex_tangent)
+                    .unwrap()
+                    .is_none());
+            } else {
+                let complex_tangent = eager_input(&ctx, complex_tangent, false);
+                assert_exact_values(
+                    &ctx.vjp(&output, &complex, &cotangent).unwrap(),
+                    expected_complex_vjp,
+                );
+                assert!(ctx
+                    .vjp_optional(&output, &real, &cotangent)
+                    .unwrap()
+                    .is_none());
+                assert_exact_values(
+                    &ctx.jvp(&output, &complex, &complex_tangent).unwrap(),
+                    expected_complex_jvp,
+                );
+                let real_tangent = eager_input(&ctx, real_tangent, false);
+                assert!(ctx
+                    .jvp_optional(&output, &real, &real_tangent)
+                    .unwrap()
+                    .is_none());
+            }
+        }
+    }
+}
+
+#[test]
+fn mixed_add_semantic_jvp_vjp_promotes_f64_c64_and_f32_c32_in_both_orders() {
+    let c64 = Complex64::new;
+    run_mixed_add_case(
+        &[1.25_f64, -2.5],
+        &[c64(3.0, 0.5), c64(-4.0, -1.25)],
+        &[0.25_f64, -0.75],
+        &[c64(-1.5, 0.25), c64(2.0, -0.5)],
+        &[c64(0.5, 0.75), c64(-1.25, -0.25)],
+        &[c64(4.25, 0.5), c64(-6.5, -1.25)],
+        &[0.5_f64, -1.25],
+        &[c64(0.5, 0.75), c64(-1.25, -0.25)],
+        &[c64(0.25, 0.0), c64(-0.75, 0.0)],
+        &[c64(-1.5, 0.25), c64(2.0, -0.5)],
+        DType::C64,
+    );
+
+    let c32 = Complex32::new;
+    run_mixed_add_case(
+        &[1.25_f32, -2.5],
+        &[c32(3.0, 0.5), c32(-4.0, -1.25)],
+        &[0.25_f32, -0.75],
+        &[c32(-1.5, 0.25), c32(2.0, -0.5)],
+        &[c32(0.5, 0.75), c32(-1.25, -0.25)],
+        &[c32(4.25, 0.5), c32(-6.5, -1.25)],
+        &[0.5_f32, -1.25],
+        &[c32(0.5, 0.75), c32(-1.25, -0.25)],
+        &[c32(0.25, 0.0), c32(-0.75, 0.0)],
+        &[c32(-1.5, 0.25), c32(2.0, -0.5)],
+        DType::C32,
+    );
+}
+
+#[test]
+fn mixed_concatenate_semantic_replay_promotes_inputs() {
+    let ctx = test_ctx();
+    let real = eager_input(&ctx, &[1.0_f64, 2.0], false);
+    let complex = eager_input(
+        &ctx,
+        &[Complex64::new(3.0, 0.5), Complex64::new(-4.0, -1.25)],
+        true,
+    );
+    let output = EagerTensor::concatenate(&[&real, &complex], 0).unwrap();
+    assert_eq!(output.dtype(), DType::C64);
+    assert_exact_values(
+        &output,
+        &[
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.5),
+            Complex64::new(-4.0, -1.25),
+        ],
+    );
+
+    let cotangent = eager_input(
+        &ctx,
+        &[
+            Complex64::new(0.5, 0.75),
+            Complex64::new(-1.25, -0.25),
+            Complex64::new(2.0, 1.0),
+            Complex64::new(-3.0, 0.5),
+        ],
+        false,
+    );
+    assert_exact_values(
+        &ctx.vjp(&output, &complex, &cotangent).unwrap(),
+        &[Complex64::new(2.0, 1.0), Complex64::new(-3.0, 0.5)],
+    );
+    assert!(ctx
+        .vjp_optional(&output, &real, &cotangent)
+        .unwrap()
+        .is_none());
+
+    let tangent = eager_input(
+        &ctx,
+        &[Complex64::new(0.25, -0.5), Complex64::new(1.5, 0.75)],
+        false,
+    );
+    assert_exact_values(
+        &ctx.jvp(&output, &complex, &tangent).unwrap(),
+        &[
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.25, -0.5),
+            Complex64::new(1.5, 0.75),
+        ],
+    );
 }

--- a/crates/tenferro-linalg/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-linalg/tests/integration/eager_tensor.rs
@@ -1041,6 +1041,39 @@ fn eigh_vector_observable_backward_grad_is_finite() {
 }
 
 #[test]
+fn mixed_real_constant_and_tracked_complex_eigh_vector_backward() {
+    let ctx = ad_test_ctx();
+    let real = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let complex = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex64::new(0.5, 0.0),
+                Complex64::new(0.0, -0.25),
+                Complex64::new(0.0, 0.25),
+                Complex64::new(0.5, 0.0),
+            ],
+        )
+        .unwrap(),
+        ctx,
+    )
+    .unwrap();
+    let mixed = real.add(&complex).unwrap();
+    let (_values, vectors) = mixed.eigh().unwrap();
+
+    vectors
+        .reduce_sum(Some(&[0, 1]))
+        .unwrap()
+        .backward()
+        .unwrap();
+    assert!(complex.grad().unwrap().is_some());
+}
+
+#[test]
 fn eig_returns_expected_complex_values_for_diagonal_matrix() {
     let a = EagerTensor::from_tensor_in(
         Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]).unwrap(),

--- a/docs/design/eager-semantic-promotion-recording.md
+++ b/docs/design/eager-semantic-promotion-recording.md
@@ -1,0 +1,98 @@
+# Eager Semantic Promotion Recording
+
+## Status
+
+Implementation design for [#1698](https://github.com/tensor4all/tenferro-rs/issues/1698).
+This fixes a mismatch between accepted eager primal execution and its deferred
+semantic AD carrier. It adds no public API and changes no dtype-promotion
+policy.
+
+## Problem
+
+Eager primal execution promotes compatible mixed-dtype inputs immediately
+before backend dispatch. Deferred semantic recording currently appends the
+original unpromoted inputs to a raw graph. A mixed F64/C64 `Add`, for example,
+executes as C64/C64 but is recorded as F64/C64.
+
+Most direct derivatives do not need to replay the primal operation. A residual-
+using downstream rule does: an untracked F64 identity plus a tracked C64 matrix,
+followed by complex `Eigh`, fails during backward when the imported primal Add
+reaches the same-dtype CPU kernel:
+
+```text
+add: dtype mismatch: expected F64, actual C64
+```
+
+Normal traced construction already inserts explicit `Convert` operations before
+promoting binary operations. The raw eager carrier bypasses that path.
+
+## Design
+
+Record the same explicit input promotion that eager execution performs.
+
+1. Add one crate-private promotion-plan helper beside eager execution. Given a
+   `StdTensorOp` and input dtypes, it returns the dtype each backend operand
+   receives.
+2. Use that helper in both owned/read eager execution promotion sites and
+   deferred semantic recording, so execution and recording cannot define
+   separate promotion vocabularies.
+3. In `record_semantic_eager_outputs`, after collecting lazy constants and
+   before operation-specific shape canonicalization, append semantic `Convert`
+   operations only where the semantic input dtype differs from its execution
+   target dtype.
+4. Keep the #1692 concatenate exact-shape step after dtype promotion. Both
+   transformations exist only in the deferred semantic graph and add no eager
+   tensor copy, transfer, materialization, or execution kernel.
+
+The shared plan covers every current eager execution promotion family:
+
+- binary Add/Sub/Mul/Div/Rem/Pow/Maximum/Minimum/Compare/DotGeneral;
+- Select value operands, leaving the predicate unchanged;
+- all Clamp and Concatenate operands;
+- Scatter operand/updates, leaving indices unchanged; and
+- DynamicUpdateSlice operand/update, leaving start indices unchanged.
+
+All other inputs retain their original dtype. Arity validation remains owned by
+existing operation/execution validation.
+
+## AD contract
+
+The `Convert` nodes make primal replay and derivative metadata identical to the
+actual eager computation. Reverse mode projects complex cotangents back to real
+tracked leaves under tenferro's real-inner-product convention; inactive real
+constants remain inactive and receive no stored cotangent. Forward mode casts
+active tangents to the promoted execution dtype.
+
+This fix does not change backend dtype support, insert implicit device
+transfers, or make an otherwise invalid dtype pair valid.
+
+## Rejected alternatives
+
+- **Downstream casts in tensor4all.** They hide an accepted tenferro eager
+  operation's incorrect AD carrier and duplicate promotion policy.
+- **Patch linalg cotangent accumulation.** The linalg seed/local mapping is
+  correct; the first invalid operation is the unpromoted primal Add replayed by
+  the derivative program.
+- **Promote concrete EagerTensor inputs before forward execution.** This repeats
+  cast kernels/materialization already owned by eager execution.
+- **Fix only Add.** The same raw-recording mismatch exists for every eager
+  promotion family listed above.
+
+## Verification
+
+- Unit-test the shared promotion plan for binary, predicate-preserving Select,
+  Clamp/Concatenate, index-preserving Scatter/DynamicUpdateSlice, and an
+  unchanged unary operation.
+- Add exact mixed F64/C64 and F32/C32 eager Add JVP/VJP tests in both operand
+  orders, including no gradient storage for inactive operands.
+- Keep the end-to-end mixed F64/C64 Add -> complex Eigh eigenvector backward
+  regression.
+- Add at least one promoted non-Add semantic replay test to prevent a one-op
+  fix; a mixed Concatenate or DotGeneral path is sufficient.
+- Verify the #1692 mixed-stack matrix remains green.
+- Run the focused autodiff integration target, formatting, clippy, and the
+  repository local PR gate. Record coverage review and both reviewer-gpt gates
+  in a curated worklog.
+
+No tolerance change is permitted. Planning is `O(input_count)` metadata work;
+only inputs whose dtype differs gain a semantic Convert node.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -24,6 +24,7 @@ migration notes live under [Plans](../plans/), not this active design index.
 | [dot-general-overhead.md](./dot-general-overhead.md) | Fixed-cost analysis for many small `dot_general` contractions |
 | [dynamic-symbolic-shapes.md](./dynamic-symbolic-shapes.md) | Dynamic and symbolic shape architecture. Covers `DynamicTruncate`, `transpose_scatter`, symbolic `slice_sizes`, the `Exact`/`UpperBound`/`Unknown` extent model, and extension equalities from graph-owned scopes through compiled guards. This is the key design doc for understanding how tenferro differs from XLA-style shape-specialized compilation. |
 | [eager-concatenate-shape-recording.md](./eager-concatenate-shape-recording.md) | Exact-shape semantic recording for eager concatenate and mixed-activity stack AD (#1692) |
+| [eager-semantic-promotion-recording.md](./eager-semantic-promotion-recording.md) | Shared eager execution/semantic input-promotion planning for AD-safe mixed dtypes (#1698) |
 | [gpu-backend-design.md](./gpu-backend-design.md) | GPU backend architecture |
 | [xla-backend.md](./xla-backend.md) | Experimental StableHLO lowering and PJRT plugin-loading peer executor over static `CompiledGraph` values |
 | [inplace-indexing.md](./inplace-indexing.md) | Partial in-place updates design |

--- a/docs/worklogs/2026-08-15-eager-semantic-promotion-recording.md
+++ b/docs/worklogs/2026-08-15-eager-semantic-promotion-recording.md
@@ -1,0 +1,89 @@
+# Issue #1698: eager semantic promotion recording
+
+## Scope
+
+Fix deferred eager AD recording so accepted mixed-dtype primal operations replay
+with the same explicit input conversions used by eager execution. This is an
+internal correctness fix with no public API, promotion-policy, tolerance,
+backend-placement, or transfer change.
+
+## Source and architecture review
+
+Reviewed:
+
+- issue [#1698](https://github.com/tensor4all/tenferro-rs/issues/1698) and the
+  standalone F64/C64 Add -> Eigh reproducer;
+- owned and borrowed eager dispatch in `crates/tenferro-ad/src/eager_exec.rs`;
+- deferred active-edge recording in `crates/tenferro-ad/src/eager.rs`;
+- canonical traced binary promotion in `crates/tenferro-runtime/src/traced.rs`;
+- core semantic Add JVP/VJP conversion and cotangent projection;
+- linalg `LinearizeThenTranspose` seed/local mapping and Eigh rules; and
+- the #1692 concatenate exact-shape recording fix.
+
+The linalg fragment mapping was correct. Eager forward dispatch promoted F64 and
+C64 operands to C64, but `record_semantic_eager_outputs` appended the original
+F64/C64 raw Add. Eigh backward replays that primal residual and reached the
+same-dtype CPU Add kernel without the execution-time conversions.
+
+## Design and review gate
+
+The durable design is
+`docs/design/eager-semantic-promotion-recording.md`. The reviewer-gpt
+pre-implementation gate returned **Correct-to-merge** before implementation.
+
+Rejected alternatives:
+
+- downstream tensor4all casts, which duplicate tenferro promotion policy;
+- linalg cotangent-accumulator changes, which target the symptom after the
+  invalid primal replay; and
+- concrete eager pre-casts, which would repeat forward kernels and copies.
+
+## Implementation
+
+- Added one allocation-free crate-private eager input-promotion descriptor
+  covering binary operations, Select, Clamp, Concatenate, Scatter, and
+  DynamicUpdateSlice.
+- Routed both owned/read eager dispatch promotion sites through that descriptor.
+- Deferred semantic recording inserts `TracedTensor::cast` only for inputs whose
+  dtype differs from the execution target, before concatenate exact-shape
+  recording.
+- Unchanged inputs remain borrowed through `Cow`; inputs with no promotion reuse
+  their existing semantic traces without added clones or graph nodes.
+
+## Verification and coverage
+
+Focused tests cover:
+
+- every promotion-plan family and an unchanged unary operation;
+- exact mixed F64/C64 and F32/C32 Add JVP/VJP behavior in both operand orders
+  and both choices of active input, including inactive cotangent absence;
+- mixed-dtype Concatenate semantic replay; and
+- the end-to-end F64/C64 Add -> complex Eigh eigenvector backward regression.
+
+Verification completed:
+
+- `cargo fmt --all` and `git diff --check` — passed.
+- `cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc` — passed.
+- `cargo test --release -p tenferro-ad --test integration` — passed (345 tests).
+- `cargo test --release -p tenferro-ad eager_input_promotion_plan_covers_all_promoted_families` — passed (1 test, 432 filtered).
+- `cargo test --release -p tenferro-linalg --features autodiff --test integration mixed_real_constant_and_tracked_complex_eigh_vector_backward` — passed (1 test, 210 filtered).
+- `cargo test --release -p tenferro-linalg --features autodiff --test integration` — passed (211 tests).
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-linalg --features autodiff --test integration mixed_real_constant_and_tracked_complex_eigh_vector_backward'` — passed, including root and standalone-extension formatting/clippy gates.
+- Worktree repository-rules deterministic review and its script tests — passed.
+
+Coverage impact was reviewed for `eager_exec.rs` (every descriptor arm plus
+owned/read execution through the integration target), `eager.rs` (mixed Add and
+Concatenate semantic replay plus unchanged #1692 stack coverage), and the
+linalg residual consumer (Add -> Eigh backward). No threshold or tolerance
+changed. The downstream tensor4all #623 GSE regression is rerun after this fix
+is merged and all six pins are updated.
+
+## Post-implementation review
+
+Reviewer-gpt round 1 approved promotion/AD semantics but returned **not
+Correct-to-merge** for two hot-path regressions and stale worklog evidence: the
+first implementation allocated dtype vectors for every eager op and cloned
+unchanged semantic traces when another input needed a cast. The promotion plan
+was replaced by an allocation-free descriptor, unchanged traces now remain
+borrowed through `Cow`, and this verification/coverage record was updated.
+Round 2 returned **Correct-to-merge** on the corrected full diff.


### PR DESCRIPTION
## Summary

- centralize eager input-promotion planning across owned/read execution and deferred semantic AD recording
- insert semantic-only `Convert` nodes before raw eager ops, preserving controls/indices and #1692 concatenate shape exactification
- keep the eager hot path allocation-free for the promotion plan and borrow unchanged semantic traces
- cover mixed F64/C64 and F32/C32 JVP/VJP, Concatenate replay, and Add -> complex Eigh backward

Closes #1698.

Blocks downstream completion of tensor4all-rs #623 until merged and repinned.

## Design and review gates

- Design: `docs/design/eager-semantic-promotion-recording.md`
- Pre-implementation reviewer-gpt: **Correct-to-merge**
- Post-implementation reviewer-gpt: initial performance/worklog findings fixed; final exact-diff verdict **Correct-to-merge**
- Worklog: `docs/worklogs/2026-08-15-eager-semantic-promotion-recording.md`

## Verification

- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-linalg --features autodiff --test integration mixed_real_constant_and_tracked_complex_eigh_vector_backward'`
- `cargo test --release -p tenferro-ad --test integration` — 345 passed
- `cargo test --release -p tenferro-ad eager_input_promotion_plan_covers_all_promoted_families` — passed
- `cargo test --release -p tenferro-linalg --features autodiff --test integration` — 211 passed
- committed-head repository-rules deterministic review — pass

## Coverage impact

Reviewed every promotion descriptor arm, owned/read execution, mixed Add and Concatenate semantic replay, the unchanged #1692 stack path, and the linalg residual consumer. No coverage threshold or numerical tolerance changed.
