### PR TITLE
feat: support einsum ellipsis notation

### DIFF
--- a/.agents/skills/tenferro-compute/SKILL.md
+++ b/.agents/skills/tenferro-compute/SKILL.md
@@ -40,8 +40,9 @@ not when changing tenferro itself.
 - **Explicit backend.** Direct operations take an explicit backend argument;
   construct the backend/runtime once and reuse it — per-call construction
   discards the buffer pool.
-- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`); `...`
-  ellipsis is unsupported.
+- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`).
+  Flat notation supports one right-aligned, broadcastable `...` ellipsis per
+  term; `EinsumNotation` provides the programmatic form.
 - **Result-returning operators.** Traced operators return `Result`; propagate
   with `?`.
 - CPU/GPU transfers are explicit; unsupported GPU operations do not silently

--- a/.agents/skills/tenferro-compute/references/pitfalls.md
+++ b/.agents/skills/tenferro-compute/references/pitfalls.md
@@ -11,10 +11,11 @@ cheatsheet](api-cheatsheet.md#direct-concrete-tensors).
 
 ## Einsum syntax
 
-Use the explicit arrow in every equation: `"ij,jk->ik"`. The tenferro dialect
-is intentionally smaller than NumPy's: `...` ellipsis is not supported, and
-`"i->ii"` is a tenferro extension rather than a general NumPy spelling. Read
-the `tenferro-einsum` guide before porting a large equation.
+Use the explicit arrow in every equation: `"ij,jk->ik"`. Flat notation
+supports one right-aligned, broadcastable `...` ellipsis per term, and
+`EinsumNotation` is the programmatic form. Parenthesized ellipsis remains
+unsupported; `"i->ii"` is a tenferro extension rather than a general NumPy
+spelling. Read the `tenferro-einsum` guide before porting a large equation.
 
 ## Extension registration
 
@@ -71,8 +72,8 @@ Same traps, keyed by the priors you arrived with.
 
 - Trace one level of `?`: traced operators return `Result`; `a.matmul(&b)` is
   a `Result`, unlike `torch.matmul` / `jnp.matmul`.
-- Einsum needs the explicit arrow and rejects `...` (see
-  [Einsum syntax](#einsum-syntax)).
+- Einsum needs the explicit arrow; flat `...` ellipsis is supported, while
+  parenthesized ellipsis is deferred (see [Einsum syntax](#einsum-syntax)).
 - The backend is not ambient: eager code must own an `EagerRuntime`, traced
   code must register an engine plus extension modules (see
   [Extension registration](#extension-registration)).

--- a/.claude/skills/tenferro-compute/SKILL.md
+++ b/.claude/skills/tenferro-compute/SKILL.md
@@ -40,8 +40,9 @@ not when changing tenferro itself.
 - **Explicit backend.** Direct operations take an explicit backend argument;
   construct the backend/runtime once and reuse it — per-call construction
   discards the buffer pool.
-- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`); `...`
-  ellipsis is unsupported.
+- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`).
+  Flat notation supports one right-aligned, broadcastable `...` ellipsis per
+  term; `EinsumNotation` provides the programmatic form.
 - **Result-returning operators.** Traced operators return `Result`; propagate
   with `?`.
 - CPU/GPU transfers are explicit; unsupported GPU operations do not silently

--- a/.claude/skills/tenferro-compute/references/pitfalls.md
+++ b/.claude/skills/tenferro-compute/references/pitfalls.md
@@ -11,10 +11,11 @@ cheatsheet](api-cheatsheet.md#direct-concrete-tensors).
 
 ## Einsum syntax
 
-Use the explicit arrow in every equation: `"ij,jk->ik"`. The tenferro dialect
-is intentionally smaller than NumPy's: `...` ellipsis is not supported, and
-`"i->ii"` is a tenferro extension rather than a general NumPy spelling. Read
-the `tenferro-einsum` guide before porting a large equation.
+Use the explicit arrow in every equation: `"ij,jk->ik"`. Flat notation
+supports one right-aligned, broadcastable `...` ellipsis per term, and
+`EinsumNotation` is the programmatic form. Parenthesized ellipsis remains
+unsupported; `"i->ii"` is a tenferro extension rather than a general NumPy
+spelling. Read the `tenferro-einsum` guide before porting a large equation.
 
 ## Extension registration
 
@@ -71,8 +72,8 @@ Same traps, keyed by the priors you arrived with.
 
 - Trace one level of `?`: traced operators return `Result`; `a.matmul(&b)` is
   a `Result`, unlike `torch.matmul` / `jnp.matmul`.
-- Einsum needs the explicit arrow and rejects `...` (see
-  [Einsum syntax](#einsum-syntax)).
+- Einsum needs the explicit arrow; flat `...` ellipsis is supported, while
+  parenthesized ellipsis is deferred (see [Einsum syntax](#einsum-syntax)).
 - The backend is not ambient: eager code must own an `EagerRuntime`, traced
   code must register an engine plus extension modules (see
   [Extension registration](#extension-registration)).

--- a/.kimi/skills/tenferro-compute/SKILL.md
+++ b/.kimi/skills/tenferro-compute/SKILL.md
@@ -40,8 +40,9 @@ not when changing tenferro itself.
 - **Explicit backend.** Direct operations take an explicit backend argument;
   construct the backend/runtime once and reuse it — per-call construction
   discards the buffer pool.
-- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`); `...`
-  ellipsis is unsupported.
+- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`).
+  Flat notation supports one right-aligned, broadcastable `...` ellipsis per
+  term; `EinsumNotation` provides the programmatic form.
 - **Result-returning operators.** Traced operators return `Result`; propagate
   with `?`.
 - CPU/GPU transfers are explicit; unsupported GPU operations do not silently

--- a/.kimi/skills/tenferro-compute/references/pitfalls.md
+++ b/.kimi/skills/tenferro-compute/references/pitfalls.md
@@ -11,10 +11,11 @@ cheatsheet](api-cheatsheet.md#direct-concrete-tensors).
 
 ## Einsum syntax
 
-Use the explicit arrow in every equation: `"ij,jk->ik"`. The tenferro dialect
-is intentionally smaller than NumPy's: `...` ellipsis is not supported, and
-`"i->ii"` is a tenferro extension rather than a general NumPy spelling. Read
-the `tenferro-einsum` guide before porting a large equation.
+Use the explicit arrow in every equation: `"ij,jk->ik"`. Flat notation
+supports one right-aligned, broadcastable `...` ellipsis per term, and
+`EinsumNotation` is the programmatic form. Parenthesized ellipsis remains
+unsupported; `"i->ii"` is a tenferro extension rather than a general NumPy
+spelling. Read the `tenferro-einsum` guide before porting a large equation.
 
 ## Extension registration
 
@@ -71,8 +72,8 @@ Same traps, keyed by the priors you arrived with.
 
 - Trace one level of `?`: traced operators return `Result`; `a.matmul(&b)` is
   a `Result`, unlike `torch.matmul` / `jnp.matmul`.
-- Einsum needs the explicit arrow and rejects `...` (see
-  [Einsum syntax](#einsum-syntax)).
+- Einsum needs the explicit arrow; flat `...` ellipsis is supported, while
+  parenthesized ellipsis is deferred (see [Einsum syntax](#einsum-syntax)).
 - The backend is not ambient: eager code must own an `EagerRuntime`, traced
   code must register an engine plus extension modules (see
   [Extension registration](#extension-registration)).

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ targets.
 - **Explicit backend.** Direct operations take an explicit backend argument;
   construct the backend/runtime once and reuse it — per-call construction
   discards the buffer pool.
-- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`); `...`
-  ellipsis is unsupported.
+- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`).
+  NumPy-style `...` ellipsis is supported in flat notation and through
+  `EinsumNotation`; parenthesized ellipsis remains unsupported.
 - **Result-returning operators.** Traced operators return `Result`; propagate
   with `?`.
 

--- a/crates/tenferro-einsum/src/builder.rs
+++ b/crates/tenferro-einsum/src/builder.rs
@@ -546,6 +546,38 @@ fn dim_expr_uses_input(dim: &DimExpr, input_idx: usize) -> bool {
     }
 }
 
+fn broadcast_initial_value(
+    builder: &mut GraphBuilder<StdTensorOp>,
+    tree: &ContractionTree,
+    value: ValueRef<StdTensorOp>,
+    labels: &[u32],
+    shape: &[DimExpr],
+) -> ValueRef<StdTensorOp> {
+    let target_shape: Vec<DimExpr> = labels
+        .iter()
+        .enumerate()
+        .map(|(axis, label)| {
+            let target = tree.label_size(*label).unwrap_or(0);
+            match shape[axis] {
+                DimExpr::Const(1) if target != 1 => DimExpr::Const(target),
+                _ => shape[axis].clone(),
+            }
+        })
+        .collect();
+    if target_shape == shape {
+        return value;
+    }
+    let outputs = builder.add_operation(
+        StdTensorOp::BroadcastInDim {
+            shape: target_shape,
+            dims: (0..labels.len()).collect(),
+        },
+        vec![value],
+        OperationRole::Primary,
+    );
+    ValueRef::Local(outputs[0])
+}
+
 /// Lower a planned einsum contraction tree into a compute graph graph.
 ///
 /// # Errors
@@ -609,6 +641,16 @@ pub(crate) fn build_einsum_graph_dim_expr(
         })
         .collect::<Result<_>>()?;
 
+    for (index, lv) in labeled.iter_mut().enumerate() {
+        lv.val = broadcast_initial_value(
+            builder,
+            tree,
+            lv.val.clone(),
+            &lv.labels,
+            &input_shapes[index],
+        );
+    }
+
     // Diagonalize repeated indices in each input
     for lv in &mut labeled {
         *lv = diagonalize_repeated(builder, lv);
@@ -629,7 +671,7 @@ pub(crate) fn build_einsum_graph_dim_expr(
         // Embed diagonal axes if output needs higher multiplicity
         let result = embed_repeated(builder, &result, output_labels)?;
 
-        // Reorder if needed
+        // Reorder if needed.
         if result.labels == *output_labels {
             return Ok(localize_value_ref(builder, result.val, &result.shape));
         }
@@ -686,7 +728,7 @@ pub(crate) fn build_einsum_graph_dim_expr(
         .collect();
     let result = reduce_val(builder, result, &extra_labels);
 
-    // Final reorder if needed
+    // Final reorder if needed.
     if result.labels == *output_labels {
         return Ok(localize_value_ref(builder, result.val, &result.shape));
     }

--- a/crates/tenferro-einsum/src/cache.rs
+++ b/crates/tenferro-einsum/src/cache.rs
@@ -1,6 +1,6 @@
 use std::mem::size_of;
 
-use crate::EinsumSubscripts;
+use crate::{EinsumAxis, EinsumNotation, EinsumSubscripts};
 
 /// Stable family identifier for the standard tenferro einsum extension.
 pub const EINSUM_EXTENSION_FAMILY_ID: &str = "tenferro.einsum.v1";
@@ -15,8 +15,8 @@ pub(crate) const EINSUM_EAGER_EXPANDED_PROGRAMS_CACHE: &str = "eager_expanded_pr
 
 /// Parsed einsum notation retained by parse caches.
 pub(crate) struct ParsedEinsum {
-    /// Canonical parsed subscripts.
-    pub(crate) subscripts: EinsumSubscripts,
+    /// Parsed rank-unresolved notation.
+    pub(crate) notation: EinsumNotation,
 }
 
 /// Return the retained-byte estimate for canonical subscripts.
@@ -25,6 +25,15 @@ pub(crate) fn einsum_subscripts_retained_bytes(subscripts: &EinsumSubscripts) ->
     saturating_sum([
         vec_of_vec_retained_bytes(&subscripts.inputs),
         vec_retained_bytes(&subscripts.output),
+    ])
+}
+
+pub(crate) fn einsum_notation_retained_bytes(notation: &EinsumNotation) -> usize {
+    saturating_sum([
+        vec_of_vec_retained_bytes(&notation.inputs),
+        vec_retained_bytes(&notation.output),
+        (notation.inputs.iter().map(Vec::capacity).sum::<usize>() + notation.output.capacity())
+            .saturating_mul(std::mem::size_of::<EinsumAxis>()),
     ])
 }
 

--- a/crates/tenferro-einsum/src/concrete.rs
+++ b/crates/tenferro-einsum/src/concrete.rs
@@ -10,18 +10,19 @@ use crate::eager::{
     eager_einsum_exec_read_into_accum, eager_einsum_read_subscripts_on_session,
     eager_einsum_subscripts_on_session, plan_subscripts,
 };
+use crate::ellipsis::resolve_einsum_notation;
 use crate::TensorDotAxes;
-use crate::{ContractionTree, EinsumSubscripts, Error, Result, Subscripts};
+use crate::{
+    parse_einsum_notation, ContractionTree, EinsumNotation, EinsumSubscripts, Error, Result,
+    Subscripts,
+};
 
-const TENSOR_EINSUM_OP: &str = "TensorEinsumExt::einsum";
 const TENSOR_EINSUM_INTO_OP: &str = "TensorEinsumIntoExt::einsum_into";
-const TENSOR_READ_EINSUM_OP: &str = "TensorReadEinsumExt::einsum_read";
 const TENSOR_READ_EINSUM_INTO_OP: &str = "TensorReadEinsumIntoExt::einsum_read_into";
 const TYPED_TENSOR_EINSUM_OP: &str = "TypedTensorEinsumExt::einsum";
 const TYPED_TENSOR_EINSUM_INTO_OP: &str = "TypedTensorEinsumIntoExt::einsum_into";
 const TYPED_TENSOR_READ_EINSUM_OP: &str = "TypedTensorReadEinsumExt::einsum_read";
 const TYPED_TENSOR_READ_EINSUM_INTO_OP: &str = "TypedTensorReadEinsumIntoExt::einsum_read_into";
-const PLAN_PREPARE_OP: &str = "ConcreteEinsumPlan::prepare";
 const PLAN_EXECUTE_OP: &str = "ConcreteEinsumPlan::execute";
 const TYPED_TENSOR_TENSORDOT_OP: &str = "TypedTensorTensordotExt::tensordot";
 
@@ -125,6 +126,25 @@ pub trait TensorEinsumExt {
     /// contraction, or [`Error::Tensor`] for a typed backend failure.
     fn einsum(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<Tensor>;
 
+    /// Execute an einsum from rank-unresolved string/programmatic notation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    /// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    /// assert_eq!(notation.input_count(), 1);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation or backend error when notation, shapes, or execution are invalid.
+    fn einsum_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+    ) -> Result<Tensor>;
+
     /// Execute an einsum from parsed integer-label subscripts.
     ///
     /// # Errors
@@ -140,7 +160,16 @@ pub trait TensorEinsumExt {
 
 impl TensorEinsumExt for [&Tensor] {
     fn einsum(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<Tensor> {
-        let subscripts = parse_subscripts(subscripts, TENSOR_EINSUM_OP)?;
+        let notation = parse_einsum_notation(subscripts)?;
+        self.einsum_notation(&notation, session)
+    }
+
+    fn einsum_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+    ) -> Result<Tensor> {
+        let subscripts = resolve_tensor_notation(self, notation)?;
         eager_einsum_subscripts_on_session(session, self, &subscripts).map_err(Error::from)
     }
 
@@ -157,6 +186,14 @@ impl TensorEinsumExt for [&Tensor] {
 impl<const N: usize> TensorEinsumExt for [&Tensor; N] {
     fn einsum(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<Tensor> {
         self.as_slice().einsum(subscripts, session)
+    }
+
+    fn einsum_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+    ) -> Result<Tensor> {
+        self.as_slice().einsum_notation(notation, session)
     }
 
     fn einsum_subscripts(
@@ -184,6 +221,26 @@ pub trait TensorEinsumIntoExt {
         out: TensorWrite<'_>,
     ) -> Result<()>;
 
+    /// Execute an einsum from rank-unresolved notation into caller-provided output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    /// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    /// assert_eq!(notation.input_count(), 1);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation or backend error when notation, shapes, or output are invalid.
+    fn einsum_into_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+        out: TensorWrite<'_>,
+    ) -> Result<()>;
+
     /// Execute an einsum from parsed integer-label subscripts into caller-provided output.
     ///
     /// # Errors
@@ -206,7 +263,17 @@ impl TensorEinsumIntoExt for [&Tensor] {
         session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()> {
-        let subscripts = parse_subscripts(subscripts, TENSOR_EINSUM_INTO_OP)?;
+        let notation = parse_einsum_notation(subscripts)?;
+        self.einsum_into_notation(&notation, session, out)
+    }
+
+    fn einsum_into_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+        out: TensorWrite<'_>,
+    ) -> Result<()> {
+        let subscripts = resolve_tensor_notation(self, notation)?;
         tensor_einsum_into_subscripts(session, self, &subscripts, out, TENSOR_EINSUM_INTO_OP)
     }
 
@@ -229,6 +296,15 @@ impl<const N: usize> TensorEinsumIntoExt for [&Tensor; N] {
         out: TensorWrite<'_>,
     ) -> Result<()> {
         self.as_slice().einsum_into(subscripts, session, out)
+    }
+
+    fn einsum_into_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+        out: TensorWrite<'_>,
+    ) -> Result<()> {
+        self.as_slice().einsum_into_notation(notation, session, out)
     }
 
     fn einsum_into_subscripts(
@@ -274,6 +350,25 @@ pub trait TypedTensorEinsumExt<T: TensorScalar> {
     /// contraction, or [`Error::Tensor`] for a typed backend failure.
     fn einsum(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<TypedTensor<T>>;
 
+    /// Execute an einsum from rank-unresolved notation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    /// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    /// assert_eq!(notation.input_count(), 1);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation or backend error when notation, shapes, or execution are invalid.
+    fn einsum_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>>;
+
     /// Execute an einsum from parsed integer-label subscripts.
     ///
     /// # Errors
@@ -289,7 +384,16 @@ pub trait TypedTensorEinsumExt<T: TensorScalar> {
 
 impl<T: TensorScalar> TypedTensorEinsumExt<T> for [&TypedTensor<T>] {
     fn einsum(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
-        let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_EINSUM_OP)?;
+        let notation = parse_einsum_notation(subscripts)?;
+        self.einsum_notation(&notation, session)
+    }
+
+    fn einsum_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let subscripts = resolve_typed_notation(self, notation)?;
         typed_einsum_subscripts(session, self, &subscripts, TYPED_TENSOR_EINSUM_OP)
     }
 
@@ -306,6 +410,14 @@ impl<T: TensorScalar> TypedTensorEinsumExt<T> for [&TypedTensor<T>] {
 impl<T: TensorScalar, const N: usize> TypedTensorEinsumExt<T> for [&TypedTensor<T>; N] {
     fn einsum(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<TypedTensor<T>> {
         self.as_slice().einsum(subscripts, session)
+    }
+
+    fn einsum_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        self.as_slice().einsum_notation(notation, session)
     }
 
     fn einsum_subscripts(
@@ -369,6 +481,25 @@ pub trait TypedTensorReadEinsumExt<T: TensorScalar> {
         session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>>;
 
+    /// Execute an einsum from rank-unresolved notation over typed views.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    /// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    /// assert_eq!(notation.input_count(), 1);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation or backend error when notation, views, or execution are invalid.
+    fn einsum_read_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>>;
+
     /// Execute an einsum from parsed integer-label subscripts over typed
     /// borrowed views.
     ///
@@ -406,7 +537,16 @@ impl<'a, T: TensorScalar> TypedTensorReadEinsumExt<T> for [TypedTensorView<'a, T
         subscripts: &str,
         session: &mut dyn BackendSession,
     ) -> Result<TypedTensor<T>> {
-        let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_READ_EINSUM_OP)?;
+        let notation = parse_einsum_notation(subscripts)?;
+        self.einsum_read_notation(&notation, session)
+    }
+
+    fn einsum_read_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        let subscripts = resolve_view_notation(self, notation)?;
         typed_view_einsum_subscripts(session, self, &subscripts, TYPED_TENSOR_READ_EINSUM_OP)
     }
 
@@ -431,6 +571,14 @@ impl<'a, T: TensorScalar, const N: usize> TypedTensorReadEinsumExt<T>
         self.as_slice().einsum_read(subscripts, session)
     }
 
+    fn einsum_read_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+    ) -> Result<TypedTensor<T>> {
+        self.as_slice().einsum_read_notation(notation, session)
+    }
+
     fn einsum_read_subscripts(
         &self,
         subscripts: &EinsumSubscripts,
@@ -452,6 +600,28 @@ pub trait TypedTensorEinsumIntoExt<T: TensorScalar> {
     fn einsum_into<'out, O>(
         &self,
         subscripts: &str,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
+    where
+        O: Into<TypedTensorWrite<'out, T>>;
+
+    /// Execute an einsum from rank-unresolved notation into typed output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    /// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    /// assert_eq!(notation.input_count(), 1);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation or backend error when notation, shapes, or output are invalid.
+    fn einsum_into_notation<'out, O>(
+        &self,
+        notation: &EinsumNotation,
         session: &mut dyn BackendSession,
         out: O,
     ) -> Result<()>
@@ -485,7 +655,20 @@ impl<T: TensorScalar> TypedTensorEinsumIntoExt<T> for [&TypedTensor<T>] {
     where
         O: Into<TypedTensorWrite<'out, T>>,
     {
-        let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_EINSUM_INTO_OP)?;
+        let notation = parse_einsum_notation(subscripts)?;
+        self.einsum_into_notation(&notation, session, out)
+    }
+
+    fn einsum_into_notation<'out, O>(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
+    where
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
+        let subscripts = resolve_typed_notation(self, notation)?;
         typed_einsum_into_subscripts(
             session,
             self,
@@ -526,6 +709,18 @@ impl<T: TensorScalar, const N: usize> TypedTensorEinsumIntoExt<T> for [&TypedTen
         O: Into<TypedTensorWrite<'out, T>>,
     {
         self.as_slice().einsum_into(subscripts, session, out)
+    }
+
+    fn einsum_into_notation<'out, O>(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
+    where
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
+        self.as_slice().einsum_into_notation(notation, session, out)
     }
 
     fn einsum_into_subscripts<'out, O>(
@@ -596,6 +791,28 @@ pub trait TypedTensorReadEinsumIntoExt<T: TensorScalar> {
     where
         O: Into<TypedTensorWrite<'out, T>>;
 
+    /// Execute an einsum from rank-unresolved notation over typed views into output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    /// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    /// assert_eq!(notation.input_count(), 1);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation or backend error when notation, views, or output are invalid.
+    fn einsum_read_into_notation<'out, O>(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
+    where
+        O: Into<TypedTensorWrite<'out, T>>;
+
     /// Execute an einsum from parsed integer-label subscripts over typed
     /// borrowed views into a caller-provided typed output.
     ///
@@ -642,7 +859,20 @@ impl<'a, T: TensorScalar> TypedTensorReadEinsumIntoExt<T> for [TypedTensorView<'
     where
         O: Into<TypedTensorWrite<'out, T>>,
     {
-        let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_READ_EINSUM_INTO_OP)?;
+        let notation = parse_einsum_notation(subscripts)?;
+        self.einsum_read_into_notation(&notation, session, out)
+    }
+
+    fn einsum_read_into_notation<'out, O>(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
+    where
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
+        let subscripts = resolve_view_notation(self, notation)?;
         typed_view_einsum_into_subscripts(
             session,
             self,
@@ -685,6 +915,19 @@ impl<'a, T: TensorScalar, const N: usize> TypedTensorReadEinsumIntoExt<T>
         O: Into<TypedTensorWrite<'out, T>>,
     {
         self.as_slice().einsum_read_into(subscripts, session, out)
+    }
+
+    fn einsum_read_into_notation<'out, O>(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+        out: O,
+    ) -> Result<()>
+    where
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
+        self.as_slice()
+            .einsum_read_into_notation(notation, session, out)
     }
 
     fn einsum_read_into_subscripts<'out, O>(
@@ -737,6 +980,25 @@ pub trait TensorReadEinsumExt {
     /// contraction, or [`Error::Tensor`] for a typed backend failure.
     fn einsum_read(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<Tensor>;
 
+    /// Execute an einsum from rank-unresolved notation over read-only inputs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    /// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    /// assert_eq!(notation.input_count(), 1);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation or backend error when notation, shapes, or execution are invalid.
+    fn einsum_read_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+    ) -> Result<Tensor>;
+
     /// Execute an einsum from parsed integer-label subscripts over read-only
     /// tensor inputs.
     ///
@@ -753,7 +1015,16 @@ pub trait TensorReadEinsumExt {
 
 impl<'a> TensorReadEinsumExt for [TensorRead<'a>] {
     fn einsum_read(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<Tensor> {
-        let subscripts = parse_subscripts(subscripts, TENSOR_READ_EINSUM_OP)?;
+        let notation = parse_einsum_notation(subscripts)?;
+        self.einsum_read_notation(&notation, session)
+    }
+
+    fn einsum_read_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+    ) -> Result<Tensor> {
+        let subscripts = resolve_read_notation(self, notation)?;
         eager_einsum_read_subscripts_on_session(session, self, &subscripts).map_err(Error::from)
     }
 
@@ -770,6 +1041,14 @@ impl<'a> TensorReadEinsumExt for [TensorRead<'a>] {
 impl<'a, const N: usize> TensorReadEinsumExt for [TensorRead<'a>; N] {
     fn einsum_read(&self, subscripts: &str, session: &mut dyn BackendSession) -> Result<Tensor> {
         self.as_slice().einsum_read(subscripts, session)
+    }
+
+    fn einsum_read_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+    ) -> Result<Tensor> {
+        self.as_slice().einsum_read_notation(notation, session)
     }
 
     fn einsum_read_subscripts(
@@ -797,6 +1076,26 @@ pub trait TensorReadEinsumIntoExt {
         out: TensorWrite<'_>,
     ) -> Result<()>;
 
+    /// Execute an einsum from rank-unresolved notation over read-only inputs into output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    /// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    /// assert_eq!(notation.input_count(), 1);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation or backend error when notation, shapes, or output are invalid.
+    fn einsum_read_into_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+        out: TensorWrite<'_>,
+    ) -> Result<()>;
+
     /// Execute an einsum from parsed integer-label subscripts over read-only inputs into output.
     ///
     /// # Errors
@@ -819,7 +1118,17 @@ impl<'a> TensorReadEinsumIntoExt for [TensorRead<'a>] {
         session: &mut dyn BackendSession,
         out: TensorWrite<'_>,
     ) -> Result<()> {
-        let subscripts = parse_subscripts(subscripts, TENSOR_READ_EINSUM_INTO_OP)?;
+        let notation = parse_einsum_notation(subscripts)?;
+        self.einsum_read_into_notation(&notation, session, out)
+    }
+
+    fn einsum_read_into_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+        out: TensorWrite<'_>,
+    ) -> Result<()> {
+        let subscripts = resolve_read_notation(self, notation)?;
         tensor_read_einsum_into_subscripts(
             session,
             self,
@@ -854,6 +1163,16 @@ impl<'a, const N: usize> TensorReadEinsumIntoExt for [TensorRead<'a>; N] {
         out: TensorWrite<'_>,
     ) -> Result<()> {
         self.as_slice().einsum_read_into(subscripts, session, out)
+    }
+
+    fn einsum_read_into_notation(
+        &self,
+        notation: &EinsumNotation,
+        session: &mut dyn BackendSession,
+        out: TensorWrite<'_>,
+    ) -> Result<()> {
+        self.as_slice()
+            .einsum_read_into_notation(notation, session, out)
     }
 
     fn einsum_read_into_subscripts(
@@ -910,8 +1229,8 @@ impl ConcreteEinsumPlan {
     where
         I: AsRef<[&'a Tensor]>,
     {
-        let subscripts = parse_subscripts(subscripts, PLAN_PREPARE_OP)?;
-        Self::prepare_subscripts_internal(input_specs(inputs.as_ref()), &subscripts)
+        let notation = parse_einsum_notation(subscripts)?;
+        Self::prepare_notation(inputs, &notation)
     }
 
     /// Prepare a plan from dtype-erased concrete tensor inputs and parsed
@@ -930,6 +1249,22 @@ impl ConcreteEinsumPlan {
         Self::prepare_subscripts_internal(input_specs(inputs.as_ref()), &subscripts)
     }
 
+    /// Prepare a plan from rank-unresolved notation and concrete tensor inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed axis tokens,
+    /// [`Error::Validation`] for rank, shape, or dtype violations, or
+    /// [`Error::Planning`] when no contraction tree can be built.
+    pub fn prepare_notation<'a, I>(inputs: I, notation: &EinsumNotation) -> Result<Self>
+    where
+        I: AsRef<[&'a Tensor]>,
+    {
+        let inputs = inputs.as_ref();
+        let subscripts = resolve_tensor_notation(inputs, notation)?;
+        Self::prepare_subscripts_internal(input_specs(inputs), &subscripts)
+    }
+
     /// Prepare a plan from typed concrete tensor inputs and string notation.
     ///
     /// # Errors
@@ -942,8 +1277,8 @@ impl ConcreteEinsumPlan {
         T: TensorScalar,
         I: AsRef<[&'a TypedTensor<T>]>,
     {
-        let subscripts = parse_subscripts(subscripts, PLAN_PREPARE_OP)?;
-        Self::prepare_subscripts_internal(typed_input_specs(inputs.as_ref()), &subscripts)
+        let notation = parse_einsum_notation(subscripts)?;
+        Self::prepare_typed_notation(inputs, &notation)
     }
 
     /// Prepare a plan from typed concrete tensor inputs and parsed integer-label
@@ -965,6 +1300,23 @@ impl ConcreteEinsumPlan {
         Self::prepare_subscripts_internal(typed_input_specs(inputs.as_ref()), &subscripts)
     }
 
+    /// Prepare a plan from rank-unresolved notation and typed concrete inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed axis tokens,
+    /// [`Error::Validation`] for rank or shape violations, or [`Error::Planning`]
+    /// when no contraction tree can be built.
+    pub fn prepare_typed_notation<'a, T, I>(inputs: I, notation: &EinsumNotation) -> Result<Self>
+    where
+        T: TensorScalar,
+        I: AsRef<[&'a TypedTensor<T>]>,
+    {
+        let inputs = inputs.as_ref();
+        let subscripts = resolve_typed_notation(inputs, notation)?;
+        Self::prepare_subscripts_internal(typed_input_specs(inputs), &subscripts)
+    }
+
     /// Prepare a plan from read-only tensor inputs and string notation.
     ///
     /// # Errors
@@ -976,8 +1328,8 @@ impl ConcreteEinsumPlan {
     where
         I: AsRef<[TensorRead<'a>]>,
     {
-        let subscripts = parse_subscripts(subscripts, PLAN_PREPARE_OP)?;
-        Self::prepare_subscripts_internal(read_input_specs(inputs.as_ref()), &subscripts)
+        let notation = parse_einsum_notation(subscripts)?;
+        Self::prepare_read_notation(inputs, &notation)
     }
 
     /// Prepare a plan from read-only tensor inputs and parsed integer-label
@@ -994,6 +1346,22 @@ impl ConcreteEinsumPlan {
     {
         let subscripts = Subscripts::from(subscripts);
         Self::prepare_subscripts_internal(read_input_specs(inputs.as_ref()), &subscripts)
+    }
+
+    /// Prepare a plan from rank-unresolved notation and read-only inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed axis tokens,
+    /// [`Error::Validation`] for rank, shape, or dtype violations, or
+    /// [`Error::Planning`] when no contraction tree can be built.
+    pub fn prepare_read_notation<'a, I>(inputs: I, notation: &EinsumNotation) -> Result<Self>
+    where
+        I: AsRef<[TensorRead<'a>]>,
+    {
+        let inputs = inputs.as_ref();
+        let subscripts = resolve_read_notation(inputs, notation)?;
+        Self::prepare_subscripts_internal(read_input_specs(inputs), &subscripts)
     }
 
     /// Number of binary contraction steps in the prepared tree (diagnostics).
@@ -1395,8 +1763,39 @@ struct ConcreteEinsumInputSpec {
     shape: Vec<usize>,
 }
 
-fn parse_subscripts(subscripts: &str, _op: &'static str) -> Result<Subscripts> {
-    Subscripts::parse(subscripts)
+fn resolve_shapes(notation: &EinsumNotation, shapes: Vec<&[usize]>) -> Result<Subscripts> {
+    resolve_einsum_notation(notation, &shapes)
+}
+
+fn resolve_tensor_notation(inputs: &[&Tensor], notation: &EinsumNotation) -> Result<Subscripts> {
+    resolve_shapes(
+        notation,
+        inputs.iter().map(|tensor| tensor.shape()).collect(),
+    )
+}
+
+fn resolve_typed_notation<T: TensorScalar>(
+    inputs: &[&TypedTensor<T>],
+    notation: &EinsumNotation,
+) -> Result<Subscripts> {
+    resolve_shapes(
+        notation,
+        inputs.iter().map(|tensor| tensor.shape()).collect(),
+    )
+}
+
+fn resolve_view_notation<'a, T: TensorScalar>(
+    inputs: &[TypedTensorView<'a, T>],
+    notation: &EinsumNotation,
+) -> Result<Subscripts> {
+    resolve_shapes(notation, inputs.iter().map(|view| view.shape()).collect())
+}
+
+fn resolve_read_notation<'a>(
+    inputs: &[TensorRead<'a>],
+    notation: &EinsumNotation,
+) -> Result<Subscripts> {
+    resolve_shapes(notation, inputs.iter().map(|input| input.shape()).collect())
 }
 
 fn input_specs(inputs: &[&Tensor]) -> Vec<ConcreteEinsumInputSpec> {
@@ -1542,26 +1941,18 @@ fn output_spec(
         }
     }
 
-    let mut output_shape = Vec::with_capacity(tree.subscripts.output.len());
-    for &label in &tree.subscripts.output {
-        let mut found = None;
-        for (input, labels) in inputs.iter().zip(tree.subscripts.inputs.iter()) {
-            if labels.len() != input.shape.len() {
-                return Err(Error::rank_mismatch(op, labels.len(), input.shape.len()));
-            }
-            if let Some(axis) = labels.iter().position(|candidate| *candidate == label) {
-                found = Some(input.shape[axis]);
-                break;
-            }
+    for (input, labels) in inputs.iter().zip(tree.subscripts.inputs.iter()) {
+        if labels.len() != input.shape.len() {
+            return Err(Error::rank_mismatch(op, labels.len(), input.shape.len()));
         }
-        let Some(extent) = found else {
-            return Err(Error::invalid_argument(
-                op,
-                "output labels",
-                format!("output label {label} is missing from inputs"),
-            ));
-        };
-        output_shape.push(extent);
+    }
+    let output_shape = tree.output_shape();
+    if output_shape.len() != tree.subscripts.output.len() {
+        return Err(Error::invalid_argument(
+            op,
+            "output labels",
+            "an output label is missing from all inputs",
+        ));
     }
     Ok(ConcreteEinsumInputSpec {
         dtype,

--- a/crates/tenferro-einsum/src/concrete_tests.rs
+++ b/crates/tenferro-einsum/src/concrete_tests.rs
@@ -7,10 +7,10 @@ use tenferro_tensor::{
 };
 
 use crate::{
-    parse_einsum_subscripts, ConcreteEinsumPlan, Error, TensorEinsumExt, TensorEinsumIntoExt,
-    TensorReadEinsumExt, TensorReadEinsumIntoExt, TensorTensordotExt, TypedTensorEinsumExt,
-    TypedTensorEinsumIntoExt, TypedTensorReadEinsumExt, TypedTensorReadEinsumIntoExt,
-    TypedTensorTensordotExt,
+    parse_einsum_subscripts, ConcreteEinsumPlan, EinsumAxis, EinsumNotation, Error,
+    TensorEinsumExt, TensorEinsumIntoExt, TensorReadEinsumExt, TensorReadEinsumIntoExt,
+    TensorTensordotExt, TypedTensorEinsumExt, TypedTensorEinsumIntoExt, TypedTensorReadEinsumExt,
+    TypedTensorReadEinsumIntoExt, TypedTensorTensordotExt,
 };
 
 fn assert_f64_tensor(tensor: &Tensor, shape: &[usize], expected: &[f64]) {
@@ -31,6 +31,164 @@ fn public_tensor_einsum_ext_executes_dtype_erased_inputs() {
         .unwrap();
 
     assert_f64_tensor(&result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn concrete_einsum_ellipsis_supports_diagonal_and_zero_rank_cases() {
+    let mut backend = CpuBackend::new();
+    let input =
+        Tensor::from_vec_col_major(vec![2, 3, 3], (0..18).map(f64::from).collect::<Vec<_>>())
+            .unwrap();
+    let vector = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+
+    let (diagonal, zero_rank) = backend
+        .with_backend_session(|session| {
+            let diagonal = [&input].einsum("...ii->...i", session)?;
+            let zero_rank = [&vector].einsum("...i->...i", session)?;
+            Ok::<_, crate::Error>((diagonal, zero_rank))
+        })
+        .unwrap();
+
+    assert_f64_tensor(&diagonal, &[2, 3], &[0.0, 1.0, 8.0, 9.0, 16.0, 17.0]);
+    assert_f64_tensor(&zero_rank, &[3], &[1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn concrete_einsum_ellipsis_supports_broadcast_and_programmatic_notation() {
+    let mut backend = CpuBackend::new();
+    let lhs = Tensor::from_vec_col_major(vec![2, 2, 3], vec![1.0_f64; 12]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1, 3, 2], vec![1.0_f64; 6]).unwrap();
+    let notation = crate::EinsumNotation::new(
+        &[
+            &[
+                crate::EinsumAxis::Ellipsis,
+                crate::EinsumAxis::Label(0),
+                crate::EinsumAxis::Label(1),
+            ],
+            &[
+                crate::EinsumAxis::Ellipsis,
+                crate::EinsumAxis::Label(1),
+                crate::EinsumAxis::Label(2),
+            ],
+        ],
+        &[
+            crate::EinsumAxis::Ellipsis,
+            crate::EinsumAxis::Label(0),
+            crate::EinsumAxis::Label(2),
+        ],
+    );
+
+    let (string_result, programmatic_result) = backend
+        .with_backend_session(|session| {
+            let string_result = [&lhs, &rhs].einsum("...ij,...jk->...ik", session)?;
+            let programmatic_result = [&lhs, &rhs].einsum_notation(&notation, session)?;
+            Ok::<_, crate::Error>((string_result, programmatic_result))
+        })
+        .unwrap();
+
+    assert_f64_tensor(&string_result, &[2, 2, 2], &[3.0; 8]);
+    assert_f64_tensor(&programmatic_result, &[2, 2, 2], &[3.0; 8]);
+}
+
+#[test]
+fn concrete_programmatic_notation_covers_read_into_and_prepared_surfaces() {
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let notation = EinsumNotation::new(
+        &[
+            &[
+                EinsumAxis::Ellipsis,
+                EinsumAxis::Label(0),
+                EinsumAxis::Label(1),
+            ],
+            &[
+                EinsumAxis::Ellipsis,
+                EinsumAxis::Label(1),
+                EinsumAxis::Label(2),
+            ],
+        ],
+        &[
+            EinsumAxis::Ellipsis,
+            EinsumAxis::Label(0),
+            EinsumAxis::Label(2),
+        ],
+    );
+    let mut backend = CpuBackend::new();
+
+    let mut erased_out = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4]).unwrap();
+    backend
+        .with_backend_session(|session| {
+            [&lhs, &rhs].einsum_into_notation(
+                &notation,
+                session,
+                TensorWrite::from_tensor(&mut erased_out),
+            )
+        })
+        .unwrap();
+    assert_f64_tensor(&erased_out, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+
+    let typed_lhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let typed_rhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let typed = backend
+        .with_backend_session(|session| {
+            [&typed_lhs, &typed_rhs].einsum_notation(&notation, session)
+        })
+        .unwrap();
+    assert_eq!(typed.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+
+    let typed_views = [typed_lhs.as_view(), typed_rhs.as_view()];
+    let typed_read = backend
+        .with_backend_session(|session| typed_views.einsum_read_notation(&notation, session))
+        .unwrap();
+    assert_eq!(typed_read.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+
+    let mut typed_out = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![0.0; 4]).unwrap();
+    backend
+        .with_backend_session(|session| {
+            [&typed_lhs, &typed_rhs].einsum_into_notation(&notation, session, &mut typed_out)
+        })
+        .unwrap();
+    assert_eq!(typed_out.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+
+    let mut typed_read_out =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![0.0; 4]).unwrap();
+    backend
+        .with_backend_session(|session| {
+            typed_views.einsum_read_into_notation(&notation, session, &mut typed_read_out)
+        })
+        .unwrap();
+    assert_eq!(
+        typed_read_out.as_slice().unwrap(),
+        &[22.0, 28.0, 49.0, 64.0]
+    );
+
+    let reads = [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)];
+    let read_result = backend
+        .with_backend_session(|session| reads.einsum_read_notation(&notation, session))
+        .unwrap();
+    assert_f64_tensor(&read_result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+    let mut read_out = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4]).unwrap();
+    backend
+        .with_backend_session(|session| {
+            reads.einsum_read_into_notation(
+                &notation,
+                session,
+                TensorWrite::from_tensor(&mut read_out),
+            )
+        })
+        .unwrap();
+    assert_f64_tensor(&read_out, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+
+    ConcreteEinsumPlan::prepare_notation([&lhs, &rhs], &notation).unwrap();
+    ConcreteEinsumPlan::prepare_typed_notation::<f64, _>([&typed_lhs, &typed_rhs], &notation)
+        .unwrap();
+    ConcreteEinsumPlan::prepare_read_notation(reads, &notation).unwrap();
 }
 
 #[test]

--- a/crates/tenferro-einsum/src/eager.rs
+++ b/crates/tenferro-einsum/src/eager.rs
@@ -30,7 +30,7 @@ enum TensorValue<'a> {
     Owned(Tensor),
 }
 
-impl TensorValue<'_> {
+impl<'a> TensorValue<'a> {
     fn as_tensor(&self) -> Option<&Tensor> {
         match self {
             Self::Borrowed(tensor) => Some(tensor),
@@ -52,6 +52,14 @@ impl TensorValue<'_> {
             Self::Borrowed(tensor) => TensorRead::from_tensor(tensor),
             Self::View(view) => TensorRead::from_view(view.clone()),
             Self::Owned(tensor) => TensorRead::from_tensor(tensor),
+        }
+    }
+
+    fn borrowed_tensor_view(&self) -> Option<TensorView<'a>> {
+        match self {
+            Self::Borrowed(tensor) => Some(tensor_as_view(tensor)),
+            Self::View(view) => Some(view.clone()),
+            Self::Owned(_) => None,
         }
     }
 
@@ -326,6 +334,40 @@ fn label_size(label: u32, operands: &[&LabeledTensor<'_>]) -> Result<usize> {
     Err(eager_invalid_config(format!(
         "label {label} missing from eager einsum operands"
     )))
+}
+
+fn broadcast_to_tree_sizes<'a>(
+    exec: &mut dyn BackendSession,
+    operand: LabeledTensor<'a>,
+    tree: &ContractionTree,
+) -> Result<LabeledTensor<'a>> {
+    let target_shape: Vec<usize> = operand
+        .labels
+        .iter()
+        .enumerate()
+        .map(|(axis, label)| tree.label_size(*label).unwrap_or(operand.shape()[axis]))
+        .collect();
+    if target_shape == operand.shape() {
+        return Ok(operand);
+    }
+    let dims: Vec<usize> = (0..operand.labels.len()).collect();
+    if let Some(view) = operand.tensor.borrowed_tensor_view() {
+        if !tensor_view_has_backend_buffer(&view) {
+            let view = broadcast_tensor_view(view, &target_shape, &dims)?;
+            return Ok(LabeledTensor {
+                tensor: TensorValue::View(view),
+                labels: operand.labels,
+            });
+        }
+    }
+    let input = operand.tensor_owned(exec)?;
+    let tensor = exec.broadcast_in_dim(&input, &target_shape, &dims)?;
+    let labels = operand.labels.clone();
+    operand.reclaim_if_owned(exec);
+    Ok(LabeledTensor {
+        tensor: TensorValue::Owned(tensor),
+        labels,
+    })
 }
 
 fn reduce_tensor<'a>(
@@ -702,6 +744,14 @@ fn eager_einsum_exec_values<'a>(
                 })
                 .collect()
         });
+
+    profile_eager_einsum_section("exec.broadcast_inputs", || -> Result<()> {
+        for index in 0..labeled.len() {
+            let operand = take_labeled(&mut labeled, index, "input")?;
+            labeled[index] = Some(broadcast_to_tree_sizes(exec, operand, tree)?);
+        }
+        Ok(())
+    })?;
 
     profile_eager_einsum_section("exec.diagonalize_inputs", || -> Result<()> {
         for index in 0..labeled.len() {

--- a/crates/tenferro-einsum/src/eager_ad.rs
+++ b/crates/tenferro-einsum/src/eager_ad.rs
@@ -25,12 +25,16 @@ use crate::cache::{
     saturating_sum, vec_retained_bytes, EINSUM_EAGER_EXPANDED_PROGRAMS_CACHE,
     EINSUM_EXTENSION_FAMILY_ID,
 };
+use crate::ellipsis::resolve_einsum_notation;
 use crate::extension::EinsumExtensionOp;
 use crate::optimize::{
     default_auto_options, hash_einsum_plan_spec, plan_specs_equal, resolve_plan_spec,
     EinsumPlanSpec,
 };
-use crate::{parse_einsum_subscripts, EinsumSubscripts, Error, Result, Subscripts, TensorDotAxes};
+use crate::{
+    parse_einsum_notation, EinsumNotation, EinsumSubscripts, Error, Result, Subscripts,
+    TensorDotAxes,
+};
 
 /// Eager einsum extension methods for slices or arrays of [`EagerTensor`] refs.
 pub trait EagerEinsumExt {
@@ -43,6 +47,21 @@ pub trait EagerEinsumExt {
     /// [`Error::Planning`] / [`Error::Runtime`] for contraction planning and
     /// execution failures.
     fn einsum(&self, subscripts: &str) -> Result<EagerTensor>;
+
+    /// Execute an einsum from rank-unresolved notation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    /// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    /// assert_eq!(notation.input_count(), 1);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation, planning, or runtime error when notation or execution is invalid.
+    fn einsum_notation(&self, notation: &EinsumNotation) -> Result<EagerTensor>;
 
     /// Execute an einsum from parsed integer labels.
     ///
@@ -86,6 +105,10 @@ impl EagerEinsumExt for [&EagerTensor] {
         einsum(self, subscripts)
     }
 
+    fn einsum_notation(&self, notation: &EinsumNotation) -> Result<EagerTensor> {
+        einsum_notation(self, notation)
+    }
+
     fn einsum_subscripts(&self, subscripts: &EinsumSubscripts) -> Result<EagerTensor> {
         einsum_subscripts(self, subscripts)
     }
@@ -94,6 +117,10 @@ impl EagerEinsumExt for [&EagerTensor] {
 impl<const N: usize> EagerEinsumExt for [&EagerTensor; N] {
     fn einsum(&self, subscripts: &str) -> Result<EagerTensor> {
         einsum(self.as_slice(), subscripts)
+    }
+
+    fn einsum_notation(&self, notation: &EinsumNotation) -> Result<EagerTensor> {
+        self.as_slice().einsum_notation(notation)
     }
 
     fn einsum_subscripts(&self, subscripts: &EinsumSubscripts) -> Result<EagerTensor> {
@@ -150,8 +177,29 @@ impl EagerTensorEinsumExt for EagerTensor {
 /// [`Error::Planning`] when no contraction path is valid, or [`Error::Runtime`]
 /// for extension registration and backend execution failures.
 pub fn einsum(inputs: &[&EagerTensor], subscripts: &str) -> Result<EagerTensor> {
-    let subscripts = parse_einsum_subscripts(subscripts)?;
-    einsum_subscripts(inputs, &subscripts)
+    let notation = parse_einsum_notation(subscripts)?;
+    einsum_notation(inputs, &notation)
+}
+
+/// Execute an einsum eagerly from rank-unresolved notation.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidSubscripts`] for invalid axis tokens,
+/// [`Error::Validation`] for input count, rank, shape, or dtype mismatches,
+/// [`Error::Planning`] for an invalid contraction path, or [`Error::Runtime`]
+/// for extension registration and backend execution failures.
+pub fn einsum_notation(inputs: &[&EagerTensor], notation: &EinsumNotation) -> Result<EagerTensor> {
+    let shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
+    let subscripts = resolve_einsum_notation(notation, &shapes)?;
+    let subscripts = EinsumSubscripts::from(subscripts);
+    let allow_broadcast = notation
+        .inputs
+        .iter()
+        .chain(std::iter::once(&notation.output))
+        .any(|term| term.contains(&crate::EinsumAxis::Ellipsis))
+        || requires_broadcast(inputs, &subscripts);
+    einsum_subscripts_with_broadcast(inputs, &subscripts, allow_broadcast)
 }
 
 /// Execute an einsum eagerly from integer labels.
@@ -188,6 +236,14 @@ pub fn einsum_subscripts(
     inputs: &[&EagerTensor],
     subscripts: &EinsumSubscripts,
 ) -> Result<EagerTensor> {
+    einsum_subscripts_with_broadcast(inputs, subscripts, false)
+}
+
+fn einsum_subscripts_with_broadcast(
+    inputs: &[&EagerTensor],
+    subscripts: &EinsumSubscripts,
+    allow_broadcast: bool,
+) -> Result<EagerTensor> {
     if let Some(result) = try_direct_binary_dot_general(inputs, subscripts) {
         return result;
     }
@@ -197,15 +253,23 @@ pub fn einsum_subscripts(
     }
 
     let output_shape_hint = infer_eager_output_shape(subscripts, inputs)?;
-    if let Some(result) = try_expand_eager_einsum(inputs, subscripts)? {
-        return Ok(result);
+    if !requires_broadcast(inputs, subscripts) {
+        if let Some(result) = try_expand_eager_einsum(inputs, subscripts)? {
+            return Ok(result);
+        }
     }
 
-    let op = Arc::new(EinsumExtensionOp::with_output_shape_hint(
-        subscripts.clone(),
-        output_shape_hint,
-        EinsumPlanSpec::Auto(default_auto_options()),
-    ));
+    let plan_spec = EinsumPlanSpec::Auto(default_auto_options());
+    let op = Arc::new(if allow_broadcast {
+        EinsumExtensionOp::with_output_shape_hint_and_broadcast(
+            subscripts.clone(),
+            output_shape_hint,
+            plan_spec,
+            true,
+        )
+    } else {
+        EinsumExtensionOp::with_output_shape_hint(subscripts.clone(), output_shape_hint, plan_spec)
+    });
     let mut outputs =
         apply_eager_with_extension_session(op, inputs, eager_cpu_extension_module()?)?;
     outputs.pop().ok_or_else(|| {
@@ -232,16 +296,47 @@ fn try_direct_binary_dot_general(
     if let Some(plan) =
         try_build_exact_output_binary_dot_plan(lhs_labels, rhs_labels, &subscripts.output)
     {
-        return Some(match plan.operand_order {
-            BinaryDotOperandOrder::Original => inputs[0]
-                .dot_general(inputs[1], plan.config)
-                .map_err(Error::Runtime),
-            BinaryDotOperandOrder::Swapped => inputs[1]
-                .dot_general(inputs[0], plan.config)
-                .map_err(Error::Runtime),
-        });
+        let (lhs, rhs) = match plan.operand_order {
+            BinaryDotOperandOrder::Original => (inputs[0], inputs[1]),
+            BinaryDotOperandOrder::Swapped => (inputs[1], inputs[0]),
+        };
+        if !exact_dot_shapes(lhs.shape(), rhs.shape(), &plan.config) {
+            return None;
+        }
+        return Some(lhs.dot_general(rhs, plan.config).map_err(Error::Runtime));
     }
     None
+}
+
+fn requires_broadcast(inputs: &[&EagerTensor], subscripts: &EinsumSubscripts) -> bool {
+    let mut sizes = std::collections::HashMap::<u32, usize>::new();
+    for (tensor, labels) in inputs.iter().zip(&subscripts.inputs) {
+        for (&label, &size) in labels.iter().zip(tensor.shape()) {
+            if let Some(previous) = sizes.insert(label, size) {
+                if previous != size && (previous == 1 || size == 1) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn exact_dot_shapes(
+    lhs_shape: &[usize],
+    rhs_shape: &[usize],
+    config: &tenferro_tensor::DotGeneralConfig,
+) -> bool {
+    config
+        .lhs_contracting_dims
+        .iter()
+        .zip(&config.rhs_contracting_dims)
+        .all(|(&lhs, &rhs)| lhs_shape[lhs] == rhs_shape[rhs])
+        && config
+            .lhs_batch_dims
+            .iter()
+            .zip(&config.rhs_batch_dims)
+            .all(|(&lhs, &rhs)| lhs_shape[lhs] == rhs_shape[rhs])
 }
 
 /// Whether the untracked whole-program eager einsum executor is enabled.
@@ -851,17 +946,22 @@ fn infer_eager_output_shape(
             ));
         }
         for (&label, &dim) in labels.iter().zip(shape.iter()) {
-            if let Some(existing) = label_dims.insert(label, dim) {
-                if existing != dim {
+            if let Some(existing) = label_dims.get_mut(&label) {
+                if *existing != dim && *existing != 1 && dim != 1 {
                     return Err(Error::validation(
                         "einsum",
                         ShapeMismatch::ExpectedActual {
-                            expected: tenferro_tensor::ShapeVec::from_vec(vec![existing]),
+                            expected: tenferro_tensor::ShapeVec::from_vec(vec![*existing]),
                             actual: tenferro_tensor::ShapeVec::from_vec(vec![dim]),
                         }
                         .into(),
                     ));
                 }
+                if *existing == 1 {
+                    *existing = dim;
+                }
+            } else {
+                label_dims.insert(label, dim);
             }
         }
     }

--- a/crates/tenferro-einsum/src/ellipsis.rs
+++ b/crates/tenferro-einsum/src/ellipsis.rs
@@ -1,0 +1,224 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::{EinsumAxis, EinsumNotation, Error, Result, Subscripts};
+
+pub(crate) fn notation_without_ellipsis(notation: &EinsumNotation) -> Result<Subscripts> {
+    let inputs = notation
+        .inputs
+        .iter()
+        .map(|term| {
+            term.iter()
+                .map(|axis| match axis {
+                    EinsumAxis::Label(label) => Ok(*label),
+                    EinsumAxis::Ellipsis => Err(Error::invalid_subscripts(
+                        "ellipsis requires rank-aware resolution",
+                    )),
+                })
+                .collect::<Result<Vec<_>>>()
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let output = notation
+        .output
+        .iter()
+        .map(|axis| match axis {
+            EinsumAxis::Label(label) => Ok(*label),
+            EinsumAxis::Ellipsis => Err(Error::invalid_subscripts(
+                "ellipsis requires rank-aware resolution",
+            )),
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Subscripts { inputs, output })
+}
+
+/// Resolve rank-polymorphic notation into the canonical planner representation.
+///
+/// Ellipsis labels are allocated outside the caller label set. This function
+/// also validates per-operand diagonal dimensions and cross-operand
+/// equal-or-one broadcasting before any backend or planner code runs.
+pub(crate) fn resolve_einsum_notation(
+    notation: &EinsumNotation,
+    shapes: &[&[usize]],
+) -> Result<Subscripts> {
+    let notation = canonicalize_ellipsis_labels(notation);
+    if notation.inputs.is_empty() {
+        return Err(Error::invalid_subscripts(
+            "einsum requires at least one input term",
+        ));
+    }
+    if notation.inputs.len() != shapes.len() {
+        return Err(Error::invalid_argument(
+            "einsum",
+            "inputs",
+            format!(
+                "einsum notation expects {} inputs, got {}",
+                notation.inputs.len(),
+                shapes.len()
+            ),
+        ));
+    }
+
+    let mut used_labels = HashSet::new();
+    let mut ellipsis_ranks = Vec::with_capacity(notation.inputs.len());
+    let mut has_input_ellipsis_with_axes = false;
+    for (term, shape) in notation.inputs.iter().zip(shapes) {
+        let explicit_count = term
+            .iter()
+            .filter(|axis| matches!(axis, EinsumAxis::Label(_)))
+            .count();
+        let has_ellipsis = term.contains(&EinsumAxis::Ellipsis);
+        if !has_ellipsis && explicit_count != shape.len() {
+            return Err(Error::rank_mismatch("einsum", explicit_count, shape.len()));
+        }
+        if has_ellipsis && explicit_count > shape.len() {
+            return Err(Error::rank_mismatch("einsum", explicit_count, shape.len()));
+        }
+        let ellipsis_rank = shape.len().saturating_sub(explicit_count);
+        has_input_ellipsis_with_axes |= has_ellipsis && ellipsis_rank > 0;
+        ellipsis_ranks.push(ellipsis_rank);
+        for axis in term {
+            if let EinsumAxis::Label(label) = axis {
+                used_labels.insert(*label);
+            }
+        }
+    }
+
+    let ellipsis_rank = ellipsis_ranks.iter().copied().max().unwrap_or(0);
+    let ellipsis_labels = fresh_labels(&used_labels, ellipsis_rank)?;
+    let input_has_ellipsis = notation
+        .inputs
+        .iter()
+        .any(|term| term.contains(&EinsumAxis::Ellipsis));
+    let output_has_ellipsis = notation.output.contains(&EinsumAxis::Ellipsis);
+    if output_has_ellipsis && !input_has_ellipsis {
+        return Err(Error::invalid_subscripts(
+            "einsum output ellipsis requires an input ellipsis",
+        ));
+    }
+    if has_input_ellipsis_with_axes && !output_has_ellipsis {
+        return Err(Error::invalid_subscripts(
+            "einsum output must contain '...' when an input ellipsis covers axes",
+        ));
+    }
+
+    let mut inputs = Vec::with_capacity(notation.inputs.len());
+    for (term_index, (term, shape)) in notation.inputs.iter().zip(shapes).enumerate() {
+        let labels = expand_term(term, ellipsis_ranks[term_index], &ellipsis_labels);
+        if labels.len() != shape.len() {
+            return Err(Error::rank_mismatch("einsum", labels.len(), shape.len()));
+        }
+        inputs.push(labels);
+    }
+
+    let output = expand_output(&notation.output, &ellipsis_labels);
+    let mut label_sizes = HashMap::new();
+    for (labels, shape) in inputs.iter().zip(shapes) {
+        let mut local_sizes = HashMap::new();
+        for (&label, &size) in labels.iter().zip(shape.iter()) {
+            if let Some(previous) = local_sizes.insert(label, size) {
+                if previous != size {
+                    return Err(Error::shape_mismatch("einsum", [previous], [size]));
+                }
+            }
+            merge_broadcast_size(&mut label_sizes, label, size)?;
+        }
+    }
+    for &label in &output {
+        if !label_sizes.contains_key(&label) {
+            return Err(Error::invalid_subscripts(format!(
+                "output label {label} is missing from all input terms"
+            )));
+        }
+    }
+
+    Ok(Subscripts { inputs, output })
+}
+
+fn canonicalize_ellipsis_labels(notation: &EinsumNotation) -> EinsumNotation {
+    let has_ellipsis = notation
+        .inputs
+        .iter()
+        .chain(std::iter::once(&notation.output))
+        .any(|term| term.contains(&EinsumAxis::Ellipsis));
+    if !has_ellipsis {
+        return notation.clone();
+    }
+
+    let mut labels = HashMap::new();
+    let mut next = 0_u32;
+    let mut remap = |axis: EinsumAxis| match axis {
+        EinsumAxis::Ellipsis => EinsumAxis::Ellipsis,
+        EinsumAxis::Label(label) => {
+            let canonical = *labels.entry(label).or_insert_with(|| {
+                let value = next;
+                next = next.saturating_add(1);
+                value
+            });
+            EinsumAxis::Label(canonical)
+        }
+    };
+    EinsumNotation {
+        inputs: notation
+            .inputs
+            .iter()
+            .map(|term| term.iter().copied().map(&mut remap).collect())
+            .collect(),
+        output: notation.output.iter().copied().map(remap).collect(),
+    }
+}
+
+fn fresh_labels(used: &HashSet<u32>, count: usize) -> Result<Vec<u32>> {
+    let mut labels = Vec::with_capacity(count);
+    let mut candidate = u32::MAX;
+    while labels.len() < count {
+        if !used.contains(&candidate) {
+            labels.push(candidate);
+            if labels.len() == count {
+                break;
+            }
+        }
+        candidate = candidate.checked_sub(1).ok_or_else(|| {
+            Error::invalid_subscripts("not enough integer labels available for ellipsis axes")
+        })?;
+    }
+    labels.reverse();
+    Ok(labels)
+}
+
+fn expand_term(term: &[EinsumAxis], rank: usize, ellipsis_labels: &[u32]) -> Vec<u32> {
+    let offset = ellipsis_labels.len().saturating_sub(rank);
+    let mut labels = Vec::new();
+    for axis in term {
+        match axis {
+            EinsumAxis::Label(label) => labels.push(*label),
+            EinsumAxis::Ellipsis => labels.extend_from_slice(&ellipsis_labels[offset..]),
+        }
+    }
+    labels
+}
+
+fn expand_output(term: &[EinsumAxis], ellipsis_labels: &[u32]) -> Vec<u32> {
+    let mut output = Vec::new();
+    for axis in term {
+        match axis {
+            EinsumAxis::Label(label) => output.push(*label),
+            EinsumAxis::Ellipsis => output.extend_from_slice(ellipsis_labels),
+        }
+    }
+    output
+}
+
+fn merge_broadcast_size(sizes: &mut HashMap<u32, usize>, label: u32, size: usize) -> Result<()> {
+    let Some(existing) = sizes.get_mut(&label) else {
+        sizes.insert(label, size);
+        return Ok(());
+    };
+    if *existing == size || *existing == 1 {
+        *existing = size;
+    } else if size != 1 {
+        return Err(Error::shape_mismatch("einsum", [*existing], [size]));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tenferro-einsum/src/ellipsis/tests.rs
+++ b/crates/tenferro-einsum/src/ellipsis/tests.rs
@@ -1,0 +1,82 @@
+use super::{notation_without_ellipsis, resolve_einsum_notation};
+use crate::{parse_einsum_notation, EinsumAxis, EinsumNotation};
+
+#[test]
+fn resolves_right_aligned_ellipsis_labels() {
+    let notation = parse_einsum_notation("...ij,...jk->...ik").unwrap();
+    let resolved = resolve_einsum_notation(&notation, &[&[2, 3, 4][..], &[1, 4, 5]]).unwrap();
+    assert_eq!(resolved.inputs[0].len(), 3);
+    assert_eq!(resolved.inputs[1].len(), 3);
+    assert_eq!(resolved.output.len(), 3);
+    assert_eq!(resolved.inputs[0][0], resolved.inputs[1][0]);
+    assert_eq!(resolved.output[0], resolved.inputs[0][0]);
+}
+
+#[test]
+fn resolves_zero_rank_ellipsis_and_programmatic_tokens() {
+    let notation = EinsumNotation::new(
+        &[&[EinsumAxis::Ellipsis, EinsumAxis::Label(7)]],
+        &[EinsumAxis::Ellipsis, EinsumAxis::Label(7)],
+    );
+    let resolved = resolve_einsum_notation(&notation, &[&[3][..]]).unwrap();
+    assert_eq!(resolved.inputs, vec![vec![0]]);
+    assert_eq!(resolved.output, vec![0]);
+}
+
+#[test]
+fn resolves_explicit_notation_without_ellipsis() {
+    let notation = EinsumNotation::new(&[&[EinsumAxis::Label(7)]], &[EinsumAxis::Label(7)]);
+    let resolved = notation_without_ellipsis(&notation).unwrap();
+    assert_eq!(resolved.inputs, vec![vec![7]]);
+    assert_eq!(resolved.output, vec![7]);
+
+    let with_ellipsis = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    assert!(notation_without_ellipsis(&with_ellipsis).is_err());
+}
+
+#[test]
+fn rejects_structural_and_label_errors() {
+    let empty = EinsumNotation {
+        inputs: Vec::new(),
+        output: Vec::new(),
+    };
+    assert!(resolve_einsum_notation(&empty, &[]).is_err());
+
+    let notation = EinsumNotation::new(&[&[EinsumAxis::Label(0)]], &[EinsumAxis::Label(0)]);
+    assert!(resolve_einsum_notation(&notation, &[]).is_err());
+    assert!(resolve_einsum_notation(&notation, &[&[]]).is_err());
+
+    let ellipsis = EinsumNotation::new(
+        &[&[EinsumAxis::Ellipsis, EinsumAxis::Label(0)]],
+        &[EinsumAxis::Ellipsis, EinsumAxis::Label(0)],
+    );
+    assert!(resolve_einsum_notation(&ellipsis, &[&[]]).is_err());
+
+    let repeated = EinsumNotation::new(
+        &[&[EinsumAxis::Label(0), EinsumAxis::Label(0)]],
+        &[EinsumAxis::Label(0)],
+    );
+    assert!(resolve_einsum_notation(&repeated, &[&[2, 3]]).is_err());
+
+    let missing = EinsumNotation::new(&[&[EinsumAxis::Label(0)]], &[EinsumAxis::Label(1)]);
+    assert!(resolve_einsum_notation(&missing, &[&[2]]).is_err());
+}
+
+#[test]
+fn accepts_both_orders_of_singleton_broadcast() {
+    let notation = parse_einsum_notation("...i,...i->...i").unwrap();
+    assert!(resolve_einsum_notation(&notation, &[&[1, 3][..], &[2, 3]]).is_ok());
+    assert!(resolve_einsum_notation(&notation, &[&[2, 3][..], &[1, 3]]).is_ok());
+}
+
+#[test]
+fn rejects_missing_output_ellipsis_and_incompatible_broadcast() {
+    let missing = parse_einsum_notation("...i->i").unwrap();
+    assert!(resolve_einsum_notation(&missing, &[&[2, 3][..]]).is_err());
+
+    let incompatible = parse_einsum_notation("...i,...i->...i").unwrap();
+    assert!(resolve_einsum_notation(&incompatible, &[&[2, 3][..], &[4, 3]]).is_err());
+
+    let invalid_output = parse_einsum_notation("i->...i").unwrap();
+    assert!(resolve_einsum_notation(&invalid_output, &[&[3][..]]).is_err());
+}

--- a/crates/tenferro-einsum/src/extension.rs
+++ b/crates/tenferro-einsum/src/extension.rs
@@ -55,6 +55,7 @@ pub(crate) struct EinsumExtensionOp {
     subscripts: EinsumSubscripts,
     plan_spec: EinsumPlanSpec,
     output_shape_hint: Option<Vec<SymDim>>,
+    allow_broadcast: bool,
 }
 
 impl std::fmt::Debug for EinsumExtensionOp {
@@ -63,6 +64,7 @@ impl std::fmt::Debug for EinsumExtensionOp {
             .field("subscripts", &self.subscripts)
             .field("plan_spec", &self.plan_spec)
             .field("output_shape_hint", &self.output_shape_hint)
+            .field("allow_broadcast", &self.allow_broadcast)
             .finish()
     }
 }
@@ -81,7 +83,18 @@ impl EinsumExtensionOp {
             subscripts,
             plan_spec,
             output_shape_hint: None,
+            allow_broadcast: false,
         }
+    }
+
+    pub(crate) fn with_plan_spec_and_broadcast(
+        subscripts: EinsumSubscripts,
+        plan_spec: EinsumPlanSpec,
+        allow_broadcast: bool,
+    ) -> Self {
+        let mut op = Self::with_plan_spec(subscripts, plan_spec);
+        op.allow_broadcast = allow_broadcast;
+        op
     }
 
     /// Create an einsum extension payload with an explicit output shape hint.
@@ -97,6 +110,19 @@ impl EinsumExtensionOp {
         op
     }
 
+    #[must_use]
+    #[cfg(feature = "autodiff")]
+    pub(crate) fn with_output_shape_hint_and_broadcast(
+        subscripts: EinsumSubscripts,
+        output_shape_hint: Vec<SymDim>,
+        plan_spec: EinsumPlanSpec,
+        allow_broadcast: bool,
+    ) -> Self {
+        let mut op = Self::with_plan_spec_and_broadcast(subscripts, plan_spec, allow_broadcast);
+        op.output_shape_hint = Some(output_shape_hint);
+        op
+    }
+
     /// Return the canonical subscripts.
     #[must_use]
     pub(crate) fn subscripts(&self) -> &EinsumSubscripts {
@@ -107,6 +133,12 @@ impl EinsumExtensionOp {
     #[must_use]
     pub(crate) fn plan_spec(&self) -> &EinsumPlanSpec {
         &self.plan_spec
+    }
+
+    #[must_use]
+    #[cfg(feature = "autodiff")]
+    pub(crate) fn allow_broadcast(&self) -> bool {
+        self.allow_broadcast
     }
 }
 
@@ -128,6 +160,7 @@ impl ExtensionOp for EinsumExtensionOp {
             hasher.write_u32(*label);
         }
         hash_einsum_plan_spec(self.plan_spec(), hasher);
+        hasher.write_u8(u8::from(self.allow_broadcast));
         if let Some(shape) = &self.output_shape_hint {
             hasher.write_usize(shape.len());
             for dim in shape {
@@ -149,6 +182,7 @@ impl ExtensionOp for EinsumExtensionOp {
             self.subscripts == that.subscripts
                 && plan_specs_equal(self.plan_spec(), that.plan_spec())
                 && self.output_shape_hint == that.output_shape_hint
+                && self.allow_broadcast == that.allow_broadcast
         })
     }
 
@@ -197,8 +231,22 @@ impl ExtensionOp for EinsumExtensionOp {
                 ));
             }
             for (&label, dim) in labels.iter().zip(shape.iter()) {
-                if let Some(existing) = label_dims.get(&label) {
-                    ctx.require_equal(existing.clone(), dim.clone())?;
+                if let Some(existing) = label_dims.get_mut(&label) {
+                    if !self.allow_broadcast {
+                        ctx.require_equal(existing.clone(), dim.clone())?;
+                        continue;
+                    }
+                    match (existing.constant_value(), dim.constant_value()) {
+                        (Some(lhs), Some(rhs)) if lhs == rhs || lhs == 1 || rhs == 1 => {
+                            *existing = SymDim::from(if lhs == 1 { rhs } else { lhs });
+                        }
+                        (Some(_lhs), Some(_rhs)) => {
+                            ctx.require_equal(existing.clone(), dim.clone())?;
+                        }
+                        (Some(1), None) => *existing = dim.clone(),
+                        (None, Some(1)) => {}
+                        _ => {}
+                    }
                 } else {
                     label_dims.insert(label, dim.clone());
                 }
@@ -515,7 +563,11 @@ fn semantic_vjp_einsum_op(
         let _tree = resolve_plan_spec(&plan_spec, &raw_subscripts, &shape_refs)
             .map_err(|source| semantic_einsum_unsupported(source.to_string()))?;
     }
-    Ok(EinsumExtensionOp::with_plan_spec(subscripts, plan_spec))
+    Ok(EinsumExtensionOp::with_plan_spec_and_broadcast(
+        subscripts,
+        plan_spec,
+        primal_op.allow_broadcast(),
+    ))
 }
 
 #[cfg(feature = "autodiff")]

--- a/crates/tenferro-einsum/src/lib.rs
+++ b/crates/tenferro-einsum/src/lib.rs
@@ -3,6 +3,8 @@
 //! This crate provides:
 //!
 //! - **String notation**: `"ij,jk->ik"` (NumPy/PyTorch compatible)
+//! - **Ellipsis notation**: `"...ij,...jk->...ik"` with right-aligned
+//!   equal-or-one broadcasting, plus programmatic [`EinsumNotation`]
 //! - **Parenthesized notation**: `"ij,(jk,kl)->il"` respects user-specified
 //!   contraction order via [`NestedEinsum`]
 //! - **Integer label notation**: using `u32` labels
@@ -69,6 +71,7 @@ mod concrete;
 mod eager;
 #[cfg(feature = "autodiff")]
 mod eager_ad;
+mod ellipsis;
 mod error;
 mod extension;
 pub mod lowering;
@@ -97,7 +100,9 @@ pub use extension::extension_module;
 pub use extension::semantic_ad_rules;
 pub use optimize::EinsumOptimize;
 pub use planning::tree::{ContractionOptimizerOptions, ContractionTree};
-pub use subscripts::{parse_einsum_subscripts, EinsumSubscripts};
+pub use subscripts::{
+    parse_einsum_notation, parse_einsum_subscripts, EinsumAxis, EinsumNotation, EinsumSubscripts,
+};
 pub use syntax::nested::NestedEinsum;
 pub use syntax::subscripts::Subscripts;
 pub use tensordot::TensorDotAxes;

--- a/crates/tenferro-einsum/src/planning/tree.rs
+++ b/crates/tenferro-einsum/src/planning/tree.rs
@@ -299,6 +299,18 @@ impl ContractionTree {
         self.steps.len()
     }
 
+    pub(crate) fn label_size(&self, label: u32) -> Option<usize> {
+        self.size_dict.get(&label).copied()
+    }
+
+    pub(crate) fn output_shape(&self) -> Vec<usize> {
+        self.subscripts
+            .output
+            .iter()
+            .filter_map(|label| self.label_size(*label))
+            .collect()
+    }
+
     /// Return the operand indices for a pairwise contraction step.
     ///
     /// The returned indices refer to the original inputs (`0..input_count`) and

--- a/crates/tenferro-einsum/src/prelude.rs
+++ b/crates/tenferro-einsum/src/prelude.rs
@@ -1,10 +1,11 @@
 //! Einsum and tensordot extension traits for concrete, eager, and traced values.
 
 pub use crate::{
-    ContractionTree, EinsumOptimize, EinsumSubscripts, TensorDotAxes, TensorEinsumExt,
-    TensorEinsumIntoExt, TensorReadEinsumExt, TensorReadEinsumIntoExt, TensorTensordotExt,
-    TraceContextEinsumExt, TracedTensorEinsumExt, TypedTensorEinsumExt, TypedTensorEinsumIntoExt,
-    TypedTensorReadEinsumExt, TypedTensorReadEinsumIntoExt, TypedTensorTensordotExt,
+    ContractionTree, EinsumAxis, EinsumNotation, EinsumOptimize, EinsumSubscripts, TensorDotAxes,
+    TensorEinsumExt, TensorEinsumIntoExt, TensorReadEinsumExt, TensorReadEinsumIntoExt,
+    TensorTensordotExt, TraceContextEinsumExt, TracedTensorEinsumExt, TypedTensorEinsumExt,
+    TypedTensorEinsumIntoExt, TypedTensorReadEinsumExt, TypedTensorReadEinsumIntoExt,
+    TypedTensorTensordotExt,
 };
 pub use tenferro_runtime::{
     DType, Tensor, TensorBackend, TensorRead, TensorScalar, TensorView, TraceContext, TraceValue,

--- a/crates/tenferro-einsum/src/subscripts.rs
+++ b/crates/tenferro-einsum/src/subscripts.rs
@@ -1,5 +1,125 @@
 use crate::{Result, Subscripts};
 
+/// One unresolved axis token in rank-polymorphic einsum notation.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_einsum::EinsumAxis;
+/// assert_eq!(EinsumAxis::Ellipsis, EinsumAxis::Ellipsis);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum EinsumAxis {
+    /// An explicit integer label.
+    Label(u32),
+    /// A NumPy-style ellipsis whose rank is resolved from the inputs.
+    Ellipsis,
+}
+
+/// Rank-unresolved einsum notation.
+///
+/// This is the programmatic counterpart of string notation such as
+/// `"...ij,...jk->...ik"`. Resolve it through an einsum operation, after input
+/// ranks are known; [`EinsumSubscripts`] remains the rank-resolved runtime form.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+/// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+/// assert_eq!(notation.input_count(), 1);
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct EinsumNotation {
+    /// Axis tokens for each input tensor.
+    pub inputs: Vec<Vec<EinsumAxis>>,
+    /// Axis tokens for the output tensor.
+    pub output: Vec<EinsumAxis>,
+}
+
+impl EinsumNotation {
+    /// Create rank-unresolved notation from axis-token arrays.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    ///
+    /// let notation = EinsumNotation::new(
+    ///     &[&[EinsumAxis::Ellipsis, EinsumAxis::Label(0)], &[EinsumAxis::Ellipsis, EinsumAxis::Label(0)]],
+    ///     &[EinsumAxis::Ellipsis],
+    /// );
+    /// assert_eq!(notation.input_count(), 2);
+    /// ```
+    pub fn new(inputs: &[&[EinsumAxis]], output: &[EinsumAxis]) -> Self {
+        Self {
+            inputs: inputs.iter().map(|axes| axes.to_vec()).collect(),
+            output: output.to_vec(),
+        }
+    }
+
+    /// Number of input operands described by this notation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    /// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    /// assert_eq!(notation.input_count(), 1);
+    /// ```
+    #[must_use]
+    pub fn input_count(&self) -> usize {
+        self.inputs.len()
+    }
+
+    /// Parse flat string notation, retaining ellipsis tokens.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::InvalidSubscripts`] for malformed separators,
+    /// labels, ellipses, or parenthesized contraction order.
+    pub fn parse(notation: &str) -> Result<Self> {
+        let (inputs_str, output_str) =
+            crate::syntax::notation::split_and_validate_notation(notation)?;
+        if inputs_str.contains(['(', ')']) || output_str.contains(['(', ')']) {
+            return Err(crate::Error::invalid_subscripts(
+                "EinsumNotation::parse does not accept parentheses; use NestedEinsum::parse for parenthesized contraction order",
+            ));
+        }
+        let inputs = inputs_str
+            .split(',')
+            .map(parse_axis_term)
+            .collect::<Result<Vec<_>>>()?;
+        let output = parse_axis_term(output_str)?;
+        Ok(Self { inputs, output })
+    }
+}
+
+fn parse_axis_term(term: &str) -> Result<Vec<EinsumAxis>> {
+    let mut chars = term.chars();
+    let mut axes = Vec::new();
+    while let Some(c) = chars.next() {
+        if c == '.' {
+            if chars.next() != Some('.') || chars.next() != Some('.') {
+                return Err(crate::Error::invalid_subscripts(
+                    "einsum ellipsis must be written as exactly three dots",
+                ));
+            }
+            if axes.contains(&EinsumAxis::Ellipsis) {
+                return Err(crate::Error::invalid_subscripts(
+                    "each einsum term may contain at most one ellipsis",
+                ));
+            }
+            axes.push(EinsumAxis::Ellipsis);
+        } else {
+            axes.push(EinsumAxis::Label(crate::syntax::notation::char_to_label(
+                c,
+            )?));
+        }
+    }
+    Ok(axes)
+}
+
 /// Canonical N-ary einsum subscripts using integer labels.
 ///
 /// String notation is a user-facing convenience. Runtime integration layers can
@@ -105,6 +225,25 @@ impl From<&EinsumSubscripts> for Subscripts {
 /// contains an invalid label, or has an invalid input/output separator.
 pub fn parse_einsum_subscripts(notation: &str) -> Result<EinsumSubscripts> {
     Subscripts::parse(notation).map(EinsumSubscripts::from)
+}
+
+/// Parse string notation into rank-unresolved axis tokens.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_einsum::{parse_einsum_notation, EinsumAxis};
+///
+/// let notation = parse_einsum_notation("...ij,...jk->...ik").unwrap();
+/// assert_eq!(notation.inputs[0][0], EinsumAxis::Ellipsis);
+/// ```
+///
+/// # Errors
+///
+/// Returns [`crate::Error::InvalidSubscripts`] for malformed notation,
+/// multiple ellipses in one term, or parenthesized contraction order.
+pub fn parse_einsum_notation(notation: &str) -> Result<EinsumNotation> {
+    EinsumNotation::parse(notation)
 }
 
 #[cfg(test)]

--- a/crates/tenferro-einsum/src/syntax/nested.rs
+++ b/crates/tenferro-einsum/src/syntax/nested.rs
@@ -77,6 +77,11 @@ impl NestedEinsum {
     /// labels are invalid, or the notation is otherwise malformed.
     pub fn parse(notation: &str) -> Result<Self> {
         let (lhs, output_str) = split_and_validate_notation(notation)?;
+        if notation.contains('.') {
+            return Err(Error::invalid_subscripts(
+                "ellipsis with parenthesized contraction order is not supported",
+            ));
+        }
 
         let output: Vec<u32> = output_str
             .chars()

--- a/crates/tenferro-einsum/src/syntax/nested/tests.rs
+++ b/crates/tenferro-einsum/src/syntax/nested/tests.rs
@@ -5,6 +5,12 @@ fn labels(s: &str) -> Vec<u32> {
 }
 
 #[test]
+fn parse_rejects_ellipsis_in_parenthesized_notation() {
+    let error = NestedEinsum::parse("(...ij,jk),kl->...il").unwrap_err();
+    assert!(error.to_string().contains("parenthesized"));
+}
+
+#[test]
 fn parse_group_preserves_intermediate_output_label_order() {
     let nested = NestedEinsum::parse("(ca,ab),cd->bd").unwrap();
 

--- a/crates/tenferro-einsum/src/syntax/notation.rs
+++ b/crates/tenferro-einsum/src/syntax/notation.rs
@@ -24,17 +24,6 @@ pub(crate) fn char_to_label(c: char) -> Result<u32> {
 ///
 /// Returns `(lhs, rhs)` where `lhs` is the input side and `rhs` is the output side.
 pub(crate) fn split_and_validate_notation(notation: &str) -> Result<(&str, &str)> {
-    if notation.contains("...") {
-        return Err(Error::invalid_subscripts(
-            "einsum ellipsis '...' is not supported yet",
-        ));
-    }
-    if notation.contains('.') {
-        return Err(Error::invalid_subscripts(
-            "einsum label '.' is reserved for ellipsis, which is not supported yet",
-        ));
-    }
-
     let parts: Vec<&str> = notation.split("->").collect();
     if parts.len() != 2 {
         return Err(Error::invalid_subscripts(format!(

--- a/crates/tenferro-einsum/src/syntax/subscripts.rs
+++ b/crates/tenferro-einsum/src/syntax/subscripts.rs
@@ -93,6 +93,11 @@ impl Subscripts {
                 "Subscripts::parse does not accept parentheses; use NestedEinsum::parse to preserve parenthesized contraction order",
             ));
         }
+        if notation.contains('.') {
+            return Err(Error::invalid_subscripts(
+                "einsum ellipsis requires rank-aware resolution; use parse_einsum_notation or an einsum operation",
+            ));
+        }
 
         let output: Vec<u32> = output_str
             .chars()

--- a/crates/tenferro-einsum/src/syntax/subscripts/tests.rs
+++ b/crates/tenferro-einsum/src/syntax/subscripts/tests.rs
@@ -21,6 +21,6 @@ fn parse_rejects_ellipsis_with_specific_error() {
         err,
         Error::InvalidSubscripts { message }
             if message.contains("ellipsis")
-                && message.contains("not supported")
+                && message.contains("rank-aware")
     ));
 }

--- a/crates/tenferro-einsum/src/tests/builder_tests.rs
+++ b/crates/tenferro-einsum/src/tests/builder_tests.rs
@@ -83,6 +83,32 @@ fn graph_identity_external_input_is_localized() {
 }
 
 #[test]
+fn graph_broadcasts_singleton_batch_before_matmul() {
+    let tree = make_tree("bij,bjk->bik", &[&[2, 2, 3], &[1, 3, 2]]);
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let a = builder.add_input(input_key(0));
+    let b = builder.add_input(input_key(1));
+
+    let result = build_einsum_graph(
+        &mut builder,
+        &tree,
+        &[ValueRef::Local(a), ValueRef::Local(b)],
+        &[vec![2, 2, 3], vec![1, 3, 2]],
+    );
+
+    builder.set_outputs(vec![unwrap_local(result)]);
+    let graph = builder.build();
+    assert!(graph.operations().iter().any(|node| {
+        matches!(
+            &node.operation,
+            StdTensorOp::BroadcastInDim { shape, dims }
+                if shape.as_slice() == [DimExpr::Const(2), DimExpr::Const(3), DimExpr::Const(2)]
+                    && dims.as_slice() == [0, 1, 2]
+        )
+    }));
+}
+
+#[test]
 fn graph_matmul_ij_jk_ik() {
     let tree = make_tree("ij,jk->ik", &[&[2, 3], &[3, 4]]);
     let mut builder = GraphBuilder::<StdTensorOp>::new();

--- a/crates/tenferro-einsum/src/traced.rs
+++ b/crates/tenferro-einsum/src/traced.rs
@@ -9,14 +9,15 @@ use tenferro_runtime::{TraceContext, TraceValue, TracedTensor};
 use tenferro_tensor::{ErrorKind, ValidationKind};
 
 use crate::cache::{
-    einsum_subscripts_retained_bytes, saturating_sum, ParsedEinsum, EINSUM_EXTENSION_FAMILY_ID,
+    einsum_notation_retained_bytes, saturating_sum, ParsedEinsum, EINSUM_EXTENSION_FAMILY_ID,
     EINSUM_PARSE_CACHE,
 };
+use crate::ellipsis::{notation_without_ellipsis, resolve_einsum_notation};
 use crate::extension::EinsumExtensionOp;
 use crate::optimize::{plan_spec_from_optimize, resolve_einsum_strategy_with_spec};
 use crate::{
-    parse_einsum_subscripts, EinsumOptimize, EinsumSubscripts, Error, Result, Subscripts,
-    TensorDotAxes,
+    parse_einsum_notation, EinsumAxis, EinsumNotation, EinsumOptimize, EinsumSubscripts, Error,
+    Result, Subscripts, TensorDotAxes,
 };
 
 /// Backend-neutral einsum tracing methods for [`TraceContext`].
@@ -57,6 +58,28 @@ pub trait TraceContextEinsumExt {
     /// program construction fails.
     fn einsum(&mut self, inputs: &[TraceValue], subscripts: &str) -> Result<TraceValue>;
 
+    /// Trace rank-unresolved notation using the default optimizer policy.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    /// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    /// assert_eq!(notation.input_count(), 1);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for invalid axis tokens,
+    /// [`Error::Validation`] for invalid input metadata, [`Error::Planning`]
+    /// for symbolic ellipsis or an invalid optimizer policy, or [`Error::Runtime`]
+    /// for graph-build failures.
+    fn einsum_notation(
+        &mut self,
+        inputs: &[TraceValue],
+        notation: &EinsumNotation,
+    ) -> Result<TraceValue>;
+
     /// Trace parsed einsum notation using the default optimizer policy.
     ///
     /// # Errors
@@ -85,6 +108,29 @@ pub trait TraceContextEinsumExt {
         optimize: EinsumOptimize,
     ) -> Result<TraceValue>;
 
+    /// Trace rank-unresolved notation with an explicit optimizer policy.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_einsum::{EinsumAxis, EinsumNotation};
+    /// let notation = EinsumNotation::new(&[&[EinsumAxis::Ellipsis]], &[]);
+    /// assert_eq!(notation.input_count(), 1);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for invalid axis tokens,
+    /// [`Error::Validation`] for invalid input metadata, [`Error::Planning`]
+    /// for symbolic ellipsis or an invalid optimizer policy, or [`Error::Runtime`]
+    /// for graph-build failures.
+    fn einsum_notation_with(
+        &mut self,
+        inputs: &[TraceValue],
+        notation: &EinsumNotation,
+        optimize: EinsumOptimize,
+    ) -> Result<TraceValue>;
+
     /// Trace parsed einsum notation with an explicit optimizer policy.
     ///
     /// # Errors
@@ -105,6 +151,14 @@ impl TraceContextEinsumExt for TraceContext {
         self.einsum_with(inputs, subscripts, EinsumOptimize::default())
     }
 
+    fn einsum_notation(
+        &mut self,
+        inputs: &[TraceValue],
+        notation: &EinsumNotation,
+    ) -> Result<TraceValue> {
+        self.einsum_notation_with(inputs, notation, EinsumOptimize::default())
+    }
+
     fn einsum_subscripts(
         &mut self,
         inputs: &[TraceValue],
@@ -120,7 +174,16 @@ impl TraceContextEinsumExt for TraceContext {
         optimize: EinsumOptimize,
     ) -> Result<TraceValue> {
         let parsed = cached_subscripts(self.extension_caches_mut(), subscripts)?;
-        self.einsum_subscripts_with(inputs, &parsed.subscripts, optimize)
+        self.einsum_notation_with(inputs, &parsed.notation, optimize)
+    }
+
+    fn einsum_notation_with(
+        &mut self,
+        inputs: &[TraceValue],
+        notation: &EinsumNotation,
+        optimize: EinsumOptimize,
+    ) -> Result<TraceValue> {
+        trace_context_einsum_notation_with(self, inputs, notation, optimize)
     }
 
     fn einsum_subscripts_with(
@@ -129,8 +192,31 @@ impl TraceContextEinsumExt for TraceContext {
         subscripts: &EinsumSubscripts,
         optimize: EinsumOptimize,
     ) -> Result<TraceValue> {
-        trace_context_einsum_subscripts_with(self, inputs, subscripts, optimize)
+        trace_context_einsum_subscripts_with(self, inputs, subscripts, optimize, false)
     }
+}
+
+fn trace_context_einsum_notation_with(
+    trace: &mut TraceContext,
+    inputs: &[TraceValue],
+    notation: &EinsumNotation,
+    optimize: EinsumOptimize,
+) -> Result<TraceValue> {
+    let allow_broadcast = notation
+        .inputs
+        .iter()
+        .chain(std::iter::once(&notation.output))
+        .any(|term| term.contains(&EinsumAxis::Ellipsis));
+    let subscripts = if allow_broadcast {
+        let shapes = trace_concrete_shapes(trace, inputs)?.ok_or_else(|| {
+            Error::planning("ellipsis einsum requires concrete input dimensions during tracing")
+        })?;
+        let shape_refs: Vec<_> = shapes.iter().map(Vec::as_slice).collect();
+        resolve_einsum_notation(notation, &shape_refs)?.into()
+    } else {
+        notation_without_ellipsis(notation)?.into()
+    };
+    trace_context_einsum_subscripts_with(trace, inputs, &subscripts, optimize, allow_broadcast)
 }
 
 fn trace_context_einsum_subscripts_with(
@@ -138,6 +224,7 @@ fn trace_context_einsum_subscripts_with(
     inputs: &[TraceValue],
     subscripts: &EinsumSubscripts,
     optimize: EinsumOptimize,
+    allow_broadcast: bool,
 ) -> Result<TraceValue> {
     if inputs.is_empty() {
         return Err(Error::invalid_argument(
@@ -167,11 +254,16 @@ fn trace_context_einsum_subscripts_with(
             let shape_refs: Vec<_> = shapes.iter().map(Vec::as_slice).collect();
             let (plan_spec, _tree) =
                 resolve_einsum_strategy_with_spec(EinsumOptimize::Tree(tree), &subs, &shape_refs)?;
-            EinsumExtensionOp::with_plan_spec(subscripts.clone(), plan_spec)
+            EinsumExtensionOp::with_plan_spec_and_broadcast(
+                subscripts.clone(),
+                plan_spec,
+                allow_broadcast,
+            )
         }
-        optimize => EinsumExtensionOp::with_plan_spec(
+        optimize => EinsumExtensionOp::with_plan_spec_and_broadcast(
             subscripts.clone(),
             plan_spec_from_optimize(optimize, &subs)?,
+            allow_broadcast,
         ),
     };
     let outputs = trace
@@ -277,7 +369,7 @@ fn cached_subscripts(
     }
 
     let parsed = Arc::new(ParsedEinsum {
-        subscripts: parse_einsum_subscripts(notation)?,
+        notation: parse_einsum_notation(notation)?,
     });
     let entry = ParsedEinsumCacheEntry {
         notation: notation.to_owned(),
@@ -285,7 +377,7 @@ fn cached_subscripts(
     };
     let retained_bytes = saturating_sum([
         entry.notation.len(),
-        einsum_subscripts_retained_bytes(&parsed.subscripts),
+        einsum_notation_retained_bytes(&parsed.notation),
     ]);
     caches.put(key, entry, retained_bytes);
     Ok(parsed)

--- a/crates/tenferro-einsum/src/util.rs
+++ b/crates/tenferro-einsum/src/util.rs
@@ -26,11 +26,19 @@ pub(crate) fn build_size_dict(
                 shapes[i].len()
             )));
         }
+        let mut local_sizes = HashMap::new();
         for (j, &label) in input_subs.iter().enumerate() {
             let size = shapes[i][j];
-            if let Some(&existing) = size_dict.get(&label) {
-                if existing != size {
-                    return Err(Error::shape_mismatch("einsum", [existing], [size]));
+            if let Some(previous) = local_sizes.insert(label, size) {
+                if previous != size {
+                    return Err(Error::shape_mismatch("einsum", [previous], [size]));
+                }
+            }
+            if let Some(existing) = size_dict.get_mut(&label) {
+                if *existing == size || *existing == 1 {
+                    *existing = size;
+                } else if size != 1 {
+                    return Err(Error::shape_mismatch("einsum", [*existing], [size]));
                 }
             } else {
                 size_dict.insert(label, size);

--- a/crates/tenferro-einsum/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-einsum/tests/integration/eager_tensor.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tenferro_ad::{EagerRuntime, EagerTensor};
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::{EagerEinsumExt, EagerTensorEinsumExt};
-use tenferro_einsum::{EinsumSubscripts, TensorDotAxes};
+use tenferro_einsum::{EinsumAxis, EinsumNotation, EinsumSubscripts, TensorDotAxes};
 use tenferro_runtime::{Error as RuntimeError, ErrorPhase, Tensor};
 use tenferro_tensor::ValidationError;
 
@@ -19,6 +19,51 @@ fn test_ctx() -> Arc<EagerRuntime> {
         std::env::set_var("TENFERRO_PROFILE_EAGER_OP_PRINT_EVERY", "1");
     }
     EagerRuntime::with_cpu_backend(CpuBackend::new()).unwrap()
+}
+
+#[test]
+fn eager_tensor_einsum_ellipsis_broadcast_matches_programmatic_notation() {
+    let ctx = test_ctx();
+    let lhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 2, 3], vec![1.0_f64; 12]).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let rhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![1, 3, 2], vec![1.0_f64; 6]).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let notation = EinsumNotation::new(
+        &[
+            &[
+                EinsumAxis::Ellipsis,
+                EinsumAxis::Label(0),
+                EinsumAxis::Label(1),
+            ],
+            &[
+                EinsumAxis::Ellipsis,
+                EinsumAxis::Label(1),
+                EinsumAxis::Label(2),
+            ],
+        ],
+        &[
+            EinsumAxis::Ellipsis,
+            EinsumAxis::Label(0),
+            EinsumAxis::Label(2),
+        ],
+    );
+
+    let string_result = [&lhs, &rhs].einsum("...ij,...jk->...ik").unwrap();
+    let programmatic_result = [&lhs, &rhs].einsum_notation(&notation).unwrap();
+
+    assert_eq!(string_result.shape(), &[2, 2, 2]);
+    assert_eq!(programmatic_result.shape(), &[2, 2, 2]);
+    assert_eq!(f64_data(&string_result.to_tensor().unwrap()), &[3.0; 8]);
+    assert_eq!(
+        f64_data(&programmatic_result.to_tensor().unwrap()),
+        &[3.0; 8]
+    );
 }
 
 #[test]
@@ -203,6 +248,34 @@ fn eager_tensor_einsum_integer_subscripts_match_string_path() {
 
     assert_eq!(c.shape(), &[2, 2]);
     assert_eq!(f64_data(&c.to_tensor().unwrap()), &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn eager_tensor_einsum_ellipsis_backward_matches_expected_values() {
+    let ctx = test_ctx();
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 2, 3], vec![1.0_f64; 12]).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let b = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 3, 2], vec![1.0_f64; 12]).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+
+    let c = [&a, &b].einsum("...ij,...jk->...ik").unwrap();
+    let loss = c.reduce_sum(Some(&[0, 1, 2])).unwrap();
+    let _ = loss.backward().unwrap();
+
+    assert_eq!(
+        f64_data(&a.grad().unwrap().unwrap().to_tensor().unwrap()),
+        &[2.0; 12]
+    );
+    assert_eq!(
+        f64_data(&b.grad().unwrap().unwrap().to_tensor().unwrap()),
+        &[2.0; 12]
+    );
 }
 
 #[test]

--- a/crates/tenferro-einsum/tests/integration/trace_context_einsum.rs
+++ b/crates/tenferro-einsum/tests/integration/trace_context_einsum.rs
@@ -1,5 +1,6 @@
 use tenferro_einsum::{
-    parse_einsum_subscripts, EinsumOptimize, TraceContextEinsumExt, EINSUM_EXTENSION_FAMILY_ID,
+    parse_einsum_subscripts, EinsumAxis, EinsumNotation, EinsumOptimize, TraceContextEinsumExt,
+    EINSUM_EXTENSION_FAMILY_ID,
 };
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_runtime::program::{ProgramInputSpec, SemanticOpRef};
@@ -32,6 +33,80 @@ fn trace_context_einsum_ext_emits_one_ordered_semantic_extension() {
             .map(|extent| extent.as_exact())
             .collect::<Vec<_>>(),
         [Some(&DimExpr::Const(2)), Some(&DimExpr::Const(2))]
+    );
+}
+
+#[test]
+fn trace_context_einsum_supports_ellipsis_broadcast_and_programmatic_notation() {
+    let batch_matrix = || {
+        ProgramInputSpec::new(
+            DType::F64,
+            [DimExpr::Const(2), DimExpr::Const(2), DimExpr::Const(3)],
+        )
+    };
+    let single_batch_matrix = || {
+        ProgramInputSpec::new(
+            DType::F64,
+            [DimExpr::Const(1), DimExpr::Const(3), DimExpr::Const(2)],
+        )
+    };
+    let notation = EinsumNotation::new(
+        &[
+            &[
+                EinsumAxis::Ellipsis,
+                EinsumAxis::Label(0),
+                EinsumAxis::Label(1),
+            ],
+            &[
+                EinsumAxis::Ellipsis,
+                EinsumAxis::Label(1),
+                EinsumAxis::Label(2),
+            ],
+        ],
+        &[
+            EinsumAxis::Ellipsis,
+            EinsumAxis::Label(0),
+            EinsumAxis::Label(2),
+        ],
+    );
+
+    let mut trace = TraceContext::new();
+    let lhs = trace.input(batch_matrix()).unwrap();
+    let rhs = trace.input(single_batch_matrix()).unwrap();
+    let string_output = trace.einsum(&[lhs, rhs], "...ij,...jk->...ik").unwrap();
+    let string_graph = trace.finish(&[string_output]).unwrap();
+    let compiled = GraphCompiler::new()
+        .compile_traced_graph(&string_graph)
+        .unwrap();
+    let lhs_tensor = Tensor::from_vec_col_major(vec![2, 2, 3], vec![1.0_f64; 12]).unwrap();
+    let rhs_tensor = Tensor::from_vec_col_major(vec![1, 3, 2], vec![1.0_f64; 6]).unwrap();
+    let result = support::run_one(&compiled, &[&lhs_tensor, &rhs_tensor]).unwrap();
+    assert_eq!(result.shape(), &[2, 2, 2]);
+    assert_eq!(result.as_slice::<f64>().unwrap(), &[3.0; 8]);
+    assert_eq!(
+        string_graph
+            .program()
+            .value_metadata(string_graph.program().outputs()[0])
+            .unwrap()
+            .shape()
+            .iter()
+            .map(|extent| extent.as_exact())
+            .collect::<Vec<_>>(),
+        vec![
+            Some(&DimExpr::Const(2)),
+            Some(&DimExpr::Const(2)),
+            Some(&DimExpr::Const(2)),
+        ]
+    );
+
+    let mut trace = TraceContext::new();
+    let lhs = trace.input(batch_matrix()).unwrap();
+    let rhs = trace.input(single_batch_matrix()).unwrap();
+    let output = trace.einsum_notation(&[lhs, rhs], &notation).unwrap();
+    let graph = trace.finish(&[output]).unwrap();
+    assert_eq!(
+        graph.program().semantic_fingerprint(),
+        string_graph.program().semantic_fingerprint()
     );
 }
 

--- a/docs/design/einsum-ellipsis.md
+++ b/docs/design/einsum-ellipsis.md
@@ -1,0 +1,40 @@
+# Einsum Ellipsis Resolution
+
+## Decision
+
+`EinsumNotation` is the unresolved public notation. Its axes are `Label(u32)` or
+`Ellipsis`; `EinsumSubscripts` remains the canonical rank-resolved integer-label
+payload used by planning, execution, lowering, caching, and AD.
+
+A single resolver expands one ellipsis per input/output after input ranks are
+known. Ellipsis labels are allocated from unused `u32` values, align from the
+right, and are shared by compatible batch axes. Input dimensions use
+NumPy-style equal-or-one broadcasting (with zero plus one producing zero).
+An input ellipsis may cover zero axes. If an input ellipsis covers axes, the
+explicit output must contain an ellipsis. Parenthesized notation remains
+unsupported in this first implementation.
+
+Concrete and eager operations resolve from concrete input shapes. Traced
+operations resolve ellipsis when dimensions are concrete; symbolic dimensions
+continue to support the existing equality constraints, while unresolved
+ellipsis broadcasting returns a typed planning/validation error rather than
+introducing a backend-specific shape rule.
+
+Singleton broadcast axes are expanded before contraction. The contraction
+planner stores the broadcasted label extent, and the eager/standard-op
+builders insert `BroadcastInDim` operations or zero-stride views as needed.
+Semantic extension payloads carry only a private permission bit for the
+shape-inference layer; the payload still contains resolved labels, and ordinary
+integer-label operations retain their existing equality guards. This keeps
+kernels and extension payloads ellipsis-free.
+
+## Rejected alternatives
+
+- A sentinel `u32` label was rejected because it would reserve a value in the
+  existing canonical integer-label API and would make unresolved rank state
+  visible to planners.
+- Backend-specific ellipsis handling was rejected; all backends consume the
+  existing resolved contraction tree.
+- Implicit output notation and ellipsis reduction by omission are deferred.
+- Parenthesized `NestedEinsum` ellipsis is deferred until its intermediate-rank
+  contract is separately specified.

--- a/docs/design/einsum.md
+++ b/docs/design/einsum.md
@@ -160,9 +160,13 @@ Autodiff eager execution remains separate from concrete `Tensor` execution:
 
 ## Subscripts And Repeated Labels
 
-`Subscripts::parse` accepts flat NumPy/PyTorch-style labels and rejects
+`Subscripts::parse` accepts flat NumPy/PyTorch-style explicit labels and rejects
 parenthesized contraction-order notation. Use `NestedEinsum::parse` when
-contraction order must be preserved.
+contraction order must be preserved. Rank-polymorphic flat notation is parsed
+as [`EinsumNotation`] and resolved only after input ranks are known; one
+right-aligned ellipsis per term supports equal-or-one batch broadcasting. The
+resolved result is converted to `Subscripts` before planning and execution.
+Parenthesized ellipsis and implicit-output equations remain unsupported.
 
 Repeated-label semantics follow the usual einsum rules:
 
@@ -194,7 +198,7 @@ The traced extension API chooses the lowering mode from input shape availability
 | Inputs | Build-time behavior | Runtime behavior |
 | --- | --- | --- |
 | All concrete shapes | optimize the contraction tree at graph build time and lower into ordinary graph ops where possible | execute the lowered graph |
-| Any symbolic shape | emit one einsum extension op | optimize from actual input shapes at runtime |
+| Any symbolic shape | emit one einsum extension op; unresolved ellipsis returns a typed planning error | optimize from actual input shapes at runtime |
 
 `tenferro_einsum` caches concrete-shape contraction trees in the extension
 cache. Runtime contraction trees are keyed by subscripts, input shapes, and the

--- a/docs/getting-started/ndarray-nalgebra-mapping.md
+++ b/docs/getting-started/ndarray-nalgebra-mapping.md
@@ -16,8 +16,9 @@ The short version is the five conventions every tenferro program must follow:
 - **Explicit backend.** Direct operations take an explicit backend argument;
   construct the backend/runtime once and reuse it — per-call construction
   discards the buffer pool.
-- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`); `...`
-  ellipsis is unsupported.
+- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`).
+  Flat notation supports one right-aligned, broadcastable `...` ellipsis per
+  term; use `EinsumNotation` for programmatic notation.
 - **Result-returning operators.** Traced operators return `Result`; propagate
   with `?`.
 

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -138,6 +138,40 @@ assert_eq!(
 ```
 <!-- end-snippet-source -->
 
+### Ellipsis and programmatic notation
+
+Flat string notation supports one NumPy-style ellipsis per term. Ellipsis
+axes right-align and broadcast dimensions of size one. The programmatic
+`EinsumNotation` form resolves to the same canonical labels before planning.
+
+<!-- snippet-source: docs/tutorial-code/src/bin/math_snippets.rs#einsum_20 -->
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::{EinsumAxis, EinsumNotation, TensorEinsumExt};
+use tenferro_tensor::{BackendSessionHost, Tensor};
+
+let lhs = Tensor::from_vec_col_major(vec![2, 2, 3], vec![1.0_f64; 12])?;
+let rhs = Tensor::from_vec_col_major(vec![1, 3, 2], vec![1.0_f64; 6])?;
+let notation = EinsumNotation::new(
+    &[
+        &[EinsumAxis::Ellipsis, EinsumAxis::Label(0), EinsumAxis::Label(1)],
+        &[EinsumAxis::Ellipsis, EinsumAxis::Label(1), EinsumAxis::Label(2)],
+    ],
+    &[EinsumAxis::Ellipsis, EinsumAxis::Label(0), EinsumAxis::Label(2)],
+);
+let mut backend = CpuBackend::new();
+let string_result = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum("...ij,...jk->...ik", session)
+})?;
+let programmatic_result = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum_notation(&notation, session)
+})?;
+assert_eq!(string_result.shape(), &[2, 2, 2]);
+assert_eq!(string_result.as_slice::<f64>()?, &[3.0; 8]);
+assert_eq!(programmatic_result.as_slice::<f64>()?, &[3.0; 8]);
+```
+<!-- end-snippet-source -->
+
 ## TensorRead And Prepared Plans
 
 Use `TensorReadEinsumExt` for dtype-erased borrowed inputs and

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,7 +7,7 @@
 - **Column-major storage.** Dense buffers are column-major: the leftmost dimension varies fastest. Row-major data passed to `from_vec_col_major` is silently reinterpreted as column-major — permuted/wrong values, never rejected.
 - **No facade crate.** `cargo add tenferro` fails by design; depend on the crates you need (`tenferro-runtime`, `tenferro-cpu`, and operation crates).
 - **Explicit backend.** Direct operations take an explicit backend argument; construct the backend/runtime once and reuse it — per-call construction discards the buffer pool.
-- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`); `...` ellipsis is unsupported.
+- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`). Flat notation supports one right-aligned, broadcastable `...` ellipsis per term; `EinsumNotation` is the programmatic form. Parenthesized ellipsis remains unsupported.
 - **Result-returning operators.** Traced operators return `Result`; propagate with `?`.
 
 ## Recipes and references
@@ -28,7 +28,7 @@
 
 ## Guides
 
-- [Einsum](https://tensor4all.org/tenferro-rs/guides/einsum.html): WARNING — tenferro's dialect requires the explicit arrow and rejects `...` ellipsis; read before porting an equation.
+- [Einsum](https://tensor4all.org/tenferro-rs/guides/einsum.html): Requires the explicit arrow; documents flat `...` ellipsis and `EinsumNotation` semantics plus the parenthesized-ellipsis limitation.
 - [Linear Algebra](https://tensor4all.org/tenferro-rs/guides/linear-algebra.html): Covers the `tenferro-linalg` operation crate and its direct, eager, and traced execution surfaces.
 - [External Linear Algebra Interop](https://tensor4all.org/tenferro-rs/guides/external-linalg-interop.html): Calling faer or BLAS/LAPACK directly on tenferro-owned storage: the direct-dependency contract, column-major leading dimensions, non-contiguous/non-host rejection, and provider thread control.
 - [Autodiff](https://tensor4all.org/tenferro-rs/guides/autodiff.html): Describes eager `backward()` and functional or traced `grad`, `vjp`, and `jvp` workflows.

--- a/docs/tutorial-code/src/bin/math_snippets.rs
+++ b/docs/tutorial-code/src/bin/math_snippets.rs
@@ -485,6 +485,38 @@ assert_eq!(
         Ok(())
     }
 
+    snippet_einsum_20()?;
+
+    // snippet source: docs/guides/einsum.md:146
+    fn snippet_einsum_20() -> Result<(), Box<dyn std::error::Error>> {
+        // snippet-start:einsum_20
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::{EinsumAxis, EinsumNotation, TensorEinsumExt};
+use tenferro_tensor::{BackendSessionHost, Tensor};
+
+let lhs = Tensor::from_vec_col_major(vec![2, 2, 3], vec![1.0_f64; 12])?;
+let rhs = Tensor::from_vec_col_major(vec![1, 3, 2], vec![1.0_f64; 6])?;
+let notation = EinsumNotation::new(
+    &[
+        &[EinsumAxis::Ellipsis, EinsumAxis::Label(0), EinsumAxis::Label(1)],
+        &[EinsumAxis::Ellipsis, EinsumAxis::Label(1), EinsumAxis::Label(2)],
+    ],
+    &[EinsumAxis::Ellipsis, EinsumAxis::Label(0), EinsumAxis::Label(2)],
+);
+let mut backend = CpuBackend::new();
+let string_result = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum("...ij,...jk->...ik", session)
+})?;
+let programmatic_result = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum_notation(&notation, session)
+})?;
+assert_eq!(string_result.shape(), &[2, 2, 2]);
+assert_eq!(string_result.as_slice::<f64>()?, &[3.0; 8]);
+assert_eq!(programmatic_result.as_slice::<f64>()?, &[3.0; 8]);
+        // snippet-end:einsum_20
+        Ok(())
+    }
+
     snippet_einsum_13()?;
 
     // snippet source: docs/guides/einsum.md:146

--- a/docs/worklogs/2026-08-17-einsum-ellipsis.md
+++ b/docs/worklogs/2026-08-17-einsum-ellipsis.md
@@ -1,0 +1,44 @@
+# Issue #1702: Einsum ellipsis
+
+## Scope
+
+Implemented flat NumPy-style ellipsis for concrete, eager, and traced einsum
+surfaces, plus the public `EinsumAxis`/`EinsumNotation` programmatic form.
+`EinsumSubscripts` remains the resolved integer-label payload consumed by the
+planner, runtime cache, lowering, and AD rules.
+
+## Decisions
+
+- Resolve one ellipsis per term after ranks are known; align axes from the
+  right and validate equal-or-one dimensions, including zero with one.
+- Allocate collision-free internal ellipsis labels and canonicalize explicit
+  labels for ellipsis notation so string and programmatic forms share cache and
+  semantic identities.
+- Broadcast singleton axes before dot/general contraction in the existing eager
+  and standard-op builders; no backend-specific ellipsis kernel was added.
+- Keep explicit `->` mandatory. Reject output ellipsis without an input
+  ellipsis, multiple ellipses per term, invalid output labels, and parenthesized
+  ellipsis. Traced ellipsis requires concrete input dimensions; existing
+  ellipsis-free symbolic equality behavior remains unchanged.
+- Carry an internal broadcast permission bit on semantic extension payloads so
+  existing symbolic equality guards are not weakened for ordinary integer-label
+  einsum.
+
+## Evidence
+
+- Resolver, parser, diagonal, broadcast, error, and zero-rank tests are in
+  `crates/tenferro-einsum/src/ellipsis.rs` and `concrete_tests.rs`.
+- Eager forward/programmatic and eager AD tests are in
+  `tests/integration/eager_tensor.rs`.
+- Traced forward execution and string/programmatic identity tests are in
+  `tests/integration/trace_context_einsum.rs`.
+- Runnable documentation is in `docs/guides/einsum.md` and
+  `docs/tutorial-code/src/bin/math_snippets.rs`; README, llms, ndarray mapping,
+  and all three skill mirrors were updated.
+
+## Deferred
+
+- Parenthesized `NestedEinsum` ellipsis and implicit-output equations remain
+  outside the issue's initial scope.
+- Fully symbolic traced broadcast disjunctions remain deferred; unresolved
+  ellipsis on symbolic dimensions returns a typed planning error.


### PR DESCRIPTION
Closes #1702

## Summary

- add flat NumPy-style ellipsis parsing and rank-aware resolution
- add public `EinsumAxis` / `EinsumNotation` programmatic notation
- align ellipsis axes from the right and support equal-or-one broadcasting
- route resolved labels through existing planning, eager, traced, runtime-cache, lowering, and AD paths
- add concrete/eager/traced execution and AD coverage
- document the API in the einsum guide, README, llms index, ndarray mapping, and all skill mirrors

Parenthesized ellipsis and implicit-output equations remain deferred. Symbolic traced ellipsis requires concrete input dimensions; unresolved symbolic cases return a typed planning error.

Design/work log: `docs/design/einsum-ellipsis.md`, `docs/worklogs/2026-08-17-einsum-ellipsis.md`

## Verification

- `cargo test -p tenferro-einsum`
- `cargo test -p tenferro-einsum --features autodiff`
- `cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-einsum --features autodiff'`
- `python3 scripts/check-coverage.py /tmp/tenferro-einsum-ellipsis-all-targets.json` (24/24 files)
- `bash scripts/build_docs_site.sh`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --dry-run --llm-skipped-reason 'local deterministic review'`
