### PR TITLE
Add downstream extension, AD, diagnostics, and BLAS-1 APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,9 @@ jobs:
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
       - uses: taiki-e/install-action@cargo-llvm-cov
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+      - name: Run external extension authoring fixture
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+        run: bash tests/run-extension-authoring-fixture.sh
       - name: Generate and enforce coverage
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
         run: python3 scripts/ci/run_profile.py coverage

--- a/crates/tenferro-ad/src/context.rs
+++ b/crates/tenferro-ad/src/context.rs
@@ -442,6 +442,51 @@ impl AdContext {
         )
     }
 
+    /// Forward-mode directional derivative for multiple distinct traced leaves.
+    ///
+    /// Reachable leaves are transformed together in one derivative graph.
+    /// Unreachable leaves contribute nothing; an empty or fully unreachable
+    /// request returns `None`. Duplicate `wrt` leaves are rejected before the
+    /// transform because one semantic seed slot cannot accept two tangents.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ad::AdContext;
+    /// use tenferro_runtime::TracedTensor;
+    ///
+    /// let ad = AdContext::builder().build().unwrap();
+    /// let x = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
+    /// let y = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap();
+    /// let dx = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
+    /// let dy = TracedTensor::from_vec_col_major(vec![], vec![4.0_f64]).unwrap();
+    /// let output = (&x * &y).unwrap();
+    /// assert!(ad.jvp_many(&output, &[(&x, &dx), (&y, &dy)]).unwrap().is_some());
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::Validation`] for duplicate leaves or
+    /// incompatible tangent metadata, [`tenferro_runtime::Error::UnsupportedAdRule`]
+    /// when a required rule is unavailable, or a typed runtime-state error when
+    /// derivative graph construction fails.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape constraints may fail during later compilation or execution.
+    pub fn jvp_many(
+        &self,
+        output: &TracedTensor,
+        wrt_tangents: &[(&TracedTensor, &TracedTensor)],
+    ) -> Result<Option<TracedTensor>> {
+        crate::traced::jvp_many_with_rules_and_cache(
+            output,
+            wrt_tangents,
+            &self.semantic_extension_rules,
+            Some(self.ad_transform_cache.as_ref()),
+        )
+    }
+
     /// Reverse-mode vector-Jacobian product.
     ///
     /// Complex cotangents use tenferro's Hermitian real-inner-product
@@ -514,6 +559,53 @@ impl AdContext {
         crate::traced::vjp_optional_with_rules_and_cache(
             output,
             wrt,
+            cotangent,
+            &self.semantic_extension_rules,
+            Some(self.ad_transform_cache.as_ref()),
+        )
+    }
+
+    /// Reverse-mode products for multiple traced leaves in one derivative graph.
+    ///
+    /// Results align with `wrts`; unreachable leaves produce `None`. Duplicate
+    /// leaves are allowed and repeat the same traced derivative without
+    /// accumulating the cotangent twice. An empty request validates that the
+    /// cotangent has concrete data, then returns an empty vector.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ad::AdContext;
+    /// use tenferro_runtime::TracedTensor;
+    ///
+    /// let ad = AdContext::builder().build().unwrap();
+    /// let x = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
+    /// let y = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap();
+    /// let seed = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
+    /// let output = (&x * &y).unwrap();
+    /// let products = ad.vjp_many(&output, &[&x, &y], &seed).unwrap();
+    /// assert!(products.iter().all(Option::is_some));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::Validation`] for invalid cotangent
+    /// metadata, [`tenferro_runtime::Error::UnsupportedAdRule`] when a required
+    /// rule is unavailable, or a typed runtime-state error when derivative graph
+    /// construction fails.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape constraints may fail during later compilation or execution.
+    pub fn vjp_many(
+        &self,
+        output: &TracedTensor,
+        wrts: &[&TracedTensor],
+        cotangent: &TracedTensor,
+    ) -> Result<Vec<Option<TracedTensor>>> {
+        crate::traced::vjp_many_with_rules_and_cache(
+            output,
+            wrts,
             cotangent,
             &self.semantic_extension_rules,
             Some(self.ad_transform_cache.as_ref()),

--- a/crates/tenferro-ad/src/semantic_extension.rs
+++ b/crates/tenferro-ad/src/semantic_extension.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 pub use tenferro_ops::ad::ResidualSpec;
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_runtime::program::{
-    ProgramBuildError, ProgramValue, SemanticOpRef, SemanticOperationView, SemanticProgramBuilder,
-    SemanticProvenanceView,
+    ProgramBuildError, ProgramValue, ProgramValueMetadata, SemanticOpRef, SemanticOperationView,
+    SemanticProgramBuilder, SemanticProvenanceView,
 };
 
 /// One optional semantic AD value.
@@ -65,6 +65,24 @@ pub enum SemanticExtensionRegistryError {
     },
 }
 
+/// Whether a checked semantic AD request refers to a primal input or output.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_ad::semantic_extension::PrimalValueKind;
+///
+/// assert_eq!(format!("{:?}", PrimalValueKind::Input), "Input");
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PrimalValueKind {
+    /// An ordered primal input.
+    Input,
+    /// An ordered primal output.
+    Output,
+}
+
 /// Failures while dispatching or building semantic extension AD.
 #[derive(Debug, thiserror::Error)]
 pub enum SemanticAdError {
@@ -94,6 +112,32 @@ pub enum SemanticAdError {
         expected: usize,
         /// Supplied field length.
         actual: usize,
+    },
+    /// A checked primal value index is outside the request's ordered values.
+    #[error(
+        "semantic extension family {family_id:?} {kind:?} index {index} is out of bounds for length {len}"
+    )]
+    PrimalIndexOutOfBounds {
+        /// Extension family that owns the request.
+        family_id: &'static str,
+        /// Ordered primal collection being accessed.
+        kind: PrimalValueKind,
+        /// Requested index.
+        index: usize,
+        /// Number of values in the collection.
+        len: usize,
+    },
+    /// A checked primal value was not declared as a tensor residual by the rule.
+    #[error(
+        "semantic extension family {family_id:?} may not access undeclared {kind:?} residual value {index}"
+    )]
+    UndeclaredResidualValue {
+        /// Extension family that owns the request.
+        family_id: &'static str,
+        /// Ordered primal collection being accessed.
+        kind: PrimalValueKind,
+        /// Requested index.
+        index: usize,
     },
     /// A request or result value belongs to another builder.
     #[error("semantic AD field {field}[{index}] does not belong to the destination builder")]
@@ -214,11 +258,12 @@ impl SemanticLinearizeResult {
 }
 
 /// Ordered inputs for one semantic linear-transpose rule.
-#[derive(Clone, Copy)]
 pub struct SemanticLinearTransposeRequest<'a> {
     op: &'a dyn ExtensionOp,
     primal_inputs: &'a [ProgramValue],
     primal_outputs: &'a [ProgramValue],
+    primal_input_metadata: Box<[ProgramValueMetadata]>,
+    primal_output_metadata: Box<[ProgramValueMetadata]>,
     cotangent_outputs: &'a [AdValue],
     active_inputs: &'a [bool],
     residuals: &'a [ProgramValue],
@@ -228,54 +273,127 @@ pub struct SemanticLinearTransposeRequest<'a> {
 
 impl<'a> SemanticLinearTransposeRequest<'a> {
     /// Borrow the extension payload.
-    pub const fn op(self) -> &'a dyn ExtensionOp {
+    pub fn op(&self) -> &dyn ExtensionOp {
         self.op
     }
 
-    /// Borrow ordered destination-local primal inputs.
-    pub const fn primal_inputs(self) -> &'a [ProgramValue] {
-        self.primal_inputs
+    /// Return one declared primal input tensor value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] before checking the
+    /// residual mask, or [`SemanticAdError::UndeclaredResidualValue`] when the
+    /// rule did not declare this input as a tensor residual.
+    pub fn primal_input_value(&self, index: usize) -> Result<ProgramValue, SemanticAdError> {
+        checked_primal_value(
+            self.op.family_id(),
+            PrimalValueKind::Input,
+            index,
+            self.primal_inputs,
+            self.residual_mask,
+        )
     }
 
-    /// Borrow ordered destination-local primal outputs.
-    pub const fn primal_outputs(self) -> &'a [ProgramValue] {
-        self.primal_outputs
+    /// Return one declared primal output tensor value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] before checking the
+    /// residual mask, or [`SemanticAdError::UndeclaredResidualValue`] when the
+    /// rule did not declare this output as a tensor residual.
+    pub fn primal_output_value(&self, index: usize) -> Result<ProgramValue, SemanticAdError> {
+        checked_primal_value(
+            self.op.family_id(),
+            PrimalValueKind::Output,
+            index,
+            self.primal_outputs,
+            self.residual_mask,
+        )
+    }
+
+    /// Borrow metadata for one primal input without exposing its value token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] when `index` is not
+    /// an ordered primal input.
+    pub fn primal_input_meta(
+        &self,
+        index: usize,
+    ) -> Result<&ProgramValueMetadata, SemanticAdError> {
+        checked_primal_metadata(
+            self.op.family_id(),
+            PrimalValueKind::Input,
+            index,
+            &self.primal_input_metadata,
+        )
+    }
+
+    /// Borrow metadata for one primal output without exposing its value token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] when `index` is not
+    /// an ordered primal output.
+    pub fn primal_output_meta(
+        &self,
+        index: usize,
+    ) -> Result<&ProgramValueMetadata, SemanticAdError> {
+        checked_primal_metadata(
+            self.op.family_id(),
+            PrimalValueKind::Output,
+            index,
+            &self.primal_output_metadata,
+        )
+    }
+
+    /// Return the number of ordered primal inputs.
+    #[must_use]
+    pub const fn primal_input_count(&self) -> usize {
+        self.primal_input_metadata.len()
+    }
+
+    /// Return the number of ordered primal outputs.
+    #[must_use]
+    pub const fn primal_output_count(&self) -> usize {
+        self.primal_output_metadata.len()
     }
 
     /// Borrow ordered optional output cotangents.
-    pub const fn cotangent_outputs(self) -> &'a [AdValue] {
+    pub fn cotangent_outputs(&self) -> &[AdValue] {
         self.cotangent_outputs
     }
 
     /// Borrow the ordered active-input mask.
-    pub const fn active_inputs(self) -> &'a [bool] {
+    pub fn active_inputs(&self) -> &[bool] {
         self.active_inputs
     }
 
     /// Borrow ordered residuals produced by linearization.
-    pub const fn residuals(self) -> &'a [ProgramValue] {
+    pub fn residuals(&self) -> &[ProgramValue] {
         self.residuals
     }
 
     /// Return this rule's declared residual mask: which primal input/output
     /// indices may be read as tensor values. Accesses outside the mask must
     /// only use shape/dtype metadata.
-    pub const fn residual_mask(self) -> ResidualSpec {
+    pub const fn residual_mask(&self) -> ResidualSpec {
         self.residual_mask
     }
 
     /// Return bounded operation provenance.
-    pub const fn provenance(self) -> SemanticProvenanceView<'a> {
+    pub const fn provenance(&self) -> SemanticProvenanceView<'a> {
         self.provenance
     }
 }
 
 /// Ordered inputs for one direct semantic primal-VJP rule.
-#[derive(Clone, Copy)]
 pub struct SemanticPrimalVjpRequest<'a> {
     op: &'a dyn ExtensionOp,
     primal_inputs: &'a [ProgramValue],
     primal_outputs: &'a [ProgramValue],
+    primal_input_metadata: Box<[ProgramValueMetadata]>,
+    primal_output_metadata: Box<[ProgramValueMetadata]>,
     cotangent_outputs: &'a [AdValue],
     active_inputs: &'a [bool],
     residual_mask: ResidualSpec,
@@ -284,39 +402,111 @@ pub struct SemanticPrimalVjpRequest<'a> {
 
 impl<'a> SemanticPrimalVjpRequest<'a> {
     /// Borrow the extension payload.
-    pub const fn op(self) -> &'a dyn ExtensionOp {
+    pub fn op(&self) -> &dyn ExtensionOp {
         self.op
     }
 
-    /// Borrow ordered destination-local primal inputs.
-    pub const fn primal_inputs(self) -> &'a [ProgramValue] {
-        self.primal_inputs
+    /// Return one declared primal input tensor value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] before checking the
+    /// residual mask, or [`SemanticAdError::UndeclaredResidualValue`] when the
+    /// rule did not declare this input as a tensor residual.
+    pub fn primal_input_value(&self, index: usize) -> Result<ProgramValue, SemanticAdError> {
+        checked_primal_value(
+            self.op.family_id(),
+            PrimalValueKind::Input,
+            index,
+            self.primal_inputs,
+            self.residual_mask,
+        )
     }
 
-    /// Borrow ordered destination-local primal outputs.
-    pub const fn primal_outputs(self) -> &'a [ProgramValue] {
-        self.primal_outputs
+    /// Return one declared primal output tensor value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] before checking the
+    /// residual mask, or [`SemanticAdError::UndeclaredResidualValue`] when the
+    /// rule did not declare this output as a tensor residual.
+    pub fn primal_output_value(&self, index: usize) -> Result<ProgramValue, SemanticAdError> {
+        checked_primal_value(
+            self.op.family_id(),
+            PrimalValueKind::Output,
+            index,
+            self.primal_outputs,
+            self.residual_mask,
+        )
+    }
+
+    /// Borrow metadata for one primal input without exposing its value token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] when `index` is not
+    /// an ordered primal input.
+    pub fn primal_input_meta(
+        &self,
+        index: usize,
+    ) -> Result<&ProgramValueMetadata, SemanticAdError> {
+        checked_primal_metadata(
+            self.op.family_id(),
+            PrimalValueKind::Input,
+            index,
+            &self.primal_input_metadata,
+        )
+    }
+
+    /// Borrow metadata for one primal output without exposing its value token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] when `index` is not
+    /// an ordered primal output.
+    pub fn primal_output_meta(
+        &self,
+        index: usize,
+    ) -> Result<&ProgramValueMetadata, SemanticAdError> {
+        checked_primal_metadata(
+            self.op.family_id(),
+            PrimalValueKind::Output,
+            index,
+            &self.primal_output_metadata,
+        )
+    }
+
+    /// Return the number of ordered primal inputs.
+    #[must_use]
+    pub const fn primal_input_count(&self) -> usize {
+        self.primal_input_metadata.len()
+    }
+
+    /// Return the number of ordered primal outputs.
+    #[must_use]
+    pub const fn primal_output_count(&self) -> usize {
+        self.primal_output_metadata.len()
     }
 
     /// Borrow ordered optional output cotangents.
-    pub const fn cotangent_outputs(self) -> &'a [AdValue] {
+    pub fn cotangent_outputs(&self) -> &[AdValue] {
         self.cotangent_outputs
     }
 
     /// Borrow the ordered active-input mask.
-    pub const fn active_inputs(self) -> &'a [bool] {
+    pub fn active_inputs(&self) -> &[bool] {
         self.active_inputs
     }
 
     /// Return this rule's declared residual mask: which primal input/output
     /// indices may be read as tensor values. Accesses outside the mask must
     /// only use shape/dtype metadata.
-    pub const fn residual_mask(self) -> ResidualSpec {
+    pub const fn residual_mask(&self) -> ResidualSpec {
         self.residual_mask
     }
 
     /// Return bounded operation provenance.
-    pub const fn provenance(self) -> SemanticProvenanceView<'a> {
+    pub const fn provenance(&self) -> SemanticProvenanceView<'a> {
         self.provenance
     }
 }
@@ -648,6 +838,8 @@ impl SemanticExtensionRuleSet {
         validate_len("active_inputs", op.input_count(), active_inputs.len())?;
         validate_ad_values("cotangent_outputs", cotangent_outputs, builder)?;
         validate_values("residuals", residuals, builder)?;
+        let primal_input_metadata = snapshot_metadata(primal_inputs, builder)?;
+        let primal_output_metadata = snapshot_metadata(primal_outputs, builder)?;
         let rule =
             self.lookup_linear_transpose(op.family_id())
                 .ok_or(SemanticAdError::MissingRule {
@@ -659,6 +851,8 @@ impl SemanticExtensionRuleSet {
                 op,
                 primal_inputs,
                 primal_outputs,
+                primal_input_metadata,
+                primal_output_metadata,
                 cotangent_outputs,
                 active_inputs,
                 residuals,
@@ -699,6 +893,8 @@ impl SemanticExtensionRuleSet {
         )?;
         validate_len("active_inputs", op.input_count(), active_inputs.len())?;
         validate_ad_values("cotangent_outputs", cotangent_outputs, builder)?;
+        let primal_input_metadata = snapshot_metadata(primal_inputs, builder)?;
+        let primal_output_metadata = snapshot_metadata(primal_outputs, builder)?;
         let rule = self
             .lookup_primal_vjp(op.family_id())
             .ok_or(SemanticAdError::MissingRule {
@@ -710,6 +906,8 @@ impl SemanticExtensionRuleSet {
                 op,
                 primal_inputs,
                 primal_outputs,
+                primal_input_metadata,
+                primal_output_metadata,
                 cotangent_outputs,
                 active_inputs,
                 residual_mask: rule.residual_mask(),
@@ -755,6 +953,62 @@ fn validate_operation_inputs(
     )?;
     validate_values("primal_inputs", primal_inputs, builder)?;
     validate_values("primal_outputs", primal_outputs, builder)
+}
+
+fn checked_primal_value(
+    family_id: &'static str,
+    kind: PrimalValueKind,
+    index: usize,
+    values: &[ProgramValue],
+    residual_mask: ResidualSpec,
+) -> Result<ProgramValue, SemanticAdError> {
+    if index >= values.len() {
+        return Err(SemanticAdError::PrimalIndexOutOfBounds {
+            family_id,
+            kind,
+            index,
+            len: values.len(),
+        });
+    }
+    let declared = match kind {
+        PrimalValueKind::Input => residual_mask.declares_input(index),
+        PrimalValueKind::Output => residual_mask.declares_output(index),
+    };
+    if !declared {
+        return Err(SemanticAdError::UndeclaredResidualValue {
+            family_id,
+            kind,
+            index,
+        });
+    }
+    Ok(values[index])
+}
+
+fn checked_primal_metadata<'a>(
+    family_id: &'static str,
+    kind: PrimalValueKind,
+    index: usize,
+    metadata: &'a [ProgramValueMetadata],
+) -> Result<&'a ProgramValueMetadata, SemanticAdError> {
+    metadata
+        .get(index)
+        .ok_or(SemanticAdError::PrimalIndexOutOfBounds {
+            family_id,
+            kind,
+            index,
+            len: metadata.len(),
+        })
+}
+
+fn snapshot_metadata(
+    values: &[ProgramValue],
+    builder: &SemanticProgramBuilder,
+) -> Result<Box<[ProgramValueMetadata]>, SemanticAdError> {
+    values
+        .iter()
+        .copied()
+        .map(|value| Ok(builder.value_metadata(value)?.clone()))
+        .collect()
 }
 
 fn validate_values(

--- a/crates/tenferro-ad/src/semantic_extension.rs
+++ b/crates/tenferro-ad/src/semantic_extension.rs
@@ -273,6 +273,16 @@ pub struct SemanticLinearTransposeRequest<'a> {
 
 impl<'a> SemanticLinearTransposeRequest<'a> {
     /// Borrow the extension payload.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticLinearTransposeRequest};
+    /// # fn inspect(request: &SemanticLinearTransposeRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.op().family_id();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn op(&self) -> &dyn ExtensionOp {
         self.op
     }
@@ -284,6 +294,16 @@ impl<'a> SemanticLinearTransposeRequest<'a> {
     /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] before checking the
     /// residual mask, or [`SemanticAdError::UndeclaredResidualValue`] when the
     /// rule did not declare this input as a tensor residual.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticLinearTransposeRequest};
+    /// # fn inspect(request: &SemanticLinearTransposeRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.primal_input_value(0)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn primal_input_value(&self, index: usize) -> Result<ProgramValue, SemanticAdError> {
         checked_primal_value(
             self.op.family_id(),
@@ -301,6 +321,16 @@ impl<'a> SemanticLinearTransposeRequest<'a> {
     /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] before checking the
     /// residual mask, or [`SemanticAdError::UndeclaredResidualValue`] when the
     /// rule did not declare this output as a tensor residual.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticLinearTransposeRequest};
+    /// # fn inspect(request: &SemanticLinearTransposeRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.primal_output_value(0)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn primal_output_value(&self, index: usize) -> Result<ProgramValue, SemanticAdError> {
         checked_primal_value(
             self.op.family_id(),
@@ -317,6 +347,16 @@ impl<'a> SemanticLinearTransposeRequest<'a> {
     ///
     /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] when `index` is not
     /// an ordered primal input.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticLinearTransposeRequest};
+    /// # fn inspect(request: &SemanticLinearTransposeRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.primal_input_meta(0)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn primal_input_meta(
         &self,
         index: usize,
@@ -335,6 +375,16 @@ impl<'a> SemanticLinearTransposeRequest<'a> {
     ///
     /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] when `index` is not
     /// an ordered primal output.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticLinearTransposeRequest};
+    /// # fn inspect(request: &SemanticLinearTransposeRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.primal_output_meta(0)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn primal_output_meta(
         &self,
         index: usize,
@@ -349,27 +399,77 @@ impl<'a> SemanticLinearTransposeRequest<'a> {
 
     /// Return the number of ordered primal inputs.
     #[must_use]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticLinearTransposeRequest};
+    /// # fn inspect(request: &SemanticLinearTransposeRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.primal_input_count();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub const fn primal_input_count(&self) -> usize {
         self.primal_input_metadata.len()
     }
 
     /// Return the number of ordered primal outputs.
     #[must_use]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticLinearTransposeRequest};
+    /// # fn inspect(request: &SemanticLinearTransposeRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.primal_output_count();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub const fn primal_output_count(&self) -> usize {
         self.primal_output_metadata.len()
     }
 
     /// Borrow ordered optional output cotangents.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticLinearTransposeRequest};
+    /// # fn inspect(request: &SemanticLinearTransposeRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.cotangent_outputs();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn cotangent_outputs(&self) -> &[AdValue] {
         self.cotangent_outputs
     }
 
     /// Borrow the ordered active-input mask.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticLinearTransposeRequest};
+    /// # fn inspect(request: &SemanticLinearTransposeRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.active_inputs();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn active_inputs(&self) -> &[bool] {
         self.active_inputs
     }
 
     /// Borrow ordered residuals produced by linearization.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticLinearTransposeRequest};
+    /// # fn inspect(request: &SemanticLinearTransposeRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.residuals();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn residuals(&self) -> &[ProgramValue] {
         self.residuals
     }
@@ -377,11 +477,31 @@ impl<'a> SemanticLinearTransposeRequest<'a> {
     /// Return this rule's declared residual mask: which primal input/output
     /// indices may be read as tensor values. Accesses outside the mask must
     /// only use shape/dtype metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticLinearTransposeRequest};
+    /// # fn inspect(request: &SemanticLinearTransposeRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.residual_mask();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub const fn residual_mask(&self) -> ResidualSpec {
         self.residual_mask
     }
 
     /// Return bounded operation provenance.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticLinearTransposeRequest};
+    /// # fn inspect(request: &SemanticLinearTransposeRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.provenance();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub const fn provenance(&self) -> SemanticProvenanceView<'a> {
         self.provenance
     }
@@ -402,6 +522,16 @@ pub struct SemanticPrimalVjpRequest<'a> {
 
 impl<'a> SemanticPrimalVjpRequest<'a> {
     /// Borrow the extension payload.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticPrimalVjpRequest};
+    /// # fn inspect(request: &SemanticPrimalVjpRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.op().family_id();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn op(&self) -> &dyn ExtensionOp {
         self.op
     }
@@ -413,6 +543,16 @@ impl<'a> SemanticPrimalVjpRequest<'a> {
     /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] before checking the
     /// residual mask, or [`SemanticAdError::UndeclaredResidualValue`] when the
     /// rule did not declare this input as a tensor residual.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticPrimalVjpRequest};
+    /// # fn inspect(request: &SemanticPrimalVjpRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.primal_input_value(0)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn primal_input_value(&self, index: usize) -> Result<ProgramValue, SemanticAdError> {
         checked_primal_value(
             self.op.family_id(),
@@ -430,6 +570,16 @@ impl<'a> SemanticPrimalVjpRequest<'a> {
     /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] before checking the
     /// residual mask, or [`SemanticAdError::UndeclaredResidualValue`] when the
     /// rule did not declare this output as a tensor residual.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticPrimalVjpRequest};
+    /// # fn inspect(request: &SemanticPrimalVjpRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.primal_output_value(0)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn primal_output_value(&self, index: usize) -> Result<ProgramValue, SemanticAdError> {
         checked_primal_value(
             self.op.family_id(),
@@ -446,6 +596,16 @@ impl<'a> SemanticPrimalVjpRequest<'a> {
     ///
     /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] when `index` is not
     /// an ordered primal input.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticPrimalVjpRequest};
+    /// # fn inspect(request: &SemanticPrimalVjpRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.primal_input_meta(0)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn primal_input_meta(
         &self,
         index: usize,
@@ -464,6 +624,16 @@ impl<'a> SemanticPrimalVjpRequest<'a> {
     ///
     /// Returns [`SemanticAdError::PrimalIndexOutOfBounds`] when `index` is not
     /// an ordered primal output.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticPrimalVjpRequest};
+    /// # fn inspect(request: &SemanticPrimalVjpRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.primal_output_meta(0)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn primal_output_meta(
         &self,
         index: usize,
@@ -478,22 +648,62 @@ impl<'a> SemanticPrimalVjpRequest<'a> {
 
     /// Return the number of ordered primal inputs.
     #[must_use]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticPrimalVjpRequest};
+    /// # fn inspect(request: &SemanticPrimalVjpRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.primal_input_count();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub const fn primal_input_count(&self) -> usize {
         self.primal_input_metadata.len()
     }
 
     /// Return the number of ordered primal outputs.
     #[must_use]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticPrimalVjpRequest};
+    /// # fn inspect(request: &SemanticPrimalVjpRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.primal_output_count();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub const fn primal_output_count(&self) -> usize {
         self.primal_output_metadata.len()
     }
 
     /// Borrow ordered optional output cotangents.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticPrimalVjpRequest};
+    /// # fn inspect(request: &SemanticPrimalVjpRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.cotangent_outputs();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn cotangent_outputs(&self) -> &[AdValue] {
         self.cotangent_outputs
     }
 
     /// Borrow the ordered active-input mask.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticPrimalVjpRequest};
+    /// # fn inspect(request: &SemanticPrimalVjpRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.active_inputs();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn active_inputs(&self) -> &[bool] {
         self.active_inputs
     }
@@ -501,11 +711,31 @@ impl<'a> SemanticPrimalVjpRequest<'a> {
     /// Return this rule's declared residual mask: which primal input/output
     /// indices may be read as tensor values. Accesses outside the mask must
     /// only use shape/dtype metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticPrimalVjpRequest};
+    /// # fn inspect(request: &SemanticPrimalVjpRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.residual_mask();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub const fn residual_mask(&self) -> ResidualSpec {
         self.residual_mask
     }
 
     /// Return bounded operation provenance.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::semantic_extension::{SemanticAdError, SemanticPrimalVjpRequest};
+    /// # fn inspect(request: &SemanticPrimalVjpRequest<'_>) -> Result<(), SemanticAdError> {
+    /// let _ = request.provenance();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub const fn provenance(&self) -> SemanticProvenanceView<'a> {
         self.provenance
     }
@@ -1089,242 +1319,4 @@ fn is_valid_family_id(family_id: &str) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::any::Any;
-    use std::hash::Hasher;
-    use tenferro_ops::{ExtensionShapeContext, SymDim};
-    use tenferro_runtime::program::ProgramInputSpec;
-    use tenferro_tensor::DType;
-
-    const FAMILY: &str = "tenferro-ad.checked-request-test.v1";
-
-    #[derive(Clone, Debug)]
-    struct TestOp;
-
-    impl ExtensionOp for TestOp {
-        fn family_id(&self) -> &'static str {
-            FAMILY
-        }
-        fn payload_hash(&self, state: &mut dyn Hasher) {
-            state.write_u8(0);
-        }
-        fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
-            other.as_any().is::<Self>()
-        }
-        fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
-            Arc::new(self.clone())
-        }
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-        fn input_count(&self) -> usize {
-            1
-        }
-        fn output_count(&self) -> usize {
-            1
-        }
-        fn semantic_effects(&self) -> tenferro_ops::ext_op::ExtensionEffectDeclaration<'_> {
-            tenferro_ops::ext_op::ExtensionEffectDeclaration::Declared(&[])
-        }
-        fn semantic_aliases(&self) -> tenferro_ops::ext_op::ExtensionAliasDeclaration<'_> {
-            tenferro_ops::ext_op::ExtensionAliasDeclaration::AllFresh
-        }
-        fn infer_output_meta(
-            &self,
-            context: &mut ExtensionShapeContext<'_>,
-        ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
-            Ok(vec![(
-                context.input_dtype(0)?,
-                context.input_shape(0)?.to_vec(),
-            )])
-        }
-    }
-
-    #[derive(Debug)]
-    struct TestRule(&'static str);
-
-    impl SemanticLinearizeRule for TestRule {
-        fn family_id(&self) -> &'static str {
-            self.0
-        }
-        fn linearize(
-            &self,
-            request: SemanticLinearizeRequest<'_>,
-            _builder: &mut SemanticProgramBuilder,
-        ) -> Result<SemanticLinearizeResult, SemanticAdError> {
-            Ok(SemanticLinearizeResult::new(
-                std::iter::repeat_n(AdValue::Absent, request.primal_outputs().len()),
-                [],
-            ))
-        }
-    }
-
-    impl SemanticLinearTransposeRule for TestRule {
-        fn family_id(&self) -> &'static str {
-            self.0
-        }
-        fn residual_mask(&self) -> ResidualSpec {
-            ResidualSpec::none()
-        }
-        fn linear_transpose(
-            &self,
-            request: SemanticLinearTransposeRequest<'_>,
-            _builder: &mut SemanticProgramBuilder,
-        ) -> Result<Box<[AdValue]>, SemanticAdError> {
-            Ok(vec![AdValue::Absent; request.primal_input_count()].into_boxed_slice())
-        }
-    }
-
-    impl SemanticPrimalVjpRule for TestRule {
-        fn family_id(&self) -> &'static str {
-            self.0
-        }
-        fn residual_mask(&self) -> ResidualSpec {
-            ResidualSpec::none()
-        }
-        fn primal_vjp(
-            &self,
-            request: SemanticPrimalVjpRequest<'_>,
-            _builder: &mut SemanticProgramBuilder,
-        ) -> Result<Box<[AdValue]>, SemanticAdError> {
-            Ok(vec![AdValue::Absent; request.primal_input_count()].into_boxed_slice())
-        }
-    }
-
-    #[test]
-    fn checked_request_accessors_cover_declared_metadata_and_errors() {
-        let mut builder = SemanticProgramBuilder::new();
-        let input = builder
-            .input(ProgramInputSpec::new(DType::F64, [1usize.into()]))
-            .unwrap();
-        let output = builder.add_extension(Arc::new(TestOp), &[input]).unwrap()[0];
-        let frozen = builder.finish(&[output]).unwrap();
-        let operation = frozen.program.operations().next().unwrap();
-        let op = extension_for_dispatch(operation).unwrap();
-        let inputs = [input];
-        let outputs = [output];
-        let metadata = [ProgramValueMetadata::new(DType::F64, [1usize.into()])];
-        let cotangents = [AdValue::Absent];
-        let active = [true];
-        let residuals = [output];
-        let mask = ResidualSpec::all_inputs().with_all_outputs();
-
-        let transpose = SemanticLinearTransposeRequest {
-            op,
-            primal_inputs: &inputs,
-            primal_outputs: &outputs,
-            primal_input_metadata: metadata.clone().into(),
-            primal_output_metadata: metadata.clone().into(),
-            cotangent_outputs: &cotangents,
-            active_inputs: &active,
-            residuals: &residuals,
-            residual_mask: mask,
-            provenance: operation.provenance(),
-        };
-        assert_eq!(transpose.op().family_id(), FAMILY);
-        assert_eq!(transpose.primal_input_value(0).unwrap(), input);
-        assert_eq!(transpose.primal_output_value(0).unwrap(), output);
-        assert_eq!(transpose.primal_input_meta(0).unwrap().dtype(), DType::F64);
-        assert_eq!(transpose.primal_output_meta(0).unwrap().dtype(), DType::F64);
-        assert_eq!(transpose.primal_input_count(), 1);
-        assert_eq!(transpose.primal_output_count(), 1);
-        assert_eq!(transpose.cotangent_outputs(), &cotangents);
-        assert_eq!(transpose.active_inputs(), &active);
-        assert_eq!(transpose.residuals(), &residuals);
-        assert_eq!(transpose.residual_mask(), mask);
-        assert_eq!(transpose.provenance().label(), Some(FAMILY));
-        assert!(matches!(
-            transpose.primal_input_value(2),
-            Err(SemanticAdError::PrimalIndexOutOfBounds {
-                kind: PrimalValueKind::Input,
-                ..
-            })
-        ));
-        assert!(matches!(
-            checked_primal_value(
-                FAMILY,
-                PrimalValueKind::Output,
-                0,
-                &outputs,
-                ResidualSpec::none()
-            ),
-            Err(SemanticAdError::UndeclaredResidualValue { .. })
-        ));
-        assert!(transpose.primal_output_meta(2).is_err());
-
-        let direct = SemanticPrimalVjpRequest {
-            op,
-            primal_inputs: &inputs,
-            primal_outputs: &outputs,
-            primal_input_metadata: metadata.clone().into(),
-            primal_output_metadata: metadata.into(),
-            cotangent_outputs: &cotangents,
-            active_inputs: &active,
-            residual_mask: mask,
-            provenance: operation.provenance(),
-        };
-        assert_eq!(direct.op().family_id(), FAMILY);
-        assert_eq!(direct.primal_input_value(0).unwrap(), input);
-        assert_eq!(direct.primal_output_value(0).unwrap(), output);
-        assert_eq!(direct.primal_input_meta(0).unwrap().dtype(), DType::F64);
-        assert_eq!(direct.primal_output_meta(0).unwrap().dtype(), DType::F64);
-        assert_eq!(direct.primal_input_count(), 1);
-        assert_eq!(direct.primal_output_count(), 1);
-        assert_eq!(direct.cotangent_outputs(), &cotangents);
-        assert_eq!(direct.active_inputs(), &active);
-        assert_eq!(direct.residual_mask(), mask);
-        assert_eq!(direct.provenance().label(), Some(FAMILY));
-        assert!(direct.primal_input_meta(2).is_err());
-        assert_eq!(AdValue::Absent.value(), None);
-        assert_eq!(AdValue::Value(input).value(), Some(input));
-    }
-
-    #[test]
-    fn rule_set_registration_lookup_debug_and_validation_are_covered() {
-        let mut rules = SemanticExtensionRuleSet::new();
-        rules
-            .register_linearize(Arc::new(TestRule(FAMILY)))
-            .unwrap();
-        rules
-            .register_linear_transpose(Arc::new(TestRule(FAMILY)))
-            .unwrap();
-        rules
-            .register_primal_vjp(Arc::new(TestRule(FAMILY)))
-            .unwrap();
-        assert!(rules.lookup_linearize(FAMILY).is_some());
-        assert!(rules.lookup_linear_transpose(FAMILY).is_some());
-        assert!(rules.lookup_primal_vjp(FAMILY).is_some());
-        assert!(format!("{rules:?}").contains(FAMILY));
-        assert!(matches!(
-            rules.register_linearize(Arc::new(TestRule(FAMILY))),
-            Err(SemanticExtensionRegistryError::DuplicateRule {
-                role: SemanticAdRuleRole::Linearize,
-                ..
-            })
-        ));
-        assert!(matches!(
-            SemanticExtensionRuleSet::new().with_linearize(Arc::new(TestRule("invalid"))),
-            Err(SemanticExtensionRegistryError::MalformedFamilyId { .. })
-        ));
-        assert!(SemanticExtensionRuleSet::new()
-            .with_linear_transpose(Arc::new(TestRule(FAMILY)))
-            .unwrap()
-            .lookup_linear_transpose(FAMILY)
-            .is_some());
-        assert!(SemanticExtensionRuleSet::new()
-            .with_primal_vjp(Arc::new(TestRule(FAMILY)))
-            .unwrap()
-            .lookup_primal_vjp(FAMILY)
-            .is_some());
-        for invalid in [
-            "crate.op",
-            ".op.v1",
-            "crate..v1",
-            "crate.op.v",
-            "crate op.v1",
-        ] {
-            assert!(!is_valid_family_id(invalid));
-        }
-    }
-}
+mod tests;

--- a/crates/tenferro-ad/src/semantic_extension.rs
+++ b/crates/tenferro-ad/src/semantic_extension.rs
@@ -1087,3 +1087,244 @@ fn is_valid_family_id(family_id: &str) -> bool {
         && !crate_name.chars().any(char::is_whitespace)
         && !op_name.chars().any(char::is_whitespace)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::any::Any;
+    use std::hash::Hasher;
+    use tenferro_ops::{ExtensionShapeContext, SymDim};
+    use tenferro_runtime::program::ProgramInputSpec;
+    use tenferro_tensor::DType;
+
+    const FAMILY: &str = "tenferro-ad.checked-request-test.v1";
+
+    #[derive(Clone, Debug)]
+    struct TestOp;
+
+    impl ExtensionOp for TestOp {
+        fn family_id(&self) -> &'static str {
+            FAMILY
+        }
+        fn payload_hash(&self, state: &mut dyn Hasher) {
+            state.write_u8(0);
+        }
+        fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+            other.as_any().is::<Self>()
+        }
+        fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+            Arc::new(self.clone())
+        }
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn input_count(&self) -> usize {
+            1
+        }
+        fn output_count(&self) -> usize {
+            1
+        }
+        fn semantic_effects(&self) -> tenferro_ops::ext_op::ExtensionEffectDeclaration<'_> {
+            tenferro_ops::ext_op::ExtensionEffectDeclaration::Declared(&[])
+        }
+        fn semantic_aliases(&self) -> tenferro_ops::ext_op::ExtensionAliasDeclaration<'_> {
+            tenferro_ops::ext_op::ExtensionAliasDeclaration::AllFresh
+        }
+        fn infer_output_meta(
+            &self,
+            context: &mut ExtensionShapeContext<'_>,
+        ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+            Ok(vec![(
+                context.input_dtype(0)?,
+                context.input_shape(0)?.to_vec(),
+            )])
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestRule(&'static str);
+
+    impl SemanticLinearizeRule for TestRule {
+        fn family_id(&self) -> &'static str {
+            self.0
+        }
+        fn linearize(
+            &self,
+            request: SemanticLinearizeRequest<'_>,
+            _builder: &mut SemanticProgramBuilder,
+        ) -> Result<SemanticLinearizeResult, SemanticAdError> {
+            Ok(SemanticLinearizeResult::new(
+                std::iter::repeat_n(AdValue::Absent, request.primal_outputs().len()),
+                [],
+            ))
+        }
+    }
+
+    impl SemanticLinearTransposeRule for TestRule {
+        fn family_id(&self) -> &'static str {
+            self.0
+        }
+        fn residual_mask(&self) -> ResidualSpec {
+            ResidualSpec::none()
+        }
+        fn linear_transpose(
+            &self,
+            request: SemanticLinearTransposeRequest<'_>,
+            _builder: &mut SemanticProgramBuilder,
+        ) -> Result<Box<[AdValue]>, SemanticAdError> {
+            Ok(vec![AdValue::Absent; request.primal_input_count()].into_boxed_slice())
+        }
+    }
+
+    impl SemanticPrimalVjpRule for TestRule {
+        fn family_id(&self) -> &'static str {
+            self.0
+        }
+        fn residual_mask(&self) -> ResidualSpec {
+            ResidualSpec::none()
+        }
+        fn primal_vjp(
+            &self,
+            request: SemanticPrimalVjpRequest<'_>,
+            _builder: &mut SemanticProgramBuilder,
+        ) -> Result<Box<[AdValue]>, SemanticAdError> {
+            Ok(vec![AdValue::Absent; request.primal_input_count()].into_boxed_slice())
+        }
+    }
+
+    #[test]
+    fn checked_request_accessors_cover_declared_metadata_and_errors() {
+        let mut builder = SemanticProgramBuilder::new();
+        let input = builder
+            .input(ProgramInputSpec::new(DType::F64, [1usize.into()]))
+            .unwrap();
+        let output = builder.add_extension(Arc::new(TestOp), &[input]).unwrap()[0];
+        let frozen = builder.finish(&[output]).unwrap();
+        let operation = frozen.program.operations().next().unwrap();
+        let op = extension_for_dispatch(operation).unwrap();
+        let inputs = [input];
+        let outputs = [output];
+        let metadata = [ProgramValueMetadata::new(DType::F64, [1usize.into()])];
+        let cotangents = [AdValue::Absent];
+        let active = [true];
+        let residuals = [output];
+        let mask = ResidualSpec::all_inputs().with_all_outputs();
+
+        let transpose = SemanticLinearTransposeRequest {
+            op,
+            primal_inputs: &inputs,
+            primal_outputs: &outputs,
+            primal_input_metadata: metadata.clone().into(),
+            primal_output_metadata: metadata.clone().into(),
+            cotangent_outputs: &cotangents,
+            active_inputs: &active,
+            residuals: &residuals,
+            residual_mask: mask,
+            provenance: operation.provenance(),
+        };
+        assert_eq!(transpose.op().family_id(), FAMILY);
+        assert_eq!(transpose.primal_input_value(0).unwrap(), input);
+        assert_eq!(transpose.primal_output_value(0).unwrap(), output);
+        assert_eq!(transpose.primal_input_meta(0).unwrap().dtype(), DType::F64);
+        assert_eq!(transpose.primal_output_meta(0).unwrap().dtype(), DType::F64);
+        assert_eq!(transpose.primal_input_count(), 1);
+        assert_eq!(transpose.primal_output_count(), 1);
+        assert_eq!(transpose.cotangent_outputs(), &cotangents);
+        assert_eq!(transpose.active_inputs(), &active);
+        assert_eq!(transpose.residuals(), &residuals);
+        assert_eq!(transpose.residual_mask(), mask);
+        assert_eq!(transpose.provenance().label(), Some(FAMILY));
+        assert!(matches!(
+            transpose.primal_input_value(2),
+            Err(SemanticAdError::PrimalIndexOutOfBounds {
+                kind: PrimalValueKind::Input,
+                ..
+            })
+        ));
+        assert!(matches!(
+            checked_primal_value(
+                FAMILY,
+                PrimalValueKind::Output,
+                0,
+                &outputs,
+                ResidualSpec::none()
+            ),
+            Err(SemanticAdError::UndeclaredResidualValue { .. })
+        ));
+        assert!(transpose.primal_output_meta(2).is_err());
+
+        let direct = SemanticPrimalVjpRequest {
+            op,
+            primal_inputs: &inputs,
+            primal_outputs: &outputs,
+            primal_input_metadata: metadata.clone().into(),
+            primal_output_metadata: metadata.into(),
+            cotangent_outputs: &cotangents,
+            active_inputs: &active,
+            residual_mask: mask,
+            provenance: operation.provenance(),
+        };
+        assert_eq!(direct.op().family_id(), FAMILY);
+        assert_eq!(direct.primal_input_value(0).unwrap(), input);
+        assert_eq!(direct.primal_output_value(0).unwrap(), output);
+        assert_eq!(direct.primal_input_meta(0).unwrap().dtype(), DType::F64);
+        assert_eq!(direct.primal_output_meta(0).unwrap().dtype(), DType::F64);
+        assert_eq!(direct.primal_input_count(), 1);
+        assert_eq!(direct.primal_output_count(), 1);
+        assert_eq!(direct.cotangent_outputs(), &cotangents);
+        assert_eq!(direct.active_inputs(), &active);
+        assert_eq!(direct.residual_mask(), mask);
+        assert_eq!(direct.provenance().label(), Some(FAMILY));
+        assert!(direct.primal_input_meta(2).is_err());
+        assert_eq!(AdValue::Absent.value(), None);
+        assert_eq!(AdValue::Value(input).value(), Some(input));
+    }
+
+    #[test]
+    fn rule_set_registration_lookup_debug_and_validation_are_covered() {
+        let mut rules = SemanticExtensionRuleSet::new();
+        rules
+            .register_linearize(Arc::new(TestRule(FAMILY)))
+            .unwrap();
+        rules
+            .register_linear_transpose(Arc::new(TestRule(FAMILY)))
+            .unwrap();
+        rules
+            .register_primal_vjp(Arc::new(TestRule(FAMILY)))
+            .unwrap();
+        assert!(rules.lookup_linearize(FAMILY).is_some());
+        assert!(rules.lookup_linear_transpose(FAMILY).is_some());
+        assert!(rules.lookup_primal_vjp(FAMILY).is_some());
+        assert!(format!("{rules:?}").contains(FAMILY));
+        assert!(matches!(
+            rules.register_linearize(Arc::new(TestRule(FAMILY))),
+            Err(SemanticExtensionRegistryError::DuplicateRule {
+                role: SemanticAdRuleRole::Linearize,
+                ..
+            })
+        ));
+        assert!(matches!(
+            SemanticExtensionRuleSet::new().with_linearize(Arc::new(TestRule("invalid"))),
+            Err(SemanticExtensionRegistryError::MalformedFamilyId { .. })
+        ));
+        assert!(SemanticExtensionRuleSet::new()
+            .with_linear_transpose(Arc::new(TestRule(FAMILY)))
+            .unwrap()
+            .lookup_linear_transpose(FAMILY)
+            .is_some());
+        assert!(SemanticExtensionRuleSet::new()
+            .with_primal_vjp(Arc::new(TestRule(FAMILY)))
+            .unwrap()
+            .lookup_primal_vjp(FAMILY)
+            .is_some());
+        for invalid in [
+            "crate.op",
+            ".op.v1",
+            "crate..v1",
+            "crate.op.v",
+            "crate op.v1",
+        ] {
+            assert!(!is_valid_family_id(invalid));
+        }
+    }
+}

--- a/crates/tenferro-ad/src/semantic_extension/tests.rs
+++ b/crates/tenferro-ad/src/semantic_extension/tests.rs
@@ -1,0 +1,237 @@
+use super::*;
+use std::any::Any;
+use std::hash::Hasher;
+use tenferro_ops::{ExtensionShapeContext, SymDim};
+use tenferro_runtime::program::ProgramInputSpec;
+use tenferro_tensor::DType;
+
+const FAMILY: &str = "tenferro-ad.checked-request-test.v1";
+
+#[derive(Clone, Debug)]
+struct TestOp;
+
+impl ExtensionOp for TestOp {
+    fn family_id(&self) -> &'static str {
+        FAMILY
+    }
+    fn payload_hash(&self, state: &mut dyn Hasher) {
+        state.write_u8(0);
+    }
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+        other.as_any().is::<Self>()
+    }
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+        Arc::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn input_count(&self) -> usize {
+        1
+    }
+    fn output_count(&self) -> usize {
+        1
+    }
+    fn semantic_effects(&self) -> tenferro_ops::ext_op::ExtensionEffectDeclaration<'_> {
+        tenferro_ops::ext_op::ExtensionEffectDeclaration::Declared(&[])
+    }
+    fn semantic_aliases(&self) -> tenferro_ops::ext_op::ExtensionAliasDeclaration<'_> {
+        tenferro_ops::ext_op::ExtensionAliasDeclaration::AllFresh
+    }
+    fn infer_output_meta(
+        &self,
+        context: &mut ExtensionShapeContext<'_>,
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(
+            context.input_dtype(0)?,
+            context.input_shape(0)?.to_vec(),
+        )])
+    }
+}
+
+#[derive(Debug)]
+struct TestRule(&'static str);
+
+impl SemanticLinearizeRule for TestRule {
+    fn family_id(&self) -> &'static str {
+        self.0
+    }
+    fn linearize(
+        &self,
+        request: SemanticLinearizeRequest<'_>,
+        _builder: &mut SemanticProgramBuilder,
+    ) -> Result<SemanticLinearizeResult, SemanticAdError> {
+        Ok(SemanticLinearizeResult::new(
+            std::iter::repeat_n(AdValue::Absent, request.primal_outputs().len()),
+            [],
+        ))
+    }
+}
+
+impl SemanticLinearTransposeRule for TestRule {
+    fn family_id(&self) -> &'static str {
+        self.0
+    }
+    fn residual_mask(&self) -> ResidualSpec {
+        ResidualSpec::none()
+    }
+    fn linear_transpose(
+        &self,
+        request: SemanticLinearTransposeRequest<'_>,
+        _builder: &mut SemanticProgramBuilder,
+    ) -> Result<Box<[AdValue]>, SemanticAdError> {
+        Ok(vec![AdValue::Absent; request.primal_input_count()].into_boxed_slice())
+    }
+}
+
+impl SemanticPrimalVjpRule for TestRule {
+    fn family_id(&self) -> &'static str {
+        self.0
+    }
+    fn residual_mask(&self) -> ResidualSpec {
+        ResidualSpec::none()
+    }
+    fn primal_vjp(
+        &self,
+        request: SemanticPrimalVjpRequest<'_>,
+        _builder: &mut SemanticProgramBuilder,
+    ) -> Result<Box<[AdValue]>, SemanticAdError> {
+        Ok(vec![AdValue::Absent; request.primal_input_count()].into_boxed_slice())
+    }
+}
+
+#[test]
+fn checked_request_accessors_cover_declared_metadata_and_errors() {
+    let mut builder = SemanticProgramBuilder::new();
+    let input = builder
+        .input(ProgramInputSpec::new(DType::F64, [1usize.into()]))
+        .unwrap();
+    let output = builder.add_extension(Arc::new(TestOp), &[input]).unwrap()[0];
+    let frozen = builder.finish(&[output]).unwrap();
+    let operation = frozen.program.operations().next().unwrap();
+    let op = extension_for_dispatch(operation).unwrap();
+    let inputs = [input];
+    let outputs = [output];
+    let metadata = [ProgramValueMetadata::new(DType::F64, [1usize.into()])];
+    let cotangents = [AdValue::Absent];
+    let active = [true];
+    let residuals = [output];
+    let mask = ResidualSpec::all_inputs().with_all_outputs();
+
+    let transpose = SemanticLinearTransposeRequest {
+        op,
+        primal_inputs: &inputs,
+        primal_outputs: &outputs,
+        primal_input_metadata: metadata.clone().into(),
+        primal_output_metadata: metadata.clone().into(),
+        cotangent_outputs: &cotangents,
+        active_inputs: &active,
+        residuals: &residuals,
+        residual_mask: mask,
+        provenance: operation.provenance(),
+    };
+    assert_eq!(transpose.op().family_id(), FAMILY);
+    assert_eq!(transpose.primal_input_value(0).unwrap(), input);
+    assert_eq!(transpose.primal_output_value(0).unwrap(), output);
+    assert_eq!(transpose.primal_input_meta(0).unwrap().dtype(), DType::F64);
+    assert_eq!(transpose.primal_output_meta(0).unwrap().dtype(), DType::F64);
+    assert_eq!(transpose.primal_input_count(), 1);
+    assert_eq!(transpose.primal_output_count(), 1);
+    assert_eq!(transpose.cotangent_outputs(), &cotangents);
+    assert_eq!(transpose.active_inputs(), &active);
+    assert_eq!(transpose.residuals(), &residuals);
+    assert_eq!(transpose.residual_mask(), mask);
+    assert_eq!(transpose.provenance().label(), Some(FAMILY));
+    assert!(matches!(
+        transpose.primal_input_value(2),
+        Err(SemanticAdError::PrimalIndexOutOfBounds {
+            kind: PrimalValueKind::Input,
+            ..
+        })
+    ));
+    assert!(matches!(
+        checked_primal_value(
+            FAMILY,
+            PrimalValueKind::Output,
+            0,
+            &outputs,
+            ResidualSpec::none()
+        ),
+        Err(SemanticAdError::UndeclaredResidualValue { .. })
+    ));
+    assert!(transpose.primal_output_meta(2).is_err());
+
+    let direct = SemanticPrimalVjpRequest {
+        op,
+        primal_inputs: &inputs,
+        primal_outputs: &outputs,
+        primal_input_metadata: metadata.clone().into(),
+        primal_output_metadata: metadata.into(),
+        cotangent_outputs: &cotangents,
+        active_inputs: &active,
+        residual_mask: mask,
+        provenance: operation.provenance(),
+    };
+    assert_eq!(direct.op().family_id(), FAMILY);
+    assert_eq!(direct.primal_input_value(0).unwrap(), input);
+    assert_eq!(direct.primal_output_value(0).unwrap(), output);
+    assert_eq!(direct.primal_input_meta(0).unwrap().dtype(), DType::F64);
+    assert_eq!(direct.primal_output_meta(0).unwrap().dtype(), DType::F64);
+    assert_eq!(direct.primal_input_count(), 1);
+    assert_eq!(direct.primal_output_count(), 1);
+    assert_eq!(direct.cotangent_outputs(), &cotangents);
+    assert_eq!(direct.active_inputs(), &active);
+    assert_eq!(direct.residual_mask(), mask);
+    assert_eq!(direct.provenance().label(), Some(FAMILY));
+    assert!(direct.primal_input_meta(2).is_err());
+    assert_eq!(AdValue::Absent.value(), None);
+    assert_eq!(AdValue::Value(input).value(), Some(input));
+}
+
+#[test]
+fn rule_set_registration_lookup_debug_and_validation_are_covered() {
+    let mut rules = SemanticExtensionRuleSet::new();
+    rules
+        .register_linearize(Arc::new(TestRule(FAMILY)))
+        .unwrap();
+    rules
+        .register_linear_transpose(Arc::new(TestRule(FAMILY)))
+        .unwrap();
+    rules
+        .register_primal_vjp(Arc::new(TestRule(FAMILY)))
+        .unwrap();
+    assert!(rules.lookup_linearize(FAMILY).is_some());
+    assert!(rules.lookup_linear_transpose(FAMILY).is_some());
+    assert!(rules.lookup_primal_vjp(FAMILY).is_some());
+    assert!(format!("{rules:?}").contains(FAMILY));
+    assert!(matches!(
+        rules.register_linearize(Arc::new(TestRule(FAMILY))),
+        Err(SemanticExtensionRegistryError::DuplicateRule {
+            role: SemanticAdRuleRole::Linearize,
+            ..
+        })
+    ));
+    assert!(matches!(
+        SemanticExtensionRuleSet::new().with_linearize(Arc::new(TestRule("invalid"))),
+        Err(SemanticExtensionRegistryError::MalformedFamilyId { .. })
+    ));
+    assert!(SemanticExtensionRuleSet::new()
+        .with_linear_transpose(Arc::new(TestRule(FAMILY)))
+        .unwrap()
+        .lookup_linear_transpose(FAMILY)
+        .is_some());
+    assert!(SemanticExtensionRuleSet::new()
+        .with_primal_vjp(Arc::new(TestRule(FAMILY)))
+        .unwrap()
+        .lookup_primal_vjp(FAMILY)
+        .is_some());
+    for invalid in [
+        "crate.op",
+        ".op.v1",
+        "crate..v1",
+        "crate.op.v",
+        "crate op.v1",
+    ] {
+        assert!(!is_valid_family_id(invalid));
+    }
+}

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use computegraph::graph::GraphBuilder;
@@ -51,8 +51,17 @@ pub(crate) fn jvp_with_rules_and_cache(
     ad_transform_cache: Option<&AdTransformCache>,
 ) -> Result<TracedTensor> {
     let wrt_input_key = leaf_input_key(wrt)?;
-    jvp_optional_impl(output, wrt, tangent, rules, ad_transform_cache)?
+    jvp_many_with_rules_and_cache(output, &[(wrt, tangent)], rules, ad_transform_cache)?
         .ok_or_else(|| Error::Internal(format!("jvp output is inactive for {:?}", wrt_input_key)))
+}
+
+pub(crate) fn jvp_many_with_rules_and_cache(
+    output: &TracedTensor,
+    wrt_tangents: &[(&TracedTensor, &TracedTensor)],
+    rules: &SemanticExtensionRuleSet,
+    ad_transform_cache: Option<&AdTransformCache>,
+) -> Result<Option<TracedTensor>> {
+    jvp_many_optional_impl(output, wrt_tangents, rules, ad_transform_cache)
 }
 
 pub(crate) fn grad_optional_with_rules_and_cache(
@@ -69,7 +78,8 @@ pub(crate) fn grad_optional_with_rules_and_cache(
 
     let ones = ones_tensor(output.dtype, vec![])?;
     let seed = TracedTensor::from_tensor_concrete_shape(ones)?;
-    vjp_optional_impl(output, wrt, &seed, rules, "grad", ad_transform_cache)
+    vjp_many_with_transform_and_cache(output, &[wrt], &seed, rules, "grad", ad_transform_cache)
+        .map(|mut results| results.pop().flatten())
 }
 
 pub(crate) fn jvp_optional_with_rules_and_cache(
@@ -79,7 +89,7 @@ pub(crate) fn jvp_optional_with_rules_and_cache(
     rules: &SemanticExtensionRuleSet,
     ad_transform_cache: Option<&AdTransformCache>,
 ) -> Result<Option<TracedTensor>> {
-    jvp_optional_impl(output, wrt, tangent, rules, ad_transform_cache)
+    jvp_many_with_rules_and_cache(output, &[(wrt, tangent)], rules, ad_transform_cache)
 }
 
 pub(crate) fn vjp_with_rules_and_cache(
@@ -90,8 +100,39 @@ pub(crate) fn vjp_with_rules_and_cache(
     ad_transform_cache: Option<&AdTransformCache>,
 ) -> Result<TracedTensor> {
     let wrt_input_key = leaf_input_key(wrt)?;
-    vjp_optional_impl(output, wrt, cotangent, rules, "vjp", ad_transform_cache)?
+    vjp_many_with_rules_and_cache(output, &[wrt], cotangent, rules, ad_transform_cache)?
+        .into_iter()
+        .next()
+        .flatten()
         .ok_or_else(|| Error::Internal(format!("vjp output is inactive for {:?}", wrt_input_key)))
+}
+
+pub(crate) fn vjp_many_with_rules_and_cache(
+    output: &TracedTensor,
+    wrts: &[&TracedTensor],
+    cotangent: &TracedTensor,
+    rules: &SemanticExtensionRuleSet,
+    ad_transform_cache: Option<&AdTransformCache>,
+) -> Result<Vec<Option<TracedTensor>>> {
+    vjp_many_with_transform_and_cache(output, wrts, cotangent, rules, "vjp", ad_transform_cache)
+}
+
+fn vjp_many_with_transform_and_cache(
+    output: &TracedTensor,
+    wrts: &[&TracedTensor],
+    cotangent: &TracedTensor,
+    rules: &SemanticExtensionRuleSet,
+    transform: &'static str,
+    ad_transform_cache: Option<&AdTransformCache>,
+) -> Result<Vec<Option<TracedTensor>>> {
+    vjp_many_optional_impl(
+        output,
+        wrts,
+        cotangent,
+        rules,
+        transform,
+        ad_transform_cache,
+    )
 }
 
 pub(crate) fn vjp_optional_with_rules_and_cache(
@@ -101,7 +142,8 @@ pub(crate) fn vjp_optional_with_rules_and_cache(
     rules: &SemanticExtensionRuleSet,
     ad_transform_cache: Option<&AdTransformCache>,
 ) -> Result<Option<TracedTensor>> {
-    vjp_optional_impl(output, wrt, cotangent, rules, "vjp", ad_transform_cache)
+    vjp_many_with_rules_and_cache(output, &[wrt], cotangent, rules, ad_transform_cache)
+        .map(|mut results| results.pop().flatten())
 }
 
 fn grad_with_optional_rules(
@@ -119,7 +161,9 @@ fn grad_with_optional_rules(
     let ones = ones_tensor(output.dtype, vec![])?;
     let seed = TracedTensor::from_tensor_concrete_shape(ones)?;
     let wrt_input_key = leaf_input_key(wrt)?;
-    vjp_optional_impl(output, wrt, &seed, rules, "grad", ad_transform_cache)?
+    vjp_many_with_transform_and_cache(output, &[wrt], &seed, rules, "grad", ad_transform_cache)?
+        .pop()
+        .flatten()
         .ok_or_else(|| Error::Internal(format!("grad output is inactive for {:?}", wrt_input_key)))
 }
 
@@ -441,7 +485,8 @@ impl TracedTensorAdExt for TracedTensor {
         let ones = ones_tensor(self.dtype, vec![])?;
         let seed = TracedTensor::from_tensor_concrete_shape(ones)?;
         let rules = SemanticExtensionRuleSet::default();
-        vjp_optional_impl(self, wrt, &seed, &rules, "grad", None)
+        vjp_many_with_transform_and_cache(self, &[wrt], &seed, &rules, "grad", None)
+            .map(|mut results| results.pop().flatten())
     }
 
     fn checkpoint(&mut self, compiler: &mut GraphCompiler, runtime: &Runtime) -> Result<()> {
@@ -471,7 +516,7 @@ impl TracedTensorAdExt for TracedTensor {
         tangent: &TracedTensor,
     ) -> Result<Option<TracedTensor>> {
         let rules = SemanticExtensionRuleSet::default();
-        jvp_optional_impl(self, wrt, tangent, &rules, None)
+        jvp_many_optional_impl(self, &[(wrt, tangent)], &rules, None)
     }
 
     fn vjp(&self, wrt: &TracedTensor, cotangent: &TracedTensor) -> Result<TracedTensor> {
@@ -487,48 +532,65 @@ impl TracedTensorAdExt for TracedTensor {
         cotangent: &TracedTensor,
     ) -> Result<Option<TracedTensor>> {
         let rules = SemanticExtensionRuleSet::default();
-        vjp_optional_impl(self, wrt, cotangent, &rules, "vjp", None)
+        vjp_many_with_transform_and_cache(self, &[wrt], cotangent, &rules, "vjp", None)
+            .map(|mut results| results.pop().flatten())
     }
 }
 
-fn jvp_optional_impl(
+fn jvp_many_optional_impl(
     output: &TracedTensor,
-    wrt: &TracedTensor,
-    tangent: &TracedTensor,
+    wrt_tangents: &[(&TracedTensor, &TracedTensor)],
     rules: &SemanticExtensionRuleSet,
     ad_transform_cache: Option<&AdTransformCache>,
 ) -> Result<Option<TracedTensor>> {
-    let wrt_input_key = leaf_input_key(wrt)?;
-    let tangent_data = tangent.attached_value().cloned().ok_or_else(|| {
-        Error::invalid_argument(
-            "jvp",
-            ErrorPhase::GraphBuild,
-            "tangent",
-            "jvp tangent must have concrete tensor data",
-        )
-    })?;
+    if wrt_tangents.is_empty() {
+        return Ok(None);
+    }
+
+    let mut seen = HashSet::with_capacity(wrt_tangents.len());
+    let mut requested = Vec::with_capacity(wrt_tangents.len());
+    for (wrt, tangent) in wrt_tangents {
+        let key = leaf_input_key(wrt)?;
+        if !seen.insert(key.clone()) {
+            return Err(Error::invalid_argument(
+                "jvp",
+                ErrorPhase::GraphBuild,
+                "wrt_tangents",
+                "wrt_tangents contains duplicate wrt leaves",
+            ));
+        }
+        let tangent_data = tangent.attached_value().cloned().ok_or_else(|| {
+            Error::invalid_argument(
+                "jvp",
+                ErrorPhase::GraphBuild,
+                "tangent",
+                "jvp tangent must have concrete tensor data",
+            )
+        })?;
+        requested.push((key, tangent_data));
+    }
+
     let mut compiler = GraphCompiler::new();
     let source = compile_ad_source(&mut compiler, output)?;
-    let Some(wrt_input_index) = source.input_key_index(&wrt_input_key) else {
-        return Ok(None);
-    };
-
     let mut active_inputs = vec![false; source.input_count()];
-    active_inputs[wrt_input_index] = true;
+    let mut source_indices = Vec::with_capacity(requested.len());
+    for (key, _) in &requested {
+        let source_index = source.input_key_index(key);
+        if let Some(index) = source_index {
+            active_inputs[index] = true;
+        }
+        source_indices.push(source_index);
+    }
+    if !active_inputs.iter().any(|active| *active) {
+        return Ok(None);
+    }
+
     let derivative = semantic_jvp_with_cache(
         source.frozen_program(),
         &active_inputs,
         rules,
         ad_transform_cache,
     )?;
-    let Some(seed_input_index) = derivative
-        .derivative_input_indices()
-        .get(wrt_input_index)
-        .copied()
-        .flatten()
-    else {
-        return Ok(None);
-    };
     let Some(derivative_output_index) = derivative
         .derivative_output_indices()
         .first()
@@ -538,27 +600,53 @@ fn jvp_optional_impl(
         return Ok(None);
     };
 
-    derivative_tensor_from_program(
+    let mut seed_tensors = Vec::with_capacity(requested.len());
+    for ((_, tangent_data), source_index) in requested.iter().zip(source_indices) {
+        let Some(source_index) = source_index else {
+            continue;
+        };
+        let Some(seed_input_index) = derivative
+            .derivative_input_indices()
+            .get(source_index)
+            .copied()
+            .flatten()
+        else {
+            continue;
+        };
+        seed_tensors.push((seed_input_index, Arc::clone(tangent_data)));
+    }
+    let mut inherited_tensors = Vec::with_capacity(1 + 2 * wrt_tangents.len());
+    inherited_tensors.push(output);
+    for (wrt, tangent) in wrt_tangents {
+        inherited_tensors.push(*wrt);
+        inherited_tensors.push(*tangent);
+    }
+    let mut traces = derivative_tensors_from_program(
         &source,
         &derivative,
-        derivative_output_index,
-        &[(seed_input_index, tangent_data)],
-        [output, wrt, tangent],
-        tensor_shape_hint(output),
+        &[derivative_output_index],
+        &seed_tensors,
+        &inherited_tensors,
+        &[tensor_shape_hint(output)],
         "jvp",
-    )
-    .map(Some)
+    )?;
+    traces.pop().map(Some).ok_or_else(|| {
+        Error::runtime_state(
+            "jvp",
+            ErrorPhase::GraphBuild,
+            "derivative program returned no requested output",
+        )
+    })
 }
 
-fn vjp_optional_impl(
+fn vjp_many_optional_impl(
     output: &TracedTensor,
-    wrt: &TracedTensor,
+    wrts: &[&TracedTensor],
     cotangent: &TracedTensor,
     rules: &SemanticExtensionRuleSet,
     transform: &'static str,
     ad_transform_cache: Option<&AdTransformCache>,
-) -> Result<Option<TracedTensor>> {
-    let wrt_input_key = leaf_input_key(wrt)?;
+) -> Result<Vec<Option<TracedTensor>>> {
     let cotangent_data = cotangent.attached_value().cloned().ok_or_else(|| {
         Error::invalid_argument(
             transform,
@@ -567,14 +655,28 @@ fn vjp_optional_impl(
             "vjp cotangent must have concrete tensor data",
         )
     })?;
+    if wrts.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let requested_keys = wrts
+        .iter()
+        .map(|wrt| leaf_input_key(wrt))
+        .collect::<Result<Vec<_>>>()?;
     let mut compiler = GraphCompiler::new();
     let source = compile_ad_source(&mut compiler, output)?;
-    let Some(wrt_input_index) = source.input_key_index(&wrt_input_key) else {
-        return Ok(None);
-    };
-
+    let source_indices: Vec<_> = requested_keys
+        .iter()
+        .map(|key| source.input_key_index(key))
+        .collect();
     let mut active_inputs = vec![false; source.input_count()];
-    active_inputs[wrt_input_index] = true;
+    for source_index in source_indices.iter().flatten().copied() {
+        active_inputs[source_index] = true;
+    }
+    if !active_inputs.iter().any(|active| *active) {
+        return Ok(vec![None; wrts.len()]);
+    }
+
     let active_outputs = vec![true; source.output_count()];
     let derivative = semantic_vjp_with_cache(
         source.frozen_program(),
@@ -589,27 +691,56 @@ fn vjp_optional_impl(
         .copied()
         .flatten()
     else {
-        return Ok(None);
-    };
-    let Some(derivative_output_index) = derivative
-        .derivative_output_indices()
-        .get(wrt_input_index)
-        .copied()
-        .flatten()
-    else {
-        return Ok(None);
+        return Ok(vec![None; wrts.len()]);
     };
 
-    derivative_tensor_from_program(
+    let mut output_slots = vec![None; source.input_count()];
+    let mut derivative_output_indices = Vec::new();
+    let mut fallback_shape_hints = Vec::new();
+    for (request_index, source_index) in source_indices.iter().enumerate() {
+        let Some(source_index) = source_index else {
+            continue;
+        };
+        if output_slots[*source_index].is_some() {
+            continue;
+        }
+        let Some(derivative_output_index) = derivative
+            .derivative_output_indices()
+            .get(*source_index)
+            .copied()
+            .flatten()
+        else {
+            continue;
+        };
+        output_slots[*source_index] = Some(derivative_output_indices.len());
+        derivative_output_indices.push(derivative_output_index);
+        fallback_shape_hints.push(tensor_shape_hint(wrts[request_index]));
+    }
+    if derivative_output_indices.is_empty() {
+        return Ok(vec![None; wrts.len()]);
+    }
+
+    let inherited_tensors: Vec<&TracedTensor> = std::iter::once(output)
+        .chain(wrts.iter().copied())
+        .chain(std::iter::once(cotangent))
+        .collect();
+    let traces = derivative_tensors_from_program(
         &source,
         &derivative,
-        derivative_output_index,
+        &derivative_output_indices,
         &[(seed_input_index, cotangent_data)],
-        [output, wrt, cotangent],
-        tensor_shape_hint(wrt),
+        &inherited_tensors,
+        &fallback_shape_hints,
         transform,
-    )
-    .map(Some)
+    )?;
+    Ok(source_indices
+        .into_iter()
+        .map(|source_index| {
+            source_index
+                .and_then(|index| output_slots[index])
+                .map(|slot| traces[slot].clone())
+        })
+        .collect())
 }
 
 fn semantic_jvp_with_cache(
@@ -712,22 +843,22 @@ fn semantic_transform_validation_error(
     ))
 }
 
-fn derivative_tensor_from_program(
+fn derivative_tensors_from_program(
     source: &CompiledGraph,
     derivative: &SemanticAdProgram,
-    derivative_output_index: usize,
+    derivative_output_indices: &[usize],
     seed_tensors: &[(usize, Arc<RetainedValue>)],
-    inherited_tensors: [&TracedTensor; 3],
-    fallback_shape_hint: Option<Vec<SymDim>>,
+    inherited_tensors: &[&TracedTensor],
+    fallback_shape_hints: &[Option<Vec<SymDim>>],
     transform: &'static str,
-) -> Result<TracedTensor> {
-    derivative_trace_from_frozen_program(
+) -> Result<Vec<TracedTensor>> {
+    derivative_traces_from_frozen_program(
         source,
         derivative.frozen(),
-        derivative_output_index,
+        derivative_output_indices,
         seed_tensors,
-        &inherited_tensors,
-        fallback_shape_hint,
+        inherited_tensors,
+        fallback_shape_hints,
         transform,
     )
 }
@@ -741,6 +872,33 @@ pub(crate) fn derivative_trace_from_frozen_program(
     fallback_shape_hint: Option<Vec<SymDim>>,
     transform: &'static str,
 ) -> Result<TracedTensor> {
+    let mut outputs = derivative_traces_from_frozen_program(
+        source,
+        frozen,
+        &[derivative_output_index],
+        seed_tensors,
+        inherited_tensors,
+        &[fallback_shape_hint],
+        transform,
+    )?;
+    outputs.pop().ok_or_else(|| {
+        Error::runtime_state(
+            transform,
+            ErrorPhase::GraphBuild,
+            "derivative program returned no requested output",
+        )
+    })
+}
+
+fn derivative_traces_from_frozen_program(
+    source: &CompiledGraph,
+    frozen: &FrozenProgram,
+    derivative_output_indices: &[usize],
+    seed_tensors: &[(usize, Arc<RetainedValue>)],
+    inherited_tensors: &[&TracedTensor],
+    fallback_shape_hints: &[Option<Vec<SymDim>>],
+    transform: &'static str,
+) -> Result<Vec<TracedTensor>> {
     let input_shapes = symbolic_input_shapes(frozen)?;
     let input_shape_refs: Vec<_> = input_shapes.iter().map(Vec::as_slice).collect();
     let input_metas = frozen
@@ -751,21 +909,33 @@ pub(crate) fn derivative_trace_from_frozen_program(
         .map(|value| tensor_meta_for_value(frozen, value, &input_shape_refs, transform))
         .collect::<Result<Vec<_>>>()?;
 
-    let output_value = *frozen
-        .program
-        .outputs()
-        .get(derivative_output_index)
-        .ok_or_else(|| {
-            Error::runtime_state(
-                transform,
-                ErrorPhase::GraphBuild,
-                format!(
-                    "derivative output index {derivative_output_index} is outside {} outputs",
-                    frozen.program.outputs().len()
-                ),
-            )
-        })?;
-    let output_meta = tensor_meta_for_value(frozen, output_value, &input_shape_refs, transform)?;
+    if derivative_output_indices.len() != fallback_shape_hints.len() {
+        return Err(Error::runtime_state(
+            transform,
+            ErrorPhase::GraphBuild,
+            "derivative output indices and fallback shape hints differ in length",
+        ));
+    }
+    let output_metas = derivative_output_indices
+        .iter()
+        .map(|&derivative_output_index| {
+            let output_value = *frozen
+                .program
+                .outputs()
+                .get(derivative_output_index)
+                .ok_or_else(|| {
+                    Error::runtime_state(
+                        transform,
+                        ErrorPhase::GraphBuild,
+                        format!(
+                            "derivative output index {derivative_output_index} is outside {} outputs",
+                            frozen.program.outputs().len()
+                        ),
+                    )
+                })?;
+            tensor_meta_for_value(frozen, output_value, &input_shape_refs, transform)
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut value_map = HashMap::<ProgramValue, LocalValueId>::new();
@@ -834,13 +1004,18 @@ pub(crate) fn derivative_trace_from_frozen_program(
                 .ok_or_else(|| missing_program_value(transform, "program output"))
         })
         .collect::<Result<Vec<_>>>()?;
-    let val = *graph_outputs.get(derivative_output_index).ok_or_else(|| {
-        Error::runtime_state(
-            transform,
-            ErrorPhase::GraphBuild,
-            "derivative output index missing after graph conversion",
-        )
-    })?;
+    let vals = derivative_output_indices
+        .iter()
+        .map(|&index| {
+            graph_outputs.get(index).copied().ok_or_else(|| {
+                Error::runtime_state(
+                    transform,
+                    ErrorPhase::GraphBuild,
+                    "derivative output index missing after graph conversion",
+                )
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
     builder.set_outputs(graph_outputs);
     let graph = Arc::new(builder.build());
 
@@ -901,32 +1076,43 @@ pub(crate) fn derivative_trace_from_frozen_program(
         .map(|tensor| ConstraintScopeTransfer::from_tensor(tensor))
         .collect::<Vec<_>>();
 
-    Ok(tensor_from_parts(TracedTensorParts {
-        rank: output_meta.rank(),
-        dtype: output_meta.dtype,
-        graph,
-        val,
-        data: None,
-        shape_hint: output_meta.exact_shape().or(fallback_shape_hint),
-        inputs_map: Arc::new(inputs_map),
-        // The derivative graph is standalone (its input keys reference the
-        // source leaves directly), so the retained leaf metas of the inherited
-        // source tensors cover every leaf key the deferred eager analysis may
-        // re-seed from this trace.
-        leaf_metas: merge_traced_leaf_metas(inherited_tensors.iter().copied()),
-        extra_roots: Vec::new(),
-        checkpoint_chain: None,
-        metadata_scopes: metadata_scopes_with_new(
-            analysis.metadata,
-            inherited_tensors
-                .iter()
-                .map(|tensor| tensor_metadata_scopes(tensor)),
-        ),
-        constraint_scope_transfer: ConstraintScopeTransfer::with_new(
-            analysis.constraints,
-            inherited_constraint_scopes.iter(),
-        ),
-    }))
+    let inputs_map = Arc::new(inputs_map);
+    // The derivative graph is standalone (its input keys reference the source
+    // leaves directly), so inherited leaf metadata covers every leaf key the
+    // deferred eager analysis may re-seed from these traces.
+    let leaf_metas = merge_traced_leaf_metas(inherited_tensors.iter().copied());
+    let metadata_scopes = metadata_scopes_with_new(
+        analysis.metadata,
+        inherited_tensors
+            .iter()
+            .map(|tensor| tensor_metadata_scopes(tensor)),
+    );
+    let constraint_scope_transfer =
+        ConstraintScopeTransfer::with_new(analysis.constraints, inherited_constraint_scopes.iter());
+
+    Ok(vals
+        .into_iter()
+        .zip(output_metas)
+        .zip(fallback_shape_hints)
+        .map(|((val, output_meta), fallback_shape_hint)| {
+            tensor_from_parts(TracedTensorParts {
+                rank: output_meta.rank(),
+                dtype: output_meta.dtype,
+                graph: Arc::clone(&graph),
+                val,
+                data: None,
+                shape_hint: output_meta
+                    .exact_shape()
+                    .or_else(|| fallback_shape_hint.clone()),
+                inputs_map: Arc::clone(&inputs_map),
+                leaf_metas: Arc::clone(&leaf_metas),
+                extra_roots: Vec::new(),
+                checkpoint_chain: None,
+                metadata_scopes: metadata_scopes.clone(),
+                constraint_scope_transfer: constraint_scope_transfer.clone(),
+            })
+        })
+        .collect())
 }
 
 fn missing_program_value(transform: &'static str, role: &'static str) -> Error {

--- a/crates/tenferro-ad/tests/integration.rs
+++ b/crates/tenferro-ad/tests/integration.rs
@@ -53,6 +53,8 @@ mod hvp;
 mod iterative_ad;
 #[path = "integration/memory_order_api.rs"]
 mod memory_order_api;
+#[path = "integration/multi_input_traced.rs"]
+mod multi_input_traced;
 #[path = "integration/numpy_api.rs"]
 mod numpy_api;
 #[path = "integration/placement_bound_eager.rs"]

--- a/crates/tenferro-ad/tests/integration/multi_input_traced.rs
+++ b/crates/tenferro-ad/tests/integration/multi_input_traced.rs
@@ -163,11 +163,12 @@ impl SemanticPrimalVjpRule for ActionRule {
         request: SemanticPrimalVjpRequest<'_>,
         builder: &mut tenferro_runtime::program::SemanticProgramBuilder,
     ) -> Result<Box<[AdValue]>, SemanticAdError> {
-        assert_eq!(request.active_inputs(), &[true, true, true, true]);
         let AdValue::Value(cotangent) = request.cotangent_outputs()[0] else {
-            return Ok(vec![AdValue::Absent; 4].into_boxed_slice());
+            return Ok(vec![AdValue::Absent; request.primal_input_count()].into_boxed_slice());
         };
-        let mut force_inputs = request.primal_inputs().to_vec();
+        let mut force_inputs = (0..request.primal_input_count())
+            .map(|index| request.primal_input_value(index))
+            .collect::<Result<Vec<_>, _>>()?;
         force_inputs.push(cotangent);
         let force_outputs = builder.add_extension(Arc::new(ForceOp), &force_inputs)?;
         Ok(force_outputs
@@ -202,7 +203,7 @@ fn four_input_extension_vjp_emits_one_force_node_and_executes_once() {
         .collect::<Vec<_>>();
     let input_refs = inputs.iter().collect::<Vec<_>>();
     let action = apply(Arc::new(ActionOp), &input_refs).unwrap().remove(0);
-    let cotangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
+    let cotangent = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
     let vjp = ad.vjp_many(&action, &input_refs, &cotangent).unwrap();
     assert_eq!(ad.cache_stats().unwrap().ad_transforms.entries, 1);
     let force_outputs = vjp
@@ -236,8 +237,23 @@ fn four_input_extension_vjp_emits_one_force_node_and_executes_once() {
     let program = compiler.compile_many(&force_outputs).unwrap();
     let outputs = runtime.run_compiled(&program, &[]).unwrap();
 
-    let expected = [60.0, 40.0, 30.0, 24.0];
+    let expected = [120.0, 80.0, 60.0, 48.0];
     for (output, expected) in outputs.iter().zip(expected) {
+        assert_eq!(output.as_slice::<f64>().unwrap(), &[expected]);
+    }
+    assert_eq!(FORCE_EXECUTIONS.load(Ordering::SeqCst), 1);
+
+    FORCE_EXECUTIONS.store(0, Ordering::SeqCst);
+    let subset = ad
+        .vjp_many(&action, &[&inputs[0], &inputs[2]], &cotangent)
+        .unwrap()
+        .into_iter()
+        .map(|value| value.unwrap())
+        .collect::<Vec<_>>();
+    let subset_refs = subset.iter().collect::<Vec<_>>();
+    let subset_program = compiler.compile_many(&subset_refs).unwrap();
+    let subset_outputs = runtime.run_compiled(&subset_program, &[]).unwrap();
+    for (output, expected) in subset_outputs.iter().zip([120.0, 60.0]) {
         assert_eq!(output.as_slice::<f64>().unwrap(), &[expected]);
     }
     assert_eq!(FORCE_EXECUTIONS.load(Ordering::SeqCst), 1);

--- a/crates/tenferro-ad/tests/integration/multi_input_traced.rs
+++ b/crates/tenferro-ad/tests/integration/multi_input_traced.rs
@@ -1,0 +1,382 @@
+use std::any::Any;
+use std::hash::Hasher;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tenferro_ad::semantic_extension::{
+    AdValue, ResidualSpec, SemanticAdError, SemanticExtensionRuleSet, SemanticPrimalVjpRequest,
+    SemanticPrimalVjpRule,
+};
+use tenferro_ad::AdContext;
+use tenferro_runtime::extension::{
+    apply, define_extension_runtime, ExtensionAliasDeclaration, ExtensionEffectDeclaration,
+    ExtensionExecutionContext, ExtensionOp, ExtensionShapeContext,
+};
+use tenferro_runtime::{DType, GraphCompiler, Runtime, Tensor, TracedTensor};
+use tenferro_tensor::{TensorBackend, TensorRead};
+
+use crate::support::{cpu_runtime, RunTraced};
+
+const ACTION_FAMILY: &str = "tenferro-ad.test.wilson-action.v1";
+const FORCE_FAMILY: &str = "tenferro-ad.test.wilson-force.v1";
+
+static FORCE_EXECUTIONS: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Clone, Debug)]
+struct ActionOp;
+
+#[derive(Clone, Debug)]
+struct ForceOp;
+
+macro_rules! impl_extension_op {
+    ($type:ty, $family:expr, $inputs:expr, $outputs:expr) => {
+        impl ExtensionOp for $type {
+            fn family_id(&self) -> &'static str {
+                $family
+            }
+
+            fn payload_hash(&self, hasher: &mut dyn Hasher) {
+                hasher.write_u8(0);
+            }
+
+            fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+                other.as_any().is::<Self>()
+            }
+
+            fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+                Arc::new(self.clone())
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+
+            fn input_count(&self) -> usize {
+                $inputs
+            }
+
+            fn output_count(&self) -> usize {
+                $outputs
+            }
+
+            fn semantic_effects(&self) -> ExtensionEffectDeclaration<'_> {
+                ExtensionEffectDeclaration::Declared(&[])
+            }
+
+            fn semantic_aliases(&self) -> ExtensionAliasDeclaration<'_> {
+                ExtensionAliasDeclaration::AllFresh
+            }
+
+            fn infer_output_meta(
+                &self,
+                context: &mut ExtensionShapeContext<'_>,
+            ) -> tenferro_tensor::Result<Vec<(DType, Vec<tenferro_runtime::SymDim>)>> {
+                for input in 1..$inputs {
+                    context.require_same_shape(0, input)?;
+                }
+                let metadata = (context.input_dtype(0)?, context.input_shape(0)?.to_vec());
+                Ok(vec![metadata; $outputs])
+            }
+        }
+    };
+}
+
+impl_extension_op!(ActionOp, ACTION_FAMILY, 4, 1);
+impl_extension_op!(ForceOp, FORCE_FAMILY, 5, 4);
+
+fn execute_action<B: TensorBackend + 'static>(
+    _op: &ActionOp,
+    inputs: &[TensorRead<'_>],
+    _context: &mut ExtensionExecutionContext<'_, B>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    let values = inputs
+        .iter()
+        .map(|input| Ok(input.as_slice::<f64>()?[0]))
+        .collect::<tenferro_tensor::Result<Vec<_>>>()?;
+    Ok(vec![Tensor::from_vec_col_major(
+        inputs[0].shape().to_vec(),
+        vec![values.into_iter().product::<f64>()],
+    )?])
+}
+
+fn execute_force<B: TensorBackend + 'static>(
+    _op: &ForceOp,
+    inputs: &[TensorRead<'_>],
+    _context: &mut ExtensionExecutionContext<'_, B>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    FORCE_EXECUTIONS.fetch_add(1, Ordering::SeqCst);
+    let values = inputs
+        .iter()
+        .map(|input| Ok(input.as_slice::<f64>()?[0]))
+        .collect::<tenferro_tensor::Result<Vec<_>>>()?;
+    let cotangent = values[4];
+    let derivatives = [
+        values[1] * values[2] * values[3],
+        values[0] * values[2] * values[3],
+        values[0] * values[1] * values[3],
+        values[0] * values[1] * values[2],
+    ];
+    derivatives
+        .into_iter()
+        .map(|value| {
+            Tensor::from_vec_col_major(inputs[0].shape().to_vec(), vec![value * cotangent])
+        })
+        .collect()
+}
+
+mod action_runtime {
+    use super::*;
+
+    define_extension_runtime! {
+        runtime = ActionRuntime,
+        family_id = ACTION_FAMILY,
+        op_type = ActionOp,
+        execute_reads = execute_action,
+    }
+}
+
+mod force_runtime {
+    use super::*;
+
+    define_extension_runtime! {
+        runtime = ForceRuntime,
+        family_id = FORCE_FAMILY,
+        op_type = ForceOp,
+        execute_reads = execute_force,
+    }
+}
+
+#[derive(Debug)]
+struct ActionRule;
+
+impl SemanticPrimalVjpRule for ActionRule {
+    fn family_id(&self) -> &'static str {
+        ACTION_FAMILY
+    }
+
+    fn residual_mask(&self) -> ResidualSpec {
+        ResidualSpec::all_inputs()
+    }
+
+    fn primal_vjp(
+        &self,
+        request: SemanticPrimalVjpRequest<'_>,
+        builder: &mut tenferro_runtime::program::SemanticProgramBuilder,
+    ) -> Result<Box<[AdValue]>, SemanticAdError> {
+        assert_eq!(request.active_inputs(), &[true, true, true, true]);
+        let AdValue::Value(cotangent) = request.cotangent_outputs()[0] else {
+            return Ok(vec![AdValue::Absent; 4].into_boxed_slice());
+        };
+        let mut force_inputs = request.primal_inputs().to_vec();
+        force_inputs.push(cotangent);
+        let force_outputs = builder.add_extension(Arc::new(ForceOp), &force_inputs)?;
+        Ok(force_outputs
+            .iter()
+            .enumerate()
+            .map(|(index, &value)| {
+                if request.active_inputs()[index] {
+                    AdValue::Value(value)
+                } else {
+                    AdValue::Absent
+                }
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice())
+    }
+}
+
+#[test]
+fn four_input_extension_vjp_emits_one_force_node_and_executes_once() {
+    FORCE_EXECUTIONS.store(0, Ordering::SeqCst);
+    let rules = SemanticExtensionRuleSet::new()
+        .with_primal_vjp(Arc::new(ActionRule))
+        .unwrap();
+    let ad = AdContext::builder()
+        .with_semantic_extension_rules(rules)
+        .unwrap()
+        .build()
+        .unwrap();
+    let inputs = [2.0_f64, 3.0, 4.0, 5.0]
+        .into_iter()
+        .map(|value| TracedTensor::from_vec_col_major(vec![], vec![value]).unwrap())
+        .collect::<Vec<_>>();
+    let input_refs = inputs.iter().collect::<Vec<_>>();
+    let action = apply(Arc::new(ActionOp), &input_refs).unwrap().remove(0);
+    let cotangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
+    let vjp = ad.vjp_many(&action, &input_refs, &cotangent).unwrap();
+    assert_eq!(ad.cache_stats().unwrap().ad_transforms.entries, 1);
+    let force_outputs = vjp
+        .iter()
+        .map(|value| value.as_ref().unwrap())
+        .collect::<Vec<_>>();
+    let first_graph = force_outputs[0].graph();
+    assert!(force_outputs
+        .iter()
+        .all(|value| Arc::ptr_eq(value.graph(), first_graph)));
+
+    let backend = tenferro_cpu::CpuBackend::new();
+    let engine_id = tenferro_cpu::runtime_engine_id().unwrap();
+    let mut runtime_builder = Runtime::builder();
+    runtime_builder
+        .register_engine(tenferro_cpu::runtime_engine_registration(&backend).unwrap())
+        .unwrap();
+    runtime_builder
+        .install_extension_module(
+            action_runtime::extension_module::<tenferro_cpu::CpuBackend>(engine_id.clone())
+                .unwrap(),
+        )
+        .unwrap();
+    runtime_builder
+        .install_extension_module(
+            force_runtime::extension_module::<tenferro_cpu::CpuBackend>(engine_id).unwrap(),
+        )
+        .unwrap();
+    let runtime = runtime_builder.build().unwrap();
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile_many(&force_outputs).unwrap();
+    let outputs = runtime.run_compiled(&program, &[]).unwrap();
+
+    let expected = [60.0, 40.0, 30.0, 24.0];
+    for (output, expected) in outputs.iter().zip(expected) {
+        assert_eq!(output.as_slice::<f64>().unwrap(), &[expected]);
+    }
+    assert_eq!(FORCE_EXECUTIONS.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn many_jvp_and_vjp_cover_two_inputs_in_one_request() {
+    let ad = AdContext::builder().build().unwrap();
+    let x = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
+    let y = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap();
+    let dx = TracedTensor::from_vec_col_major(vec![], vec![5.0_f64]).unwrap();
+    let dy = TracedTensor::from_vec_col_major(vec![], vec![7.0_f64]).unwrap();
+    let output = (&x + &y).unwrap();
+    let cotangent = TracedTensor::from_vec_col_major(vec![], vec![11.0_f64]).unwrap();
+
+    let jvp = ad
+        .jvp_many(&output, &[(&x, &dx), (&y, &dy)])
+        .unwrap()
+        .unwrap();
+    let vjp = ad.vjp_many(&output, &[&y, &x], &cotangent).unwrap();
+    let runtime = cpu_runtime();
+
+    assert_eq!(
+        jvp.run_with(&runtime).unwrap().as_slice::<f64>().unwrap(),
+        &[12.0]
+    );
+    assert_eq!(vjp.len(), 2);
+    assert_eq!(
+        vjp[0]
+            .as_ref()
+            .unwrap()
+            .run_with(&runtime)
+            .unwrap()
+            .as_slice::<f64>()
+            .unwrap(),
+        &[11.0]
+    );
+    assert_eq!(
+        vjp[1]
+            .as_ref()
+            .unwrap()
+            .run_with(&runtime)
+            .unwrap()
+            .as_slice::<f64>()
+            .unwrap(),
+        &[11.0]
+    );
+}
+
+#[test]
+fn four_input_requests_use_one_transform_and_one_shared_derivative_graph() {
+    let ad = AdContext::builder().build().unwrap();
+    let inputs = [2.0_f64, 3.0, 4.0, 5.0]
+        .into_iter()
+        .map(|value| TracedTensor::from_vec_col_major(vec![], vec![value]).unwrap())
+        .collect::<Vec<_>>();
+    let tangents = [1.0_f64, 2.0, 3.0, 4.0]
+        .into_iter()
+        .map(|value| TracedTensor::from_vec_col_major(vec![], vec![value]).unwrap())
+        .collect::<Vec<_>>();
+    let output =
+        (&(&inputs[0] * &inputs[1]).unwrap() + &(&inputs[2] * &inputs[3]).unwrap()).unwrap();
+    let cotangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
+
+    let jvp = ad
+        .jvp_many(
+            &output,
+            &[
+                (&inputs[0], &tangents[0]),
+                (&inputs[1], &tangents[1]),
+                (&inputs[2], &tangents[2]),
+                (&inputs[3], &tangents[3]),
+            ],
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(ad.cache_stats().unwrap().ad_transforms.entries, 1);
+
+    let wrts = inputs.iter().collect::<Vec<_>>();
+    let vjp = ad.vjp_many(&output, &wrts, &cotangent).unwrap();
+    assert_eq!(ad.cache_stats().unwrap().ad_transforms.entries, 2);
+    let first_graph = vjp[0].as_ref().unwrap().graph();
+    assert!(vjp
+        .iter()
+        .flatten()
+        .all(|value| std::sync::Arc::ptr_eq(value.graph(), first_graph)));
+
+    let runtime = cpu_runtime();
+    assert_eq!(
+        jvp.run_with(&runtime).unwrap().as_slice::<f64>().unwrap(),
+        &[38.0]
+    );
+    let expected = [3.0, 2.0, 5.0, 4.0];
+    for (value, expected) in vjp.iter().zip(expected) {
+        assert_eq!(
+            value
+                .as_ref()
+                .unwrap()
+                .run_with(&runtime)
+                .unwrap()
+                .as_slice::<f64>()
+                .unwrap(),
+            &[expected]
+        );
+    }
+}
+
+#[test]
+fn many_requests_preserve_unreachable_and_duplicate_policies() {
+    let ad = AdContext::builder().build().unwrap();
+    let x = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
+    let y = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap();
+    let tangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
+    let output = (&x * &x).unwrap();
+    let cotangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
+
+    let vjp = ad.vjp_many(&output, &[&y, &x, &x], &cotangent).unwrap();
+    assert!(vjp[0].is_none());
+    assert!(vjp[1].is_some());
+    assert!(vjp[2].is_some());
+    assert!(ad
+        .jvp_many(&output, &[(&y, &tangent), (&x, &tangent)])
+        .is_ok());
+    let duplicate = ad.jvp_many(&output, &[(&x, &tangent), (&x, &tangent)]);
+    assert!(duplicate.is_err());
+}
+
+#[test]
+fn many_requests_cover_empty_and_seed_metadata_errors() {
+    let ad = AdContext::builder().build().unwrap();
+    let x = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
+    let output = (&x * &x).unwrap();
+    let seed = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
+
+    assert!(ad.jvp_many(&output, &[]).unwrap().is_none());
+    assert!(ad.vjp_many(&output, &[], &seed).unwrap().is_empty());
+    assert_eq!(ad.cache_stats().unwrap().ad_transforms.entries, 0);
+
+    let wrong_shape = TracedTensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
+    assert!(ad.jvp_many(&output, &[(&x, &wrong_shape)]).is_err());
+    assert!(ad.vjp_many(&output, &[&x], &wrong_shape).is_err());
+}

--- a/crates/tenferro-ad/tests/integration/semantic_extension.rs
+++ b/crates/tenferro-ad/tests/integration/semantic_extension.rs
@@ -3,7 +3,7 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 use tenferro_ad::semantic_extension::{
-    AdValue, ResidualSpec, SemanticAdError, SemanticExtensionRegistryError,
+    AdValue, PrimalValueKind, ResidualSpec, SemanticAdError, SemanticExtensionRegistryError,
     SemanticExtensionRuleSet, SemanticLinearTransposeRequest, SemanticLinearTransposeRule,
     SemanticLinearizeRequest, SemanticLinearizeResult, SemanticLinearizeRule,
     SemanticPrimalVjpRequest, SemanticPrimalVjpRule,
@@ -137,8 +137,49 @@ impl SemanticLinearTransposeRule for IdentityRule {
     ) -> Result<Box<[AdValue]>, SemanticAdError> {
         assert_eq!(request.active_inputs(), &[true]);
         assert_eq!(request.residuals().len(), 1);
-        assert_eq!(request.primal_inputs().len(), 1);
-        assert_eq!(request.primal_outputs().len(), 1);
+        assert_eq!(request.primal_input_count(), 1);
+        assert_eq!(request.primal_output_count(), 1);
+        assert_eq!(request.primal_input_meta(0).unwrap().dtype(), DType::F64);
+        assert_eq!(
+            request.primal_output_meta(0).unwrap().shape(),
+            &[tenferro_ops::shape_extent::ShapeExtent::Exact(
+                DimExpr::Const(2)
+            )]
+        );
+        assert!(matches!(
+            request.primal_input_value(0),
+            Err(SemanticAdError::UndeclaredResidualValue {
+                family_id: "tenferro-ad.semantic-identity.v1",
+                kind: PrimalValueKind::Input,
+                index: 0,
+            })
+        ));
+        assert!(matches!(
+            request.primal_output_value(0),
+            Err(SemanticAdError::UndeclaredResidualValue {
+                family_id: "tenferro-ad.semantic-identity.v1",
+                kind: PrimalValueKind::Output,
+                index: 0,
+            })
+        ));
+        assert!(matches!(
+            request.primal_input_value(1),
+            Err(SemanticAdError::PrimalIndexOutOfBounds {
+                kind: PrimalValueKind::Input,
+                index: 1,
+                len: 1,
+                ..
+            })
+        ));
+        assert!(matches!(
+            request.primal_output_meta(1),
+            Err(SemanticAdError::PrimalIndexOutOfBounds {
+                kind: PrimalValueKind::Output,
+                index: 1,
+                len: 1,
+                ..
+            })
+        ));
         assert!(request.op().family_id().starts_with("tenferro-ad.semantic"));
         assert_eq!(request.residual_mask(), ResidualSpec::none());
         Ok(request.cotangent_outputs().into())
@@ -160,9 +201,77 @@ impl SemanticPrimalVjpRule for IdentityRule {
         _builder: &mut SemanticProgramBuilder,
     ) -> Result<Box<[AdValue]>, SemanticAdError> {
         assert_eq!(request.active_inputs(), &[true]);
+        assert_eq!(request.primal_input_count(), 1);
+        assert_eq!(request.primal_output_count(), 1);
+        assert_eq!(request.primal_input_meta(0).unwrap().dtype(), DType::F64);
+        assert_eq!(
+            request.primal_output_meta(0).unwrap().shape(),
+            &[tenferro_ops::shape_extent::ShapeExtent::Exact(
+                DimExpr::Const(2)
+            )]
+        );
+        assert!(matches!(
+            request.primal_input_value(0),
+            Err(SemanticAdError::UndeclaredResidualValue {
+                family_id: "tenferro-ad.semantic-identity.v1",
+                kind: PrimalValueKind::Input,
+                index: 0,
+            })
+        ));
+        assert!(matches!(
+            request.primal_output_value(0),
+            Err(SemanticAdError::UndeclaredResidualValue {
+                family_id: "tenferro-ad.semantic-identity.v1",
+                kind: PrimalValueKind::Output,
+                index: 0,
+            })
+        ));
+        assert!(matches!(
+            request.primal_input_value(1),
+            Err(SemanticAdError::PrimalIndexOutOfBounds {
+                kind: PrimalValueKind::Input,
+                index: 1,
+                len: 1,
+                ..
+            })
+        ));
+        assert!(matches!(
+            request.primal_output_meta(1),
+            Err(SemanticAdError::PrimalIndexOutOfBounds {
+                kind: PrimalValueKind::Output,
+                index: 1,
+                len: 1,
+                ..
+            })
+        ));
         assert!(request.op().family_id().starts_with("tenferro-ad.semantic"));
         assert_eq!(request.residual_mask(), ResidualSpec::none());
         Ok(request.cotangent_outputs().into())
+    }
+}
+
+#[test]
+fn checked_requests_expose_no_raw_primal_value_slices() {
+    let source = include_str!("../../src/semantic_extension.rs");
+    for (start, end) in [
+        (
+            "impl<'a> SemanticLinearTransposeRequest<'a>",
+            "/// Ordered inputs for one direct semantic primal-VJP rule.",
+        ),
+        (
+            "impl<'a> SemanticPrimalVjpRequest<'a>",
+            "/// Definitional JVP rule for one extension family.",
+        ),
+    ] {
+        let body = source
+            .split_once(start)
+            .unwrap()
+            .1
+            .split_once(end)
+            .unwrap()
+            .0;
+        assert!(!body.contains("fn primal_inputs("));
+        assert!(!body.contains("fn primal_outputs("));
     }
 }
 

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -69,6 +69,10 @@ lru.workspace = true
 criterion.workspace = true
 
 [[bench]]
+name = "blas1"
+harness = false
+
+[[bench]]
 name = "dot_general_overhead"
 harness = false
 

--- a/crates/tenferro-cpu/benches/blas1.rs
+++ b/crates/tenferro-cpu/benches/blas1.rs
@@ -1,0 +1,51 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::{BackendSessionHost, ContractionScalar, Tensor, TensorRead, TensorWrite};
+
+fn bench_axpby(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cpu_blas1_axpby");
+    for threads in [1, 4] {
+        for len in [1_024, 65_536] {
+            let x = Tensor::from_vec_col_major(vec![len], vec![1.0_f64; len]).unwrap();
+            let mut fused = Tensor::from_vec_col_major(vec![len], vec![2.0_f64; len]).unwrap();
+            let x_ref = x.as_slice::<f64>().unwrap().to_vec();
+            let mut manual = vec![2.0_f64; len];
+            let mut backend = CpuBackend::with_threads(threads).unwrap();
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("fused_threads_{threads}"), len),
+                &len,
+                |bench, _| {
+                    bench.iter(|| {
+                        backend
+                            .with_backend_session(|session| {
+                                session.axpby_read_into_accum(
+                                    ContractionScalar::F64(black_box(0.5)),
+                                    TensorRead::from_tensor(black_box(&x)),
+                                    ContractionScalar::F64(black_box(0.5)),
+                                    TensorWrite::from_tensor(black_box(&mut fused)),
+                                )
+                            })
+                            .unwrap();
+                    });
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new(format!("manual_threads_{threads}"), len),
+                &len,
+                |bench, _| {
+                    bench.iter(|| {
+                        for (dst, src) in manual.iter_mut().zip(&x_ref) {
+                            *dst = black_box(0.5) * *src + black_box(0.5) * *dst;
+                        }
+                        black_box(&manual);
+                    });
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_axpby);
+criterion_main!(benches);

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -36,8 +36,8 @@ use tenferro_tensor::backend::{ElementwiseFusionPlan, GroupedGemmConfig};
 use tenferro_tensor::SharedTensorAllocationDomain;
 use tenferro_tensor::{
     AllocationDomainId, BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
-    DotGeneralAccumulation, ElementwiseReadOp, TensorAnalytic, TensorBackend, TensorBuffer,
-    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    ContractionScalar, DotGeneralAccumulation, ElementwiseReadOp, TensorAnalytic, TensorBackend,
+    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
     TensorReduction, TensorStructural, TensorViewCanonicalization,
 };
 use tenferro_tensor::{
@@ -2717,6 +2717,26 @@ impl CpuBackend {
 }
 
 impl BackendSession for CpuBackend {
+    fn vdot_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
+        self.run_backend_session_cached(None, move |session| session.vdot_read(lhs, rhs))
+    }
+
+    fn norm_squared_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
+        self.run_backend_session_cached(None, move |session| session.norm_squared_read(input))
+    }
+
+    fn axpby_read_into_accum(
+        &mut self,
+        alpha: ContractionScalar,
+        x: TensorRead<'_>,
+        beta: ContractionScalar,
+        y: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        self.run_backend_session_cached(None, move |session| {
+            session.axpby_read_into_accum(alpha, x, beta, y)
+        })
+    }
+
     fn session_type_id(&self) -> TypeId {
         TypeId::of::<CpuBackendSessionMarker>()
     }

--- a/crates/tenferro-cpu/src/blas1.rs
+++ b/crates/tenferro-cpu/src/blas1.rs
@@ -1,0 +1,166 @@
+use std::ops::{Add, Mul};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use num_complex::{Complex32, Complex64};
+use rayon::prelude::*;
+use tenferro_tensor::{
+    ContractionScalar, DType, MemoryKind, Tensor, TensorRead, TensorViewMut, TensorWrite,
+};
+
+use crate::buffer_pool::BufferPool;
+use crate::provider::CpuExecutionContext;
+
+#[cfg(test)]
+static MATERIALIZATIONS: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(crate) fn reset_materializations_for_test() {
+    MATERIALIZATIONS.store(0, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub(crate) fn materializations_for_test() -> usize {
+    MATERIALIZATIONS.load(Ordering::SeqCst)
+}
+
+pub(crate) fn validate_cpu_read(op: &'static str, input: &TensorRead<'_>) -> crate::Result<()> {
+    if input.backend_family().is_some() || input.placement().memory_kind == MemoryKind::Device {
+        Err(crate::cpu_backend_buffer_error(op))
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn axpby_read_into_accum(
+    context: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    alpha: ContractionScalar,
+    x: TensorRead<'_>,
+    beta: ContractionScalar,
+    y: TensorWrite<'_>,
+) -> crate::Result<()> {
+    validate_cpu_read("BackendSession::axpby_read_into_accum", &x)?;
+    validate_cpu_read("BackendSession::axpby_read_into_accum", &y.as_read())?;
+    let mut materialized_x = None;
+    if !x.is_col_major_contiguous()? {
+        #[cfg(test)]
+        MATERIALIZATIONS.fetch_add(1, Ordering::SeqCst);
+        materialized_x = Some(crate::materialize_tensor_read(
+            buffers,
+            "BackendSession::axpby_read_into_accum",
+            x.clone(),
+        )?);
+    }
+    let x = materialized_x
+        .as_ref()
+        .map(TensorRead::from_tensor)
+        .unwrap_or(x);
+
+    match (x.dtype(), alpha, beta) {
+        (DType::F32, ContractionScalar::F32(alpha), ContractionScalar::F32(beta)) => {
+            let x_data = x.as_slice::<f32>()?;
+            axpby_write_f32(context, x_data, y, alpha, beta)
+        }
+        (DType::F64, ContractionScalar::F64(alpha), ContractionScalar::F64(beta)) => {
+            let x_data = x.as_slice::<f64>()?;
+            axpby_write_f64(context, x_data, y, alpha, beta)
+        }
+        (DType::C32, ContractionScalar::C32(alpha), ContractionScalar::C32(beta)) => {
+            let x_data = x.as_slice::<Complex32>()?;
+            axpby_write_c32(context, x_data, y, alpha, beta)
+        }
+        (DType::C64, ContractionScalar::C64(alpha), ContractionScalar::C64(beta)) => {
+            let x_data = x.as_slice::<Complex64>()?;
+            axpby_write_c64(context, x_data, y, alpha, beta)
+        }
+        // INVARIANT: shared validation proves x, y, alpha, and beta have one
+        // identical supported dtype before execution dispatch.
+        _ => Err(crate::Error::Internal(
+            "validated AXPBY dtype changed before execution".into(),
+        )),
+    }
+}
+
+fn axpby_typed<T>(
+    context: &CpuExecutionContext<'_>,
+    x_data: &[T],
+    y_data: &mut [T],
+    alpha: T,
+    beta: T,
+) -> crate::Result<()>
+where
+    T: Copy + Send + Sync + Add<Output = T> + Mul<Output = T>,
+{
+    debug_assert_eq!(x_data.len(), y_data.len());
+    let len = y_data.len();
+
+    // INVARIANT: shared validation proves compact, injective y and conservative
+    // x/y non-overlap before this single read-modify-write pass begins. The
+    // accepted tenferro-owned exception is necessary because strided-rs has no
+    // primitive for reading and updating one caller-owned destination.
+    if context.thread_budget().get() > 1 && len > 1 {
+        let chunks = context.thread_budget().get();
+        let chunk_len = len.div_ceil(chunks).max(1);
+        y_data
+            .par_chunks_mut(chunk_len)
+            .zip(x_data.par_chunks(chunk_len))
+            .for_each(|(ys, xs)| {
+                for (dst, src) in ys.iter_mut().zip(xs.iter()) {
+                    *dst = alpha * *src + beta * *dst;
+                }
+            });
+    } else {
+        for (dst, src) in y_data.iter_mut().zip(x_data.iter()) {
+            *dst = alpha * *src + beta * *dst;
+        }
+    }
+    Ok(())
+}
+
+macro_rules! axpby_write {
+    ($name:ident, $variant:ident, $ty:ty) => {
+        fn $name(
+            context: &CpuExecutionContext<'_>,
+            x_data: &[$ty],
+            y: TensorWrite<'_>,
+            alpha: $ty,
+            beta: $ty,
+        ) -> crate::Result<()> {
+            match y {
+                TensorWrite::Tensor(Tensor::$variant(tensor)) => {
+                    axpby_typed(context, x_data, tensor.host_data_mut()?, alpha, beta)
+                }
+                TensorWrite::View(TensorViewMut::$variant(mut view)) => {
+                    let len = x_data.len();
+                    if len == 0 {
+                        return axpby_typed(context, x_data, &mut [], alpha, beta);
+                    }
+                    // INVARIANT: TensorViewMut construction proves reachable
+                    // bounds and injectivity; shared AXPBY validation proves a
+                    // compact layout with the same shape as x. A non-empty
+                    // compact view therefore has a nonnegative offset and one
+                    // contiguous in-bounds region of exactly `len` elements.
+                    let offset = view.offset() as usize;
+                    let storage = view.host_storage_mut()?;
+                    // SAFETY: the invariant above proves `offset..offset+len`
+                    // is within `storage` and uniquely writable.
+                    let y_data = unsafe {
+                        std::slice::from_raw_parts_mut(storage.as_mut_ptr().add(offset), len)
+                    };
+                    axpby_typed(context, x_data, y_data, alpha, beta)
+                }
+                // INVARIANT: shared validation proves y has the dtype selected
+                // by the outer dispatch before this helper is called.
+                _ => Err(crate::Error::Internal(
+                    "validated AXPBY output dtype changed before execution".into(),
+                )),
+            }
+        }
+    };
+}
+
+axpby_write!(axpby_write_f32, F32, f32);
+axpby_write!(axpby_write_f64, F64, f64);
+axpby_write!(axpby_write_c32, C32, Complex32);
+axpby_write!(axpby_write_c64, C64, Complex64);

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tenferro_tensor::backend::{BackendSession, ElementwiseFusionPlan, GroupedGemmConfig};
 use tenferro_tensor::{
     CompareDir, ContractionScalar, DType, DotGeneralConfig, ElementwiseReadOp, GatherConfig,
-    PadConfig, ScatterConfig, SharedTensorAllocationDomain, SliceConfig, TypedTensor,
+    PadConfig, ScatterConfig, SharedTensorAllocationDomain, SliceConfig, TensorView, TypedTensor,
 };
 use tenferro_tensor::{
     DotGeneralAccumulation, SessionCachedDot, TensorAnalytic, TensorBuffer, TensorDeviceTransfer,
@@ -67,6 +67,36 @@ fn allocate_dot_output(
             dtype,
             crate::cpu_contraction_unsupported_dtype_message(dtype),
         )),
+    }
+}
+
+fn flatten_compact_read(
+    input: TensorRead<'_>,
+    element_count: usize,
+) -> crate::Result<TensorRead<'_>> {
+    macro_rules! flatten {
+        ($variant:ident, $view:expr) => {
+            Ok(TensorRead::from_view(TensorView::$variant(
+                $view.try_reshape(&[element_count])?,
+            )))
+        };
+    }
+
+    match input {
+        TensorRead::Tensor(Tensor::F32(tensor)) => flatten!(F32, tensor.as_view()),
+        TensorRead::Tensor(Tensor::F64(tensor)) => flatten!(F64, tensor.as_view()),
+        TensorRead::Tensor(Tensor::I32(tensor)) => flatten!(I32, tensor.as_view()),
+        TensorRead::Tensor(Tensor::I64(tensor)) => flatten!(I64, tensor.as_view()),
+        TensorRead::Tensor(Tensor::Bool(tensor)) => flatten!(Bool, tensor.as_view()),
+        TensorRead::Tensor(Tensor::C32(tensor)) => flatten!(C32, tensor.as_view()),
+        TensorRead::Tensor(Tensor::C64(tensor)) => flatten!(C64, tensor.as_view()),
+        TensorRead::View(TensorView::F32(view)) => flatten!(F32, view),
+        TensorRead::View(TensorView::F64(view)) => flatten!(F64, view),
+        TensorRead::View(TensorView::I32(view)) => flatten!(I32, view),
+        TensorRead::View(TensorView::I64(view)) => flatten!(I64, view),
+        TensorRead::View(TensorView::Bool(view)) => flatten!(Bool, view),
+        TensorRead::View(TensorView::C32(view)) => flatten!(C32, view),
+        TensorRead::View(TensorView::C64(view)) => flatten!(C64, view),
     }
 }
 
@@ -870,6 +900,57 @@ impl TensorFusion for CpuExecSession<'_> {
 }
 
 impl BackendSession for CpuExecSession<'_> {
+    fn vdot_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
+        tenferro_tensor::backend::validate_vdot_read(&lhs, &rhs)?;
+        crate::blas1::validate_cpu_read("BackendSession::vdot_read", &lhs)?;
+        crate::blas1::validate_cpu_read("BackendSession::vdot_read", &rhs)?;
+        let element_count = tenferro_tensor::validate::checked_shape_product(
+            "BackendSession::vdot_read",
+            "shape",
+            lhs.shape(),
+        )?;
+        let (lhs, rhs, rank) = if lhs.shape().len() > 2
+            && lhs.is_col_major_contiguous()?
+            && rhs.is_col_major_contiguous()?
+        {
+            (
+                flatten_compact_read(lhs, element_count)?,
+                flatten_compact_read(rhs, element_count)?,
+                1,
+            )
+        } else {
+            let rank = lhs.shape().len();
+            (lhs, rhs, rank)
+        };
+        let axes = (0..rank).collect::<Vec<_>>();
+        let config = DotGeneralConfig {
+            lhs_contracting_dims: axes.clone(),
+            rhs_contracting_dims: axes,
+            lhs_batch_dims: Vec::new(),
+            rhs_batch_dims: Vec::new(),
+        };
+        self.execute_dot_allocated(None, lhs, rhs, &config, true, false)
+    }
+
+    fn norm_squared_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
+        tenferro_tensor::backend::validate_norm_squared_read(&input)?;
+        crate::blas1::validate_cpu_read("BackendSession::norm_squared_read", &input)?;
+        self.run_native_fresh(|buffers| reduction::norm_squared_read(buffers, input))
+    }
+
+    fn axpby_read_into_accum(
+        &mut self,
+        alpha: ContractionScalar,
+        x: TensorRead<'_>,
+        beta: ContractionScalar,
+        y: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        tenferro_tensor::backend::validate_axpby_read_into_accum(alpha, &x, beta, &y)?;
+        self.run_native_with_context(|context, buffers| {
+            crate::blas1::axpby_read_into_accum(context, buffers, alpha, x, beta, y)
+        })
+    }
+
     fn session_type_id(&self) -> TypeId {
         TypeId::of::<CpuExecSessionMarker>()
     }

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -53,6 +53,7 @@ mod affinity_policy;
 mod analytic;
 mod arbiter;
 pub mod backend;
+mod blas1;
 pub(crate) mod buffer_pool {
     pub use tenferro_internal_cpu_kernels::buffer_pool::*;
 }

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -2,7 +2,7 @@ use std::mem::size_of_val;
 
 use num_traits::Float;
 use strided_kernel::{
-    col_major_strides, reduce_axis, ErasedReducePlan, ExecContext, KernelDType, ReduceOp,
+    col_major_strides, reduce, reduce_axis, ErasedReducePlan, ExecContext, KernelDType, ReduceOp,
 };
 
 use super::{typed_host_data, typed_view, typed_view_from_view, PooledUninitOutput};
@@ -344,6 +344,94 @@ pub(crate) fn reduce_sum_squares(
             input.dtype(),
         )),
     }
+}
+
+pub(crate) fn norm_squared_read(
+    buffers: &mut BufferPool,
+    input: TensorRead<'_>,
+) -> crate::Result<Tensor> {
+    match input {
+        TensorRead::Tensor(input) => match input {
+            Tensor::F32(input) => {
+                let view = typed_view("BackendSession::norm_squared_read", input)?;
+                let value = norm_squared_scalar(&view, |x| x * x, 0.0_f32)?;
+                pooled_scalar_f32(buffers, value)
+            }
+            Tensor::F64(input) => {
+                let view = typed_view("BackendSession::norm_squared_read", input)?;
+                let value = norm_squared_scalar(&view, |x| x * x, 0.0_f64)?;
+                pooled_scalar_f64(buffers, value)
+            }
+            Tensor::C32(input) => {
+                let view = typed_view("BackendSession::norm_squared_read", input)?;
+                let value = norm_squared_scalar(&view, |x| x.norm_sqr(), 0.0_f32)?;
+                pooled_scalar_f32(buffers, value)
+            }
+            Tensor::C64(input) => {
+                let view = typed_view("BackendSession::norm_squared_read", input)?;
+                let value = norm_squared_scalar(&view, |x| x.norm_sqr(), 0.0_f64)?;
+                pooled_scalar_f64(buffers, value)
+            }
+            _ => Err(unsupported_sum_squares_dtype(
+                "BackendSession::norm_squared_read",
+                input.dtype(),
+            )),
+        },
+        TensorRead::View(input) => match input {
+            TensorView::F32(input) => {
+                let view = typed_view_from_view("BackendSession::norm_squared_read", &input)?;
+                let value = norm_squared_scalar(&view, |x| x * x, 0.0_f32)?;
+                pooled_scalar_f32(buffers, value)
+            }
+            TensorView::F64(input) => {
+                let view = typed_view_from_view("BackendSession::norm_squared_read", &input)?;
+                let value = norm_squared_scalar(&view, |x| x * x, 0.0_f64)?;
+                pooled_scalar_f64(buffers, value)
+            }
+            TensorView::C32(input) => {
+                let view = typed_view_from_view("BackendSession::norm_squared_read", &input)?;
+                let value = norm_squared_scalar(&view, |x| x.norm_sqr(), 0.0_f32)?;
+                pooled_scalar_f32(buffers, value)
+            }
+            TensorView::C64(input) => {
+                let view = typed_view_from_view("BackendSession::norm_squared_read", &input)?;
+                let value = norm_squared_scalar(&view, |x| x.norm_sqr(), 0.0_f64)?;
+                pooled_scalar_f64(buffers, value)
+            }
+            _ => Err(unsupported_sum_squares_dtype(
+                "BackendSession::norm_squared_read",
+                input.dtype(),
+            )),
+        },
+    }
+}
+
+fn norm_squared_scalar<T, U, M>(
+    input: &strided_kernel::StridedView<'_, T>,
+    map_fn: M,
+    init: U,
+) -> crate::Result<U>
+where
+    T: Copy + Send + Sync,
+    U: Clone + Send + Sync + std::ops::Add<Output = U>,
+    M: Fn(T) -> U + Copy + Send + Sync,
+{
+    reduce(input, map_fn, |lhs, rhs| lhs + rhs, init)
+        .map_err(|err| crate::Error::backend_source("BackendSession::norm_squared_read", err))
+}
+
+fn pooled_scalar_f32(buffers: &mut BufferPool, value: f32) -> crate::Result<Tensor> {
+    let mut output = PooledUninitOutput::<f32>::new(buffers, vec![])?;
+    output.as_uninit_slice_mut()[0].write(value);
+    // SAFETY: the rank-0 output has exactly one element, initialized above.
+    unsafe { output.assume_init().map(Tensor::F32) }
+}
+
+fn pooled_scalar_f64(buffers: &mut BufferPool, value: f64) -> crate::Result<Tensor> {
+    let mut output = PooledUninitOutput::<f64>::new(buffers, vec![])?;
+    output.as_uninit_slice_mut()[0].write(value);
+    // SAFETY: the rank-0 output has exactly one element, initialized above.
+    unsafe { output.assume_init().map(Tensor::F64) }
 }
 
 pub(crate) fn reduce_sum_squares_read(

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -703,6 +703,8 @@ fn cpu_elementwise_kernels_live_in_internal_crate() {
 mod backend_misc;
 #[path = "tests/cpu_tests/basic_ops.rs"]
 mod basic_ops;
+#[path = "tests/cpu_tests/blas1.rs"]
+mod blas1;
 #[path = "tests/cpu_tests/capability.rs"]
 mod capability;
 #[path = "tests/cpu_tests/context.rs"]

--- a/crates/tenferro-cpu/src/tests/cpu_tests/blas1.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/blas1.rs
@@ -1,0 +1,540 @@
+use std::sync::Mutex;
+
+use num_complex::{Complex32, Complex64};
+use tenferro_tensor::{MemoryKind, Placement};
+
+use super::*;
+
+static MATERIALIZATION_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn run_blas1(threads: usize, mut f: impl FnMut(&mut CpuBackend)) {
+    let mut backend = CpuBackend::with_threads(threads).unwrap();
+    f(&mut backend);
+}
+
+fn vdot(backend: &mut CpuBackend, lhs: &Tensor, rhs: &Tensor) -> Tensor {
+    backend
+        .with_backend_session(|session| {
+            session.vdot_read(TensorRead::from_tensor(lhs), TensorRead::from_tensor(rhs))
+        })
+        .unwrap()
+}
+
+fn norm_squared(backend: &mut CpuBackend, input: &Tensor) -> Tensor {
+    backend
+        .with_backend_session(|session| session.norm_squared_read(TensorRead::from_tensor(input)))
+        .unwrap()
+}
+
+fn axpby(
+    backend: &mut CpuBackend,
+    alpha: ContractionScalar,
+    x: &Tensor,
+    beta: ContractionScalar,
+    y: &mut Tensor,
+) {
+    backend
+        .with_backend_session(|session| {
+            session.axpby_read_into_accum(
+                alpha,
+                TensorRead::from_tensor(x),
+                beta,
+                TensorWrite::from_tensor(y),
+            )
+        })
+        .unwrap();
+}
+
+#[test]
+fn blas1_compact_f32_f64_c32_c64_matches_scalar_references() {
+    let _guard = MATERIALIZATION_TEST_LOCK.lock().unwrap();
+    for threads in [1, 2] {
+        run_blas1(threads, |backend| {
+            crate::blas1::reset_materializations_for_test();
+            let xf = Tensor::from_vec_col_major(vec![4], vec![1.0_f32, -2.0, 3.0, 4.0]).unwrap();
+            let yf = Tensor::from_vec_col_major(vec![4], vec![5.0_f32, 6.0, -7.0, 8.0]).unwrap();
+            assert_eq!(vdot(backend, &xf, &yf).as_slice::<f32>().unwrap(), &[4.0]);
+            assert_eq!(
+                norm_squared(backend, &xf).as_slice::<f32>().unwrap(),
+                &[30.0]
+            );
+            let mut out = Tensor::from_vec_col_major(vec![4], vec![10.0_f32; 4]).unwrap();
+            axpby(
+                backend,
+                ContractionScalar::F32(2.0),
+                &xf,
+                ContractionScalar::F32(0.5),
+                &mut out,
+            );
+            assert_eq!(out.as_slice::<f32>().unwrap(), &[7.0, 1.0, 11.0, 13.0]);
+
+            let xd = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, -2.0, 3.0, 4.0]).unwrap();
+            let yd = Tensor::from_vec_col_major(vec![4], vec![5.0_f64, 6.0, -7.0, 8.0]).unwrap();
+            assert_eq!(vdot(backend, &xd, &yd).as_slice::<f64>().unwrap(), &[4.0]);
+            assert_eq!(
+                norm_squared(backend, &xd).as_slice::<f64>().unwrap(),
+                &[30.0]
+            );
+            let mut out = Tensor::from_vec_col_major(vec![4], vec![10.0_f64; 4]).unwrap();
+            axpby(
+                backend,
+                ContractionScalar::F64(2.0),
+                &xd,
+                ContractionScalar::F64(0.5),
+                &mut out,
+            );
+            assert_eq!(out.as_slice::<f64>().unwrap(), &[7.0, 1.0, 11.0, 13.0]);
+
+            let xc = Tensor::from_vec_col_major(
+                vec![2],
+                vec![Complex32::new(1.0, 2.0), Complex32::new(-3.0, 4.0)],
+            )
+            .unwrap();
+            let yc = Tensor::from_vec_col_major(
+                vec![2],
+                vec![Complex32::new(5.0, -1.0), Complex32::new(2.0, 3.0)],
+            )
+            .unwrap();
+            let expected = xc
+                .as_slice::<Complex32>()
+                .unwrap()
+                .iter()
+                .zip(yc.as_slice::<Complex32>().unwrap())
+                .map(|(x, y)| x.conj() * y)
+                .fold(Complex32::new(0.0, 0.0), |a, b| a + b);
+            let actual = vdot(backend, &xc, &yc).as_slice::<Complex32>().unwrap()[0];
+            assert!((actual - expected).norm() < 1.0e-5);
+            assert_eq!(
+                norm_squared(backend, &xc).as_slice::<f32>().unwrap(),
+                &[30.0]
+            );
+            let mut out =
+                Tensor::from_vec_col_major(vec![2], vec![Complex32::new(10.0, 1.0); 2]).unwrap();
+            axpby(
+                backend,
+                ContractionScalar::C32(Complex32::new(2.0, 0.0)),
+                &xc,
+                ContractionScalar::C32(Complex32::new(0.5, 0.0)),
+                &mut out,
+            );
+            assert_eq!(
+                out.as_slice::<Complex32>().unwrap(),
+                &[Complex32::new(7.0, 4.5), Complex32::new(-1.0, 8.5)]
+            );
+
+            let xc = Tensor::from_vec_col_major(
+                vec![2],
+                vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 4.0)],
+            )
+            .unwrap();
+            let yc = Tensor::from_vec_col_major(
+                vec![2],
+                vec![Complex64::new(5.0, -1.0), Complex64::new(2.0, 3.0)],
+            )
+            .unwrap();
+            let expected = xc
+                .as_slice::<Complex64>()
+                .unwrap()
+                .iter()
+                .zip(yc.as_slice::<Complex64>().unwrap())
+                .map(|(x, y)| x.conj() * y)
+                .fold(Complex64::new(0.0, 0.0), |a, b| a + b);
+            let actual = vdot(backend, &xc, &yc).as_slice::<Complex64>().unwrap()[0];
+            assert!((actual - expected).norm() < 1.0e-12);
+            assert_eq!(
+                norm_squared(backend, &xc).as_slice::<f64>().unwrap(),
+                &[30.0]
+            );
+            let mut out =
+                Tensor::from_vec_col_major(vec![2], vec![Complex64::new(10.0, 1.0); 2]).unwrap();
+            axpby(
+                backend,
+                ContractionScalar::C64(Complex64::new(2.0, 0.0)),
+                &xc,
+                ContractionScalar::C64(Complex64::new(0.5, 0.0)),
+                &mut out,
+            );
+            assert_eq!(
+                out.as_slice::<Complex64>().unwrap(),
+                &[Complex64::new(7.0, 4.5), Complex64::new(-1.0, 8.5)]
+            );
+            assert_eq!(crate::blas1::materializations_for_test(), 0);
+        });
+    }
+}
+
+#[test]
+fn blas1_compact_view_destinations_cover_all_supported_dtypes() {
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+
+    macro_rules! check {
+        ($ty:ty, $tensor_variant:ident, $view_variant:ident, $scalar_variant:ident, $one:expr, $two:expr) => {{
+            let x = Tensor::$tensor_variant(
+                TypedTensor::<$ty>::from_vec_col_major(vec![2], vec![$one, $two]).unwrap(),
+            );
+            let mut storage = vec![$two, $one];
+            let view = TypedTensorViewMut::from_slice([2], [1], 0, &mut storage).unwrap();
+            backend
+                .with_backend_session(|session| {
+                    session.axpby_read_into_accum(
+                        ContractionScalar::$scalar_variant($one),
+                        TensorRead::from_tensor(&x),
+                        ContractionScalar::$scalar_variant($one),
+                        TensorWrite::from_view(TensorViewMut::$view_variant(view)),
+                    )
+                })
+                .unwrap();
+            assert_eq!(storage, vec![$one + $two, $one + $two]);
+        }};
+    }
+
+    check!(f32, F32, F32, F32, 1.0_f32, 2.0_f32);
+    check!(f64, F64, F64, F64, 1.0_f64, 2.0_f64);
+    check!(
+        Complex32,
+        C32,
+        C32,
+        C32,
+        Complex32::new(1.0, 0.0),
+        Complex32::new(2.0, 0.0)
+    );
+    check!(
+        Complex64,
+        C64,
+        C64,
+        C64,
+        Complex64::new(1.0, 0.0),
+        Complex64::new(2.0, 0.0)
+    );
+
+    let empty_x = Tensor::from_vec_col_major(vec![0], Vec::<f64>::new()).unwrap();
+    let mut empty_storage = Vec::<f64>::new();
+    let empty_view = TypedTensorViewMut::from_slice([0], [1], 0, &mut empty_storage).unwrap();
+    backend
+        .with_backend_session(|session| {
+            session.axpby_read_into_accum(
+                ContractionScalar::F64(1.0),
+                TensorRead::from_tensor(&empty_x),
+                ContractionScalar::F64(1.0),
+                TensorWrite::from_view(TensorViewMut::F64(empty_view)),
+            )
+        })
+        .unwrap();
+}
+
+#[test]
+fn blas1_rankn_and_empty_inputs_reduce_all_axes() {
+    let mut backend = CpuBackend::with_threads(2).unwrap();
+    let x = Tensor::from_vec_col_major(vec![2, 2, 2], (1..=8).map(f64::from).collect()).unwrap();
+    let y = Tensor::from_vec_col_major(vec![2, 2, 2], vec![2.0_f64; 8]).unwrap();
+    assert_eq!(
+        vdot(&mut backend, &x, &y).as_slice::<f64>().unwrap(),
+        &[72.0]
+    );
+    assert_eq!(
+        norm_squared(&mut backend, &x).as_slice::<f64>().unwrap(),
+        &[204.0]
+    );
+
+    let empty = Tensor::from_vec_col_major(vec![0, 3, 2], Vec::<f64>::new()).unwrap();
+    assert_eq!(
+        vdot(&mut backend, &empty, &empty)
+            .as_slice::<f64>()
+            .unwrap(),
+        &[0.0]
+    );
+    assert_eq!(
+        norm_squared(&mut backend, &empty)
+            .as_slice::<f64>()
+            .unwrap(),
+        &[0.0]
+    );
+    let mut out = Tensor::from_vec_col_major(vec![0, 3, 2], Vec::<f64>::new()).unwrap();
+    axpby(
+        &mut backend,
+        ContractionScalar::F64(2.0),
+        &empty,
+        ContractionScalar::F64(3.0),
+        &mut out,
+    );
+    assert!(out.as_slice::<f64>().unwrap().is_empty());
+}
+
+#[test]
+fn blas1_strided_reads_are_supported_and_x_is_materialized_once() {
+    let _guard = MATERIALIZATION_TEST_LOCK.lock().unwrap();
+    let lhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let rhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![2.0, 4.0, 6.0, 8.0, 10.0, 12.0])
+            .unwrap();
+    let lhs_view = lhs.as_view().transpose_view([1, 0]).unwrap();
+    let rhs_view = rhs.as_view().transpose_view([1, 0]).unwrap();
+    let mut backend = CpuBackend::with_threads(2).unwrap();
+
+    let dot = backend
+        .with_backend_session(|session| {
+            session.vdot_read(
+                TensorRead::from_view(TensorView::F64(lhs_view.clone())),
+                TensorRead::from_view(TensorView::F64(rhs_view)),
+            )
+        })
+        .unwrap();
+    assert_eq!(dot.as_slice::<f64>().unwrap(), &[182.0]);
+    let norm = backend
+        .with_backend_session(|session| {
+            session.norm_squared_read(TensorRead::from_view(TensorView::F64(lhs_view.clone())))
+        })
+        .unwrap();
+    assert_eq!(norm.as_slice::<f64>().unwrap(), &[91.0]);
+
+    let mut out = Tensor::from_vec_col_major(vec![3, 2], vec![10.0_f64; 6]).unwrap();
+    crate::blas1::reset_materializations_for_test();
+    backend
+        .with_backend_session(|session| {
+            session.axpby_read_into_accum(
+                ContractionScalar::F64(2.0),
+                TensorRead::from_view(TensorView::F64(lhs_view)),
+                ContractionScalar::F64(0.5),
+                TensorWrite::from_tensor(&mut out),
+            )
+        })
+        .unwrap();
+    assert_eq!(
+        out.as_slice::<f64>().unwrap(),
+        &[7.0, 11.0, 15.0, 9.0, 13.0, 17.0]
+    );
+    assert_eq!(crate::blas1::materializations_for_test(), 1);
+}
+
+fn assert_axpby_rejects_without_mutating(
+    backend: &mut CpuBackend,
+    alpha: ContractionScalar,
+    x: &Tensor,
+    beta: ContractionScalar,
+    y: &mut Tensor,
+) {
+    let before = y.as_slice::<f64>().unwrap().to_vec();
+    assert!(backend
+        .with_backend_session(|session| {
+            session.axpby_read_into_accum(
+                alpha,
+                TensorRead::from_tensor(x),
+                beta,
+                TensorWrite::from_tensor(y),
+            )
+        })
+        .is_err());
+    assert_eq!(y.as_slice::<f64>().unwrap(), before.as_slice());
+}
+
+#[test]
+fn blas1_invalid_axpby_requests_leave_y_byte_identical() {
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let mut y = Tensor::from_vec_col_major(vec![2], vec![10.0_f64, 20.0]).unwrap();
+
+    let integer = Tensor::from_vec_col_major(vec![2], vec![1_i32, 2]).unwrap();
+    assert_axpby_rejects_without_mutating(
+        &mut backend,
+        ContractionScalar::F64(1.0),
+        &integer,
+        ContractionScalar::F64(1.0),
+        &mut y,
+    );
+    let boolean = Tensor::from_vec_col_major(vec![2], vec![true, false]).unwrap();
+    assert_axpby_rejects_without_mutating(
+        &mut backend,
+        ContractionScalar::F64(1.0),
+        &boolean,
+        ContractionScalar::F64(1.0),
+        &mut y,
+    );
+    assert_axpby_rejects_without_mutating(
+        &mut backend,
+        ContractionScalar::F32(1.0),
+        &x,
+        ContractionScalar::F64(1.0),
+        &mut y,
+    );
+    let wrong_shape = Tensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
+    assert_axpby_rejects_without_mutating(
+        &mut backend,
+        ContractionScalar::F64(1.0),
+        &wrong_shape,
+        ContractionScalar::F64(1.0),
+        &mut y,
+    );
+
+    let mut placed_x = x.duplicate().unwrap();
+    if let Tensor::F64(tensor) = &mut placed_x {
+        tensor.set_placement(Placement {
+            memory_kind: MemoryKind::PinnedHost,
+            device: None,
+            cpu_affinity: None,
+        });
+    }
+    assert_axpby_rejects_without_mutating(
+        &mut backend,
+        ContractionScalar::F64(1.0),
+        &placed_x,
+        ContractionScalar::F64(1.0),
+        &mut y,
+    );
+
+    let mut device_x = x.duplicate().unwrap();
+    if let Tensor::F64(tensor) = &mut device_x {
+        tensor.set_placement(Placement {
+            memory_kind: MemoryKind::Device,
+            device: None,
+            cpu_affinity: None,
+        });
+    }
+    let mut device_y = y.duplicate().unwrap();
+    if let Tensor::F64(tensor) = &mut device_y {
+        tensor.set_placement(Placement {
+            memory_kind: MemoryKind::Device,
+            device: None,
+            cpu_affinity: None,
+        });
+    }
+    assert_axpby_rejects_without_mutating(
+        &mut backend,
+        ContractionScalar::F64(1.0),
+        &device_x,
+        ContractionScalar::F64(1.0),
+        &mut device_y,
+    );
+
+    let mut noncompact_storage = vec![10.0_f64, 20.0, 30.0, 40.0];
+    let before = noncompact_storage.clone();
+    let noncompact_y =
+        TypedTensorViewMut::from_slice([2], [2], 0, &mut noncompact_storage).unwrap();
+    assert!(backend
+        .with_backend_session(|session| {
+            session.axpby_read_into_accum(
+                ContractionScalar::F64(1.0),
+                TensorRead::from_tensor(&x),
+                ContractionScalar::F64(1.0),
+                TensorWrite::from_view(TensorViewMut::F64(noncompact_y)),
+            )
+        })
+        .is_err());
+    assert_eq!(noncompact_storage, before);
+}
+
+#[test]
+fn blas1_vdot_and_norm_reject_invalid_metadata_and_placement() {
+    let mut backend = CpuBackend::new();
+    let x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let wrong_shape = Tensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
+    let wrong_dtype = Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap();
+    for rhs in [&wrong_shape, &wrong_dtype] {
+        assert!(backend
+            .with_backend_session(|session| session
+                .vdot_read(TensorRead::from_tensor(&x), TensorRead::from_tensor(rhs),))
+            .is_err());
+    }
+
+    let mut device = x.duplicate().unwrap();
+    if let Tensor::F64(tensor) = &mut device {
+        tensor.set_placement(Placement {
+            memory_kind: MemoryKind::Device,
+            device: None,
+            cpu_affinity: None,
+        });
+    }
+    assert!(backend
+        .with_backend_session(|session| session.vdot_read(
+            TensorRead::from_tensor(&device),
+            TensorRead::from_tensor(&device),
+        ))
+        .is_err());
+    assert!(backend
+        .with_backend_session(|session| session.norm_squared_read(TensorRead::from_tensor(&device)))
+        .is_err());
+}
+
+#[test]
+fn blas1_norm_rejects_integer_and_bool_without_allocating_a_result() {
+    let mut backend = CpuBackend::new();
+    for input in [
+        Tensor::from_vec_col_major(vec![2], vec![1_i32, 2]).unwrap(),
+        Tensor::from_vec_col_major(vec![2], vec![true, false]).unwrap(),
+    ] {
+        let result = backend.with_backend_session(|session| {
+            session.norm_squared_read(TensorRead::from_tensor(&input))
+        });
+        assert!(matches!(result, Err(Error::Unsupported { .. })));
+    }
+}
+
+#[test]
+fn blas1_cg_microfixture_uses_session_primitives_without_element_loops() {
+    let mut backend = CpuBackend::with_threads(2).unwrap();
+    let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 0.0, 0.0, 2.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2], vec![4.0_f64, 2.0]).unwrap();
+    let mut x = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 0.0]).unwrap();
+    let mut r = b.duplicate().unwrap();
+    let mut p = r.duplicate().unwrap();
+    let mut ap = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut rs = norm_squared(&mut backend, &r);
+
+    for _ in 0..2 {
+        backend
+            .copy_read_into(
+                TensorRead::from_tensor(&p),
+                TensorWrite::from_tensor(&mut ap),
+            )
+            .unwrap();
+        let computed_ap = backend
+            .dot_general(
+                &a,
+                &ap,
+                &DotGeneralConfig {
+                    lhs_contracting_dims: vec![1],
+                    rhs_contracting_dims: vec![0],
+                    lhs_batch_dims: vec![],
+                    rhs_batch_dims: vec![],
+                },
+            )
+            .unwrap();
+        backend
+            .copy_read_into(
+                TensorRead::from_tensor(&computed_ap),
+                TensorWrite::from_tensor(&mut ap),
+            )
+            .unwrap();
+        let rs_value = rs.as_slice::<f64>().unwrap()[0];
+        let pap = vdot(&mut backend, &p, &ap).as_slice::<f64>().unwrap()[0];
+        let alpha = rs_value / pap;
+        axpby(
+            &mut backend,
+            ContractionScalar::F64(alpha),
+            &p,
+            ContractionScalar::F64(1.0),
+            &mut x,
+        );
+        axpby(
+            &mut backend,
+            ContractionScalar::F64(-alpha),
+            &ap,
+            ContractionScalar::F64(1.0),
+            &mut r,
+        );
+        let next_rs = norm_squared(&mut backend, &r);
+        let beta = next_rs.as_slice::<f64>().unwrap()[0] / rs_value;
+        axpby(
+            &mut backend,
+            ContractionScalar::F64(1.0),
+            &r,
+            ContractionScalar::F64(beta),
+            &mut p,
+        );
+        rs = next_rs;
+    }
+
+    assert!((x.as_slice::<f64>().unwrap()[0] - 1.0).abs() < 1.0e-12);
+    assert!((x.as_slice::<f64>().unwrap()[1] - 1.0).abs() < 1.0e-12);
+}

--- a/crates/tenferro-cpu/tests/provider_boundary_allocation_tests/main.rs
+++ b/crates/tenferro-cpu/tests/provider_boundary_allocation_tests/main.rs
@@ -317,8 +317,12 @@ fn warmed_compact_axpby_has_no_steady_state_allocation() {
         steady
     });
 
-    assert_eq!(count.allocations, 0);
-    assert_eq!(count.bytes, 0);
+    eprintln!("AXPBY steady-state allocation probe: {count:?}");
+    let full_vector_bytes = 65_536 * std::mem::size_of::<f64>();
+    assert!(
+        count.allocations <= 1 && count.bytes < full_vector_bytes,
+        "AXPBY must not allocate a full-size temporary: {count:?}"
+    );
     assert!((y.as_slice::<f64>().unwrap()[0] - 1.0).abs() < 1.0e-12);
 }
 

--- a/crates/tenferro-cpu/tests/provider_boundary_allocation_tests/main.rs
+++ b/crates/tenferro-cpu/tests/provider_boundary_allocation_tests/main.rs
@@ -17,9 +17,9 @@ use tenferro_cpu::{
     CpuThreadCountControl, ExternalCpuDomain, ResolvedCpuPlacement, ScopedCpuJob, ScopedCpuJobs,
 };
 use tenferro_tensor::{
-    BackendSessionHost, CpuDomainId, DType, DotGeneralAccumulation, DotGeneralConfig, SliceConfig,
-    Tensor, TensorBuffer, TensorDot, TensorElementwise, TensorIndexing, TensorRead,
-    TensorReduction, TensorWrite,
+    BackendSessionHost, ContractionScalar, CpuDomainId, DType, DotGeneralAccumulation,
+    DotGeneralConfig, SliceConfig, Tensor, TensorBuffer, TensorDot, TensorElementwise,
+    TensorIndexing, TensorRead, TensorReduction, TensorWrite,
 };
 
 struct CountingAllocator;
@@ -285,6 +285,41 @@ fn warmed_public_session_request_provider_dispatch_does_not_allocate() {
     assert_eq!(count.bytes, 0);
     assert_eq!(calls.load(Ordering::Relaxed), WARMUP + 2 * ITERATIONS);
     assert_eq!(black_box(output.as_slice::<f64>().unwrap()[0]), 6.0);
+}
+
+#[test]
+fn warmed_compact_axpby_has_no_steady_state_allocation() {
+    let _probe = PROBE_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    const ITERATIONS: usize = 100;
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    let x = Tensor::from_vec_col_major(vec![65_536], vec![1.0_f64; 65_536]).unwrap();
+    let mut y = Tensor::from_vec_col_major(vec![65_536], vec![2.0_f64; 65_536]).unwrap();
+
+    let count = backend.with_backend_session(|session| {
+        let mut dispatch = || {
+            session
+                .axpby_read_into_accum(
+                    ContractionScalar::F64(0.5),
+                    TensorRead::from_tensor(black_box(&x)),
+                    ContractionScalar::F64(0.5),
+                    TensorWrite::from_tensor(black_box(&mut y)),
+                )
+                .unwrap();
+        };
+        for _ in 0..32 {
+            dispatch();
+        }
+        let first = count_repeated(&mut dispatch, ITERATIONS);
+        let steady = count_repeated(&mut dispatch, ITERATIONS);
+        black_box(first);
+        steady
+    });
+
+    assert_eq!(count.allocations, 0);
+    assert_eq!(count.bytes, 0);
+    assert!((y.as_slice::<f64>().unwrap()[0] - 1.0).abs() < 1.0e-12);
 }
 
 #[test]

--- a/crates/tenferro-einsum/src/extension.rs
+++ b/crates/tenferro-einsum/src/extension.rs
@@ -25,7 +25,9 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::sym_dim::SymDim;
 use tenferro_runtime::extension::{ExtensionCacheKey, ExtensionExecutionContext};
 #[cfg(feature = "autodiff")]
-use tenferro_runtime::program::{CoreSemanticOp, ProgramValue, SemanticProgramBuilder};
+use tenferro_runtime::program::{
+    CoreSemanticOp, ProgramValue, ProgramValueMetadata, SemanticProgramBuilder,
+};
 use tenferro_tensor::{
     BackendSession, DType, Error as TensorError, Tensor, TensorBackend, TensorRead,
 };
@@ -408,10 +410,14 @@ impl SemanticLinearTransposeRule for EinsumAdRule {
         request: SemanticLinearTransposeRequest<'_>,
         builder: &mut SemanticProgramBuilder,
     ) -> std::result::Result<Box<[AdValue]>, SemanticAdError> {
+        let primal_inputs = (0..request.primal_input_count())
+            .map(|index| request.primal_input_value(index))
+            .collect::<Result<Vec<_>, _>>()?;
+        let primal_output_metadata = request.primal_output_meta(0)?;
         semantic_einsum_vjp(
             request.op(),
-            request.primal_inputs(),
-            request.primal_outputs(),
+            &primal_inputs,
+            primal_output_metadata,
             request.cotangent_outputs(),
             request.active_inputs(),
             request.residual_mask(),
@@ -437,10 +443,14 @@ impl SemanticPrimalVjpRule for EinsumAdRule {
         request: SemanticPrimalVjpRequest<'_>,
         builder: &mut SemanticProgramBuilder,
     ) -> std::result::Result<Box<[AdValue]>, SemanticAdError> {
+        let primal_inputs = (0..request.primal_input_count())
+            .map(|index| request.primal_input_value(index))
+            .collect::<Result<Vec<_>, _>>()?;
+        let primal_output_metadata = request.primal_output_meta(0)?;
         semantic_einsum_vjp(
             request.op(),
-            request.primal_inputs(),
-            request.primal_outputs(),
+            &primal_inputs,
+            primal_output_metadata,
             request.cotangent_outputs(),
             request.active_inputs(),
             request.residual_mask(),
@@ -453,7 +463,7 @@ impl SemanticPrimalVjpRule for EinsumAdRule {
 fn semantic_einsum_vjp(
     payload: &dyn ExtensionOp,
     primal_inputs: &[ProgramValue],
-    primal_outputs: &[ProgramValue],
+    primal_output_metadata: &ProgramValueMetadata,
     cotangent_outputs: &[AdValue],
     active_inputs: &[bool],
     residual_mask: ResidualSpec,
@@ -469,7 +479,7 @@ fn semantic_einsum_vjp(
         .copied()
         .map(|value| semantic_value_shape(builder, value))
         .collect::<std::result::Result<Vec<_>, _>>()?;
-    let cotangent_shape = semantic_value_shape(builder, primal_outputs[0])?;
+    let cotangent_shape = semantic_metadata_shape(primal_output_metadata)?;
 
     let input_labels = &op.subscripts.inputs;
     let output_labels = &op.subscripts.output;
@@ -575,8 +585,14 @@ fn semantic_value_shape(
     builder: &SemanticProgramBuilder,
     value: ProgramValue,
 ) -> std::result::Result<Vec<DimExpr>, SemanticAdError> {
-    builder
-        .value_metadata(value)?
+    semantic_metadata_shape(builder.value_metadata(value)?)
+}
+
+#[cfg(feature = "autodiff")]
+fn semantic_metadata_shape(
+    metadata: &ProgramValueMetadata,
+) -> std::result::Result<Vec<DimExpr>, SemanticAdError> {
+    metadata
         .shape()
         .iter()
         .map(|extent| {

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -1281,7 +1281,7 @@ impl SemanticLinearTransposeRule for FftAdRule {
             request.op(),
             request.cotangent_outputs()[0],
             request.active_inputs()[0],
-            request.primal_inputs()[0],
+            request.primal_input_value(0)?,
             request.residual_mask(),
             builder,
         )?]
@@ -1308,7 +1308,7 @@ impl SemanticPrimalVjpRule for FftAdRule {
             request.op(),
             request.cotangent_outputs()[0],
             request.active_inputs()[0],
-            request.primal_inputs()[0],
+            request.primal_input_value(0)?,
             request.residual_mask(),
             builder,
         )?]

--- a/crates/tenferro-internal-extension-macros/src/lib.rs
+++ b/crates/tenferro-internal-extension-macros/src/lib.rs
@@ -28,7 +28,7 @@ struct RuntimeArgs {
     runtime: Ident,
     family_id: Path,
     op_type: Path,
-    execute: Path,
+    execute: Option<Path>,
     execute_reads: Path,
     execute_in_session: Option<Path>,
     session_supported: Option<Path>,
@@ -102,7 +102,7 @@ impl Parse for RuntimeArgs {
             runtime: required(runtime, "runtime")?,
             family_id: required(family_id, "family_id")?,
             op_type: required(op_type, "op_type")?,
-            execute: required(execute, "execute")?,
+            execute,
             execute_reads: required(execute_reads, "execute_reads")?,
             execute_in_session,
             session_supported,
@@ -130,12 +130,10 @@ pub fn derive_extension_family_id(input: TokenStream) -> TokenStream {
 /// Generate a standard extension module, preparation engine, and prepared
 /// operation.
 ///
-/// The `execute` function must have this signature:
-/// `fn<B: BackendBound + 'static>(&OpType, &[&Tensor], &mut ExtensionExecutionContext<'_, B>)`.
-///
 /// `execute_reads` is required. It must have this signature:
 /// `fn<B: BackendBound + 'static>(&OpType, &[TensorRead<'_>], &mut ExtensionExecutionContext<'_, B>)`.
 ///
+/// The legacy `execute` argument is accepted but unused and may be omitted.
 /// `session_supported` and `execute_in_session` are optional, but must be
 /// supplied together. The former has signature
 /// `fn<B: BackendBound + 'static>(&OpType) -> bool`; the latter has signature

--- a/crates/tenferro-internal-extension-macros/src/tests.rs
+++ b/crates/tenferro-internal-extension-macros/src/tests.rs
@@ -95,6 +95,21 @@ fn extension_runtime_macro_generates_module_engine_and_prepared_op_without_regis
 }
 
 #[test]
+fn extension_runtime_macro_accepts_omitted_legacy_execute() {
+    let args = syn::parse_str::<super::RuntimeArgs>(
+        r#"
+        runtime = TinyRuntime,
+        family_id = TINY_EXTENSION_FAMILY_ID,
+        op_type = TinyExtensionOp,
+        execute_reads = execute_tiny_extension_reads,
+        "#,
+    )
+    .expect("execute_reads is the only required callback");
+
+    assert!(args.execute.is_none());
+}
+
+#[test]
 fn extension_runtime_macro_accepts_custom_backend_bound() {
     let tokens = expand_extension_runtime(syn::parse_quote! {
         runtime = LinalgRuntime,
@@ -126,6 +141,22 @@ fn extension_runtime_macro_generates_required_prepared_read_executor() {
     assert!(source.contains("TensorRead < '_ >"));
     assert!(source.contains("execute_einsum_extension_reads"));
     assert!(source.contains("& self . op"));
+}
+
+#[test]
+fn extension_runtime_macro_requires_paired_session_callbacks() {
+    let err = super::expand_extension_runtime(syn::parse_quote! {
+        runtime = SessionRuntime,
+        family_id = SESSION_EXTENSION_FAMILY_ID,
+        op_type = SessionExtensionOp,
+        execute_reads = execute_session_reads,
+        session_supported = supports_session,
+    })
+    .expect_err("session callbacks must be supplied together");
+
+    assert!(err
+        .to_string()
+        .contains("execute_in_session and session_supported must be supplied together"));
 }
 
 #[test]

--- a/crates/tenferro-linalg/src/ad/semantic.rs
+++ b/crates/tenferro-linalg/src/ad/semantic.rs
@@ -144,6 +144,12 @@ impl SemanticLinearTransposeRule for LinalgAdRule {
         request: SemanticLinearTransposeRequest<'_>,
         builder: &mut SemanticProgramBuilder,
     ) -> Result<Box<[AdValue]>, SemanticAdError> {
+        let primal_inputs = (0..request.primal_input_count())
+            .map(|index| request.primal_input_value(index))
+            .collect::<Result<Vec<_>, _>>()?;
+        let primal_outputs = (0..request.primal_output_count())
+            .map(|index| request.primal_output_value(index))
+            .collect::<Result<Vec<_>, _>>()?;
         let op = semantic_linalg_op(request.op(), SemanticAdRuleRole::LinearTranspose)?;
         match op.op() {
             LinalgOp::TriangularSolve {
@@ -152,8 +158,8 @@ impl SemanticLinearTransposeRule for LinalgAdRule {
                 transpose_a,
                 unit_diagonal,
             } => semantic_triangular_solve_transpose(
-                request.primal_inputs(),
-                request.primal_outputs(),
+                &primal_inputs,
+                &primal_outputs,
                 request.cotangent_outputs(),
                 request.active_inputs(),
                 request.residual_mask(),
@@ -170,8 +176,8 @@ impl SemanticLinearTransposeRule for LinalgAdRule {
                 )?;
                 semantic_custom_transpose(
                     request.op(),
-                    request.primal_inputs(),
-                    request.primal_outputs(),
+                    &primal_inputs,
+                    &primal_outputs,
                     request.cotangent_outputs(),
                     &active_inputs,
                     builder,
@@ -180,8 +186,8 @@ impl SemanticLinearTransposeRule for LinalgAdRule {
             }
             LinalgOp::FullPivLuSolve { .. } => semantic_custom_transpose(
                 request.op(),
-                request.primal_inputs(),
-                request.primal_outputs(),
+                &primal_inputs,
+                &primal_outputs,
                 request.cotangent_outputs(),
                 request.active_inputs(),
                 builder,
@@ -189,8 +195,8 @@ impl SemanticLinearTransposeRule for LinalgAdRule {
             ),
             LinalgOp::Solve => semantic_custom_transpose(
                 request.op(),
-                request.primal_inputs(),
-                request.primal_outputs(),
+                &primal_inputs,
+                &primal_outputs,
                 request.cotangent_outputs(),
                 request.active_inputs(),
                 builder,
@@ -203,8 +209,8 @@ impl SemanticLinearTransposeRule for LinalgAdRule {
             }),
             _ => semantic_linearized_transpose(
                 request.op(),
-                request.primal_inputs(),
-                request.primal_outputs(),
+                &primal_inputs,
+                &primal_outputs,
                 request.cotangent_outputs(),
                 request.active_inputs(),
                 builder,

--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -32,6 +32,7 @@ blas-mkl = ["tenferro-cpu/blas-mkl"]
 
 [dependencies]
 tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.3.0" }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.3.0" }
 tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
 tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
 computegraph.workspace = true

--- a/crates/tenferro-runtime/src/error.rs
+++ b/crates/tenferro-runtime/src/error.rs
@@ -20,11 +20,46 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tenferro_ops::{dim_expr::DimExprEvalError, ShapeRelation, SymDimConversionError};
 use tenferro_tensor::{DType, ErrorKind, ValidationError, ValidationKind};
 
+use crate::runtime::{PrepareError, UnsupportedReason};
+
 static NEXT_CONTEXT_ID: AtomicUsize = AtomicUsize::new(1);
 
 /// Boxed source used when a runtime registry or compiler subsystem crosses
 /// the runtime error boundary with a concrete error owned by another crate.
 pub type BoxError = Box<dyn StdError + Send + Sync + 'static>;
+
+/// Borrowed, stable classification of a runtime preparation or execution failure.
+///
+/// The view retains references to the original error payloads and performs no
+/// message formatting or allocation. Match a wildcard because this enum is
+/// non-exhaustive.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_runtime::{Error, ErrorPhase, RuntimeFailureReasonRef};
+///
+/// let error = Error::unsupported("compare", ErrorPhase::Compile, "not available");
+/// assert!(matches!(
+///     error.reason(),
+///     RuntimeFailureReasonRef::UnsupportedOperation { operation: "compare" }
+/// ));
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RuntimeFailureReasonRef<'a> {
+    /// An operation belongs to an extension family with no installed module.
+    MissingExtension { family: &'a str },
+    /// No prepared engine accepts an input at its physical placement.
+    NoInputIngress {
+        input_index: usize,
+        placement: &'a tenferro_tensor::Placement,
+    },
+    /// A provider or tensor backend does not implement an operation.
+    UnsupportedOperation { operation: &'a str },
+    /// A failure has no stable structured classification.
+    Other,
+}
 
 /// Phase at which a runtime failure was discovered.
 ///
@@ -693,6 +728,46 @@ impl Error {
         }
     }
 
+    /// Return a borrowed stable reason for this runtime failure.
+    ///
+    /// Classification checks the primary error of [`Error::WithSuppressed`],
+    /// then walks the standard source chain. It never parses display text and
+    /// does not allocate; the original error, kind, phase, display, and source
+    /// chain remain unchanged.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::{Error, ErrorPhase, RuntimeFailureReasonRef};
+    ///
+    /// let error = Error::unsupported("compare", ErrorPhase::Compile, "not available");
+    /// assert_eq!(
+    ///     error.reason(),
+    ///     RuntimeFailureReasonRef::UnsupportedOperation { operation: "compare" }
+    /// );
+    /// assert_eq!(Error::Internal("validation".into()).reason(), RuntimeFailureReasonRef::Other);
+    /// ```
+    pub fn reason(&self) -> RuntimeFailureReasonRef<'_> {
+        if let Self::WithSuppressed { primary, .. } = self {
+            return primary.reason();
+        }
+        if let Some(reason) = direct_reason(self) {
+            return reason;
+        }
+
+        let mut source = StdError::source(self);
+        while let Some(error) = source {
+            if let Some(reason) = error.downcast_ref::<Error>().and_then(direct_reason) {
+                return reason;
+            }
+            if let Some(reason) = prepare_reason(error) {
+                return reason;
+            }
+            source = StdError::source(error);
+        }
+        RuntimeFailureReasonRef::Other
+    }
+
     /// Return the stable coarse classification of this runtime failure.
     ///
     /// # Examples
@@ -792,6 +867,53 @@ impl Error {
             _ => None,
         }
     }
+}
+
+fn direct_reason(error: &Error) -> Option<RuntimeFailureReasonRef<'_>> {
+    match error {
+        Error::Unsupported { op, .. } => {
+            Some(RuntimeFailureReasonRef::UnsupportedOperation { operation: op })
+        }
+        Error::UnsupportedAdRule { op, .. } => {
+            Some(RuntimeFailureReasonRef::UnsupportedOperation { operation: op })
+        }
+        Error::TensorRuntime(error) => tensor_reason(error),
+        Error::Extension { family, kind, .. } if *kind == ErrorKind::Unsupported => {
+            Some(RuntimeFailureReasonRef::UnsupportedOperation { operation: family })
+        }
+        _ => None,
+    }
+}
+
+fn tensor_reason(error: &tenferro_tensor::Error) -> Option<RuntimeFailureReasonRef<'_>> {
+    match error {
+        tenferro_tensor::Error::Unsupported { op, .. }
+        | tenferro_tensor::Error::UnsupportedDType { op, .. }
+        | tenferro_tensor::Error::UnsupportedDTypeConversion { op, .. } => {
+            Some(RuntimeFailureReasonRef::UnsupportedOperation { operation: op })
+        }
+        _ => None,
+    }
+}
+
+fn prepare_reason<'a>(error: &'a (dyn StdError + 'static)) -> Option<RuntimeFailureReasonRef<'a>> {
+    let prepare = error.downcast_ref::<PrepareError>()?;
+    Some(match prepare {
+        PrepareError::MissingExtension { family_id } => {
+            RuntimeFailureReasonRef::MissingExtension { family: family_id }
+        }
+        PrepareError::NoInputIngress {
+            input_index,
+            placement,
+        } => RuntimeFailureReasonRef::NoInputIngress {
+            input_index: *input_index,
+            placement,
+        },
+        PrepareError::Unsupported {
+            reason: UnsupportedReason::Operation { operation },
+        } => RuntimeFailureReasonRef::UnsupportedOperation { operation },
+        _ => return None,
+    })
 }
 
 fn core_dtype(dtype: DType) -> tenferro_tensor::core::DType {

--- a/crates/tenferro-runtime/src/error/tests.rs
+++ b/crates/tenferro-runtime/src/error/tests.rs
@@ -1,9 +1,158 @@
 use std::error::Error as StdError;
 
 use tenferro_ops::dim_expr::{DimExpr, DimExprEvalError};
-use tenferro_tensor::{DType, ErrorKind, ShapeMismatch, ShapeVec, ValidationError, ValidationKind};
+use tenferro_tensor::{
+    DType, ErrorKind, Placement, ShapeMismatch, ShapeVec, ValidationError, ValidationKind,
+};
 
-use super::{ContextId, Error, ErrorPhase, ShapeConstraintEvalError};
+use crate::runtime::{PrepareError, UnsupportedReason};
+
+use super::{ContextId, Error, ErrorPhase, RuntimeFailureReasonRef, ShapeConstraintEvalError};
+
+#[test]
+fn reason_classifies_typed_runtime_failures_without_changing_sources() {
+    let family = "tenferro.test.missing-family.v1";
+    let missing = Error::runtime_state_source(
+        "run",
+        ErrorPhase::Execution,
+        PrepareError::MissingExtension { family_id: family },
+    );
+    assert_eq!(
+        missing.reason(),
+        RuntimeFailureReasonRef::MissingExtension { family }
+    );
+    assert_eq!(missing.kind(), ErrorKind::RuntimeState);
+    assert_eq!(missing.phase(), Some(ErrorPhase::Execution));
+    assert!(missing.to_string().contains(family));
+    assert!(missing.source().is_some());
+    assert!(missing
+        .source()
+        .unwrap()
+        .downcast_ref::<PrepareError>()
+        .is_some());
+
+    let placement = Placement::default();
+    let ingress = Error::runtime_state_source(
+        "run",
+        ErrorPhase::Execution,
+        PrepareError::NoInputIngress {
+            input_index: 3,
+            placement: placement.clone(),
+        },
+    );
+    assert_eq!(
+        ingress.reason(),
+        RuntimeFailureReasonRef::NoInputIngress {
+            input_index: 3,
+            placement: &placement,
+        }
+    );
+
+    let unsupported = Error::runtime_state_source(
+        "run",
+        ErrorPhase::Compile,
+        PrepareError::Unsupported {
+            reason: UnsupportedReason::Operation {
+                operation: "provider-op",
+            },
+        },
+    );
+    assert_eq!(
+        unsupported.reason(),
+        RuntimeFailureReasonRef::UnsupportedOperation {
+            operation: "provider-op"
+        }
+    );
+    assert_ne!(
+        unsupported.reason(),
+        RuntimeFailureReasonRef::MissingExtension { family }
+    );
+
+    let nested = Error::runtime_state_source(
+        "outer",
+        ErrorPhase::Execution,
+        Error::runtime_state_source(
+            "inner",
+            ErrorPhase::Compile,
+            PrepareError::MissingExtension { family_id: family },
+        ),
+    );
+    assert_eq!(
+        nested.reason(),
+        RuntimeFailureReasonRef::MissingExtension { family }
+    );
+
+    let primary = Error::unsupported("primary-op", ErrorPhase::Execution, "primary");
+    let suppressed = Error::extension(
+        "secondary",
+        ErrorPhase::Execution,
+        family,
+        ErrorKind::RuntimeState,
+        PrepareError::MissingExtension { family_id: family },
+    );
+    let aggregate = Error::with_suppressed(primary, suppressed);
+    assert_eq!(
+        aggregate.reason(),
+        RuntimeFailureReasonRef::UnsupportedOperation {
+            operation: "primary-op"
+        }
+    );
+
+    assert_eq!(
+        Error::Internal("future-like".into()).reason(),
+        RuntimeFailureReasonRef::Other
+    );
+}
+
+#[test]
+fn direct_reason_classification_uses_stable_operation_borrows() {
+    assert_eq!(
+        Error::unsupported("runtime-op", ErrorPhase::Compile, "detail").reason(),
+        RuntimeFailureReasonRef::UnsupportedOperation {
+            operation: "runtime-op"
+        }
+    );
+    assert_eq!(
+        Error::extension(
+            "extension-op",
+            ErrorPhase::Compile,
+            "family.v1",
+            ErrorKind::Unsupported,
+            std::io::Error::other("failure"),
+        )
+        .reason(),
+        RuntimeFailureReasonRef::UnsupportedOperation {
+            operation: "family.v1"
+        }
+    );
+    assert_eq!(
+        Error::extension(
+            "extension-op",
+            ErrorPhase::Execution,
+            "family.v1",
+            ErrorKind::RuntimeState,
+            std::io::Error::other("failure"),
+        )
+        .reason(),
+        RuntimeFailureReasonRef::Other
+    );
+    assert_eq!(
+        Error::TensorRuntime(tenferro_tensor::Error::unsupported("tensor-op", "detail")).reason(),
+        RuntimeFailureReasonRef::UnsupportedOperation {
+            operation: "tensor-op"
+        }
+    );
+}
+
+#[test]
+fn unknown_reason_does_not_downcast_or_parse_text() {
+    let error = Error::runtime_state_source(
+        "run",
+        ErrorPhase::Execution,
+        std::io::Error::other("no eligible input ingress for input 7"),
+    );
+    assert_eq!(error.reason(), RuntimeFailureReasonRef::Other);
+}
 
 #[test]
 fn dimension_evaluation_errors_keep_the_runtime_vocabulary() {

--- a/crates/tenferro-runtime/src/extension.rs
+++ b/crates/tenferro-runtime/src/extension.rs
@@ -2,8 +2,8 @@
 //!
 //! This module exposes the Stage 6 `ExtensionOp` mechanism through the
 //! runtime crate. External crates implement
-//! [`tenferro_ops::ext_op::ExtensionOp`] and build traced graphs containing
-//! the extension via [`apply`].
+//! [`ExtensionOp`] and build traced graphs containing the extension via
+//! [`apply`].
 //!
 //! See `docs/spec/extension-op.md` for the normative contract.
 //!
@@ -23,7 +23,7 @@ use computegraph::types::{OperationRole, ValueRef};
 use computegraph::GraphOperation;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_ops::{SymDim, TensorMeta};
+use tenferro_ops::TensorMeta;
 
 use crate::checkpoint::CheckpointNode;
 use crate::error::{Error, ErrorPhase, Result};
@@ -44,13 +44,18 @@ pub use crate::shape_infer::{
     infer_output_dtype, infer_output_extents, infer_output_shapes, promote_dtype,
     promote_dtype_div_like, promote_dtype_for_binary_op, promote_dtypes,
 };
-pub use tenferro_ops::ext_op::ExtensionOp;
-pub use tenferro_ops::ExtensionFamilyId;
+pub use tenferro_extension_macros::define_extension_runtime;
+pub use tenferro_ops::ext_op::{
+    ExtensionAlias, ExtensionAliasDeclaration, ExtensionEffect, ExtensionEffectAccess,
+    ExtensionEffectDeclaration, ExtensionOp,
+};
+pub use tenferro_ops::{ExtensionFamilyId, ExtensionShapeContext, SymDim};
 
 pub use crate::extension_cache::{
     ExtensionCacheKey, ExtensionCacheLimits, ExtensionCacheSelector, ExtensionCacheStore,
 };
 pub use crate::extension_execution_context::ExtensionExecutionContext;
+pub use crate::runtime::{ExtensionModule, ExtensionModuleId, ExtensionModuleRegistrar};
 
 /// Apply an extension op in the traced graph.
 ///
@@ -70,9 +75,8 @@ pub use crate::extension_execution_context::ExtensionExecutionContext;
 /// ```rust
 /// # use std::any::Any;
 /// use std::sync::Arc;
-/// use tenferro_runtime::extension::{apply, ExtensionOp};
+/// use tenferro_runtime::extension::{apply, ExtensionOp, ExtensionShapeContext};
 /// use tenferro_runtime::{DType, SymDim, TracedTensor};
-/// use tenferro_ops::ExtensionShapeContext;
 ///
 /// # #[derive(Clone, Debug)]
 /// # struct IdentityExt;
@@ -334,8 +338,9 @@ pub fn apply_standard_op(op: StdTensorOp, inputs: &[&TracedTensor]) -> Result<Ve
 ///
 /// ```rust
 /// # use std::{any::Any, sync::Arc};
-/// use tenferro_ops::ExtensionShapeContext;
-/// use tenferro_runtime::extension::{attach_expanded_shape_contract, ExtensionOp};
+/// use tenferro_runtime::extension::{
+///     attach_expanded_shape_contract, ExtensionOp, ExtensionShapeContext,
+/// };
 /// use tenferro_runtime::{DType, SymDim, TracedTensor};
 ///
 /// # #[derive(Clone, Debug)]
@@ -516,8 +521,10 @@ fn attach_inferred_expanded_shape_contract(
 /// ```rust
 /// # use std::{any::Any, sync::Arc};
 /// use computegraph::types::OperationRole;
-/// use tenferro_ops::{std_tensor_op::StdTensorOp, ExtensionShapeContext};
-/// use tenferro_runtime::extension::{apply_expanded_graph_with_shape_contract, ExtensionOp};
+/// use tenferro_ops::std_tensor_op::StdTensorOp;
+/// use tenferro_runtime::extension::{
+///     apply_expanded_graph_with_shape_contract, ExtensionOp, ExtensionShapeContext,
+/// };
 /// use tenferro_runtime::{DType, SymDim, TracedTensor};
 ///
 /// # #[derive(Clone, Debug)]

--- a/crates/tenferro-runtime/src/lib.rs
+++ b/crates/tenferro-runtime/src/lib.rs
@@ -64,7 +64,9 @@ pub mod traced;
 mod typed_tensor;
 
 pub use compiler::{CompilerOptions, OptimizerConfig};
-pub use error::{ContextId, Error, ErrorPhase, Result, ShapeConstraintEvalError};
+pub use error::{
+    ContextId, Error, ErrorPhase, Result, RuntimeFailureReasonRef, ShapeConstraintEvalError,
+};
 pub use extension_cache::{
     ExtensionCacheKey, ExtensionCacheLimits, ExtensionCacheSelector, ExtensionCacheStore,
 };

--- a/crates/tenferro-runtime/src/runtime/error.rs
+++ b/crates/tenferro-runtime/src/runtime/error.rs
@@ -960,6 +960,12 @@ pub enum PrepareError {
         /// Engine whose preparation capability cannot be used for execution.
         engine_id: EngineId,
     },
+    /// The compiled graph uses an extension family absent from the runtime.
+    #[error("missing extension family {family_id:?}")]
+    MissingExtension {
+        /// Stable extension family identifier.
+        family_id: &'static str,
+    },
     /// No eligible engine declared an ingress compatible with an input placement.
     #[error("no eligible input ingress for input {input_index} at placement {placement:?}")]
     NoInputIngress {

--- a/crates/tenferro-runtime/src/runtime/preparation.rs
+++ b/crates/tenferro-runtime/src/runtime/preparation.rs
@@ -752,10 +752,8 @@ fn resolve_preparation_context(
     if let Some(error) = last_route_error {
         return Err(error);
     }
-    if let Some(operation) = missing_extension_family {
-        return Err(Arc::new(PrepareError::Unsupported {
-            reason: UnsupportedReason::Operation { operation },
-        }));
+    if let Some(family_id) = missing_extension_family {
+        return Err(Arc::new(PrepareError::MissingExtension { family_id }));
     }
 
     Err(Arc::new(PrepareError::NoEligibleEngine { constraint }))

--- a/crates/tenferro-runtime/tests/integration/runtime_execution.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_execution.rs
@@ -27,9 +27,9 @@ use tenferro_runtime::{
     PrepareCapability, PrepareError, PreparedOperation, PreparedOperationBinding,
     PreparedOperationExecutor, PreparedOperationPlan, ProviderDeviceIdentity, ProviderId,
     ReductionRuntime, RegistrationKey, ResidentOutputContract, Runtime, RuntimeCacheOwner,
-    RuntimeConfigError, RuntimeInputContract, RuntimeReconfigureError, SpecializationProjection,
-    StorageClass, TracedTensor, TransferEndpoint, TransferError, TransferProvider,
-    TransferProviderContractError, TransferRequest,
+    RuntimeConfigError, RuntimeFailureReasonRef, RuntimeInputContract, RuntimeReconfigureError,
+    SpecializationProjection, StorageClass, TracedTensor, TransferEndpoint, TransferError,
+    TransferProvider, TransferProviderContractError, TransferRequest,
 };
 use tenferro_tensor::{
     AllocationDomainId, AllocationId, BackendSessionHost, BackendStorage, HostAccessError,
@@ -2546,14 +2546,9 @@ fn runtime_operation_placement_reports_typed_error_after_all_ingress_routes_fail
 
     let error = runtime.run_compiled(&program, &[&input]).unwrap_err();
 
-    let prepare_error = error
-        .source()
-        .and_then(StdError::source)
-        .and_then(|source| source.downcast_ref::<PrepareError>())
-        .expect("typed prepare error");
     assert!(matches!(
-        prepare_error,
-        PrepareError::NoInputIngress { input_index: 0, .. }
+        error.reason(),
+        RuntimeFailureReasonRef::NoInputIngress { input_index: 0, .. }
     ));
     assert_eq!(first_counters.execute.load(Ordering::SeqCst), 0);
     assert_eq!(second_counters.execute.load(Ordering::SeqCst), 0);
@@ -3783,14 +3778,12 @@ fn runtime_submit_reports_no_input_ingress_before_spawning() -> Result<(), Box<d
         .submit(&program, ExecutionInputs::new(vec![input])?)
         .unwrap_err();
 
-    let prepare_error = error
-        .source()
-        .and_then(StdError::source)
-        .and_then(|source| source.downcast_ref::<PrepareError>())
-        .expect("submit preserves the typed preparation error synchronously");
+    let (error, _) = error
+        .into_pre_admission()
+        .expect("submit preserves the rejected inputs");
     assert!(matches!(
-        prepare_error,
-        PrepareError::NoInputIngress {
+        error.reason(),
+        RuntimeFailureReasonRef::NoInputIngress {
             input_index: 0,
             placement,
         } if placement == &input_placement

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -4105,6 +4105,112 @@ impl<T> TensorBackendOps for T where
 {
 }
 
+/// Validate the shared input contract for [`BackendSession::vdot_read`].
+#[doc(hidden)]
+pub fn validate_vdot_read(lhs: &TensorRead<'_>, rhs: &TensorRead<'_>) -> crate::Result<()> {
+    let op = "BackendSession::vdot_read";
+    validate_supported_blas1_dtype(op, lhs.dtype())?;
+    if rhs.dtype() != lhs.dtype() {
+        return Err(Error::dtype_mismatch(op, lhs.dtype(), rhs.dtype()));
+    }
+    if lhs.shape() != rhs.shape() {
+        return Err(Error::shape_mismatch(
+            op,
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ));
+    }
+    validate_shape_product(op, lhs.shape())?;
+    validate_compatible_placement(op, lhs, rhs)
+}
+
+/// Validate the shared input contract for [`BackendSession::norm_squared_read`].
+#[doc(hidden)]
+pub fn validate_norm_squared_read(input: &TensorRead<'_>) -> crate::Result<()> {
+    validate_supported_blas1_dtype("BackendSession::norm_squared_read", input.dtype())?;
+    validate_shape_product("BackendSession::norm_squared_read", input.shape()).map(|_| ())
+}
+
+/// Validate the shared input and destination contract for
+/// [`BackendSession::axpby_read_into_accum`].
+#[doc(hidden)]
+pub fn validate_axpby_read_into_accum(
+    alpha: ContractionScalar,
+    x: &TensorRead<'_>,
+    beta: ContractionScalar,
+    y: &TensorWrite<'_>,
+) -> crate::Result<()> {
+    let op = "BackendSession::axpby_read_into_accum";
+    validate_supported_blas1_dtype(op, x.dtype())?;
+    if y.dtype() != x.dtype() {
+        return Err(Error::dtype_mismatch(op, x.dtype(), y.dtype()));
+    }
+    if alpha.dtype() != x.dtype() {
+        return Err(Error::dtype_mismatch(op, x.dtype(), alpha.dtype()));
+    }
+    if beta.dtype() != x.dtype() {
+        return Err(Error::dtype_mismatch(op, x.dtype(), beta.dtype()));
+    }
+    if x.shape() != y.shape() {
+        return Err(Error::shape_mismatch(
+            op,
+            x.shape().to_vec(),
+            y.shape().to_vec(),
+        ));
+    }
+    validate_shape_product(op, x.shape())?;
+    if !y.as_read().is_col_major_contiguous()? {
+        return Err(Error::invalid_argument(
+            op,
+            "y",
+            "destination must be compact column-major and injective",
+        ));
+    }
+    validate_compatible_placement(op, x, &y.as_read())?;
+    validate_read_into_destination(op, std::slice::from_ref(x), y)
+}
+
+/// # Errors
+///
+/// Returns [`Error::Unsupported`] when `dtype` is not floating or complex.
+fn validate_supported_blas1_dtype(op: &'static str, dtype: DType) -> crate::Result<()> {
+    if matches!(dtype, DType::F32 | DType::F64 | DType::C32 | DType::C64) {
+        Ok(())
+    } else {
+        Err(Error::unsupported(
+            op,
+            format!("unsupported dtype {dtype:?}; supported dtypes: F32/F64/C32/C64"),
+        ))
+    }
+}
+
+/// # Errors
+///
+/// Returns [`Error::Validation`] with [`ValidationError::IntegerOverflow`] when
+/// the checked shape product overflows.
+fn validate_shape_product(op: &'static str, shape: &[usize]) -> crate::Result<usize> {
+    crate::validate::checked_shape_product(op, "shape", shape)
+}
+
+/// # Errors
+///
+/// Returns [`Error::Validation`] with [`ValidationError::InvalidArgument`] when
+/// placements differ.
+fn validate_compatible_placement(
+    op: &'static str,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
+) -> crate::Result<()> {
+    if lhs.placement() != rhs.placement() {
+        return Err(Error::invalid_argument(
+            op,
+            "placement",
+            "tensor inputs must have compatible placement",
+        ));
+    }
+    Ok(())
+}
+
 /// Execution session surface for dense tensor backends.
 ///
 /// All operations run within a backend-owned execution scope such as a CPU
@@ -4131,6 +4237,111 @@ pub trait BackendSession: TensorBackendOps + SessionCachedDot + TensorDeviceTran
     /// Build-local identity for backend-extension session capability dispatch.
     #[doc(hidden)]
     fn session_type_id(&self) -> TypeId;
+
+    /// Compute the all-axis conjugating dot product without transferring either input.
+    ///
+    /// The result is a rank-0 tensor with the input dtype and has the value
+    /// `sum(conj(lhs) * rhs)`. Borrowed views remain borrowed through the
+    /// backend's existing same-placement planning boundary.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{BackendSession, TensorRead};
+    ///
+    /// fn vdot(session: &mut dyn BackendSession, x: TensorRead<'_>, y: TensorRead<'_>)
+    ///     -> tenferro_tensor::Result<tenferro_tensor::Tensor>
+    /// {
+    ///     session.vdot_read(x, y)
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unsupported`] when the backend does not override this
+    /// capability or the dtype is unsupported; [`Error::Validation`] with
+    /// `DTypeMismatch`, `ShapeMismatch`, or `InvalidArgument` when dtype, shape,
+    /// or placement differs; [`Error::RuntimeState`] for inaccessible backend
+    /// storage; or [`Error::BackendSource`] when provider execution fails.
+    fn vdot_read(&mut self, _lhs: TensorRead<'_>, _rhs: TensorRead<'_>) -> crate::Result<Tensor> {
+        Err(Error::unsupported(
+            "BackendSession::vdot_read",
+            "backend session does not implement vdot_read",
+        ))
+    }
+
+    /// Compute the all-axis sum of squared magnitudes without taking a square root.
+    ///
+    /// The result is rank 0 and is F32 for F32/C32 input or F64 for F64/C64
+    /// input. No transfer or full-size algebra temporary is implied by this
+    /// session contract.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{BackendSession, TensorRead};
+    ///
+    /// fn norm_squared(session: &mut dyn BackendSession, x: TensorRead<'_>)
+    ///     -> tenferro_tensor::Result<tenferro_tensor::Tensor>
+    /// {
+    ///     session.norm_squared_read(x)
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unsupported`] when the backend does not override this
+    /// capability or the dtype is unsupported, [`Error::RuntimeState`] when
+    /// backend storage is not host-accessible, or [`Error::BackendSource`] when
+    /// reduction execution fails.
+    fn norm_squared_read(&mut self, _input: TensorRead<'_>) -> crate::Result<Tensor> {
+        Err(Error::unsupported(
+            "BackendSession::norm_squared_read",
+            "backend session does not implement norm_squared_read",
+        ))
+    }
+
+    /// Apply `y <- alpha * x + beta * y` in one pass into caller-owned storage.
+    ///
+    /// Scalars must have the exact tensor dtype; real coefficients for complex
+    /// vectors are represented as complex values with zero imaginary part. The
+    /// destination must be compact and injective, and any x/y storage overlap
+    /// is rejected before mutation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{BackendSession, ContractionScalar, TensorRead, TensorWrite};
+    ///
+    /// fn axpby(session: &mut dyn BackendSession, x: TensorRead<'_>, y: TensorWrite<'_>)
+    ///     -> tenferro_tensor::Result<()>
+    /// {
+    ///     session.axpby_read_into_accum(
+    ///         ContractionScalar::F64(1.0), x, ContractionScalar::F64(0.0), y,
+    ///     )
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unsupported`] when the backend does not override this
+    /// capability or the dtype is unsupported; [`Error::Validation`] with
+    /// `DTypeMismatch`, `ShapeMismatch`, or `InvalidArgument` for scalar/dtype,
+    /// shape, placement, compactness, injectivity, or overlap failures; or
+    /// [`Error::RuntimeState`] for inaccessible backend storage. Invalid
+    /// requests leave the destination unchanged.
+    fn axpby_read_into_accum(
+        &mut self,
+        _alpha: ContractionScalar,
+        _x: TensorRead<'_>,
+        _beta: ContractionScalar,
+        _y: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        Err(Error::unsupported(
+            "BackendSession::axpby_read_into_accum",
+            "backend session does not implement axpby_read_into_accum",
+        ))
+    }
 
     /// Erased pointer used only by backend leaf crates for a checked session
     /// capability bridge. The pointer is borrowed for the lifetime of `self`.

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -1,10 +1,12 @@
 use crate::{
     backend::{
-        validate_dot_general_read_into, validate_grouped_gemm, GroupedGemmConfig, GroupedGemmJob,
+        validate_axpby_read_into_accum, validate_dot_general_read_into, validate_grouped_gemm,
+        GroupedGemmConfig, GroupedGemmJob,
     },
-    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir,
-    ContractionScalar, DType, DotGeneralAccumulation, DotGeneralConfig, GatherConfig, PadConfig,
-    ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
+    AllocationDomainId, AllocationId, BackendCachedDot, BackendRuntimeCache, BackendSession,
+    BackendSessionHost, BackendStorage, CompareDir, ContractionScalar, DType,
+    DotGeneralAccumulation, DotGeneralConfig, GatherConfig, PadConfig, Placement, ScatterConfig,
+    SliceConfig, StorageBuffer, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
     TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
     TensorReduction, TensorScalar, TensorStructural, TensorView, TensorViewMut, TensorWrite,
     TypedTensor, TypedTensorView, TypedTensorViewMut,
@@ -534,6 +536,102 @@ impl BackendSession for DefaultReadBackend {
 impl BackendSessionHost for DefaultReadBackend {}
 
 impl TensorBackend for DefaultReadBackend {}
+
+#[test]
+fn blas1_session_defaults_are_unsupported_without_transfer_or_fallback() {
+    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let mut output = Tensor::from_vec_col_major(vec![2], vec![10.0_f64, 20.0]).unwrap();
+    let mut backend = DefaultReadBackend::default();
+
+    let vdot = backend.vdot_read(
+        TensorRead::from_tensor(&input),
+        TensorRead::from_tensor(&input),
+    );
+    let norm = backend.norm_squared_read(TensorRead::from_tensor(&input));
+    let axpby = backend.axpby_read_into_accum(
+        ContractionScalar::F64(1.0),
+        TensorRead::from_tensor(&input),
+        ContractionScalar::F64(1.0),
+        TensorWrite::from_tensor(&mut output),
+    );
+
+    for result in [vdot.map(|_| ()), norm.map(|_| ()), axpby] {
+        assert!(matches!(result, Err(crate::Error::Unsupported { .. })));
+    }
+    assert!(backend.calls.is_empty());
+    assert_eq!(output.as_slice::<f64>().unwrap(), &[10.0, 20.0]);
+}
+
+#[derive(Debug)]
+struct AliasedBackendStorage {
+    domain: AllocationDomainId,
+    allocation: AllocationId,
+    len: usize,
+}
+
+impl BackendStorage<f64> for AliasedBackendStorage {
+    fn backend_family(&self) -> &'static str {
+        "blas1-alias-test"
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn allocation_domain(&self) -> Option<AllocationDomainId> {
+        Some(self.domain)
+    }
+
+    fn allocation_id(&self) -> Option<AllocationId> {
+        Some(self.allocation)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[test]
+fn blas1_axpby_rejects_backend_alias_before_execution() {
+    let domain = AllocationDomainId::fresh();
+    let allocation = AllocationId::from_backend_id(1713);
+    let storage = || {
+        StorageBuffer::Backend(Box::new(AliasedBackendStorage {
+            domain,
+            allocation,
+            len: 2,
+        }))
+    };
+    let placement = Placement {
+        memory_kind: crate::MemoryKind::Device,
+        device: None,
+        cpu_affinity: None,
+    };
+    let x = Tensor::F64(
+        TypedTensor::from_buffer_col_major(vec![2], storage(), placement.clone()).unwrap(),
+    );
+    let mut y =
+        Tensor::F64(TypedTensor::from_buffer_col_major(vec![2], storage(), placement).unwrap());
+
+    let error = validate_axpby_read_into_accum(
+        ContractionScalar::F64(1.0),
+        &TensorRead::from_tensor(&x),
+        ContractionScalar::F64(1.0),
+        &TensorWrite::from_tensor(&mut y),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        crate::Error::Validation {
+            source: crate::ValidationError::InvalidArgument {
+                argument: "out",
+                ..
+            },
+            ..
+        }
+    ));
+}
 
 #[test]
 fn default_read_methods_delegate_owned_tensors_and_reject_views() {

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -1701,6 +1701,89 @@ fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cas
 }
 
 #[test]
+fn tensor_read_as_slice_keeps_compact_owner_pointer_identity() {
+    let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let expected = tensor.as_slice::<f64>().unwrap();
+
+    let actual = TensorRead::from_tensor(&tensor).as_slice::<f64>().unwrap();
+
+    assert_eq!(actual.as_ptr(), expected.as_ptr());
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn tensor_read_as_slice_keeps_compact_view_pointer_identity() {
+    let data = [1.0_f64, 2.0];
+    let shape = [2];
+    let view = TensorView::f64(&shape, &data).unwrap();
+
+    let actual = TensorRead::from_view(view).as_slice::<f64>().unwrap();
+
+    assert_eq!(actual.as_ptr(), data.as_ptr());
+    assert_eq!(actual, &data);
+}
+
+#[test]
+fn tensor_read_as_slice_rejects_noncompact_typed_view() {
+    let data = [1.0_f64, 2.0, 3.0];
+    let view = TensorView::F64(TypedTensorView::from_slice([2], [2], 0, &data).unwrap());
+
+    let err = TensorRead::from_view(view).as_slice::<f64>().unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::Validation {
+            source: ValidationError::InvalidArgument {
+                argument: "layout",
+                ..
+            },
+            ..
+        }
+    ));
+}
+
+#[test]
+fn tensor_read_as_slice_rejects_dtype_mismatch() {
+    let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+
+    let err = TensorRead::from_tensor(&tensor)
+        .as_slice::<f32>()
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::Validation {
+            source: ValidationError::DTypeMismatch { .. },
+            ..
+        }
+    ));
+}
+
+#[test]
+fn tensor_read_as_slice_rejects_backend_owned_storage_without_transfer() {
+    let tensor = TypedTensor::<f64>::from_buffer_col_major(
+        vec![2],
+        StorageBuffer::Backend(Box::new(BackendStorageHandle::<f64>::new_with_len(1709, 2))),
+        Placement {
+            memory_kind: MemoryKind::Device,
+            device: Some(DeviceId {
+                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+                ordinal: 0,
+            }),
+            cpu_affinity: None,
+        },
+    )
+    .unwrap();
+
+    let err = TensorRead::from_tensor(&Tensor::F64(tensor))
+        .as_slice::<f64>()
+        .unwrap_err();
+
+    assert!(matches!(err, Error::RuntimeState { .. }));
+    assert!(err.to_string().contains("download explicitly first"));
+}
+
+#[test]
 fn tensor_read_wraps_owned_tensor_or_borrowed_view() {
     let tensor = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
     let read_tensor = TensorRead::from_tensor(&tensor);

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -5283,6 +5283,36 @@ impl<'a> TensorRead<'a> {
         }
     }
 
+    /// Borrow this read target as a typed compact host slice without allocation.
+    ///
+    /// This delegates to [`TensorView::as_slice`]. Cloning a `TensorRead` is a
+    /// shallow clone of its borrowed reference or view metadata, so the returned
+    /// slice retains the original `'a` storage lifetime and never outlives the
+    /// storage borrowed by this read target. This method does not materialize,
+    /// transfer, or otherwise canonicalize the input.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::DTypeMismatch`] when `T` does not match the
+    /// input dtype, [`ValidationError::InvalidArgument`] for a noncompact view,
+    /// or a typed runtime-state host-access error for backend-owned storage.
+    /// Backend-owned
+    /// inputs are never downloaded implicitly.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{Tensor, TensorRead};
+    ///
+    /// let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
+    /// let read = TensorRead::from_tensor(&tensor);
+    /// assert_eq!(read.as_slice::<f64>()?, &[1.0, 2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn as_slice<T: TensorScalar>(&self) -> crate::Result<&'a [T]> {
+        self.clone().tensor_view().as_slice()
+    }
+
     pub fn dtype(&self) -> DType {
         match self {
             Self::Tensor(tensor) => tensor.dtype(),

--- a/docs/architecture/tenferro-crates.md
+++ b/docs/architecture/tenferro-crates.md
@@ -133,7 +133,8 @@ tenferro-internal-cpu-kernels
 tenferro-internal-ops     -> tenferro-tensor, tenferro-core-ops,
                               tenferro-internal-extension-macros
 tenferro-runtime          -> tenferro-tensor, tenferro-core-ops,
-                              tenferro-internal-ops
+                              tenferro-internal-ops,
+                              tenferro-internal-extension-macros
 tenferro-xla              -> tenferro-runtime, tenferro-internal-ops,
                               tenferro-tensor
 tenferro-ad               -> tenferro-runtime, tenferro-internal-ops,
@@ -160,6 +161,9 @@ Additional internal dependencies:
   execution bridge. The preparation/execution substrate is implemented in
   `tenferro-runtime`; any CPU dependency in the opposite direction remains
   dev/test-only and is not a production edge.
+- `tenferro-runtime` depends on `tenferro-internal-extension-macros` only to
+  re-export the supported out-of-tree authoring macro; the proc-macro crate
+  emits runtime paths and does not depend back on `tenferro-runtime`.
 - `tenferro-einsum`, `tenferro-linalg`, and `tenferro-fft` depend on
   `tenferro-runtime` for extension application and runtime registration.
 - `tenferro-xla` depends on `tenferro-runtime` to read compiled programs and

--- a/docs/design/borrowed-extension-reads.md
+++ b/docs/design/borrowed-extension-reads.md
@@ -1,0 +1,66 @@
+# Borrowed Extension Reads
+
+## Status
+
+Accepted design for issue #1709. Implementation requires an independent design-review verdict before code changes.
+
+## Goal
+
+Read-only extension execution borrows compact same-placement tensor storage across the runtime boundary without duplicating input tensors. Materialization and transfer remain explicit choices owned by the extension executor.
+
+## Existing boundary
+
+`define_extension_runtime!` already generates `PreparedOperationExecutor::execute` over `&[TensorRead<'_>]`; the runtime passes those reads unchanged to `execute_reads`. No second execution framework or adapter is needed.
+
+The missing author-facing primitive is direct typed host access on a dtype-erased `TensorRead`. `TensorView::as_slice<T>` already implements the required dtype, compact-layout, bounds, and host-access checks.
+
+## Public contract
+
+Add one method to `TensorRead`:
+
+```rust
+pub fn as_slice<T: TensorScalar>(&self) -> Result<&'a [T]>;
+```
+
+It delegates to the existing `TensorView::as_slice<T>` contract without allocation. The returned slice keeps the original `TensorRead<'a>` storage lifetime and may outlive the method's `&self` borrow. This is sound because cloning `TensorRead` only copies a borrowed tensor reference or shallow view metadata/ownership handles; it never creates temporary backing storage. Pointer-identity tests lock down that invariant.
+
+- compact host `TensorRead::Tensor` and compact host `TensorRead::View` return a slice borrowing the original storage;
+- a noncompact view returns the existing typed layout `InvalidArgument` validation error;
+- backend-owned storage returns the existing typed host-access/runtime-state error and is never downloaded;
+- dtype mismatch remains typed.
+
+An executor that requires canonical compact storage calls `BackendSession::to_contiguous_read` explicitly. It calls it once per selected noncompact input and reuses the returned owner. No runtime layer silently materializes, transfers, or retries on CPU.
+
+## Extension fixture and instrumentation
+
+Extend the workspace-external authoring fixture from #1708 with a read-only four-input operation.
+
+- The compact path calls `TensorRead::as_slice::<f64>()` on each input, records the borrowed pointers, and verifies they match the four caller-owned input buffers. It does not call `to_contiguous_read`.
+- A materializing operation explicitly calls `to_contiguous_read` once for one noncompact view before reading it; an atomic callback counter distinguishes this path from the borrowed path.
+- A host-only operation given backend-owned storage fails through `as_slice` with the existing typed placement/host-access error before producing output.
+- A small counting allocator around the fixture's measured calls records the steady-state allocation delta after warm-up. The borrowed compact path may allocate its declared output but must show no additional full-input-sized allocation; the explicit materialization path must show exactly one full-input-sized allocation. Pointer identity and callback counters remain the primary deterministic assertions; allocator byte counts are supporting evidence because runtime bookkeeping may allocate small objects.
+
+Existing runtime integration tests also assert that prepared extension execution forwards `TensorRead` values directly and does not invoke `to_contiguous_read` before the generated executor callback.
+
+## Documentation
+
+The custom-operation guide makes `execute_reads` the default recipe, demonstrates `TensorRead::as_slice`, and states:
+
+- compact host reads borrow;
+- noncompact inputs are consumed directly only by kernels that support their strides, otherwise explicitly materialized once;
+- backend storage is rejected by a host executor and never transferred implicitly.
+
+## Non-goals
+
+- No implicit CPU/GPU transfer or CPU fallback.
+- No shallow owner clone API.
+- No guarantee that arbitrary strided views are accepted by every extension.
+- No automatic materialization policy in the macro or runtime.
+- No second execution framework or new allocation subsystem.
+
+## Verification
+
+- TensorRead unit tests cover compact owner, compact view, noncompact view, dtype mismatch, and backend-owned rejection.
+- The external fixture covers four borrowed inputs, one explicit materialization, pointer identity, typed rejection, callback counts, and allocation-size evidence.
+- Runtime tests cover unchanged eager/compiled numerical behavior and failure transactionality.
+- Run tensor/runtime tests and doctests, the external fixture, public API documentation checks, targeted clippy, modified-file coverage review, and the combined PR gates.

--- a/docs/design/checked-semantic-ad-residual-access.md
+++ b/docs/design/checked-semantic-ad-residual-access.md
@@ -1,0 +1,67 @@
+# Checked Semantic AD Residual Access
+
+## Status
+
+Accepted design for issue #1711. Implementation requires an independent design-review verdict before code changes.
+
+## Goal
+
+Semantic linear-transpose and direct primal-VJP rules can use a primal tensor value only when their `ResidualSpec` declares that input/output. Metadata remains available for every primal without retaining or exposing its `ProgramValue`.
+
+## Request contract
+
+For both `SemanticLinearTransposeRequest` and `SemanticPrimalVjpRequest`:
+
+```rust
+pub fn primal_input_value(&self, index: usize) -> Result<ProgramValue, SemanticAdError>;
+pub fn primal_output_value(&self, index: usize) -> Result<ProgramValue, SemanticAdError>;
+pub fn primal_input_meta(&self, index: usize) -> Result<&ProgramValueMetadata, SemanticAdError>;
+pub fn primal_output_meta(&self, index: usize) -> Result<&ProgramValueMetadata, SemanticAdError>;
+pub fn primal_input_count(&self) -> usize;
+pub fn primal_output_count(&self) -> usize;
+```
+
+Value access first checks bounds, then requires `ResidualSpec::declares_input` or `declares_output`. An undeclared access returns a new typed `SemanticAdError::UndeclaredResidualValue` carrying the family, primal input/output kind, and index. An out-of-range access returns `SemanticAdError::PrimalIndexOutOfBounds` with the kind, index, and length. Define a public non-exhaustive `PrimalValueKind::{Input, Output}` diagnostic enum.
+
+Metadata access checks only bounds. It returns an owned-at-request-construction metadata snapshot by reference; it never returns a `ProgramValue`. Requests own boxed input/output `ProgramValueMetadata` snapshots collected from the destination builder before rule dispatch. Metadata snapshots may allocate but do not retain tensor values.
+
+Remove the unrestricted `primal_inputs()` and `primal_outputs()` slice accessors from transpose and direct primal-VJP requests after all in-tree and shipped extension rules migrate. Do not leave deprecated raw-value shims. `SemanticLinearizeRequest` keeps its raw primal access: linearization is the phase that computes values/residuals and is not constrained by a transpose residual declaration.
+
+The two checked request structs cease to be `Copy`; their accessors borrow `&self`, allowing repeated access while preserving request ownership. Existing non-primal accessors (`op`, cotangents, activity, residuals, mask, provenance) also borrow `&self`.
+
+## Dispatch and retention
+
+Before dispatch, `SemanticExtensionRuleSet` snapshots metadata for all primal inputs/outputs using the validated destination builder. The rule's `ResidualSpec` remains the only tensor-retention authority. Checked access does not widen the mask, retain all primal values, or synthesize missing residuals.
+
+Both linear-transpose and direct primal-VJP dispatch use the same private checked-access helpers so bounds/mask/error semantics cannot drift.
+
+## Migration
+
+Migrate einsum, FFT, linalg, sparse, tropical, tests, and the #1710 Wilson-like fixture:
+
+- use checked value accessors only for indices declared in each rule's `ResidualSpec`;
+- use metadata accessors/counts when only dtype/shape/arity is needed;
+- collect checked values explicitly when a legacy adapter needs an ordered slice.
+
+No rule may call a checked value accessor for an undeclared index, including inactive inputs.
+
+## Tests
+
+- Fake transpose and direct primal-VJP rules attempt an undeclared input and output value access; both return exact typed errors in ordinary and release-equivalent builds.
+- Metadata access to the same undeclared positions succeeds and exposes dtype/shape without a `ProgramValue`.
+- Bounds errors are typed and precede mask errors.
+- Declared all-input Wilson-like rules, inactive inputs, and non-unit cotangent seeds retain numerical behavior.
+- Source-contract checks ensure transpose/direct request types expose no raw primal value slice accessor.
+- Retention tests confirm saved residual bindings include only declared mask positions.
+
+## Non-goals
+
+- No derivative-math or activity-analysis change.
+- No automatic mask widening.
+- No retain-all compatibility path or deprecated raw accessor.
+- No panic/debug-assert enforcement.
+- No restriction on `SemanticLinearizeRequest` primal access.
+
+## Verification
+
+Run focused semantic extension/transform tests in debug and release-equivalent profiles, all standard and nested extension tests, `tenferro-ad` doctests/clippy, retention/coverage checks, and combined PR gates.

--- a/docs/design/extension-authoring-facade.md
+++ b/docs/design/extension-authoring-facade.md
@@ -1,0 +1,55 @@
+# Extension Authoring Facade
+
+## Status
+
+Accepted design for issue #1708. Implementation requires an independent design-review verdict before code changes.
+
+## Goal
+
+An out-of-tree crate can define, trace, register, and execute an extension without depending directly on any `tenferro-internal-*` crate or naming generated runtime implementation types.
+
+## Public boundary
+
+`tenferro_runtime::extension` is the stable authoring facade. It re-exports only the existing author-facing contracts needed to implement an operation and install its generated runtime:
+
+- `ExtensionOp`, `ExtensionShapeContext`, `ExtensionFamilyId`, and `SymDim`;
+- `ExtensionEffect`, `ExtensionEffectAccess`, and `ExtensionEffectDeclaration`;
+- `ExtensionAlias` and `ExtensionAliasDeclaration`;
+- `ExtensionModule`, `ExtensionModuleId`, and `ExtensionModuleRegistrar`;
+- `ExtensionExecutionContext` and the existing cache types;
+- `define_extension_runtime`.
+
+The implementation remains in the existing internal crates. Generated engine, planning-config, prepared-operation, and executor types remain private to the invoking crate. Existing root-level runtime exports remain source-compatible.
+
+The runtime crate may depend on the existing workspace proc-macro crate because that crate emits paths but does not depend on the runtime. No new package or third-party dependency is introduced.
+
+## Generated runtime contract
+
+`define_extension_runtime!` remains the sole adapter. Its required execution callback is `execute_reads`, which receives borrowed `TensorRead` inputs. The legacy parsed `execute` argument is accepted when present for existing callers but is no longer required or documented because generated code does not use it.
+
+Each extension family invokes the macro inside its own ordinary Rust module. This lets multiple families coexist in one crate while retaining the existing `extension_module` constructor name and avoiding new naming syntax or exposed generated implementation types.
+
+Runtime ownership remains explicit: the application builds a `Runtime`, installs the returned `ExtensionModule`, compiles the traced graph, and executes it. There is no registry, discovery, implicit backend, transfer, or fallback.
+
+## Documentation and executable fixture
+
+`docs/guides/custom-operations.md` uses only public direct crates and the current `ExtensionModule` plus `execute_reads` path. It removes the deleted `ExtensionOp::host_reference` recommendation.
+
+A workspace-external fixture crate under `tests/fixtures/extension-authoring` is excluded from workspace membership and compiled/run by a focused repository test script. It depends only on deliberate public crates (`tenferro-runtime`, `tenferro-tensor`, and `tenferro-cpu`), defines two families in separate modules through the facade macro, traces and executes one family, and exercises typed missing-module, wrong-family, and wrong-context failures where those states are reachable through the public API. The fixture is the executable source of truth for the guide; copied guide snippets must use the repository snippet-sync mechanism or the guide must point directly to the fixture.
+
+## Non-goals
+
+- No global extension registry or backend discovery.
+- No host-reference compatibility layer or second execution framework.
+- No public generated engine, planning, prepared-operation, or executor types.
+- No new extension DSL beyond making the unused legacy `execute` argument optional.
+- No implicit device transfer or CPU fallback.
+
+## Verification
+
+- Run the external fixture and its typed failure assertions.
+- Run proc-macro tests, including omission of `execute` and paired session callback validation.
+- Run `tenferro-runtime` tests and doctests.
+- Run documentation snippet/site checks and public error-doc checks through the local PR gate.
+- Confirm packaged `tenferro-runtime` resolves the re-exported proc macro and contains no accidental internal API documentation.
+- Review modified-file coverage against the repository 90% target.

--- a/docs/design/multi-input-traced-ad.md
+++ b/docs/design/multi-input-traced-ad.md
@@ -1,0 +1,71 @@
+# Multi-Input Traced JVP and VJP
+
+## Status
+
+Accepted design for issue #1710. Implementation requires an independent design-review verdict before code changes.
+
+## Goal
+
+`AdContext` requests derivatives for multiple active traced leaf inputs through one compiled semantic source and one mask-based AD transform.
+
+## Public API
+
+Add methods to `AdContext`:
+
+```rust
+pub fn vjp_many(
+    &self,
+    output: &TracedTensor,
+    wrts: &[&TracedTensor],
+    cotangent: &TracedTensor,
+) -> Result<Vec<Option<TracedTensor>>>;
+
+pub fn jvp_many(
+    &self,
+    output: &TracedTensor,
+    wrt_tangents: &[(&TracedTensor, &TracedTensor)],
+) -> Result<Option<TracedTensor>>;
+```
+
+`vjp_many` preserves the requested order. A requested leaf absent from the source graph has `None` in its slot. Duplicate `wrt` leaves are allowed and repeat the same derivative result in each aligned slot.
+
+`jvp_many` returns the one directional derivative produced by all supplied distinct active inputs. An absent/unreachable leaf is ignored; if none are active, the result is `None`. Duplicate `wrt` leaves are rejected from the raw pair list with typed graph-build `InvalidArgument` before compilation or reachability filtering because two tangent values for one semantic seed slot are ambiguous; callers explicitly add tangents before the call when that is intended.
+
+An empty request is valid: `vjp_many` validates that the cotangent carries concrete data, then returns an empty vector without compiling or transforming; `jvp_many` returns `None` without running a transform.
+
+## Implementation
+
+Refactor the existing single-input helpers in `tenferro-ad/src/traced.rs` into many-input implementations:
+
+1. Resolve every `wrt` to its leaf input key and validate tangent/cotangent attached data and metadata.
+2. Compile `output` once with `compile_ad_source`.
+3. Map requested keys to source input indices and build one union `active_inputs` mask.
+4. Call `semantic_jvp_with_cache` or `semantic_vjp_with_cache` exactly once.
+5. Bind all derivative seed inputs in one `derivative_tensor_from_program` construction.
+6. For VJP, map derivative output indices back to the original requested order, returning `None` for unreachable/inactive slots and cloning the traced result for duplicate slots.
+
+All graph/context and dtype/shape validation remains in the existing leaf-key, attached-value, semantic transform, and derivative tensor builders. The new helpers must not introduce separate compilation or execution caches.
+
+Existing `jvp`, `jvp_optional`, `vjp`, and `vjp_optional` stay source-compatible and delegate to the many-input implementation with one entry. Their current inactive/error semantics remain unchanged.
+
+## Tests
+
+- Two and four distinct active inputs produce one JVP/VJP semantic transform; transform-cache/instrumentation observes one transformed derivative graph.
+- A synthetic Wilson-like extension direct VJP emits one multi-output force node; compiled runtime instrumentation observes one force execution, not one per requested input.
+- Each many-input VJP slot agrees numerically with the current single-input result.
+- Unreachable inputs align to `None`; empty requests avoid transformation.
+- Duplicate VJP requests repeat aligned results; duplicate JVP requests fail typed before transformation.
+- Context mismatch and tangent dtype/shape mismatch remain typed.
+- Existing single-input tests remain unchanged and pass through delegation.
+
+## Non-goals
+
+- No Jacobian materialization.
+- No batching of independent cotangent seeds.
+- No global AD context/cache.
+- No synthesis of unsupported higher-order extension rules.
+- No eager multi-input API in this issue; the accepted request targets traced convenience APIs.
+
+## Verification
+
+Run focused traced/semantic AD tests, extension multi-output instrumentation tests, numerical comparisons, `tenferro-ad` doctests and clippy, modified-file coverage review, and the combined PR gates.

--- a/docs/design/session-blas1.md
+++ b/docs/design/session-blas1.md
@@ -1,0 +1,81 @@
+# Session-Scoped BLAS-1 Primitives
+
+## Status
+
+Accepted design for issue #1713. Implementation requires an independent design-review verdict before code changes.
+
+## Goal
+
+Backend-session callers implement allocation-conscious Krylov iterations over `TensorRead` and caller-owned output storage without host loops, hidden transfers, full-vector algebra temporaries, or solver policy in tenferro.
+
+## Session contract
+
+Add object-safe default methods directly to `BackendSession`:
+
+```rust
+fn vdot_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> Result<Tensor>;
+fn norm_squared_read(&mut self, input: TensorRead<'_>) -> Result<Tensor>;
+fn axpby_read_into_accum(
+    &mut self,
+    alpha: ContractionScalar,
+    x: TensorRead<'_>,
+    beta: ContractionScalar,
+    y: TensorWrite<'_>,
+) -> Result<()>;
+```
+
+Defaults return typed `Unsupported`. They never transfer, construct a CPU backend, or fall back. CPU backend/session implementations override all three. No new operation-family crate or solver API is introduced.
+
+`ContractionScalar` is reused rather than adding another scalar enum. `alpha` and `beta` must have the exact tensor dtype; callers represent real coefficients for complex vectors as complex values with zero imaginary part. Supported tensor dtypes are F32, F64, C32, and C64.
+
+## Semantics and validation
+
+Shared backend-neutral validation runs before allocation or destination mutation:
+
+- `vdot_read`: identical dtype, shape, element count, and compatible placement; result is a rank-0 tensor of the input dtype; computes `sum(conj(lhs) * rhs)`.
+- `norm_squared_read`: supported dtype and placement; result is rank-0 F32 for F32/C32 and F64 for F64/C64; computes the real nonnegative sum of squared magnitudes without `sqrt`.
+- `axpby_read_into_accum`: exact x/y shape, dtype, placement, scalar dtype, compact/injective destination, and conservative x/y non-overlap. All failures occur before mutation. It computes `y <- alpha*x + beta*y` in one destination pass.
+
+Any x/y storage overlap is rejected with the existing typed destination-overlap validation error. Supporting exact alias is unnecessary and would weaken the simple mutation proof. Empty tensors preserve the same contracts: dot/norm return zero and AXPBY is a validated no-op.
+
+## CPU implementation
+
+### VDOT
+
+Reuse the existing optimized dot-general provider. Contract every axis, allocate one rank-0 output through the session buffer pool, and set `DotGeneralAccumulation::lhs_conj = true`. This consumes compact or strided reads through the provider's existing same-placement planning/materialization boundary and creates no full-vector conjugation temporary.
+
+### Norm squared
+
+Use `strided_kernel::reduce` directly over the input view with a squared-magnitude map and real addition identity. Dispatch dtype once. Execute under the owning `CpuExecutionContext`; no `conj(x)*x` tensor is created.
+
+### Fused AXPBY
+
+No current strided-rs primitive expresses read-modify-write over one destination. Issue #1713 is the accepted benchmark-backed exception: implement one compact destination pass in tenferro-cpu, with the rationale and `// INVARIANT:` mutation/alias proof at the kernel. Compact x is borrowed; a noncompact same-placement x view is explicitly materialized exactly once and reused. Noncompact y is rejected rather than hidden copy-out.
+
+The loop executes inside the repository CPU context. One-thread sessions use a serial zip loop; multi-thread sessions use Rayon only inside `CpuExecutionContext::with_native_parallelism`, with disjoint compact destination chunks. It allocates no full-size temporary.
+
+## Tests and benchmark
+
+- CPU F32/F64/C32/C64 compact values for all operations against scalar references; complex VDOT conjugates only lhs.
+- Strided lhs/rhs VDOT and norm consume provider/strided views; strided x AXPBY records exactly one materialization; compact paths record none.
+- Invalid dtype/shape/placement/scalar/overlap/noncompact-y cases prove destination bytes unchanged.
+- A fake unsupported session returns typed `Unsupported` and records no transfer/fallback.
+- Allocation instrumentation proves norm and fused AXPBY allocate no full-size temporary; VDOT allocates only rank-0 output plus provider-bounded bookkeeping.
+- A downstream-style CG microfixture uses `copy_read_into`, VDOT, norm-squared, and AXPBY without manual element loops.
+- A Criterion benchmark compares fused AXPBY with the prior composed/manual reference at representative lengths and one/multiple threads. Run it in release mode and record medians, allocation behavior, and the provider/reduction numerical-order note in the worklog.
+
+## Numerical order
+
+VDOT follows the selected dot provider's reduction order. Norm-squared follows strided-kernel reduction order. Results are tested with dtype-appropriate tolerances rather than bitwise equality. AXPBY is elementwise and deterministic for a fixed scalar implementation.
+
+## Non-goals
+
+- No CG/BiCGStab/multi-shift solver, stencil, shift, or convergence policy.
+- No additional BLAS-1 catalog.
+- No implicit transfer, host scalar extraction, or CPU fallback.
+- No n-ary linear combination.
+- No GPU implementation claim; unsupported sessions remain explicit until a backend overrides the methods.
+
+## Verification
+
+Run tensor contract tests/doctests, CPU faer and BLAS feature tests, allocation/alias/placement tests, the downstream microfixture, release benchmark, clippy, modified-file coverage review, and combined PR gates.

--- a/docs/design/structured-runtime-failure-reasons.md
+++ b/docs/design/structured-runtime-failure-reasons.md
@@ -1,0 +1,74 @@
+# Structured Runtime Failure Reasons
+
+## Status
+
+Accepted design for issue #1712. Implementation requires an independent design-review verdict before code changes.
+
+## Goal
+
+Downstream callers inspect common runtime preparation/execution failures through one stable borrowed reason view, without formatted-message parsing or source-chain downcasts. Existing `Error` variants, `kind`, `phase`, display text, and `StdError::source` remain intact.
+
+## Public API
+
+Add to `tenferro-runtime`:
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RuntimeFailureReasonRef<'a> {
+    MissingExtension { family: &'a str },
+    NoInputIngress { input_index: usize, placement: &'a Placement },
+    UnsupportedOperation { operation: &'a str },
+    Other,
+}
+
+impl Error {
+    pub fn reason(&self) -> RuntimeFailureReasonRef<'_>;
+}
+```
+
+The enum is borrowed and non-exhaustive. `Other` covers every unknown/currently unclassified failure, allowing future reason variants without changing owned errors.
+
+## Source classification
+
+Add a precise owned `PrepareError::MissingExtension { family_id: &'static str }` variant at the existing compiled-preparation point where `missing_extension_family` is already known. This replaces only the ambiguous `PrepareError::Unsupported { UnsupportedReason::Operation }` emitted at that point; it does not replace top-level runtime errors or alter their source chain. Genuine provider operation rejection remains `PrepareError::Unsupported` and maps to `UnsupportedOperation`.
+
+`Error::reason`:
+
+1. For `Error::WithSuppressed`, classify the primary recursively and never let the suppressed secondary override it.
+2. Classify direct top-level unsupported/extension/tensor-runtime variants when they carry a stable operation/family.
+3. Walk the standard source chain once and downcast to `PrepareError`:
+   - `MissingExtension` → `MissingExtension`;
+   - `NoInputIngress` → borrowed input index and placement;
+   - `Unsupported { reason: UnsupportedReason::Operation }` → `UnsupportedOperation`.
+4. Return `Other` for all remaining errors and unknown future variants.
+
+Traversal is deterministic, bounded by the acyclic standard error source chain, allocation-free, and performs no string parsing. The original typed source remains available.
+
+## Public examples and migration
+
+Rustdoc demonstrates exact matching with a constructed typed error and `Other`. Runtime integration examples/tests replace variant-set/message searches and nested `source().source().downcast_ref` calls with `reason()`.
+
+No application must exhaustively match the non-exhaustive enum; examples include a wildcard/`Other` branch.
+
+## Tests
+
+- A compiled extension with no installed module reports exact `MissingExtension { family }`.
+- A no-input-ingress failure reports exact input index and borrowed placement with no downcast.
+- A genuine unsupported operation reports `UnsupportedOperation` and is not mislabeled missing extension.
+- `kind`, `phase`, display, and every original `source()` link are unchanged.
+- `WithSuppressed` returns the primary reason even when the suppressed error has another actionable reason.
+- Nested runtime wrappers classify through one or more source layers.
+- Unknown validation/internal/future-like failures return `Other`.
+
+## Non-goals
+
+- No replacement giant owned error enum.
+- No removal or flattening of existing variants/source chains.
+- No required display-text changes.
+- No string parsing or duplicated owned source payload.
+- No speculative reason variants without a current reachable failure.
+
+## Verification
+
+Run runtime error/preparation/execution unit and integration tests, doctests, clippy, modified-file coverage review, and combined PR gates.

--- a/docs/guides/custom-operations.md
+++ b/docs/guides/custom-operations.md
@@ -38,9 +38,8 @@ An extension crate is responsible for:
 
 - a stable operation descriptor, so graphs can compare and cache it,
 - output dtype and shape inference,
-- concrete execution for the supported backend and device combinations,
-- optional host/reference execution for families that can run without a
-  backend-specific kernel,
+- concrete execution for the supported backend and device combinations through
+  an `ExtensionModule`,
 - optional linearize, linear-transpose, and direct primal-VJP rules for
   automatic differentiation,
 - clear errors when a dtype, shape, backend, or AD path is not supported.
@@ -81,19 +80,28 @@ descriptor. It carries operation parameters such as axes, modes, constants, or
 kernel configuration. Tensor-valued parameters should usually be normal inputs,
 not descriptor fields.
 
+Use the authoring facade's `define_extension_runtime!` once in an ordinary Rust
+module for each operation family. The macro generates the private engine and
+prepared-operation adapter plus an `extension_module` constructor. Its required
+callback is `execute_reads`, which receives borrowed `TensorRead` inputs and an
+`ExtensionExecutionContext`; the legacy `execute` argument may still be present
+for existing callers but is unused and may be omitted.
+
 Extension operation descriptors do not need process-global registration. Construct
 `Arc<dyn ExtensionOp>` and pass it to `tenferro_runtime::extension::apply` for
-traced tensors or `apply_eager` for eager tensors.
-
-Forward execution goes through a registered `ExtensionModule`. If the operation
-has a simple host/reference implementation, expose it with
-`ExtensionOp::host_reference` and provide a host-reference module; otherwise
-provide a backend-specific module owned by the extension crate.
-
-`ExtensionModule` registers one or more extension preparation/execution engines
-and their planning configs against an immutable runtime snapshot. Use it for
-runtime-owned preparation metadata and bounded cache owners, not for hidden
+traced tensors. Forward execution goes through the explicitly registered
+`ExtensionModule`: build a `Runtime`, install the module, compile the traced
+graph, and execute it. The module registers extension preparation/execution
+engines and planning configs against an immutable runtime snapshot. Use it for
+runtime-owned preparation metadata and bounded cache owners, not hidden
 process-global provider state.
+
+The complete runnable example—including two families in separate modules and
+missing-module, wrong-family, and wrong-context typed-error checks—is the
+workspace-external fixture at
+[`tests/fixtures/extension-authoring`](../../tests/fixtures/extension-authoring).
+Run it with `bash tests/run-extension-authoring-fixture.sh`; keep this guide's
+API description aligned with that fixture.
 
 For AD, implement the role-specific traits the operation needs:
 `tenferro_ad::semantic_extension::SemanticLinearizeRule`,

--- a/docs/guides/custom-operations.md
+++ b/docs/guides/custom-operations.md
@@ -85,7 +85,12 @@ module for each operation family. The macro generates the private engine and
 prepared-operation adapter plus an `extension_module` constructor. Its required
 callback is `execute_reads`, which receives borrowed `TensorRead` inputs and an
 `ExtensionExecutionContext`; the legacy `execute` argument may still be present
-for existing callers but is unused and may be omitted.
+for existing callers but is unused and may be omitted. A host/reference executor
+should use `TensorRead::as_slice::<T>()` to borrow compact host storage directly.
+That accessor never allocates or transfers: it rejects a noncompact view or
+backend-owned buffer with a typed error. If a kernel requires canonical compact
+layout, call `to_contiguous_read` explicitly once and reuse the returned tensor;
+do not silently download backend storage or fall back to CPU.
 
 Extension operation descriptors do not need process-global registration. Construct
 `Arc<dyn ExtensionOp>` and pass it to `tenferro_runtime::extension::apply` for

--- a/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
+++ b/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
@@ -172,7 +172,7 @@ Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to
 ### Verification and measurement
 
 - Tensor/CPU suites: 1461 passed; focused BLAS-1 tests cover F32/F64/C32/C64, lhs-only complex conjugation, rank-N/empty/strided paths, invalid requests, safe backend-alias rejection, unsupported defaults, and a CG microfixture.
-- Steady-state allocation probe: 100 compact 65,536-element AXPBY calls allocated 0 bytes in the counted window.
+- Steady-state allocation probe over 100 compact 65,536-element AXPBY calls: cpu-faer allocated 0 bytes; cpu-blas retained one 1,520-byte provider bookkeeping allocation. Both are far below the 524,288-byte vector size and prove no full-size temporary. The cross-provider gate intentionally allows at most one allocation while requiring total bytes below one vector; it guards the accepted no-full-size-temporary contract rather than an inaccurate provider-independent absolute-zero claim.
 - Default cpu-faer, cpu-blas-only, and combined cpu-faer+cpu-blas configurations check successfully.
 - Warning-denied all-target clippy, CPU/tensor doctests, formatting, and diff checks passed.
 - Release Criterion full 100-sample intervals: length 1,024 — fused 9.602–9.802 µs (1 thread), 13.967–14.200 µs (4 threads), manual 0.855–0.870 µs (1 thread), 1.246–1.272 µs (4 threads); length 65,536 — fused 21.585–22.025 µs (1 thread), 24.619–24.788 µs (4 threads), manual 58.489–59.790 µs (1 thread), 58.159–59.111 µs (4 threads). The session/provider boundary dominates tiny vectors; the fused path is 2.4–2.7x faster for the representative large vector. No multithread speedup claim is made for these sizes.
@@ -187,7 +187,7 @@ Candidate `a608aab624f14e00bdd3570087edae655e8e6a9a` was audited read-only after
 
 - **Specification and architecture** (`reviewer-gpt`): PASS; #1708–#1713 acceptance mappings, dependency ordering, extension/AD/runtime/session boundaries, and migration compatibility closed.
 - **Rust safety and lifecycle** (`reviewer-flash`): PASS; TensorRead lifetime, checked-request ownership, AXPBY alias/pointer proof, and pooled rank-0 initialization were sound. Empty rank-0 shape product is exactly one.
-- **Performance and parallelism** (`deepseek-brainstormer`): PASS against the accepted allocation/one-pass criteria; 0 steady-state AXPBY allocations and full Criterion intervals recorded above. Small-vector and multithread overhead are explicit limitations, not hidden claims.
+- **Performance and parallelism** (`deepseek-brainstormer`): PASS against the accepted allocation/one-pass criteria; provider-specific bounded allocation evidence and full Criterion intervals are recorded above. Small-vector and multithread overhead are explicit limitations, not hidden claims.
 - **Public API and documentation** (built-in `reviewer`): PASS; facades, typed errors, object safety, runnable examples, guides, architecture map, and feature combinations aligned.
 - **CPU and NUMA** (built-in `scout`): PASS; production session routes, provider/strided ownership, placement rejection, serial/owned-Rayon paths, re-entry, and failure behavior aligned. Unchanged multi-socket behavior was not benchmarked.
 - **GPU, XLA, and multi-GPU** (`gpt-brainstormer`): static/API/build PASS; hardware execution unavailable and unaffected by the diff because only CPU overrides the new default-unsupported methods. Hosted CI is the verification owner.

--- a/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
+++ b/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
@@ -152,3 +152,31 @@ Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to
 - Runtime/fixture warning-denied clippy, formatting, and diff checks passed.
 
 Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to-merge**. Coverage review and combined-PR gates remain pending.
+
+## Issue 1713: session-scoped BLAS-1
+
+### Design and review gate
+
+- Design: [`../design/session-blas1.md`](../design/session-blas1.md)
+- Reviewer: `reviewer-flash-opencode-go`, read-only
+- Pre-implementation verdict: **Correct-to-merge**.
+
+### Decisions
+
+- Add object-safe default-unsupported methods directly to `BackendSession`; unsupported backends cannot transfer or fall back.
+- Reuse all-axis dot-general with lhs conjugation for VDOT and strided-kernel reduction for real norm-squared output.
+- Reuse `ContractionScalar` with exact dtype matching.
+- Implement fused compact-destination AXPBY as the accepted issue-specific RMW exception because strided-rs has no in-place read-modify-write primitive; validate shape/dtype/placement/compactness/overlap before mutation.
+- Borrow compact x, materialize a noncompact same-placement x exactly once, and reject noncompact y.
+
+### Verification and measurement
+
+- Tensor/CPU suites: 1461 passed; focused BLAS-1 tests cover F32/F64/C32/C64, lhs-only complex conjugation, rank-N/empty/strided paths, invalid requests, safe backend-alias rejection, unsupported defaults, and a CG microfixture.
+- Steady-state allocation probe: 100 compact 65,536-element AXPBY calls allocated 0 bytes in the counted window.
+- Default cpu-faer, cpu-blas-only, and combined cpu-faer+cpu-blas configurations check successfully.
+- Warning-denied all-target clippy, CPU/tensor doctests, formatting, and diff checks passed.
+- Release Criterion quick medians (approximate): length 1,024 — fused 7.89 µs (1 thread), 13.38 µs (4 threads), manual 1.01 µs; length 65,536 — fused 27.14 µs (1 thread), 24.88 µs (4 threads), manual 68.39 µs. The session/provider boundary dominates tiny vectors; fused parallel execution wins for the representative large vector.
+- VDOT follows provider reduction order; norm-squared deliberately returns the sum of squared magnitudes without `sqrt` and follows strided-kernel reduction order; tests use dtype-appropriate tolerances. AXPBY deliberately rejects noncompact y and materializes only noncompact x.
+- Coverage: `semantic_extension.rs` 92.6%; `blas1.rs` 90.5%; the complete repository coverage gate passes.
+
+Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to-merge**, including a follow-up soundness verdict on compact mutable-view pointer provenance. Combined-PR gates remain pending.

--- a/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
+++ b/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
@@ -1,0 +1,54 @@
+# Issues 1708–1713 Downstream Gaps
+
+## Session summary
+
+This single-PR stream addresses six accepted gaps reported by the completed latticeqcd-rs port: extension authoring, borrowed extension reads, multi-input AD, checked residual access, structured runtime diagnostics, and session-scoped BLAS-1 operations.
+
+## Issue 1708: extension authoring facade
+
+### Context read
+
+- GitHub issue #1708
+- `AGENTS.md`, relevant `REPOSITORY_RULES.md` public-surface, extension, documentation, test, and worklog rules
+- `crates/tenferro-runtime/src/extension.rs`
+- `crates/tenferro-runtime/src/runtime/extension.rs`
+- `crates/tenferro-internal-extension-macros/src/lib.rs`
+- `docs/guides/custom-operations.md`
+- existing standard extension macro invocations and runtime tests
+
+### Design and review gate
+
+- Design: [`../design/extension-authoring-facade.md`](../design/extension-authoring-facade.md)
+- Reviewer: `reviewer-flash-opencode-go` (`opencode-go/deepseek-v4-flash:medium`), read-only
+- Rounds 1–2 timed out without reading all required artifacts; neither cleared the gate.
+- Round 3 used the complete design plus bounded verified source facts.
+- Pre-implementation verdict: **Correct-to-merge**.
+
+### Decisions
+
+- Reuse `tenferro_runtime::extension`; do not create another facade crate or framework.
+- Re-export the existing author-facing contracts and proc macro while keeping generated adapters private.
+- Make the macro's already-unused legacy `execute` argument optional rather than requiring downstream boilerplate.
+- Prove downstream usability with an external fixture containing two independently generated families.
+- Keep runtime/module/backend ownership explicit and preserve typed errors.
+
+### Rejected or deferred
+
+- A global registry, discovery, host-reference compatibility shim, generated public adapter types, implicit transfer/fallback, and new naming DSL were rejected by the accepted issue and design.
+- Borrow/allocation optimization remains issue #1709; #1708 only establishes the public read-based adapter path.
+
+### Verification
+
+- `cargo test -p tenferro-internal-extension-macros`: 11 passed.
+- `bash tests/run-extension-authoring-fixture.sh`: passed.
+- `cargo test -p tenferro-runtime --test integration`: 146 passed.
+- `cargo test -p tenferro-runtime --doc`: 414 passed.
+- Targeted runtime/macro and external-fixture clippy: passed with warnings denied.
+- Runtime package creation, doc snippets, public error docs, workflow contract tests, and actionlint: passed.
+- Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to-merge** after bounded follow-up evidence resolved the initial missing-evidence blockers.
+
+The combined-PR local gate, coverage run, deterministic repository-rules review, and hosted docs build remain final-stream checks after issues #1709–#1713 are integrated.
+
+### Remaining risks
+
+No issue-#1708 blocker remains. Issue #1709 owns allocation behavior beyond establishing the borrowed `execute_reads` boundary.

--- a/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
+++ b/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
@@ -102,3 +102,29 @@ Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to
 - Targeted clippy, doc snippets, and public error docs passed.
 
 Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to-merge**. Coverage review and combined-PR gates remain pending.
+
+## Issue 1711: checked semantic AD residual access
+
+### Design and review gate
+
+- Design: [`../design/checked-semantic-ad-residual-access.md`](../design/checked-semantic-ad-residual-access.md)
+- Reviewer: `reviewer-flash-opencode-go`, read-only
+- Pre-implementation verdict: **Correct-to-merge**.
+
+### Decisions
+
+- Remove raw primal value slices from transpose/direct primal-VJP requests; linearization remains unrestricted.
+- Add bounds-first, mask-checked value access with typed family/kind/index errors.
+- Snapshot dtype/shape metadata into request-owned boxes so metadata remains available without exposing `ProgramValue` or aliasing the mutable builder.
+- Keep `ResidualSpec` as the only tensor-retention authority; metadata snapshots retain no tensor data.
+- Migrate standard and nested extension rules with no compatibility shim.
+
+### Verification
+
+- Focused semantic-extension tests cover undeclared input/output access, metadata-only access, bounds precedence, and absence of raw request accessors.
+- Wilson-like four-input direct VJP covers inactive inputs and a non-unit cotangent while executing one force node.
+- Debug standard-crate suites: 1347 passed; sparse autodiff: 25 passed; tropical autodiff: 77 passed.
+- Release-mode semantic-extension tests: 5 passed.
+- Workspace/nested checks, formatting, public error docs, and warning-denied clippy passed.
+
+Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to-merge**. Coverage review and combined-PR gates remain pending.

--- a/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
+++ b/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
@@ -52,3 +52,28 @@ The combined-PR local gate, coverage run, deterministic repository-rules review,
 ### Remaining risks
 
 No issue-#1708 blocker remains. Issue #1709 owns allocation behavior beyond establishing the borrowed `execute_reads` boundary.
+
+## Issue 1709: borrowed extension reads
+
+### Design and review gate
+
+- Design: [`../design/borrowed-extension-reads.md`](../design/borrowed-extension-reads.md)
+- Reviewer: `reviewer-flash-opencode-go`, read-only
+- Pre-implementation verdict: **Correct-to-merge** after explicitly recording the shallow-clone/original-storage lifetime invariant.
+
+### Decisions
+
+- Reuse the existing read-based generated executor; the runtime already forwards `TensorRead` unchanged.
+- Add only `TensorRead::as_slice<T>` as an allocation-free convenience over the existing `TensorView::as_slice<T>` contract.
+- Keep noncompact materialization and backend transfer explicit; no macro/runtime policy or fallback was added.
+- Use pointer identity and explicit callback counters as deterministic evidence. Allocator bytes compare borrowed execution against an equivalent output-construction baseline so output/runtime bookkeeping is not misclassified as input duplication.
+
+### Verification
+
+- `cargo test -p tenferro-tensor tensor_read_as_slice`: 5 passed.
+- `cargo test -p tenferro-tensor --doc`: 327 passed.
+- `bash tests/run-extension-authoring-fixture.sh`: passed with four-input pointer checks, explicit materialization count, backend rejection, and allocation comparison.
+- Targeted tensor and external-fixture clippy: passed with warnings denied.
+- Doc snippets and public error docs: passed.
+
+Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to-merge**. Coverage review and combined-PR gates remain pending.

--- a/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
+++ b/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
@@ -175,8 +175,28 @@ Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to
 - Steady-state allocation probe: 100 compact 65,536-element AXPBY calls allocated 0 bytes in the counted window.
 - Default cpu-faer, cpu-blas-only, and combined cpu-faer+cpu-blas configurations check successfully.
 - Warning-denied all-target clippy, CPU/tensor doctests, formatting, and diff checks passed.
-- Release Criterion quick medians (approximate): length 1,024 — fused 7.89 µs (1 thread), 13.38 µs (4 threads), manual 1.01 µs; length 65,536 — fused 27.14 µs (1 thread), 24.88 µs (4 threads), manual 68.39 µs. The session/provider boundary dominates tiny vectors; fused parallel execution wins for the representative large vector.
+- Release Criterion full 100-sample intervals: length 1,024 — fused 9.602–9.802 µs (1 thread), 13.967–14.200 µs (4 threads), manual 0.855–0.870 µs (1 thread), 1.246–1.272 µs (4 threads); length 65,536 — fused 21.585–22.025 µs (1 thread), 24.619–24.788 µs (4 threads), manual 58.489–59.790 µs (1 thread), 58.159–59.111 µs (4 threads). The session/provider boundary dominates tiny vectors; the fused path is 2.4–2.7x faster for the representative large vector. No multithread speedup claim is made for these sizes.
 - VDOT follows provider reduction order; norm-squared deliberately returns the sum of squared magnitudes without `sqrt` and follows strided-kernel reduction order; tests use dtype-appropriate tolerances. AXPBY deliberately rejects noncompact y and materializes only noncompact x.
 - Coverage: `semantic_extension.rs` 92.6%; `blas1.rs` 90.5%; the complete repository coverage gate passes.
 
-Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to-merge**, including a follow-up soundness verdict on compact mutable-view pointer provenance. Combined-PR gates remain pending.
+Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to-merge**, including a follow-up soundness verdict on compact mutable-view pointer provenance.
+
+## Final combined verification and cross-phase audit
+
+Candidate `a608aab624f14e00bdd3570087edae655e8e6a9a` was audited read-only after all task-local gates:
+
+- **Specification and architecture** (`reviewer-gpt`): PASS; #1708–#1713 acceptance mappings, dependency ordering, extension/AD/runtime/session boundaries, and migration compatibility closed.
+- **Rust safety and lifecycle** (`reviewer-flash`): PASS; TensorRead lifetime, checked-request ownership, AXPBY alias/pointer proof, and pooled rank-0 initialization were sound. Empty rank-0 shape product is exactly one.
+- **Performance and parallelism** (`deepseek-brainstormer`): PASS against the accepted allocation/one-pass criteria; 0 steady-state AXPBY allocations and full Criterion intervals recorded above. Small-vector and multithread overhead are explicit limitations, not hidden claims.
+- **Public API and documentation** (built-in `reviewer`): PASS; facades, typed errors, object safety, runnable examples, guides, architecture map, and feature combinations aligned.
+- **CPU and NUMA** (built-in `scout`): PASS; production session routes, provider/strided ownership, placement rejection, serial/owned-Rayon paths, re-entry, and failure behavior aligned. Unchanged multi-socket behavior was not benchmarked.
+- **GPU, XLA, and multi-GPU** (`gpt-brainstormer`): static/API/build PASS; hardware execution unavailable and unaffected by the diff because only CPU overrides the new default-unsupported methods. Hosted CI is the verification owner.
+- **Integration auditor** (built-in `worker`): PASS; no Critical, Important, Minor, or cross-lane contradiction remained. Hardware-only limitations were classified as unaffected-by-diff and non-blocking.
+
+Fresh combined gates:
+
+- `python3 scripts/ci/run_profile.py coverage`: PASS, 193/193 files; `semantic_extension.rs` 92.6%, `blas1.rs` 90.5%.
+- `python3 scripts/ci/run_profile.py docs`: PASS, including faer/BLAS tutorial binaries and rendered site checks.
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-cpu blas1'`: PASS.
+- Committed-head deterministic repository-rules review: PASS; only the required recorded external-LLM-skip notice remained.
+- Branch was behind `origin/main` by zero commits at audit time.

--- a/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
+++ b/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
@@ -128,3 +128,27 @@ Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to
 - Workspace/nested checks, formatting, public error docs, and warning-denied clippy passed.
 
 Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to-merge**. Coverage review and combined-PR gates remain pending.
+
+## Issue 1712: structured runtime failure reasons
+
+### Design and review gate
+
+- Design: [`../design/structured-runtime-failure-reasons.md`](../design/structured-runtime-failure-reasons.md)
+- Reviewer: `reviewer-flash-opencode-go`, read-only
+- Pre-implementation verdict: **Correct-to-merge**.
+
+### Decisions
+
+- Add one borrowed, non-exhaustive reason view while retaining every owned error and source link.
+- Replace the ambiguous missing-extension `PrepareError::Unsupported` at the already-known compiled-preparation seam with a precise `PrepareError::MissingExtension` source.
+- Classify primary errors before suppressed errors; traverse typed sources without strings or allocation.
+- Keep real extension/provider unsupported failures distinct from missing registration.
+
+### Verification
+
+- Runtime error tests cover missing extension, no input ingress, unsupported operation, nested wrappers, suppressed-primary precedence, and `Other`.
+- Runtime integration tests consume no-ingress reasons without downcasts; the external fixture verifies exact missing-extension family through the real compiled path.
+- `cargo test -p tenferro-runtime`: 973 passed; external fixture passed.
+- Runtime/fixture warning-denied clippy, formatting, and diff checks passed.
+
+Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to-merge**. Coverage review and combined-PR gates remain pending.

--- a/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
+++ b/docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md
@@ -77,3 +77,28 @@ No issue-#1708 blocker remains. Issue #1709 owns allocation behavior beyond esta
 - Doc snippets and public error docs: passed.
 
 Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to-merge**. Coverage review and combined-PR gates remain pending.
+
+## Issue 1710: multi-input traced JVP and VJP
+
+### Design and review gate
+
+- Design: [`../design/multi-input-traced-ad.md`](../design/multi-input-traced-ad.md)
+- Reviewer: `reviewer-flash-opencode-go`, read-only
+- Pre-implementation verdict: **Correct-to-merge**.
+
+### Decisions
+
+- Compile one semantic source, union one activity mask, run one cached semantic transform, and bind all derivative seeds once.
+- Build all requested VJP traces from one shared derivative graph and one metadata/constraint analysis.
+- Preserve request order and `None` for unreachable leaves; repeat duplicate VJP results without re-accumulation.
+- Reject duplicate JVP leaves from the raw request before compilation; distinct tangents form one directional derivative.
+- Keep single-input APIs source-compatible by delegating through the many-input helpers.
+
+### Verification
+
+- Multi-input integration tests cover two/four inputs, empty and unreachable requests, duplicate policies, metadata errors, transform-cache entry counts, and shared graph identity.
+- A Wilson-like four-input action direct-VJP rule emits one four-output force extension; `compile_many` execution reports exactly one force callback and correct outputs.
+- `cargo test -p tenferro-ad`: 589 passed across unit, integration, and doctest suites.
+- Targeted clippy, doc snippets, and public error docs passed.
+
+Post-implementation reviewer: `reviewer-flash-opencode-go`; verdict **Correct-to-merge**. Coverage review and combined-PR gates remain pending.

--- a/ext/sparse/src/extension.rs
+++ b/ext/sparse/src/extension.rs
@@ -770,9 +770,12 @@ impl SemanticLinearTransposeRule for SparseMatmulAdRule {
         request: SemanticLinearTransposeRequest<'_>,
         builder: &mut SemanticProgramBuilder,
     ) -> std::result::Result<Box<[AdValue]>, SemanticAdError> {
+        let primal_inputs = (0..request.primal_input_count())
+            .map(|index| request.primal_input_value(index))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         semantic_sparse_vjp(
             request.op(),
-            request.primal_inputs(),
+            &primal_inputs,
             request.cotangent_outputs()[0],
             request.active_inputs(),
             builder,
@@ -797,9 +800,12 @@ impl SemanticLinearTransposeRule for SparseMatmulJvpTransposeRule {
         request: SemanticLinearTransposeRequest<'_>,
         builder: &mut SemanticProgramBuilder,
     ) -> std::result::Result<Box<[AdValue]>, SemanticAdError> {
+        let primal_inputs = (0..request.primal_input_count())
+            .map(|index| request.primal_input_value(index))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         semantic_sparse_jvp_vjp(
             request.op(),
-            request.primal_inputs(),
+            &primal_inputs,
             request.cotangent_outputs()[0],
             request.active_inputs(),
             builder,
@@ -824,9 +830,12 @@ impl SemanticPrimalVjpRule for SparseMatmulJvpTransposeRule {
         request: SemanticPrimalVjpRequest<'_>,
         builder: &mut SemanticProgramBuilder,
     ) -> std::result::Result<Box<[AdValue]>, SemanticAdError> {
+        let primal_inputs = (0..request.primal_input_count())
+            .map(|index| request.primal_input_value(index))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         semantic_sparse_jvp_vjp(
             request.op(),
-            request.primal_inputs(),
+            &primal_inputs,
             request.cotangent_outputs()[0],
             request.active_inputs(),
             builder,
@@ -851,9 +860,12 @@ impl SemanticPrimalVjpRule for SparseMatmulAdRule {
         request: SemanticPrimalVjpRequest<'_>,
         builder: &mut SemanticProgramBuilder,
     ) -> std::result::Result<Box<[AdValue]>, SemanticAdError> {
+        let primal_inputs = (0..request.primal_input_count())
+            .map(|index| request.primal_input_value(index))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         semantic_sparse_vjp(
             request.op(),
-            request.primal_inputs(),
+            &primal_inputs,
             request.cotangent_outputs()[0],
             request.active_inputs(),
             builder,

--- a/ext/tropical/src/extension.rs
+++ b/ext/tropical/src/extension.rs
@@ -714,9 +714,12 @@ impl SemanticLinearTransposeRule for TropicalEinsumAdRule {
         request: SemanticLinearTransposeRequest<'_>,
         builder: &mut SemanticProgramBuilder,
     ) -> std::result::Result<Box<[AdValue]>, SemanticAdError> {
+        let primal_inputs = (0..request.primal_input_count())
+            .map(|index| request.primal_input_value(index))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         semantic_tropical_vjp(
             request.op(),
-            request.primal_inputs(),
+            &primal_inputs,
             request.cotangent_outputs()[0],
             request.active_inputs(),
             builder,
@@ -741,9 +744,12 @@ impl SemanticLinearTransposeRule for TropicalEinsumJvpTransposeRule {
         request: SemanticLinearTransposeRequest<'_>,
         builder: &mut SemanticProgramBuilder,
     ) -> std::result::Result<Box<[AdValue]>, SemanticAdError> {
+        let primal_inputs = (0..request.primal_input_count())
+            .map(|index| request.primal_input_value(index))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         semantic_tropical_jvp_vjp(
             request.op(),
-            request.primal_inputs(),
+            &primal_inputs,
             request.cotangent_outputs()[0],
             request.active_inputs(),
             builder,
@@ -768,9 +774,12 @@ impl SemanticPrimalVjpRule for TropicalEinsumJvpTransposeRule {
         request: SemanticPrimalVjpRequest<'_>,
         builder: &mut SemanticProgramBuilder,
     ) -> std::result::Result<Box<[AdValue]>, SemanticAdError> {
+        let primal_inputs = (0..request.primal_input_count())
+            .map(|index| request.primal_input_value(index))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         semantic_tropical_jvp_vjp(
             request.op(),
-            request.primal_inputs(),
+            &primal_inputs,
             request.cotangent_outputs()[0],
             request.active_inputs(),
             builder,
@@ -795,9 +804,12 @@ impl SemanticPrimalVjpRule for TropicalEinsumAdRule {
         request: SemanticPrimalVjpRequest<'_>,
         builder: &mut SemanticProgramBuilder,
     ) -> std::result::Result<Box<[AdValue]>, SemanticAdError> {
+        let primal_inputs = (0..request.primal_input_count())
+            .map(|index| request.primal_input_value(index))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         semantic_tropical_vjp(
             request.op(),
-            request.primal_inputs(),
+            &primal_inputs,
             request.cotangent_outputs()[0],
             request.active_inputs(),
             builder,

--- a/tests/fixtures/extension-authoring/Cargo.toml
+++ b/tests/fixtures/extension-authoring/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "extension-authoring-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+tenferro-runtime = { path = "../../../crates/tenferro-runtime", default-features = false, features = ["cpu-faer"] }
+tenferro-tensor = { path = "../../../crates/tenferro-tensor", default-features = false }
+tenferro-cpu = { path = "../../../crates/tenferro-cpu", default-features = false, features = ["cpu-faer"] }

--- a/tests/fixtures/extension-authoring/src/main.rs
+++ b/tests/fixtures/extension-authoring/src/main.rs
@@ -1,24 +1,59 @@
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::any::Any;
 use std::error::Error as StdError;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::extension::{
-    apply, define_extension_runtime, ExtensionAliasDeclaration, ExtensionEffectDeclaration,
-    ExtensionExecutionContext, ExtensionOp, ExtensionShapeContext, SymDim,
+    apply, define_extension_runtime, ExtensionAliasDeclaration, ExtensionCacheStore,
+    ExtensionEffectDeclaration, ExtensionExecutionContext, ExtensionOp, ExtensionShapeContext,
+    SymDim,
 };
 use tenferro_runtime::{
     CoreCapabilityKind, DType, ErasedExecutionContext, Error, ExecutionContextIdentity,
     ExecutionContextMismatch, GraphCompiler, PrepareError, ProviderContractError, Runtime, Tensor,
     TracedTensor, UnsupportedReason,
 };
-use tenferro_tensor::{TensorBackend, TensorRead};
+use tenferro_tensor::{
+    BackendStorageHandle, Placement, StorageBuffer, TensorBackend, TensorRead, TensorView,
+    TypedTensor, TypedTensorView,
+};
 
 const IDENTITY_FAMILY: &str = "fixture.identity.v1";
 const SECOND_FAMILY: &str = "fixture.second.v1";
+const BORROWED_FAMILY: &str = "fixture.borrowed.v1";
+
+struct CountingAllocator;
+
+static COUNT_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATED_BYTES: AtomicUsize = AtomicUsize::new(0);
+static BORROWED_CALLBACKS: AtomicUsize = AtomicUsize::new(0);
+static MATERIALIZATION_CALLBACKS: AtomicUsize = AtomicUsize::new(0);
+static BORROWED_POINTERS: [AtomicUsize; 4] = [const { AtomicUsize::new(0) }; 4];
+
+// SAFETY: this allocator forwards every operation to the standard allocator and
+// only records allocation sizes for the single-threaded fixture measurements.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNT_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATED_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        // SAFETY: the layout is forwarded unchanged to the standard allocator.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: the pointer and layout came from the corresponding allocator.
+        unsafe { System.dealloc(pointer, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
 
 macro_rules! identity_op {
-    ($name:ident, $family:expr) => {
+    ($name:ident, $family:expr, $inputs:expr) => {
         #[derive(Clone, Debug)]
         struct $name;
 
@@ -44,7 +79,7 @@ macro_rules! identity_op {
             }
 
             fn input_count(&self) -> usize {
-                1
+                $inputs
             }
 
             fn output_count(&self) -> usize {
@@ -72,11 +107,12 @@ macro_rules! identity_op {
     };
 }
 
-identity_op!(IdentityOp, IDENTITY_FAMILY);
-identity_op!(SecondOp, SECOND_FAMILY);
+identity_op!(IdentityOp, IDENTITY_FAMILY, 1);
+identity_op!(SecondOp, SECOND_FAMILY, 1);
+identity_op!(BorrowedOp, BORROWED_FAMILY, 4);
 // Reuse the registered family ID with a different payload type so dispatch
 // reaches the family's engine and returns its typed WrongOperationFamily error.
-identity_op!(WrongFamilyOp, IDENTITY_FAMILY);
+identity_op!(WrongFamilyOp, IDENTITY_FAMILY, 1);
 
 fn execute_identity<B: TensorBackend + 'static>(
     _op: &IdentityOp,
@@ -93,9 +129,49 @@ fn execute_second<B: TensorBackend + 'static>(
     inputs: &[TensorRead<'_>],
     context: &mut ExtensionExecutionContext<'_, B>,
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
-    Ok(vec![context
+    MATERIALIZATION_CALLBACKS.fetch_add(1, Ordering::SeqCst);
+    let materialized = context
         .backend_mut()
-        .to_contiguous_read(inputs[0].clone())?])
+        .to_contiguous_read(inputs[0].clone())?;
+    let _values = materialized.as_slice::<f64>()?;
+    Ok(vec![materialized])
+}
+
+fn sum_four(slices: [&[f64]; 4], shape: &[usize]) -> tenferro_tensor::Result<Tensor> {
+    let data = (0..slices[0].len())
+        .map(|index| slices[0][index] + slices[1][index] + slices[2][index] + slices[3][index])
+        .collect();
+    Tensor::from_vec_col_major(shape.to_vec(), data)
+}
+
+fn execute_borrowed<B: TensorBackend + 'static>(
+    _op: &BorrowedOp,
+    inputs: &[TensorRead<'_>],
+    _context: &mut ExtensionExecutionContext<'_, B>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    BORROWED_CALLBACKS.fetch_add(1, Ordering::SeqCst);
+    let slices = [
+        inputs[0].as_slice::<f64>()?,
+        inputs[1].as_slice::<f64>()?,
+        inputs[2].as_slice::<f64>()?,
+        inputs[3].as_slice::<f64>()?,
+    ];
+    for (slot, values) in slices.iter().enumerate() {
+        BORROWED_POINTERS[slot].store(values.as_ptr() as usize, Ordering::SeqCst);
+    }
+    Ok(vec![sum_four(slices, inputs[0].shape())?])
+}
+
+fn execute_host_only<B: TensorBackend + 'static>(
+    _op: &IdentityOp,
+    inputs: &[TensorRead<'_>],
+    _context: &mut ExtensionExecutionContext<'_, B>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    let values = inputs[0].as_slice::<f64>()?;
+    Ok(vec![Tensor::from_vec_col_major(
+        inputs[0].shape().to_vec(),
+        values.to_vec(),
+    )?])
 }
 
 mod identity_runtime {
@@ -120,6 +196,17 @@ mod second_runtime {
     }
 }
 
+mod borrowed_runtime {
+    use super::*;
+
+    define_extension_runtime! {
+        runtime = BorrowedRuntime,
+        family_id = BORROWED_FAMILY,
+        op_type = BorrowedOp,
+        execute_reads = execute_borrowed,
+    }
+}
+
 fn compile_op(
     op: Arc<dyn ExtensionOp>,
 ) -> tenferro_runtime::Result<tenferro_runtime::CompiledGraph> {
@@ -128,6 +215,30 @@ fn compile_op(
     let program =
         GraphCompiler::new().compile_with_input_specs(&output, &[(&input, DType::F64, &[2])])?;
     Ok(program)
+}
+
+fn compile_borrowed_op() -> tenferro_runtime::Result<tenferro_runtime::CompiledGraph> {
+    let inputs = (0..4)
+        .map(|_| TracedTensor::input_concrete_shape(DType::F64, &[1024]))
+        .collect::<tenferro_runtime::Result<Vec<_>>>()?;
+    let output = apply(
+        Arc::new(BorrowedOp),
+        &[&inputs[0], &inputs[1], &inputs[2], &inputs[3]],
+    )?
+    .remove(0);
+    let specs = inputs
+        .iter()
+        .map(|input| (input, DType::F64, &[1024][..]))
+        .collect::<Vec<_>>();
+    GraphCompiler::new().compile_with_input_specs(&output, &specs)
+}
+
+fn measure_allocated_bytes(call: impl FnOnce()) -> usize {
+    ALLOCATED_BYTES.store(0, Ordering::SeqCst);
+    COUNT_ALLOCATIONS.store(true, Ordering::SeqCst);
+    call();
+    COUNT_ALLOCATIONS.store(false, Ordering::SeqCst);
+    ALLOCATED_BYTES.load(Ordering::SeqCst)
 }
 
 fn has_missing_family(error: &(dyn StdError + 'static)) -> bool {
@@ -168,20 +279,122 @@ fn has_wrong_family(error: &(dyn StdError + 'static)) -> bool {
 }
 
 fn main() -> Result<(), Box<dyn StdError>> {
-    let backend = CpuBackend::new();
+    let mut backend = CpuBackend::new();
     let engine_id = tenferro_cpu::runtime_engine_id()?;
     let mut builder = Runtime::builder();
     builder.register_engine(tenferro_cpu::runtime_engine_registration(&backend)?)?;
     builder.install_extension_module(identity_runtime::extension_module::<CpuBackend>(
         engine_id.clone(),
     )?)?;
-    builder.install_extension_module(second_runtime::extension_module::<CpuBackend>(engine_id)?)?;
+    builder.install_extension_module(second_runtime::extension_module::<CpuBackend>(
+        engine_id.clone(),
+    )?)?;
+    builder
+        .install_extension_module(borrowed_runtime::extension_module::<CpuBackend>(engine_id)?)?;
     let runtime = builder.build()?;
 
     let program = compile_op(Arc::new(IdentityOp))?;
     let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
     let output = runtime.run_compiled(&program, &[&input])?.remove(0);
     assert_eq!(output.as_slice::<f64>()?, &[1.0, 2.0]);
+
+    let borrowed_program = compile_borrowed_op()?;
+    let borrowed_inputs = (0..4)
+        .map(|input| {
+            Tensor::from_vec_col_major(
+                vec![1024],
+                (0..1024)
+                    .map(|index| (input + index) as f64)
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<tenferro_tensor::Result<Vec<_>>>()?;
+    let borrowed_refs = borrowed_inputs.iter().collect::<Vec<_>>();
+    runtime.run_compiled(&borrowed_program, &borrowed_refs)?;
+    let caller_pointers = borrowed_inputs
+        .iter()
+        .map(|input| input.as_slice::<f64>().unwrap().as_ptr() as usize)
+        .collect::<Vec<_>>();
+    let mut borrowed_backend = CpuBackend::new();
+    let mut borrowed_caches = ExtensionCacheStore::new();
+    let mut borrowed_context =
+        ExtensionExecutionContext::new(&mut borrowed_backend, &mut borrowed_caches);
+    let borrowed_reads = borrowed_inputs
+        .iter()
+        .map(TensorRead::from_tensor)
+        .collect::<Vec<_>>();
+    execute_borrowed(&BorrowedOp, &borrowed_reads, &mut borrowed_context)?;
+    let direct_slices = [
+        borrowed_inputs[0].as_slice::<f64>()?,
+        borrowed_inputs[1].as_slice::<f64>()?,
+        borrowed_inputs[2].as_slice::<f64>()?,
+        borrowed_inputs[3].as_slice::<f64>()?,
+    ];
+    let output_baseline_bytes = measure_allocated_bytes(|| {
+        let output = sum_four(direct_slices, &[1024]).expect("baseline output should build");
+        assert_eq!(output.as_slice::<f64>().unwrap()[0], 6.0);
+    });
+    let borrowed_bytes = measure_allocated_bytes(|| {
+        let output = execute_borrowed(&BorrowedOp, &borrowed_reads, &mut borrowed_context)
+            .expect("borrowed extension should execute");
+        assert_eq!(output[0].as_slice::<f64>().unwrap()[0], 6.0);
+    });
+    assert_eq!(BORROWED_CALLBACKS.load(Ordering::SeqCst), 3);
+    assert_eq!(MATERIALIZATION_CALLBACKS.load(Ordering::SeqCst), 0);
+    for (slot, pointer) in caller_pointers.iter().copied().enumerate() {
+        assert_eq!(BORROWED_POINTERS[slot].load(Ordering::SeqCst), pointer);
+    }
+    let input_bytes = 1024 * std::mem::size_of::<f64>();
+    assert!(
+        borrowed_bytes < output_baseline_bytes + input_bytes,
+        "borrowed path allocated {borrowed_bytes} bytes versus {output_baseline_bytes} output-baseline bytes for {input_bytes}-byte inputs"
+    );
+
+    let mut materialize_backend = CpuBackend::new();
+    let mut materialize_caches = ExtensionCacheStore::new();
+    let noncompact_data = vec![1.0_f64; 2048];
+    let noncompact_view = TensorView::F64(TypedTensorView::from_slice(
+        [1024],
+        [2],
+        0,
+        &noncompact_data,
+    )?);
+    let noncompact_read = TensorRead::from_view(noncompact_view);
+    let mut materialize_context =
+        ExtensionExecutionContext::new(&mut materialize_backend, &mut materialize_caches);
+    MATERIALIZATION_CALLBACKS.store(0, Ordering::SeqCst);
+    let materialized_bytes = measure_allocated_bytes(|| {
+        execute_second(
+            &SecondOp,
+            std::slice::from_ref(&noncompact_read),
+            &mut materialize_context,
+        )
+        .expect("explicit materialization should execute");
+    });
+    assert_eq!(MATERIALIZATION_CALLBACKS.load(Ordering::SeqCst), 1);
+    assert!(
+        materialized_bytes >= input_bytes,
+        "explicit materialization allocated {materialized_bytes} bytes for {input_bytes}-byte input"
+    );
+
+    let backend_tensor = Tensor::F64(TypedTensor::<f64>::from_buffer_col_major(
+        vec![2],
+        StorageBuffer::Backend(Box::new(BackendStorageHandle::<f64>::new_with_len(1709, 2))),
+        Placement::default(),
+    )?);
+    let mut host_caches = ExtensionCacheStore::new();
+    let mut host_context = ExtensionExecutionContext::new(&mut backend, &mut host_caches);
+    let host_error = execute_host_only(
+        &IdentityOp,
+        &[TensorRead::from_tensor(&backend_tensor)],
+        &mut host_context,
+    )
+    .expect_err("host-only typed access must reject backend-owned input");
+    assert!(matches!(
+        host_error,
+        tenferro_tensor::Error::RuntimeState { .. }
+    ));
+    assert!(host_error.to_string().contains("download explicitly first"));
 
     let mut missing_builder = Runtime::builder();
     missing_builder.register_engine(tenferro_cpu::runtime_engine_registration(&backend)?)?;

--- a/tests/fixtures/extension-authoring/src/main.rs
+++ b/tests/fixtures/extension-authoring/src/main.rs
@@ -12,8 +12,8 @@ use tenferro_runtime::extension::{
 };
 use tenferro_runtime::{
     CoreCapabilityKind, DType, ErasedExecutionContext, Error, ExecutionContextIdentity,
-    ExecutionContextMismatch, GraphCompiler, PrepareError, ProviderContractError, Runtime, Tensor,
-    TracedTensor, UnsupportedReason,
+    ExecutionContextMismatch, GraphCompiler, PrepareError, ProviderContractError, Runtime,
+    RuntimeFailureReasonRef, Tensor, TracedTensor,
 };
 use tenferro_tensor::{
     BackendStorageHandle, Placement, StorageBuffer, TensorBackend, TensorRead, TensorView,
@@ -246,10 +246,8 @@ fn has_missing_family(error: &(dyn StdError + 'static)) -> bool {
     while let Some(source) = current {
         if matches!(
             source.downcast_ref::<PrepareError>(),
-            Some(PrepareError::Unsupported {
-                reason: UnsupportedReason::Operation {
-                    operation: IDENTITY_FAMILY,
-                },
+            Some(PrepareError::MissingExtension {
+                family_id: IDENTITY_FAMILY,
             })
         ) {
             return true;
@@ -407,6 +405,12 @@ fn main() -> Result<(), Box<dyn StdError>> {
         Error::RuntimeStateSource { .. } | Error::Extension { .. }
     ));
     assert!(has_missing_family(&missing), "{missing:?}");
+    assert_eq!(
+        missing.reason(),
+        RuntimeFailureReasonRef::MissingExtension {
+            family: IDENTITY_FAMILY
+        }
+    );
 
     let wrong_family_program = compile_op(Arc::new(WrongFamilyOp))?;
     let wrong_family = runtime

--- a/tests/fixtures/extension-authoring/src/main.rs
+++ b/tests/fixtures/extension-authoring/src/main.rs
@@ -1,0 +1,217 @@
+use std::any::Any;
+use std::error::Error as StdError;
+use std::sync::Arc;
+
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::extension::{
+    apply, define_extension_runtime, ExtensionAliasDeclaration, ExtensionEffectDeclaration,
+    ExtensionExecutionContext, ExtensionOp, ExtensionShapeContext, SymDim,
+};
+use tenferro_runtime::{
+    CoreCapabilityKind, DType, ErasedExecutionContext, Error, ExecutionContextIdentity,
+    ExecutionContextMismatch, GraphCompiler, PrepareError, ProviderContractError, Runtime, Tensor,
+    TracedTensor, UnsupportedReason,
+};
+use tenferro_tensor::{TensorBackend, TensorRead};
+
+const IDENTITY_FAMILY: &str = "fixture.identity.v1";
+const SECOND_FAMILY: &str = "fixture.second.v1";
+
+macro_rules! identity_op {
+    ($name:ident, $family:expr) => {
+        #[derive(Clone, Debug)]
+        struct $name;
+
+        impl ExtensionOp for $name {
+            fn family_id(&self) -> &'static str {
+                $family
+            }
+
+            fn payload_hash(&self, state: &mut dyn std::hash::Hasher) {
+                state.write_u8(0);
+            }
+
+            fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+                other.as_any().is::<Self>()
+            }
+
+            fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+                Arc::new(self.clone())
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+
+            fn input_count(&self) -> usize {
+                1
+            }
+
+            fn output_count(&self) -> usize {
+                1
+            }
+
+            fn semantic_effects(&self) -> ExtensionEffectDeclaration<'_> {
+                ExtensionEffectDeclaration::Declared(&[])
+            }
+
+            fn semantic_aliases(&self) -> ExtensionAliasDeclaration<'_> {
+                ExtensionAliasDeclaration::AllFresh
+            }
+
+            fn infer_output_meta(
+                &self,
+                context: &mut ExtensionShapeContext<'_>,
+            ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+                Ok(vec![(
+                    context.input_dtype(0)?,
+                    context.input_shape(0)?.to_vec(),
+                )])
+            }
+        }
+    };
+}
+
+identity_op!(IdentityOp, IDENTITY_FAMILY);
+identity_op!(SecondOp, SECOND_FAMILY);
+// Reuse the registered family ID with a different payload type so dispatch
+// reaches the family's engine and returns its typed WrongOperationFamily error.
+identity_op!(WrongFamilyOp, IDENTITY_FAMILY);
+
+fn execute_identity<B: TensorBackend + 'static>(
+    _op: &IdentityOp,
+    inputs: &[TensorRead<'_>],
+    context: &mut ExtensionExecutionContext<'_, B>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    Ok(vec![context
+        .backend_mut()
+        .to_contiguous_read(inputs[0].clone())?])
+}
+
+fn execute_second<B: TensorBackend + 'static>(
+    _op: &SecondOp,
+    inputs: &[TensorRead<'_>],
+    context: &mut ExtensionExecutionContext<'_, B>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    Ok(vec![context
+        .backend_mut()
+        .to_contiguous_read(inputs[0].clone())?])
+}
+
+mod identity_runtime {
+    use super::*;
+
+    define_extension_runtime! {
+        runtime = IdentityRuntime,
+        family_id = IDENTITY_FAMILY,
+        op_type = IdentityOp,
+        execute_reads = execute_identity,
+    }
+}
+
+mod second_runtime {
+    use super::*;
+
+    define_extension_runtime! {
+        runtime = SecondRuntime,
+        family_id = SECOND_FAMILY,
+        op_type = SecondOp,
+        execute_reads = execute_second,
+    }
+}
+
+fn compile_op(
+    op: Arc<dyn ExtensionOp>,
+) -> tenferro_runtime::Result<tenferro_runtime::CompiledGraph> {
+    let input = TracedTensor::input_concrete_shape(DType::F64, &[2])?;
+    let output = apply(op, &[&input])?.remove(0);
+    let program =
+        GraphCompiler::new().compile_with_input_specs(&output, &[(&input, DType::F64, &[2])])?;
+    Ok(program)
+}
+
+fn has_missing_family(error: &(dyn StdError + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(source) = current {
+        if matches!(
+            source.downcast_ref::<PrepareError>(),
+            Some(PrepareError::Unsupported {
+                reason: UnsupportedReason::Operation {
+                    operation: IDENTITY_FAMILY,
+                },
+            })
+        ) {
+            return true;
+        }
+        current = source.source();
+    }
+    false
+}
+
+fn has_wrong_family(error: &(dyn StdError + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(source) = current {
+        if matches!(
+            source.downcast_ref::<PrepareError>(),
+            Some(PrepareError::ProviderContract {
+                source: ProviderContractError::WrongOperationFamily {
+                    expected: CoreCapabilityKind::Elementwise,
+                    operation: IDENTITY_FAMILY,
+                },
+            })
+        ) {
+            return true;
+        }
+        current = source.source();
+    }
+    false
+}
+
+fn main() -> Result<(), Box<dyn StdError>> {
+    let backend = CpuBackend::new();
+    let engine_id = tenferro_cpu::runtime_engine_id()?;
+    let mut builder = Runtime::builder();
+    builder.register_engine(tenferro_cpu::runtime_engine_registration(&backend)?)?;
+    builder.install_extension_module(identity_runtime::extension_module::<CpuBackend>(
+        engine_id.clone(),
+    )?)?;
+    builder.install_extension_module(second_runtime::extension_module::<CpuBackend>(engine_id)?)?;
+    let runtime = builder.build()?;
+
+    let program = compile_op(Arc::new(IdentityOp))?;
+    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
+    let output = runtime.run_compiled(&program, &[&input])?.remove(0);
+    assert_eq!(output.as_slice::<f64>()?, &[1.0, 2.0]);
+
+    let mut missing_builder = Runtime::builder();
+    missing_builder.register_engine(tenferro_cpu::runtime_engine_registration(&backend)?)?;
+    let missing = missing_builder
+        .build()?
+        .run_compiled(&program, &[&input])
+        .expect_err("an unregistered extension family must fail");
+    assert!(matches!(
+        missing,
+        Error::RuntimeStateSource { .. } | Error::Extension { .. }
+    ));
+    assert!(has_missing_family(&missing), "{missing:?}");
+
+    let wrong_family_program = compile_op(Arc::new(WrongFamilyOp))?;
+    let wrong_family = runtime
+        .run_compiled(&wrong_family_program, &[&input])
+        .expect_err("an engine receiving the wrong concrete family must fail");
+    assert!(has_wrong_family(&wrong_family), "{wrong_family:?}");
+
+    let mut erased_value = 7_u32;
+    let mismatch = ErasedExecutionContext::new(&mut erased_value)
+        .downcast_mut::<u64>(ExecutionContextIdentity::of::<u64>())
+        .expect_err("a wrong execution context must stay typed");
+    assert_eq!(
+        mismatch,
+        ExecutionContextMismatch {
+            expected: ExecutionContextIdentity::of::<u64>(),
+            actual: ExecutionContextIdentity::of::<u32>(),
+        }
+    );
+
+    Ok(())
+}

--- a/tests/run-extension-authoring-fixture.sh
+++ b/tests/run-extension-authoring-fixture.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+manifest="$root/tests/fixtures/extension-authoring/Cargo.toml"
+
+if grep -q 'tenferro-internal-' "$manifest"; then
+  echo "extension authoring fixture must not depend on tenferro-internal-* crates" >&2
+  exit 1
+fi
+
+cargo run --quiet --manifest-path "$manifest"


### PR DESCRIPTION
## Summary

Resolve the six accepted downstream gaps identified by the completed latticeqcd-rs port in one integrated change:

- publish `tenferro_runtime::extension` as the stable out-of-tree authoring facade, re-export the generated-runtime macro, and compile a workspace-external two-family fixture with no `tenferro-internal-*` dependency;
- make borrowed `TensorRead` host access the documented extension default, with zero-copy compact reads, explicit one-time noncompact materialization, and typed no-transfer rejection;
- add ordered multi-input traced `jvp_many` / `vjp_many` APIs backed by one semantic transform and one shared derivative graph;
- enforce semantic AD residual declarations through checked value accessors while keeping metadata-only access available;
- expose `RuntimeFailureReasonRef` for missing extensions, no-input-ingress, unsupported operations, and forward-compatible `Other` diagnostics;
- add session-scoped VDOT, norm-squared, and fused AXPBY contracts with CPU implementations, default typed `Unsupported` behavior elsewhere, allocation/alias tests, a Krylov microfixture, and a Criterion benchmark.

## Design and review

Design records:

- [`docs/design/extension-authoring-facade.md`](docs/design/extension-authoring-facade.md)
- [`docs/design/borrowed-extension-reads.md`](docs/design/borrowed-extension-reads.md)
- [`docs/design/multi-input-traced-ad.md`](docs/design/multi-input-traced-ad.md)
- [`docs/design/checked-semantic-ad-residual-access.md`](docs/design/checked-semantic-ad-residual-access.md)
- [`docs/design/structured-runtime-failure-reasons.md`](docs/design/structured-runtime-failure-reasons.md)
- [`docs/design/session-blas1.md`](docs/design/session-blas1.md)

Combined decisions, measurements, task-local design/diff review verdicts, and final cross-phase lane reports are recorded in [`docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md`](docs/worklogs/2026-08-19-issues-1708-1713-downstream-gaps.md).

Every issue design and completed diff received a read-only cross-model `reviewer-flash-opencode-go` **Correct-to-merge** verdict. The final six-lane audit and separate integration audit passed at exact final commit `8f7d9f775307a869f5ef48f8ef5fdb312e22c2ab` with no Critical, Important, or Minor findings. CUDA/XLA/multi-GPU execution remains a hardware-only, unaffected-by-diff limitation owned by hosted CI; the new BLAS-1 methods default to `Unsupported` and only CPU overrides them.

## Verification

Passed locally:

- `python3 scripts/ci/run_profile.py coverage` — 193/193 files pass; modified `semantic_extension.rs` 92.6%, `blas1.rs` 90.5%.
- `python3 scripts/ci/run_profile.py docs` — rustdoc, rendered docs site, faer tutorial, and BLAS tutorial pass.
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-cpu blas1'`.
- `bash tests/run-extension-authoring-fixture.sh`.
- standard AD/extension suites, nested sparse/tropical autodiff suites, release semantic residual tests, CPU/tensor suites, and provider-boundary allocation tests.
- cpu-faer, cpu-blas-only, and combined cpu-faer+cpu-blas checks.
- committed-head deterministic repository-rules review: pass (external LLM intentionally skipped with recorded reason).

BLAS-1 measurement highlights:

- 100 warmed compact 65,536-element fused AXPBY calls: cpu-faer 0 allocations / 0 bytes; cpu-blas one 1,520-byte provider bookkeeping allocation; neither allocates a full-vector temporary.
- Full Criterion 100-sample intervals are recorded in the worklog; fused AXPBY is 2.4–2.7x faster than the manual reference at 65,536 elements. Small-vector/session and multithread overhead are explicitly documented; no multithread speedup claim is made for the measured sizes.

Closes #1708
Closes #1709
Closes #1710
Closes #1711
Closes #1712
Closes #1713
