### PR TITLE
Fix eager semantic metadata scope retention

### DIFF
--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -32,8 +32,7 @@ use tenferro_gpu::webgpu::WebGpuBackend;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::{std_tensor_op::StdTensorOp, SymDim, TensorMeta};
 use tenferro_runtime::ad_support::{
-    analyze_deferred_semantic_trace, compile_ad_source, ones_tensor, tensor_from_parts,
-    ConstraintScopeTransfer, RetainedValue, TracedTensorParts,
+    analyze_deferred_semantic_trace, compile_ad_source, ones_tensor, RetainedValue,
 };
 use tenferro_runtime::program::{ProgramValueMetadata, SemanticFingerprint, SemanticProgram};
 use tenferro_runtime::{
@@ -4152,50 +4151,14 @@ fn record_semantic_eager_outputs(
     if let Some(exact_semantic_inputs) = &exact_semantic_inputs {
         semantic_inputs = exact_semantic_inputs.iter().collect();
     }
-    // Deferred materialization (issue #1665 steps 6-7): append the op to the
-    // raw `Graph<StdTensorOp>` carrier only. Metadata inference, registry
-    // registration, and constraint discovery run once at the first AD request
-    // via `analyze_deferred_semantic_trace`, reusing the existing
-    // compile/AdTransformCache/prepared-derivative machinery.
-    let append = tenferro_runtime::extension::append_raw_op(op.clone(), &semantic_inputs)?;
-    if append.output_ids.len() != output_metadata.len() {
-        return Err(Error::Internal(format!(
-            "semantic eager recording expected {} outputs for {op:?}, got {}",
-            output_metadata.len(),
-            append.output_ids.len()
-        )));
-    }
-    let inputs_map =
-        tenferro_runtime::ad_support::merge_traced_inputs_map(semantic_inputs.iter().copied());
-    let leaf_metas =
-        tenferro_runtime::ad_support::merge_traced_leaf_metas(semantic_inputs.iter().copied());
-    let mut extra_roots = Vec::new();
-    for input in &semantic_inputs {
-        extra_roots.extend(tenferro_runtime::ad_support::extra_roots(input));
-    }
-    // ponytail: eager semantic traces never checkpoint, so the carrier keeps
-    // `checkpoint_chain = None` instead of merging input chains.
-    let outputs = append
-        .output_ids
-        .iter()
-        .zip(output_metadata)
-        .map(|(&val, meta)| {
-            tensor_from_parts(TracedTensorParts {
-                rank: meta.rank(),
-                dtype: meta.dtype,
-                graph: Arc::clone(&append.graph),
-                val,
-                data: None,
-                shape_hint: None,
-                inputs_map: Arc::clone(&inputs_map),
-                leaf_metas: Arc::clone(&leaf_metas),
-                extra_roots: extra_roots.clone(),
-                checkpoint_chain: None,
-                metadata_scopes: Vec::new(),
-                constraint_scope_transfer: ConstraintScopeTransfer::empty(),
-            })
-        })
-        .collect::<Vec<_>>();
+    // Deferred materialization (issue #1665 steps 6-7): append only a raw
+    // carrier. The runtime helper retains metadata scopes introduced by the
+    // promotion/exactification helpers without analyzing this operation.
+    let outputs = tenferro_runtime::extension::append_raw_eager_outputs(
+        op.clone(),
+        &semantic_inputs,
+        output_metadata,
+    )?;
     Ok(outputs.into_iter().map(Some).collect())
 }
 

--- a/crates/tenferro-ad/tests/integration/eager_tensor/context_and_promotion.rs
+++ b/crates/tenferro-ad/tests/integration/eager_tensor/context_and_promotion.rs
@@ -427,6 +427,68 @@ fn mixed_add_semantic_jvp_vjp_promotes_f64_c64_and_f32_c32_in_both_orders() {
     );
 }
 
+fn temporary_mixed_promotion_graph(ctx: &Arc<EagerRuntime>) -> (EagerTensor, EagerTensor) {
+    let x = eager_input(ctx, &[-4.0_f64], true);
+    let output = {
+        let magnitude_input = x.neg().unwrap();
+        let magnitude = {
+            let exponent = eager_input(ctx, &[0.5_f64], false);
+            magnitude_input.pow(&exponent).unwrap()
+        };
+        let factor = eager_input(ctx, &[Complex64::new(0.0, 1.0)], false);
+        magnitude.mul(&factor).unwrap()
+    };
+    (x, output)
+}
+
+#[test]
+fn temporary_constants_before_mixed_promotion_retain_metadata_for_derivatives() {
+    let ctx = test_ctx();
+    let (x, output) = temporary_mixed_promotion_graph(&ctx);
+    output.reduce_sum(Some(&[0])).unwrap().backward().unwrap();
+    assert_eq!(
+        x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
+        &[0.0_f64]
+    );
+
+    let ctx = test_ctx();
+    let (x, output) = temporary_mixed_promotion_graph(&ctx);
+    let cotangent = eager_input(&ctx, &[Complex64::new(0.0, 1.0)], false);
+    assert_exact_values(&ctx.vjp(&output, &x, &cotangent).unwrap(), &[-0.25_f64]);
+
+    let ctx = test_ctx();
+    let (x, output) = temporary_mixed_promotion_graph(&ctx);
+    let tangent = eager_input(&ctx, &[1.0_f64], false);
+    assert_exact_values(
+        &ctx.jvp(&output, &x, &tangent).unwrap(),
+        &[Complex64::new(0.0, -0.25)],
+    );
+}
+
+fn concatenate_with_temporary_exactified_input(
+    ctx: &Arc<EagerRuntime>,
+    tracked: &EagerTensor,
+) -> EagerTensor {
+    let temporary = eager_input(ctx, &[3.0_f64, 4.0], false).neg().unwrap();
+    EagerTensor::concatenate(&[tracked, &temporary], 0)
+        .unwrap()
+        .neg()
+        .unwrap()
+}
+
+#[test]
+fn temporary_exactified_concatenate_input_retains_metadata_for_vjp() {
+    let ctx = test_ctx();
+    let x = eager_input(&ctx, &[1.0_f64, 2.0], true);
+    let output = concatenate_with_temporary_exactified_input(&ctx, &x);
+    let cotangent = eager_input(&ctx, &[1.0_f64, 2.0, 3.0, 4.0], false);
+
+    assert_exact_values(
+        &ctx.vjp(&output, &x, &cotangent).unwrap(),
+        &[-1.0_f64, -2.0],
+    );
+}
+
 #[test]
 fn mixed_concatenate_semantic_replay_promotes_inputs() {
     let ctx = test_ctx();

--- a/crates/tenferro-runtime/src/extension.rs
+++ b/crates/tenferro-runtime/src/extension.rs
@@ -23,7 +23,7 @@ use computegraph::types::{OperationRole, ValueRef};
 use computegraph::GraphOperation;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_ops::SymDim;
+use tenferro_ops::{SymDim, TensorMeta};
 
 use crate::checkpoint::CheckpointNode;
 use crate::error::{Error, ErrorPhase, Result};
@@ -194,6 +194,53 @@ pub fn append_raw_op(op: StdTensorOp, inputs: &[&TracedTensor]) -> Result<RawApp
         graph: Arc::new(builder.build()),
         output_ids,
     })
+}
+
+/// Append an eager semantic op and retain its private runtime carrier state.
+#[doc(hidden)]
+pub fn append_raw_eager_outputs(
+    op: StdTensorOp,
+    inputs: &[&TracedTensor],
+    output_metadata: &[TensorMeta],
+) -> Result<Vec<TracedTensor>> {
+    let append = append_raw_op(op.clone(), inputs)?;
+    if append.output_ids.len() != output_metadata.len() {
+        return Err(Error::Internal(format!(
+            "semantic eager recording expected {} outputs for {op:?}, got {}",
+            output_metadata.len(),
+            append.output_ids.len()
+        )));
+    }
+
+    let inputs_map = merge_traced_inputs_map(inputs.iter().copied());
+    let leaf_metas = merge_traced_leaf_metas(inputs.iter().copied());
+    let mut extra_roots = Vec::new();
+    for input in inputs {
+        extra_roots.extend(input.extra_roots.iter().cloned());
+    }
+    let metadata_scopes =
+        MetadataScopeChain::merge(inputs.iter().map(|input| &input.metadata_scopes));
+
+    Ok(append
+        .output_ids
+        .into_iter()
+        .zip(output_metadata)
+        .map(|(val, meta)| TracedTensor {
+            id: next_traced_id(),
+            rank: meta.rank(),
+            dtype: meta.dtype,
+            graph: Arc::clone(&append.graph),
+            val,
+            data: None,
+            shape_hint: None,
+            inputs_map: Arc::clone(&inputs_map),
+            leaf_metas: Arc::clone(&leaf_metas),
+            extra_roots: extra_roots.clone(),
+            checkpoint_chain: None,
+            metadata_scopes: metadata_scopes.clone(),
+            constraint_scopes: ConstraintScopeChain::empty(),
+        })
+        .collect())
 }
 
 /// Run the deferred analysis half of an append once: register metadata and

--- a/crates/tenferro-runtime/src/extension/tests.rs
+++ b/crates/tenferro-runtime/src/extension/tests.rs
@@ -550,6 +550,34 @@ fn append_raw_op_builds_carrier_without_analysis() {
 }
 
 #[test]
+fn raw_eager_outputs_share_and_retain_helper_metadata_scopes() {
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let helper = x.cast(DType::C64).unwrap();
+    let helper_key = helper.graph.values()[helper.val].key.clone();
+    let op: Arc<dyn ExtensionOp> = Arc::new(TestExtension {
+        input_count: 1,
+        output_count: 2,
+        inferred_outputs: 2,
+    });
+    let output_metadata = vec![
+        TensorMeta::exact(DType::C64, vec![SymDim::from(2)]),
+        TensorMeta::exact(DType::C64, vec![SymDim::from(2)]),
+    ];
+
+    let outputs =
+        append_raw_eager_outputs(StdTensorOp::Extension(op), &[&helper], &output_metadata).unwrap();
+    assert_eq!(outputs.len(), 2);
+    assert!(outputs[0]
+        .metadata_scopes
+        .shares_root(&outputs[1].metadata_scopes));
+
+    drop(helper);
+    assert_eq!(registered_meta(&helper_key).unwrap().dtype, DType::C64);
+    drop(outputs);
+    assert!(registered_meta(&helper_key).is_err());
+}
+
+#[test]
 fn append_then_analyze_registers_output_metadata() {
     let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let y = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();

--- a/crates/tenferro-runtime/src/metadata.rs
+++ b/crates/tenferro-runtime/src/metadata.rs
@@ -67,6 +67,21 @@ impl MetadataScopeChain {
         }
     }
 
+    pub(crate) fn merge<'a>(inherited: impl IntoIterator<Item = &'a MetadataScopeChain>) -> Self {
+        let parents: Vec<_> = inherited.into_iter().cloned().collect();
+        match parents.as_slice() {
+            [] => Self::empty(),
+            [only] => only.clone(),
+            _ => Self {
+                node: Arc::new(MetadataScopeChainNode {
+                    scope: None,
+                    parents,
+                    materialized: OnceLock::new(),
+                }),
+            },
+        }
+    }
+
     pub(crate) fn from_materialized(scopes: Vec<Arc<GlobalMetadataScope>>) -> Self {
         let mut chain = Self::empty();
         for scope in scopes.into_iter().rev() {
@@ -84,23 +99,56 @@ impl MetadataScopeChain {
             .materialized
             .get_or_init(|| {
                 let mut scopes = Vec::new();
-                let mut seen = HashSet::new();
-                self.extend_materialized(&mut scopes, &mut seen);
+                let mut seen_scopes = HashSet::new();
+                let mut seen_nodes = HashSet::new();
+                let mut visited_nodes = 0;
+                self.extend_materialized(
+                    &mut scopes,
+                    &mut seen_scopes,
+                    &mut seen_nodes,
+                    &mut visited_nodes,
+                );
                 scopes
             })
             .as_slice()
     }
 
+    #[cfg(test)]
+    pub(crate) fn materialize_with_visit_count(&self) -> (Vec<Arc<GlobalMetadataScope>>, usize) {
+        let mut scopes = Vec::new();
+        let mut seen_scopes = HashSet::new();
+        let mut seen_nodes = HashSet::new();
+        let mut visited_nodes = 0;
+        self.extend_materialized(
+            &mut scopes,
+            &mut seen_scopes,
+            &mut seen_nodes,
+            &mut visited_nodes,
+        );
+        (scopes, visited_nodes)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn shares_root(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.node, &other.node)
+    }
+
     fn extend_materialized(
         &self,
         scopes: &mut Vec<Arc<GlobalMetadataScope>>,
-        seen: &mut HashSet<*const GlobalMetadataScope>,
+        seen_scopes: &mut HashSet<*const GlobalMetadataScope>,
+        seen_nodes: &mut HashSet<*const MetadataScopeChainNode>,
+        visited_nodes: &mut usize,
     ) {
+        if !seen_nodes.insert(Arc::as_ptr(&self.node)) {
+            return;
+        }
+        *visited_nodes += 1;
         if let Some(scope) = &self.node.scope {
-            push_metadata_scope_seen(scopes, seen, Arc::clone(scope));
+            push_metadata_scope_seen(scopes, seen_scopes, Arc::clone(scope));
         }
         for parent in &self.node.parents {
-            parent.extend_materialized(scopes, seen);
+            parent.extend_materialized(scopes, seen_scopes, seen_nodes, visited_nodes);
         }
     }
 }
@@ -603,3 +651,6 @@ where
 {
     Error::runtime_state_source("metadata", crate::ErrorPhase::Compile, error)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/tenferro-runtime/src/metadata/tests.rs
+++ b/crates/tenferro-runtime/src/metadata/tests.rs
@@ -1,0 +1,48 @@
+use computegraph::types::ValueKey;
+
+use super::*;
+use crate::traced::next_input_key;
+
+fn scope() -> Arc<GlobalMetadataScope> {
+    Arc::new(
+        register_scoped_value_metadata(
+            ValueKey::Input(next_input_key()),
+            TensorMeta::exact(DType::F64, vec![]),
+        )
+        .unwrap(),
+    )
+}
+
+#[test]
+fn metadata_scope_merge_reuses_single_parent_chain() {
+    let parent = MetadataScopeChain::with_scope(scope(), []);
+    let merged = MetadataScopeChain::merge([&parent]);
+
+    assert!(merged.shares_root(&parent));
+}
+
+#[test]
+fn metadata_scope_materialization_deduplicates_shared_nodes_and_scopes() {
+    let shared = MetadataScopeChain::with_scope(scope(), []);
+    let repeated_scope = scope();
+    let left = MetadataScopeChain::with_scope(Arc::clone(&repeated_scope), [&shared]);
+    let right = MetadataScopeChain::with_scope(repeated_scope, [&shared]);
+    let merged = MetadataScopeChain::merge([&left, &right]);
+
+    let (scopes, visited_nodes) = merged.materialize_with_visit_count();
+    assert_eq!(scopes.len(), 2);
+    assert_eq!(visited_nodes, 4);
+}
+
+#[test]
+fn metadata_scope_shared_history_materializes_in_linear_node_visits() {
+    let depth = 512;
+    let mut chain = MetadataScopeChain::with_scope(scope(), []);
+    for _ in 0..depth {
+        chain = MetadataScopeChain::merge([&chain, &chain]);
+    }
+
+    let (scopes, visited_nodes) = chain.materialize_with_visit_count();
+    assert_eq!(scopes.len(), 1);
+    assert_eq!(visited_nodes, depth + 1);
+}

--- a/docs/design/eager-semantic-metadata-scope-retention.md
+++ b/docs/design/eager-semantic-metadata-scope-retention.md
@@ -1,0 +1,49 @@
+# Eager Semantic Metadata-Scope Retention
+
+Status: implemented for issue [#1700](https://github.com/tensor4all/tenferro-rs/issues/1700).
+
+## Problem
+
+Eager AD records active operations into a raw semantic trace and defers whole-graph metadata analysis until the first derivative request. Mixed-dtype promotion and exact-shape concatenate recording may insert ordinary `TracedTensor` helper nodes (`Convert` or `Reshape`) into that raw trace. Those helper nodes own scoped metadata registrations for the external parent value they consume.
+
+`record_semantic_eager_outputs` currently constructs the next raw carrier with an empty metadata-scope list. When a helper tensor is a local temporary, its scope is dropped after recording even though the raw output graph still references the helper's output. Deferred compilation then fails with `missing input metadata`.
+
+The minimal reproducer is a tracked `F64` chain containing a temporary untracked exponent, followed by a mixed `F64 * C64` operation. The promotion cast consumes the non-leaf raw trace, and `backward()` fails after the cast temporary has been dropped.
+
+## Required behavior
+
+- A raw eager semantic output must retain every metadata scope needed by its final semantic inputs.
+- Retention must work after promotion casts and concatenate exactification reshapes.
+- Shared scope histories and shared chain nodes must remain pointer-deduplicated; scope propagation must be persistent and must not materialize or scan whole histories per eager operation.
+- The eager primal path, dtype promotion, active-edge pruning, public traced behavior, and deferred analysis timing remain unchanged.
+- No tensor is materialized and no AD graph is detached.
+
+## Design
+
+Keep `MetadataScopeChain` private to `tenferro-runtime` and extend the existing runtime-owned raw-append seam with a hidden carrier-construction helper. The helper receives the final `&TracedTensor` inputs and output metadata, appends the raw operation, merges private runtime state (input maps, leaf metadata, roots, and metadata-scope chains), and returns output `TracedTensor` carriers. Existing public hidden `RawAppend` and `TracedTensorParts` layouts remain unchanged.
+
+`MetadataScopeChain::merge` returns the empty chain for no parents, clones the existing chain for one parent, and creates one parent-only node for multiple inputs. Materialization tracks both scope pointers and chain-node pointers so diamond-shaped histories visit each shared node once. Ordinary traced helpers continue adding one new scope above inherited chains; raw eager operations add no scope.
+
+After promotion and concatenate exactification select the final `semantic_inputs`, `record_semantic_eager_outputs` delegates carrier construction to the runtime helper. The helper computes one persistent merged chain and clones that token into every output carrier. No scope vector is materialized per eager operation, and no new public transfer type crosses the crate boundary. The carrier only keeps scopes already required by helper graph boundaries alive until deferred analysis consumes the complete graph.
+
+No public tensor API, existing public hidden struct layout, operation semantics, backend contract, or dependency changes.
+
+## Rejected alternatives
+
+- **Keep temporary constants alive in downstream callers.** This leaks an internal RAII requirement into users and does not fix composed eager graphs.
+- **Materialize or detach before mixed operations.** This destroys AD connectivity.
+- **Replace promotion casts with a second raw-op construction path.** That duplicates traced graph assembly and leaves exactification reshapes with the same lifetime problem.
+- **Flatten scope vectors directly in `tenferro-ad` or at `TracedTensorParts`.** This either permits duplicate histories or scans and clones an accumulating history per eager operation, producing quadratic graph-construction work.
+- **Replace `TracedTensorParts::metadata_scopes` with a transfer token.** Despite `#[doc(hidden)]`, this is a public struct-literal field and changing it would be source-breaking. The runtime-owned construction helper keeps the persistent type private instead.
+
+## Verification
+
+Add an eager promotion integration regression whose temporary exponent, intermediate values, and complex factor all leave scope before differentiation. Verify:
+
+1. scalar `backward()` succeeds and records the expected real gradient;
+2. functional VJP with a complex cotangent returns the expected real projection;
+3. functional JVP returns the expected complex directional derivative.
+
+Add a concatenate regression where an exactified temporary constant and its intermediate values are dropped before a downstream operation and differentiation. Add runtime-owned chain tests proving the single-parent fast path, pointer deduplication, and linear node visits for shared histories. Add a raw-carrier construction test proving one private merged chain is shared across multiple outputs and retains helper metadata after the helper tensor is dropped.
+
+Run the focused regressions, the `tenferro-ad` and `tenferro-runtime` test suites, the repository fast PR gate, and the deterministic repository-rules review. Hosted CI remains responsible for the full backend and coverage matrices.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -25,6 +25,7 @@ migration notes live under [Plans](../plans/), not this active design index.
 | [dynamic-symbolic-shapes.md](./dynamic-symbolic-shapes.md) | Dynamic and symbolic shape architecture. Covers `DynamicTruncate`, `transpose_scatter`, symbolic `slice_sizes`, the `Exact`/`UpperBound`/`Unknown` extent model, and extension equalities from graph-owned scopes through compiled guards. This is the key design doc for understanding how tenferro differs from XLA-style shape-specialized compilation. |
 | [eager-concatenate-shape-recording.md](./eager-concatenate-shape-recording.md) | Exact-shape semantic recording for eager concatenate and mixed-activity stack AD (#1692) |
 | [eager-semantic-promotion-recording.md](./eager-semantic-promotion-recording.md) | Shared eager execution/semantic input-promotion planning for AD-safe mixed dtypes (#1698) |
+| [eager-semantic-metadata-scope-retention.md](./eager-semantic-metadata-scope-retention.md) | Metadata-scope lifetime transfer across eager semantic helper nodes (#1700) |
 | [gpu-backend-design.md](./gpu-backend-design.md) | GPU backend architecture |
 | [xla-backend.md](./xla-backend.md) | Experimental StableHLO lowering and PJRT plugin-loading peer executor over static `CompiledGraph` values |
 | [inplace-indexing.md](./inplace-indexing.md) | Partial in-place updates design |

--- a/docs/worklogs/2026-08-15-eager-semantic-metadata-scope-retention.md
+++ b/docs/worklogs/2026-08-15-eager-semantic-metadata-scope-retention.md
@@ -1,0 +1,72 @@
+# Eager semantic metadata-scope retention
+
+## Session summary
+
+Issue [#1700](https://github.com/tensor4all/tenferro-rs/issues/1700) was isolated while validating tensor4all-rs #623 against tenferro commit `8a8196a95363158f147b1feff2bc3b2d4bc4d267`. A mixed-dtype eager operation fails during deferred AD compilation when promotion casts a non-leaf raw semantic trace that depends on a temporary untracked constant.
+
+## Context reviewed
+
+- `AGENTS.md`, `CONTRIBUTING.md`, `REPOSITORY_RULES.md`
+- shared tensor4all repository, performance, docs/tests, and Rust numerical rules
+- `ai/contribution-workflows/bugfix-pr.md`
+- `ai/contribution-workflows/repository-remediation.md`
+- `crates/tenferro-ad/src/eager.rs`
+- `crates/tenferro-ad/src/eager_exec.rs`
+- `crates/tenferro-runtime/src/ad_support.rs`
+- `crates/tenferro-runtime/src/metadata.rs`
+- `crates/tenferro-runtime/src/traced.rs`
+- eager promotion integration tests
+- design records for #1692 and #1698
+
+## Reproduction and classification
+
+Classification: **Auto Fix**. Existing eager AD behavior requires graph-owned dependencies to survive temporary Rust values; no public API or AD semantics change is needed.
+
+The issue reproducer combines a tracked `F64` value, a `pow` with a temporary untracked exponent, and a later mixed `F64 * C64`. Either operation alone succeeds. Their composition fails because the semantic promotion `Convert` owns metadata scopes that the following raw carrier discards.
+
+## Decision
+
+Retain the pointer-deduplicated metadata-scope histories of the final semantic inputs in each raw eager output. Runtime metadata ownership performs a persistent private-chain merge in a hidden carrier-construction helper extending the existing raw-append seam; the eager layer delegates after selecting its final semantic inputs. `RawAppend` and `TracedTensorParts` keep their existing public hidden layouts. Metadata materialization deduplicates both scopes and shared chain nodes.
+
+Rejected downstream lifetime workarounds, primal materialization, duplicate raw cast assembly, eager-local scope deduplication, scope-vector materialization at the per-operation parts boundary, and a source-breaking public transfer field. See `docs/design/eager-semantic-metadata-scope-retention.md`.
+
+## Review gates
+
+- Pre-implementation design review round 1 (`reviewer-gpt`): **Findings**. It approved the root-cause and ownership direction but rejected per-operation vector materialization as potentially quadratic and required concatenate plus chain-scaling coverage.
+- Pre-implementation design review round 2 (`reviewer-gpt`): **Findings**. It approved persistent complexity and expanded coverage, but identified replacing `TracedTensorParts::metadata_scopes` as a source-breaking change to a public hidden struct.
+- Pre-implementation design review round 3 (`reviewer-gpt`): **Correct-to-implement**. It confirmed correctness, source compatibility, layering, persistent-chain complexity, and the expanded test plan.
+- Post-implementation full-diff review (`reviewer-gpt`): **Correct-to-merge**. It reported no Critical, Important, or Minor findings after reviewing the complete 546-line patch, all new files, source context, and verification evidence.
+
+## Implementation
+
+- Added persistent `MetadataScopeChain::merge` with empty/single-parent fast paths.
+- Added node-identity deduplication during metadata-scope materialization.
+- Added `extension::append_raw_eager_outputs`, which keeps the private chain in `tenferro-runtime`, shares one merged chain across outputs, and leaves `RawAppend` / `TracedTensorParts` source layouts unchanged.
+- Replaced eager-layer manual carrier assembly with the runtime helper after semantic promotion and exactification.
+- Added runtime chain-scaling, scope/node deduplication, multi-output sharing, and RAII lifetime tests.
+- Added mixed-promotion backward/VJP/JVP and concatenate exactification lifetime regressions.
+
+## Verification
+
+Passed:
+
+- `cargo test -p tenferro-runtime metadata_scope -- --nocapture` (4 passed)
+- `cargo test -p tenferro-runtime raw_eager_outputs_share_and_retain_helper_metadata_scopes -- --nocapture` (1 passed)
+- `cargo test -p tenferro-ad temporary_constants_before_mixed_promotion_retain_metadata_for_derivatives -- --nocapture` (1 passed)
+- `cargo test -p tenferro-ad temporary_exactified_concatenate_input_retains_metadata_for_vjp -- --nocapture` (1 passed)
+- `cargo test -p tenferro-runtime` (968 passed)
+- `cargo test -p tenferro-ad` (582 passed)
+- `cargo fmt --all`
+- `git diff --check`
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-ad temporary_constants_before_mixed_promotion_retain_metadata_for_derivatives'`
+- `python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run --llm-skipped-reason 'local deterministic review' --output-json /tmp/tenferro-1700-rules-preview.json` (pass; expected LLM-skipped warning only)
+
+The deterministic rules review was rerun against the committed head and passed with the expected LLM-skipped warning only.
+
+## Coverage impact
+
+Reviewed. The new tests directly exercise every added merge/materialization branch, shared-node and shared-scope deduplication, multi-output chain sharing, helper-scope RAII lifetime, promotion retention through all eager derivative entry paths, and concatenate exactification retention. No code or tests were removed, and no coverage threshold changed.
+
+## Remaining risks
+
+Hosted CI remains responsible for complete workspace, backend, feature, GPU, and coverage matrices. No local correctness or review blocker remains.


### PR DESCRIPTION
> [!IMPORTANT]
> This is an AI-assisted bug fix. The repository-local bug-fix scope gate was applied before implementation.

## Type

- [x] Bug fix
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1700

## Summary

Eager semantic recording inserted ordinary traced `Convert`/`Reshape` helpers for mixed-dtype promotion and concatenate exactification, then discarded the helpers' metadata-scope ownership when constructing the next raw carrier. If the helper inputs were temporaries, deferred AD compilation later failed with `missing input metadata`.

This PR:

- persistently merges the final semantic inputs' private metadata-scope chains;
- constructs raw eager carriers inside `tenferro-runtime`, where the private chain is owned;
- keeps `RawAppend` and `TracedTensorParts` source layouts unchanged;
- deduplicates both scope and chain-node identities during materialization;
- adds temporary-lifetime regressions for backward, VJP, JVP, and concatenate exactification;
- adds scaling, multi-output sharing, and RAII lifetime coverage.

No public tensor API, AD semantics, eager primal behavior, backend contract, dependency, or deferred-analysis timing changes.

Base: `8a8196a95363158f147b1feff2bc3b2d4bc4d267`
Branch: `fix/1700-eager-metadata-retention`

## Scope and neighborhood scan

Classification: **Auto Fix**. This repairs existing intended eager AD graph-lifetime behavior without a new API, operation, backend, dependency, feature, or semantic policy.

The scan covered promotion casts, concatenate exactification reshapes, raw eager carrier assembly, ordinary traced unary scope inheritance, metadata-chain materialization, constraint-chain persistence, multi-output carrier construction, and all eager derivative entry points. The same root cause was fixed once at the shared raw-carrier construction boundary. No separate subsystem finding was deferred.

## Work log

- [`docs/worklogs/2026-08-15-eager-semantic-metadata-scope-retention.md`](docs/worklogs/2026-08-15-eager-semantic-metadata-scope-retention.md)
- Design: [`docs/design/eager-semantic-metadata-scope-retention.md`](docs/design/eager-semantic-metadata-scope-retention.md)

Design review required three rounds; the final pre-implementation `reviewer-gpt` verdict was **Correct-to-implement**. The post-implementation complete-diff `reviewer-gpt` verdict was **Correct-to-merge** with no findings.

## Verification

- `cargo test -p tenferro-runtime metadata_scope -- --nocapture`
- `cargo test -p tenferro-runtime raw_eager_outputs_share_and_retain_helper_metadata_scopes -- --nocapture`
- `cargo test -p tenferro-ad temporary_constants_before_mixed_promotion_retain_metadata_for_derivatives -- --nocapture`
- `cargo test -p tenferro-ad temporary_exactified_concatenate_input_retains_metadata_for_vjp -- --nocapture`
- `cargo test -p tenferro-runtime` — 968 passed
- `cargo test -p tenferro-ad` — 582 passed
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-ad temporary_constants_before_mixed_promotion_retain_metadata_for_derivatives'`
- committed-head deterministic repository-rules review — pass (expected external-LLM-skipped warning only)
- `cargo fmt --all -- --check`
- `git diff --check`

Coverage impact was reviewed: tests exercise every new merge/materialization branch, node/scope deduplication, multi-output sharing, RAII scope lifetime, and promotion/concatenate derivative paths. No threshold changed. Hosted CI owns complete workspace, backend, feature, GPU, and coverage matrices.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules review (deterministic; the external LLM review is permanently disabled) and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. (Not a feature.)
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
