### PR TITLE
feat(cpu): add caller-managed external admission

### DIFF
--- a/crates/tenferro-ad/tests/ui/eager_backend_owner_private.stderr
+++ b/crates/tenferro-ad/tests/ui/eager_backend_owner_private.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `tenferro_ad::EagerBackend`
  --> tests/ui/eager_backend_owner_private.rs:1:5
   |
 1 | use tenferro_ad::EagerBackend;
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no `EagerBackend` in the root
+  |     ^^^^^^^^^^^^^------------
+  |                  |
+  |                  no `EagerBackend` in the root
   |
 help: a similar name exists in the module
   |

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -1,7 +1,7 @@
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::fmt;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 
 use thiserror::Error;
@@ -349,8 +349,10 @@ impl ResourceArbiter {
                     owner: waiter.owner,
                 });
                 return Ok(ResourcePermit {
-                    inner: Arc::clone(&self.inner),
-                    id,
+                    kind: ResourcePermitKind::Arbitrated {
+                        inner: Arc::clone(&self.inner),
+                        id,
+                    },
                     owner,
                     reentrant,
                 });
@@ -399,8 +401,10 @@ impl ResourceArbiter {
             .ok_or(ResourceArbiterError::RequestIdExhausted)?;
         state.active.push(ActiveRequest { id, request, owner });
         Ok(Some(ResourcePermit {
-            inner: Arc::clone(&self.inner),
-            id,
+            kind: ResourcePermitKind::Arbitrated {
+                inner: Arc::clone(&self.inner),
+                id,
+            },
             owner,
             reentrant,
         }))
@@ -442,14 +446,32 @@ impl ResourceArbiter {
     }
 }
 
+enum ResourcePermitKind {
+    Arbitrated { inner: Arc<ArbiterInner>, id: u64 },
+    CallerManaged { active: Arc<AtomicBool> },
+}
+
 pub(crate) struct ResourcePermit {
-    inner: Arc<ArbiterInner>,
-    id: u64,
+    kind: ResourcePermitKind,
     owner: ResourceOwner,
     reentrant: bool,
 }
 
 impl ResourcePermit {
+    pub(crate) fn caller_managed(active: Arc<AtomicBool>, owner: ResourceOwner) -> Self {
+        if active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            panic!("{BACKEND_REENTRY_PANIC}");
+        }
+        Self {
+            kind: ResourcePermitKind::CallerManaged { active },
+            owner,
+            reentrant: false,
+        }
+    }
+
     pub(crate) fn is_reentrant(&self) -> bool {
         self.reentrant
     }
@@ -461,27 +483,38 @@ impl ResourcePermit {
 
 impl fmt::Debug for ResourcePermit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ResourcePermit")
-            .field("id", &self.id)
-            .finish_non_exhaustive()
+        let mut permit = f.debug_struct("ResourcePermit");
+        match &self.kind {
+            ResourcePermitKind::Arbitrated { id, .. } => permit.field("id", id),
+            ResourcePermitKind::CallerManaged { .. } => {
+                permit.field("admission", &"caller-managed")
+            }
+        };
+        permit.finish_non_exhaustive()
     }
 }
 
 impl Drop for ResourcePermit {
     fn drop(&mut self) {
-        let mut state = self
-            .inner
-            .state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if let Some(position) = state.active.iter().position(|active| active.id == self.id) {
-            state.active.swap_remove(position);
+        match &self.kind {
+            ResourcePermitKind::Arbitrated { inner, id } => {
+                let mut state = inner
+                    .state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if let Some(position) = state.active.iter().position(|active| active.id == *id) {
+                    state.active.swap_remove(position);
+                }
+                // Always broadcast: the request-id-exhaustion recovery loop parks on
+                // the condvar WITHOUT a waiter-list entry (until active and waiters
+                // are both empty), so the waiter list cannot tell whether a thread is
+                // parked. Skipping here would risk stranding that recovery waiter.
+                inner.changed.notify_all();
+            }
+            ResourcePermitKind::CallerManaged { active } => {
+                active.store(false, Ordering::Release);
+            }
         }
-        // Always broadcast: the request-id-exhaustion recovery loop parks on
-        // the condvar WITHOUT a waiter-list entry (until active and waiters
-        // are both empty), so the waiter list cannot tell whether a thread is
-        // parked. Skipping here would risk stranding that recovery waiter.
-        self.inner.changed.notify_all();
     }
 }
 

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -13,7 +13,9 @@ use crate::arbiter::{
     ResourcePermit,
 };
 use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
-use crate::dot_runtime::{CpuProviderBundle, CpuProviderBundleInstallError};
+use crate::dot_runtime::{
+    CpuProviderBundle, CpuProviderBundleInstallError, CpuProviderDomainContract,
+};
 use crate::engine::{CpuEngine, EngineResources};
 use crate::indexed_plan_cache::{
     IndexedPlanCache, IndexedPlanCacheLimits, DEFAULT_INDEXED_PLAN_CACHE_LIMITS,
@@ -24,7 +26,7 @@ use crate::placement::{
 };
 use crate::provider::{CpuExecutionContext, CpuOperationEntry, ParallelMode};
 use crate::{
-    discover_cpu_topology, CpuDomainId, CpuDomainOwnership, CpuExecutorAffinity,
+    discover_cpu_topology, CpuAdmissionMode, CpuDomainId, CpuDomainOwnership, CpuExecutorAffinity,
     CpuExecutorShutdown, CpuId, CpuPlacement, CpuPlacementError, CpuPlacementGuarantee, CpuSet,
     CpuTopology, CpuTopologyError, ExternalCpuDomain, NumaNodeId, ResolvedCpuPlacement,
 };
@@ -314,6 +316,7 @@ impl CpuBackendKind {
 ///     mode,
 ///     CpuExecutionMode::Managed
 ///         | CpuExecutionMode::ExternalManaged
+///         | CpuExecutionMode::CallerManaged
 ///         | CpuExecutionMode::ProviderDefaultExclusive
 ///         | CpuExecutionMode::Compatibility
 /// ));
@@ -322,8 +325,10 @@ impl CpuBackendKind {
 pub enum CpuExecutionMode {
     /// tenferro owns a pinned Rayon engine for the resolved CPU placement.
     Managed,
-    /// The application supplied and owns the selected CPU domain executor.
+    /// The application supplied an executor with cooperative CPU-set admission.
     ExternalManaged,
+    /// The application supplied the executor and owns cross-domain admission.
+    CallerManaged,
     /// An external provider owns worker placement under a process-wide permit.
     ProviderDefaultExclusive,
     /// A legacy unpinned Rayon context is used because managed affinity is unavailable.
@@ -459,7 +464,8 @@ impl From<CpuBackendError> for crate::Error {
                 | CpuPlacementError::ManagedAffinityUnavailable { .. }
                 | CpuPlacementError::NumaDiscoveryUnavailable { .. }
                 | CpuPlacementError::UnknownNumaNode { .. }
-                | CpuPlacementError::UnregisteredExternalPlacement { .. } => {
+                | CpuPlacementError::UnregisteredExternalPlacement { .. }
+                | CpuPlacementError::UnregisteredExternalDomain { .. } => {
                     Self::runtime_state_source(op, source)
                 }
                 CpuPlacementError::ExternalProviderAffinityUnmanaged { .. } => {
@@ -496,10 +502,11 @@ pub struct CpuExecutionInfo {
     resolved_placement: Option<ResolvedCpuPlacement>,
     topology: CpuTopology,
     domain_id: CpuDomainId,
-    domain_cpus: CpuSet,
+    domain_cpus: Option<CpuSet>,
     worker_count: usize,
     thread_budget: usize,
-    placement_guarantee: CpuPlacementGuarantee,
+    placement_guarantee: Option<CpuPlacementGuarantee>,
+    admission_mode: CpuAdmissionMode,
     domain_ownership: CpuDomainOwnership,
     executor_affinity: CpuExecutorAffinity,
     executor_shutdown: CpuExecutorShutdown,
@@ -587,10 +594,12 @@ impl CpuExecutionInfo {
     ///
     /// ```
     /// let info = tenferro_cpu::CpuBackend::new().execution_info();
-    /// assert!(!info.domain_cpus().is_empty());
+    /// if let Some(cpus) = info.domain_cpus() {
+    ///     assert!(!cpus.is_empty());
+    /// }
     /// ```
-    pub fn domain_cpus(&self) -> &CpuSet {
-        &self.domain_cpus
+    pub fn domain_cpus(&self) -> Option<&CpuSet> {
+        self.domain_cpus.as_ref()
     }
 
     /// Return the worker count of the selected domain executor.
@@ -631,8 +640,22 @@ impl CpuExecutionInfo {
     ///     .placement_guarantee();
     /// let _ = format!("{guarantee:?}");
     /// ```
-    pub fn placement_guarantee(&self) -> CpuPlacementGuarantee {
+    pub fn placement_guarantee(&self) -> Option<CpuPlacementGuarantee> {
         self.placement_guarantee
+    }
+
+    /// Return the selected domain's admission contract.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::{CpuAdmissionMode, CpuBackend};
+    ///
+    /// let mode: CpuAdmissionMode = CpuBackend::new().execution_info().admission_mode();
+    /// assert_eq!(mode, CpuAdmissionMode::CooperativeCpuSet);
+    /// ```
+    pub fn admission_mode(&self) -> CpuAdmissionMode {
+        self.admission_mode
     }
 
     /// Return whether tenferro or the application owns the selected domain.
@@ -694,8 +717,18 @@ impl CpuExecutionInfo {
     }
 }
 
-fn provider_diagnostic(kind: CpuBackendKind, ownership: CpuDomainOwnership) -> &'static str {
+fn provider_diagnostic(
+    kind: CpuBackendKind,
+    ownership: CpuDomainOwnership,
+    admission_mode: CpuAdmissionMode,
+) -> &'static str {
     if ownership == CpuDomainOwnership::ExternalManaged {
+        if admission_mode == CpuAdmissionMode::CallerManaged {
+            // INVARIANT: public caller-managed constructors validate and select
+            // CpuBackendKind::Faer before building the external registry.
+            debug_assert_eq!(kind, CpuBackendKind::Faer);
+            return "faer (caller-managed CPU executor and admission)";
+        }
         return match kind {
             CpuBackendKind::Faer => "faer (externally managed CPU executor)",
             CpuBackendKind::Blas => "BLAS/LAPACK (externally managed CPU executor)",
@@ -951,6 +984,20 @@ impl CpuBackendState {
             .ok_or(CpuPlacementError::UnregisteredExternalPlacement { requested })
     }
 
+    fn external_engine_for_id(
+        &self,
+        domain: CpuDomainId,
+    ) -> Result<Arc<CpuEngine>, CpuPlacementError> {
+        let CpuEngineRegistry::ExternalPrebuilt(registry) = &self.engines else {
+            return Err(CpuPlacementError::UnregisteredExternalDomain { domain });
+        };
+        registry
+            .by_id
+            .get(&domain)
+            .cloned()
+            .ok_or(CpuPlacementError::UnregisteredExternalDomain { domain })
+    }
+
     fn is_external(&self) -> bool {
         matches!(&self.engines, CpuEngineRegistry::ExternalPrebuilt(_))
     }
@@ -1080,6 +1127,42 @@ fn resolve_discovered_topology(
         backend: kind,
         source,
     })
+}
+
+fn external_engine_resolution(
+    engine: &CpuEngine,
+    requested: CpuPlacement,
+    kind: CpuBackendKind,
+) -> Result<ResolvedCpuExecution, CpuPlacementError> {
+    match engine.domain().admission_mode() {
+        CpuAdmissionMode::CooperativeCpuSet => engine
+            .placement()
+            .cloned()
+            .map(ResolvedCpuExecution::ExternalManaged)
+            .ok_or(CpuPlacementError::InternalState {
+                requested,
+                backend: kind,
+                message: "cooperative external domain has no placement",
+            }),
+        CpuAdmissionMode::CallerManaged => Ok(ResolvedCpuExecution::ExternalCallerManaged),
+    }
+}
+
+fn external_domain_backend_kind(
+    op: &'static str,
+    domains: &[ExternalCpuDomain],
+) -> Result<CpuBackendKind, CpuBackendError> {
+    let kind = if domains
+        .iter()
+        .any(|domain| domain.admission_mode() == CpuAdmissionMode::CallerManaged)
+    {
+        CpuBackendKind::Faer
+    } else {
+        CpuBackendKind::default_compiled()
+    };
+    ensure_cpu_backend_kind_available(kind, op)
+        .map_err(|error| constructor_tensor_error(op, error))?;
+    Ok(kind)
 }
 
 fn coordinator_node_domain_ids(topology: &CpuTopology) -> BTreeMap<NumaNodeId, CpuDomainId> {
@@ -1336,7 +1419,8 @@ impl CpuBackend {
         domains: impl IntoIterator<Item = ExternalCpuDomain>,
     ) -> Result<Self, CpuBackendError> {
         let op = "CpuBackend::from_external_managed_domains";
-        let kind = CpuBackendKind::default_compiled();
+        let domains: Vec<_> = domains.into_iter().collect();
+        let kind = external_domain_backend_kind(op, &domains)?;
         let topology = resolve_discovered_topology(kind, discover_cpu_topology())
             .map_err(|source| CpuBackendError::placement(op, source))?;
         Self::from_external_managed_domains_with_topology_arbiter_and_provider_bundle(
@@ -1344,6 +1428,7 @@ impl CpuBackend {
             domains,
             topology,
             ResourceArbiter::global(),
+            kind,
             CpuProviderBundle::standard(kind, false),
         )
     }
@@ -1408,7 +1493,8 @@ impl CpuBackend {
         provider_bundle: CpuProviderBundle,
     ) -> Result<Self, CpuBackendError> {
         let op = "CpuBackend::from_external_managed_domains_with_provider_bundle";
-        let kind = CpuBackendKind::default_compiled();
+        let domains: Vec<_> = domains.into_iter().collect();
+        let kind = external_domain_backend_kind(op, &domains)?;
         let topology = resolve_discovered_topology(kind, discover_cpu_topology())
             .map_err(|source| CpuBackendError::placement(op, source))?;
         Self::from_external_managed_domains_with_topology_arbiter_and_provider_bundle(
@@ -1416,6 +1502,7 @@ impl CpuBackend {
             domains,
             topology,
             ResourceArbiter::global(),
+            kind,
             provider_bundle,
         )
     }
@@ -1425,6 +1512,7 @@ impl CpuBackend {
         domains: impl IntoIterator<Item = ExternalCpuDomain>,
         topology: CpuTopology,
         arbiter: ResourceArbiter,
+        kind: CpuBackendKind,
         provider_bundle: CpuProviderBundle,
     ) -> Result<Self, CpuBackendError> {
         let domains: Vec<_> = domains.into_iter().collect();
@@ -1441,70 +1529,72 @@ impl CpuBackend {
                     ExternalCpuDomainRegistryError::DuplicateDomainId { id: domain.id() }.into(),
                 );
             }
-            match domain.placement() {
-                ResolvedCpuPlacement::NumaNode { id, .. } => {
-                    if !node_ids.insert(*id) {
-                        return Err(ExternalCpuDomainRegistryError::DuplicatePlacementIdentity {
-                            placement: CpuPlacement::NumaNode(*id),
+            if let Some(placement) = domain.placement() {
+                match placement {
+                    ResolvedCpuPlacement::NumaNode { id, .. } => {
+                        if !node_ids.insert(*id) {
+                            return Err(
+                                ExternalCpuDomainRegistryError::DuplicatePlacementIdentity {
+                                    placement: CpuPlacement::NumaNode(*id),
+                                }
+                                .into(),
+                            );
                         }
-                        .into());
+                    }
+                    ResolvedCpuPlacement::AllAllowed { cpus } => {
+                        if has_all_allowed {
+                            return Err(
+                                ExternalCpuDomainRegistryError::DuplicatePlacementIdentity {
+                                    placement: CpuPlacement::AllAllowed,
+                                }
+                                .into(),
+                            );
+                        }
+                        has_all_allowed = true;
+                        if domain.placement_guarantee()
+                            == Some(CpuPlacementGuarantee::ExactDeclared)
+                            && cpus != topology.allowed_cpus()
+                        {
+                            return Err(ExternalCpuDomainRegistryError::ExactAllAllowedMismatch {
+                                domain: domain.id(),
+                                declared: cpus.clone(),
+                                allowed: topology.allowed_cpus().clone(),
+                            }
+                            .into());
+                        }
                     }
                 }
-                ResolvedCpuPlacement::AllAllowed { cpus } => {
-                    if has_all_allowed {
-                        return Err(ExternalCpuDomainRegistryError::DuplicatePlacementIdentity {
-                            placement: CpuPlacement::AllAllowed,
-                        }
-                        .into());
+                if let Some(cpu) = placement
+                    .cpus()
+                    .as_slice()
+                    .iter()
+                    .copied()
+                    .find(|cpu| !topology.allowed_cpus().contains(*cpu))
+                {
+                    return Err(ExternalCpuDomainRegistryError::CpuOutsideAllowedSet {
+                        domain: domain.id(),
+                        cpu,
                     }
-                    has_all_allowed = true;
-                    if domain.placement_guarantee() == CpuPlacementGuarantee::ExactDeclared
-                        && cpus != topology.allowed_cpus()
-                    {
-                        return Err(ExternalCpuDomainRegistryError::ExactAllAllowedMismatch {
-                            domain: domain.id(),
-                            declared: cpus.clone(),
-                            allowed: topology.allowed_cpus().clone(),
-                        }
-                        .into());
-                    }
+                    .into());
                 }
             }
-            if let Some(cpu) = domain
-                .cpus()
-                .as_slice()
-                .iter()
-                .copied()
-                .find(|cpu| !topology.allowed_cpus().contains(*cpu))
-            {
-                return Err(ExternalCpuDomainRegistryError::CpuOutsideAllowedSet {
-                    domain: domain.id(),
-                    cpu,
-                }
-                .into());
-            }
         }
-        if !domain_ids.contains(&default_domain) {
-            return Err(
-                ExternalCpuDomainRegistryError::MissingDefaultDomain { default_domain }.into(),
-            );
-        }
-
         let buffer_limit = crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES;
         let mut by_id = BTreeMap::new();
         let mut by_node = BTreeMap::new();
         let mut all_allowed = None;
         for domain in domains {
             let id = domain.id();
-            let placement = domain.placement().clone();
+            let placement = domain.placement().cloned();
             let engine = Arc::new(CpuEngine::from_external(domain, buffer_limit));
             match placement {
-                ResolvedCpuPlacement::NumaNode { id, .. } => {
+                Some(ResolvedCpuPlacement::NumaNode { id, .. }) => {
                     by_node.insert(id, Arc::clone(&engine));
                 }
-                ResolvedCpuPlacement::AllAllowed { .. } => {
+                Some(ResolvedCpuPlacement::AllAllowed { .. }) => {
                     all_allowed = Some(Arc::clone(&engine));
                 }
+                None => {}
             }
             by_id.insert(id, engine);
         }
@@ -1513,8 +1603,21 @@ impl CpuBackend {
                 ExternalCpuDomainRegistryError::MissingDefaultDomain { default_domain }.into(),
             );
         };
-        let resolved = ResolvedCpuExecution::ExternalManaged(engine.placement().clone());
-        let kind = CpuBackendKind::default_compiled();
+        let resolved = match engine.domain().admission_mode() {
+            CpuAdmissionMode::CooperativeCpuSet => ResolvedCpuExecution::ExternalManaged(
+                engine.placement().cloned().ok_or_else(|| {
+                    CpuBackendError::placement(
+                        "CpuBackend external domain resolution",
+                        CpuPlacementError::InternalState {
+                            requested: CpuPlacement::Auto,
+                            backend: kind,
+                            message: "cooperative external domain has no placement",
+                        },
+                    )
+                })?,
+            ),
+            CpuAdmissionMode::CallerManaged => ResolvedCpuExecution::ExternalCallerManaged,
+        };
         let backend = Self {
             runtime_identity: CpuRuntimeIdentity::fresh(),
             shared: Arc::new(CpuBackendState {
@@ -1755,6 +1858,46 @@ impl CpuBackend {
         )
     }
 
+    /// Select a registered externally managed domain by stable identity.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::num::NonZeroUsize;
+    /// use std::sync::Arc;
+    /// use tenferro_cpu::{CpuBackend, ExternalCpuDomain, RayonCpuDomainExecutor};
+    /// use tenferro_tensor::CpuDomainId;
+    ///
+    /// let pool = Arc::new(rayon::ThreadPoolBuilder::new().num_threads(1).build()?);
+    /// let id = CpuDomainId::new(5);
+    /// let domain = ExternalCpuDomain::new_caller_managed(
+    ///     id,
+    ///     Arc::new(RayonCpuDomainExecutor::new(pool)),
+    ///     NonZeroUsize::MIN,
+    /// )?;
+    /// let backend = CpuBackend::from_external_managed_domains(id, [domain])?;
+    /// assert_eq!(backend.for_domain(id)?.execution_info().domain_id(), id);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuPlacementError::UnregisteredExternalDomain`] when this is not
+    /// an external coordinator or `domain` is not registered.
+    pub fn for_domain(&self, domain: CpuDomainId) -> Result<Self, CpuPlacementError> {
+        let engine = self.shared.external_engine_for_id(domain)?;
+        let resolved = external_engine_resolution(&engine, CpuPlacement::Auto, self.kind())?;
+        Ok(Self {
+            runtime_identity: CpuRuntimeIdentity::fresh(),
+            shared: Arc::clone(&self.shared),
+            requested: CpuPlacement::Auto,
+            resolved,
+            engine,
+            provider_bundle: self.provider_bundle.clone(),
+            allocation_domain: self.allocation_domain.clone(),
+        })
+    }
+
     fn for_placement_with_affinity(
         &self,
         requested: CpuPlacement,
@@ -1762,11 +1905,12 @@ impl CpuBackend {
     ) -> Result<Self, CpuPlacementError> {
         if self.shared.is_external() {
             let engine = self.shared.external_engine_for(requested)?;
+            let resolved = external_engine_resolution(&engine, requested, self.kind())?;
             return Ok(Self {
                 runtime_identity: CpuRuntimeIdentity::fresh(),
                 shared: Arc::clone(&self.shared),
                 requested,
-                resolved: ResolvedCpuExecution::ExternalManaged(engine.placement().clone()),
+                resolved,
                 engine,
                 provider_bundle: self.provider_bundle.clone(),
                 allocation_domain: self.allocation_domain.clone(),
@@ -1791,7 +1935,8 @@ impl CpuBackend {
         }
         let engine_placement = match &resolved {
             ResolvedCpuExecution::Managed(placement) => placement.clone(),
-            ResolvedCpuExecution::ExternalManaged(_) => {
+            ResolvedCpuExecution::ExternalManaged(_)
+            | ResolvedCpuExecution::ExternalCallerManaged => {
                 return Err(CpuPlacementError::InternalState {
                     requested,
                     backend: self.kind(),
@@ -1859,6 +2004,7 @@ impl CpuBackend {
             ResolvedCpuExecution::Managed(placement)
             | ResolvedCpuExecution::ExternalManaged(placement) => Some(placement),
             ResolvedCpuExecution::Compatibility
+            | ResolvedCpuExecution::ExternalCallerManaged
             | ResolvedCpuExecution::ProviderDefaultExclusive => None,
         }
     }
@@ -1905,19 +2051,22 @@ impl CpuBackend {
         let domain = self.engine.domain();
         let capabilities = domain.executor_capabilities();
         let (executor_affinity, executor_shutdown) =
-            if domain.ownership() == CpuDomainOwnership::ExternalManaged {
-                (
+            match (domain.ownership(), domain.admission_mode()) {
+                (CpuDomainOwnership::ExternalManaged, CpuAdmissionMode::CooperativeCpuSet) => (
                     CpuExecutorAffinity::CallerDeclaredUnverified,
                     CpuExecutorShutdown::CallerOwned,
-                )
-            } else {
-                (capabilities.affinity, capabilities.shutdown)
+                ),
+                (CpuDomainOwnership::ExternalManaged, CpuAdmissionMode::CallerManaged) => {
+                    (capabilities.affinity, CpuExecutorShutdown::CallerOwned)
+                }
+                (CpuDomainOwnership::Managed, _) => (capabilities.affinity, capabilities.shutdown),
             };
         CpuExecutionInfo {
             backend_kind: self.kind(),
             execution_mode: match &self.resolved {
                 ResolvedCpuExecution::Managed(_) => CpuExecutionMode::Managed,
                 ResolvedCpuExecution::ExternalManaged(_) => CpuExecutionMode::ExternalManaged,
+                ResolvedCpuExecution::ExternalCallerManaged => CpuExecutionMode::CallerManaged,
                 ResolvedCpuExecution::ProviderDefaultExclusive => {
                     CpuExecutionMode::ProviderDefaultExclusive
                 }
@@ -1927,14 +2076,19 @@ impl CpuBackend {
             resolved_placement: self.resolved_placement().cloned(),
             topology: self.shared.topology.clone(),
             domain_id: domain.id(),
-            domain_cpus: domain.cpus().clone(),
+            domain_cpus: domain.cpus().cloned(),
             worker_count: capabilities.worker_count.get(),
             thread_budget: domain.thread_budget().get(),
             placement_guarantee: domain.placement_guarantee(),
+            admission_mode: domain.admission_mode(),
             domain_ownership: domain.ownership(),
             executor_affinity,
             executor_shutdown,
-            provider_diagnostic: provider_diagnostic(self.kind(), domain.ownership()),
+            provider_diagnostic: provider_diagnostic(
+                self.kind(),
+                domain.ownership(),
+                domain.admission_mode(),
+            ),
         }
     }
 
@@ -2017,13 +2171,20 @@ impl CpuBackend {
         let allowed = self.shared.topology.allowed_cpus();
         let validate_engine = |engine: &CpuEngine| {
             let domain = engine.domain();
-            bundle.validate_for_domain(
-                domain.id(),
-                domain.thread_budget(),
-                domain.placement_guarantee(),
-                domain.cpus(),
-                allowed,
-            )
+            let contract = match (domain.placement_guarantee(), domain.cpus()) {
+                (Some(placement_guarantee), Some(domain_cpus)) => {
+                    CpuProviderDomainContract::CooperativeCpuSet {
+                        placement_guarantee,
+                        domain_cpus,
+                        process_allowed_cpus: allowed,
+                    }
+                }
+                (None, None) => CpuProviderDomainContract::CallerManaged,
+                // INVARIANT: CpuResourceDomain stores placement and guarantee in
+                // the same admission enum variant, so their optionality matches.
+                _ => unreachable!("CPU domain placement and guarantee must match"),
+            };
+            bundle.validate_for_domain(domain.id(), domain.thread_budget(), contract)
         };
 
         match &self.shared.engines {
@@ -2050,9 +2211,11 @@ impl CpuBackend {
                     bundle.validate_for_domain(
                         domain_id,
                         budget,
-                        CpuPlacementGuarantee::ExactDeclared,
-                        node.cpus(),
-                        allowed,
+                        CpuProviderDomainContract::CooperativeCpuSet {
+                            placement_guarantee: CpuPlacementGuarantee::ExactDeclared,
+                            domain_cpus: node.cpus(),
+                            process_allowed_cpus: allowed,
+                        },
                     )?;
                 }
             }
@@ -2685,6 +2848,18 @@ impl CpuBackend {
                 .shared
                 .arbiter
                 .acquire_recovering(placement.cpus().clone(), owner),
+            ResolvedCpuExecution::ExternalCallerManaged => {
+                // INVARIANT: this resolved mode is created only from a domain
+                // whose admission variant owns the matching active-entry flag.
+                let active = self
+                    .engine
+                    .domain()
+                    .caller_managed_active()
+                    .unwrap_or_else(|| {
+                        unreachable!("caller-managed execution needs a local admission guard")
+                    });
+                ResourcePermit::caller_managed(active, owner)
+            }
             ResolvedCpuExecution::Compatibility => self
                 .shared
                 .arbiter
@@ -2705,6 +2880,7 @@ impl CpuBackend {
             | ResolvedCpuExecution::ExternalManaged(placement) => {
                 self.shared.arbiter.try_acquire(placement.cpus().clone())
             }
+            ResolvedCpuExecution::ExternalCallerManaged => Ok(None),
             ResolvedCpuExecution::Compatibility => self
                 .shared
                 .arbiter

--- a/crates/tenferro-cpu/src/backend/tests/external_managed.rs
+++ b/crates/tenferro-cpu/src/backend/tests/external_managed.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -291,6 +292,7 @@ fn external_constructor_rejects_an_initial_incompatible_bundle_atomically() {
             [domain],
             topology([0, 1, 2, 3]),
             ResourceArbiter::new(),
+            CpuBackendKind::Faer,
             bundle_with_gemm_capabilities(controlled_external_capabilities()),
         )
         .unwrap_err();
@@ -337,6 +339,7 @@ fn external_constructor_accepts_the_initial_standard_faer_bundle() {
             )],
             topology([0, 1, 2, 3]),
             ResourceArbiter::new(),
+            CpuBackendKind::Faer,
             bundle.clone(),
         )
         .unwrap();
@@ -360,6 +363,7 @@ fn external_constructor_rejects_the_initial_uncontrolled_standard_blas_bundle() 
             )],
             topology([0, 1]),
             ResourceArbiter::new(),
+            CpuBackendKind::Blas,
             CpuProviderBundle::standard(CpuBackendKind::Blas, false),
         )
         .unwrap_err();
@@ -454,13 +458,13 @@ fn external_diagnostics_distinguish_worker_count_and_thread_budget() {
     assert_eq!(info.execution_mode(), CpuExecutionMode::ExternalManaged);
     assert_eq!(info.domain_id(), CpuDomainId::new(17));
     assert_eq!(info.resolved_placement(), Some(&placement));
-    assert_eq!(info.domain_cpus(), placement.cpus());
+    assert_eq!(info.domain_cpus(), Some(placement.cpus()));
     assert_eq!(info.worker_count(), 3);
     assert_eq!(info.thread_budget(), 2);
     assert_eq!(backend.num_threads(), 2);
     assert_eq!(
         info.placement_guarantee(),
-        CpuPlacementGuarantee::AdvisoryDeclared
+        Some(CpuPlacementGuarantee::AdvisoryDeclared)
     );
     assert_eq!(info.domain_ownership(), CpuDomainOwnership::ExternalManaged);
     assert_eq!(
@@ -1183,6 +1187,229 @@ fn external_prebuilt_engines_are_counted_once_by_buffer_controls() {
     }
 }
 
+#[cfg(not(feature = "cpu-faer"))]
+#[test]
+fn caller_managed_public_constructor_requires_faer_before_backend_construction() {
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap(),
+    );
+    let domain = caller_managed_domain(20, pool, 1);
+    let error =
+        CpuBackend::from_external_managed_domains(CpuDomainId::new(20), [domain]).unwrap_err();
+    assert!(matches!(error, CpuBackendError::Tensor(_)));
+    assert!(error.to_string().contains("cpu-faer"));
+}
+
+#[test]
+fn caller_managed_same_pool_entry_uses_only_the_declared_rayon_team() {
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .thread_name(|index| format!("caller-managed-a-{index}"))
+            .build()
+            .unwrap(),
+    );
+    let weak_pool = Arc::downgrade(&pool);
+    let domain = ExternalCpuDomain::new_caller_managed(
+        CpuDomainId::new(21),
+        Arc::new(crate::RayonCpuDomainExecutor::new(Arc::clone(&pool))),
+        NonZeroUsize::new(2).unwrap(),
+    )
+    .unwrap();
+    let mut backend = external_backend(CpuDomainId::new(21), [domain], topology([0])).unwrap();
+
+    let names = Arc::new(std::sync::Mutex::new(BTreeSet::new()));
+    let observed = Arc::clone(&names);
+    pool.install(|| {
+        backend
+            .with_linalg_pool(|context, _| {
+                assert_eq!(context.thread_budget().get(), 2);
+                assert_eq!(context.admission_mode(), CpuAdmissionMode::CallerManaged);
+                assert!(context.cpus().is_none());
+                context.with_native_parallelism(|| {
+                    rayon::broadcast(|_| {
+                        observed
+                            .lock()
+                            .unwrap()
+                            .insert(std::thread::current().name().unwrap_or("").to_owned());
+                    });
+                });
+                Ok(())
+            })
+            .unwrap();
+    });
+
+    let names = names.lock().unwrap();
+    assert_eq!(names.len(), 2);
+    assert!(names
+        .iter()
+        .all(|name| name.starts_with("caller-managed-a-")));
+    drop(names);
+    drop(pool);
+    assert!(weak_pool.upgrade().is_some());
+    drop(backend);
+    assert!(weak_pool.upgrade().is_none());
+}
+
+#[test]
+fn distinct_caller_managed_domains_overlap_and_select_by_id() {
+    let pool_a = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap(),
+    );
+    let pool_b = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap(),
+    );
+    let domains = [
+        caller_managed_domain(31, Arc::clone(&pool_a), 1),
+        caller_managed_domain(32, Arc::clone(&pool_b), 1),
+    ];
+    let mut backend_a = external_backend(CpuDomainId::new(31), domains, topology([0])).unwrap();
+    let mut backend_b = backend_a.for_domain(CpuDomainId::new(32)).unwrap();
+    assert_eq!(
+        backend_a.execution_info().execution_mode(),
+        CpuExecutionMode::CallerManaged
+    );
+    assert_eq!(backend_b.execution_info().domain_id(), CpuDomainId::new(32));
+    assert!(backend_a.execution_info().resolved_placement().is_none());
+    assert!(backend_b.execution_info().domain_cpus().is_none());
+    assert_eq!(
+        backend_a.execution_info().executor_affinity(),
+        CpuExecutorAffinity::None
+    );
+    assert_eq!(
+        backend_a.execution_info().executor_shutdown(),
+        CpuExecutorShutdown::CallerOwned
+    );
+
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_a_tx, release_a_rx) = mpsc::channel();
+    let (release_b_tx, release_b_rx) = mpsc::channel();
+    let first = std::thread::spawn(move || {
+        backend_a
+            .with_linalg_pool(move |_, _| {
+                entered_tx.send(31).unwrap();
+                release_a_rx.recv().unwrap();
+                Ok(())
+            })
+            .unwrap();
+    });
+    let entered_tx = entered_rx;
+    let (second_entered_tx, second_entered_rx) = mpsc::channel();
+    let second = std::thread::spawn(move || {
+        backend_b
+            .with_linalg_pool(move |_, _| {
+                second_entered_tx.send(32).unwrap();
+                release_b_rx.recv().unwrap();
+                Ok(())
+            })
+            .unwrap();
+    });
+
+    let first_id = entered_tx.recv_timeout(Duration::from_secs(2));
+    let second_id = second_entered_rx.recv_timeout(Duration::from_secs(2));
+    release_a_tx.send(()).unwrap();
+    release_b_tx.send(()).unwrap();
+    first.join().unwrap();
+    second.join().unwrap();
+    assert_eq!(first_id.unwrap(), 31);
+    assert_eq!(second_id.unwrap(), 32);
+}
+
+#[test]
+fn caller_managed_public_reentry_is_rejected_and_unwind_releases_admission() {
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .build()
+            .unwrap(),
+    );
+    let domain = caller_managed_domain(41, Arc::clone(&pool), 2);
+    let mut backend = external_backend(CpuDomainId::new(41), [domain], topology([0])).unwrap();
+    let mut nested = backend.clone();
+
+    backend
+        .with_linalg_pool(|_, _| {
+            let (result_tx, result_rx) = mpsc::channel();
+            rayon::scope(|scope| {
+                scope.spawn(move |_| {
+                    let rejected = catch_unwind(AssertUnwindSafe(|| {
+                        nested.with_linalg_pool(|_, _| Ok(())).unwrap();
+                    }))
+                    .is_err();
+                    result_tx.send(rejected).unwrap();
+                });
+            });
+            assert!(result_rx.recv().unwrap());
+            Ok(())
+        })
+        .unwrap();
+
+    let panic = catch_unwind(AssertUnwindSafe(|| {
+        backend
+            .with_linalg_pool(|_, _| -> crate::Result<()> { panic!("fixture unwind") })
+            .unwrap();
+    }));
+    assert!(panic.is_err());
+    backend.with_linalg_pool(|_, _| Ok(())).unwrap();
+}
+
+#[test]
+fn caller_managed_constructor_rejects_external_provider_workers_before_execution() {
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .build()
+            .unwrap(),
+    );
+    let domain = caller_managed_domain(51, pool, 2);
+    let error =
+        CpuBackend::from_external_managed_domains_with_topology_arbiter_and_provider_bundle(
+            CpuDomainId::new(51),
+            [domain],
+            topology([0]),
+            ResourceArbiter::new(),
+            CpuBackendKind::Faer,
+            bundle_with_gemm_capabilities(controlled_external_capabilities()),
+        )
+        .unwrap_err();
+
+    let CpuBackendError::Tensor(error) = error else {
+        panic!("caller-managed provider rejection must retain the typed tensor wrapper");
+    };
+    let source = std::error::Error::source(&error)
+        .and_then(|source| source.downcast_ref::<CpuProviderBundleInstallError>())
+        .unwrap();
+    assert!(matches!(
+        source,
+        CpuProviderBundleInstallError::IncompatibleDomain {
+            source: crate::CpuProviderDomainError::CallerManagedPlacementNotEnforceable { .. },
+            ..
+        }
+    ));
+}
+
+fn caller_managed_domain(
+    id: u64,
+    pool: Arc<rayon::ThreadPool>,
+    thread_budget: usize,
+) -> ExternalCpuDomain {
+    ExternalCpuDomain::new_caller_managed(
+        CpuDomainId::new(id),
+        Arc::new(crate::RayonCpuDomainExecutor::new(pool)),
+        NonZeroUsize::new(thread_budget).unwrap(),
+    )
+    .unwrap()
+}
+
 fn external_backend(
     default_domain: CpuDomainId,
     domains: impl IntoIterator<Item = ExternalCpuDomain>,
@@ -1193,6 +1420,7 @@ fn external_backend(
         domains,
         topology,
         ResourceArbiter::new(),
+        CpuBackendKind::Faer,
         CpuProviderBundle::standard(CpuBackendKind::Faer, false),
     )
 }

--- a/crates/tenferro-cpu/src/domain_executor.rs
+++ b/crates/tenferro-cpu/src/domain_executor.rs
@@ -1,6 +1,9 @@
 use std::fmt::Debug;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use rayon::prelude::*;
 
 /// Inner parallel-region support offered by a CPU domain executor.
 ///
@@ -450,6 +453,84 @@ pub trait CpuDomainExecutor: Debug + Send + Sync + 'static {
     /// [`CpuDomainExecutorError::Cancellation`], or
     /// [`CpuDomainExecutorError::PanicBridge`] for executor-owned failures.
     fn install(&self, job: &mut dyn ScopedCpuJob) -> Result<(), CpuDomainExecutorError>;
+}
+
+/// Adapter that executes CPU-domain jobs on one caller-owned Rayon pool.
+///
+/// The adapter retains the supplied pool and never creates, reconfigures, or
+/// shuts it down. [`CpuDomainExecutor`] remains the primary injection contract;
+/// this type is only a convenience for Rayon hosts.
+///
+/// # Examples
+///
+/// ```rust
+/// use std::sync::Arc;
+/// use tenferro_cpu::{CpuDomainExecutor, RayonCpuDomainExecutor};
+///
+/// let pool = Arc::new(rayon::ThreadPoolBuilder::new().num_threads(2).build()?);
+/// let executor = RayonCpuDomainExecutor::new(Arc::clone(&pool));
+/// assert_eq!(executor.capabilities().worker_count.get(), 2);
+/// assert_eq!(Arc::strong_count(&pool), 2);
+/// # Ok::<(), rayon::ThreadPoolBuildError>(())
+/// ```
+pub struct RayonCpuDomainExecutor {
+    pool: Arc<rayon::ThreadPool>,
+}
+
+impl std::fmt::Debug for RayonCpuDomainExecutor {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RayonCpuDomainExecutor")
+            .field("worker_count", &self.pool.current_num_threads())
+            .finish_non_exhaustive()
+    }
+}
+
+impl RayonCpuDomainExecutor {
+    /// Retain one caller-owned Rayon pool as a CPU-domain executor.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::sync::Arc;
+    /// use tenferro_cpu::{CpuDomainExecutor, RayonCpuDomainExecutor};
+    ///
+    /// let pool = Arc::new(rayon::ThreadPoolBuilder::new().num_threads(2).build()?);
+    /// let executor = RayonCpuDomainExecutor::new(pool);
+    /// assert_eq!(executor.capabilities().worker_count.get(), 2);
+    /// # Ok::<(), rayon::ThreadPoolBuildError>(())
+    /// ```
+    pub fn new(pool: Arc<rayon::ThreadPool>) -> Self {
+        Self { pool }
+    }
+}
+
+impl CpuDomainExecutor for RayonCpuDomainExecutor {
+    fn capabilities(&self) -> CpuDomainExecutorCapabilities {
+        // INVARIANT: Rayon rejects thread pools with zero workers.
+        let worker_count =
+            NonZeroUsize::new(self.pool.current_num_threads()).unwrap_or(NonZeroUsize::MIN);
+        CpuDomainExecutorCapabilities {
+            worker_count,
+            outer_parallelism: worker_count.get() > 1,
+            inner_parallelism: CpuInnerParallelism::Rayon,
+            reentrancy: CpuExecutorReentrancy::SameExecutor,
+            affinity: CpuExecutorAffinity::None,
+            shutdown: CpuExecutorShutdown::CallerOwned,
+        }
+    }
+
+    fn submit(&self, jobs: &dyn ScopedCpuJobs) -> Result<(), CpuDomainExecutorError> {
+        self.pool.install(|| {
+            (0..jobs.len())
+                .into_par_iter()
+                .try_for_each(|index| jobs.run(index))
+        })
+    }
+
+    fn install(&self, job: &mut dyn ScopedCpuJob) -> Result<(), CpuDomainExecutorError> {
+        self.pool.install(|| job.run())
+    }
 }
 
 pub(crate) struct ScopedJob<F, R> {

--- a/crates/tenferro-cpu/src/domain_executor/tests.rs
+++ b/crates/tenferro-cpu/src/domain_executor/tests.rs
@@ -1,5 +1,7 @@
+use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use super::*;
 
@@ -97,6 +99,42 @@ fn outer_submission_is_synchronous_and_indexed() {
     executor.submit(&jobs).unwrap();
 
     assert_eq!(seen.map(|value| value.load(Ordering::Relaxed)), [1, 1]);
+}
+
+#[test]
+fn caller_owned_rayon_adapter_uses_only_the_supplied_pool_for_install_and_submit() {
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .thread_name(|index| format!("caller-adapter-{index}"))
+            .build()
+            .unwrap(),
+    );
+    let executor = RayonCpuDomainExecutor::new(Arc::clone(&pool));
+
+    let installed_name = pool.install(|| {
+        install_scoped(&executor, || {
+            std::thread::current().name().unwrap_or("").to_owned()
+        })
+        .unwrap()
+    });
+    assert!(installed_name.starts_with("caller-adapter-"));
+
+    let names = Arc::new(Mutex::new(BTreeSet::new()));
+    let observed = Arc::clone(&names);
+    let jobs = indexed_jobs(64, move |_| {
+        observed
+            .lock()
+            .unwrap()
+            .insert(std::thread::current().name().unwrap_or("").to_owned());
+        Ok(())
+    });
+    executor.submit(&jobs).unwrap();
+    assert!(names
+        .lock()
+        .unwrap()
+        .iter()
+        .all(|name| name.starts_with("caller-adapter-")));
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/dot_runtime.rs
+++ b/crates/tenferro-cpu/src/dot_runtime.rs
@@ -198,6 +198,16 @@ pub(crate) struct CpuProviderBundleInner {
     pub(crate) dot_general: DotGeneralRuntime,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum CpuProviderDomainContract<'a> {
+    CooperativeCpuSet {
+        placement_guarantee: CpuPlacementGuarantee,
+        domain_cpus: &'a CpuSet,
+        process_allowed_cpus: &'a CpuSet,
+    },
+    CallerManaged,
+}
+
 /// Immutable direct provider slots installed on a CPU backend.
 ///
 /// Clones share the same slot identity and may safely share compatible
@@ -285,20 +295,30 @@ impl CpuProviderBundle {
         &self,
         domain_id: CpuDomainId,
         thread_budget: std::num::NonZeroUsize,
-        placement_guarantee: CpuPlacementGuarantee,
-        domain_cpus: &CpuSet,
-        process_allowed_cpus: &CpuSet,
+        contract: CpuProviderDomainContract<'_>,
     ) -> std::result::Result<(), CpuProviderBundleInstallError> {
         let runtime = self.dot_general();
         let validate = |provider, capabilities| {
-            crate::provider_capability::validate_provider_for_domain(
-                capabilities,
-                thread_budget,
-                placement_guarantee,
-                domain_cpus,
-                process_allowed_cpus,
-            )
-            .map_err(|source| CpuProviderBundleInstallError::IncompatibleDomain {
+            let result = match contract {
+                CpuProviderDomainContract::CooperativeCpuSet {
+                    placement_guarantee,
+                    domain_cpus,
+                    process_allowed_cpus,
+                } => crate::provider_capability::validate_provider_for_domain(
+                    capabilities,
+                    thread_budget,
+                    placement_guarantee,
+                    domain_cpus,
+                    process_allowed_cpus,
+                ),
+                CpuProviderDomainContract::CallerManaged => {
+                    crate::provider_capability::validate_provider_for_caller_managed_domain(
+                        capabilities,
+                        thread_budget,
+                    )
+                }
+            };
+            result.map_err(|source| CpuProviderBundleInstallError::IncompatibleDomain {
                 domain_id,
                 provider,
                 source,

--- a/crates/tenferro-cpu/src/dot_runtime/tests.rs
+++ b/crates/tenferro-cpu/src/dot_runtime/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     validate_axis_groups, validate_dot_general, validate_layout_metadata, CpuProviderBundle,
-    GroupedJobState, PackedJobStates, GROUPED_INLINE_JOB_CAPACITY, GROUPED_JOBS_PER_STATE_WORD,
+    CpuProviderDomainContract, GroupedJobState, PackedJobStates, GROUPED_INLINE_JOB_CAPACITY,
+    GROUPED_JOBS_PER_STATE_WORD,
 };
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::gemm::GemmAnalysisCache;
@@ -1039,9 +1040,11 @@ fn provider_capabilities_are_snapshotted_once_when_the_bundle_is_built() {
         .validate_for_domain(
             crate::CpuDomainId::new(17),
             NonZeroUsize::new(2).unwrap(),
-            crate::CpuPlacementGuarantee::ExactDeclared,
-            &cpus,
-            &cpus,
+            CpuProviderDomainContract::CooperativeCpuSet {
+                placement_guarantee: crate::CpuPlacementGuarantee::ExactDeclared,
+                domain_cpus: &cpus,
+                process_allowed_cpus: &cpus,
+            },
         )
         .unwrap();
 

--- a/crates/tenferro-cpu/src/engine.rs
+++ b/crates/tenferro-cpu/src/engine.rs
@@ -110,7 +110,7 @@ impl CpuEngine {
         &self.domain
     }
 
-    pub(crate) fn placement(&self) -> &ResolvedCpuPlacement {
+    pub(crate) fn placement(&self) -> Option<&ResolvedCpuPlacement> {
         self.domain.placement()
     }
 }

--- a/crates/tenferro-cpu/src/engine/tests.rs
+++ b/crates/tenferro-cpu/src/engine/tests.rs
@@ -18,12 +18,12 @@ fn engine_caps_workers_to_its_cpu_domain_and_owns_resources() {
         CpuEngine::new_managed(CpuDomainId::new(0), placement.clone(), usize::MAX, 0).unwrap();
 
     assert_eq!(engine.domain().thread_budget().get(), selected.len());
-    assert_eq!(engine.placement(), &placement);
+    assert_eq!(engine.placement(), Some(&placement));
     assert_eq!(engine.domain().id(), CpuDomainId::new(0));
     assert_eq!(engine.domain().ownership(), CpuDomainOwnership::Managed);
     assert_eq!(
         engine.domain().placement_guarantee(),
-        CpuPlacementGuarantee::ExactDeclared
+        Some(CpuPlacementGuarantee::ExactDeclared)
     );
     let resources = engine.resources.lock().unwrap();
     assert_eq!(resources.buffers.max_retained_capacity_bytes(), 0);
@@ -43,13 +43,13 @@ fn engine_from_context_preserves_placement_context_and_resources() {
         4096,
     );
 
-    assert_eq!(engine.placement(), &placement);
+    assert_eq!(engine.placement(), Some(&placement));
     assert_eq!(engine.domain().thread_budget().get(), 1);
     assert_eq!(Arc::strong_count(&context), 2);
     assert_eq!(engine.domain().id(), CpuDomainId::new(3));
     assert_eq!(
         engine.domain().placement_guarantee(),
-        CpuPlacementGuarantee::AdvisoryDeclared
+        Some(CpuPlacementGuarantee::AdvisoryDeclared)
     );
     let resources = engine.resources.lock().unwrap();
     assert_eq!(resources.buffers.max_retained_capacity_bytes(), 4096);
@@ -87,7 +87,7 @@ fn external_engine_moves_the_resource_domain_without_a_staging_context() {
     let engine = CpuEngine::from_external(external, 2048);
 
     assert_eq!(engine.domain().id(), CpuDomainId::new(9));
-    assert_eq!(engine.placement(), &placement);
+    assert_eq!(engine.placement(), Some(&placement));
     assert_eq!(
         engine.domain().ownership(),
         CpuDomainOwnership::ExternalManaged

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -153,7 +153,8 @@ pub use capability::cpu_capabilities;
 pub use context::{CpuContext, CpuContextError};
 pub use domain_executor::{
     CpuDomainExecutor, CpuDomainExecutorCapabilities, CpuDomainExecutorError, CpuExecutorAffinity,
-    CpuExecutorReentrancy, CpuExecutorShutdown, CpuInnerParallelism, ScopedCpuJob, ScopedCpuJobs,
+    CpuExecutorReentrancy, CpuExecutorShutdown, CpuInnerParallelism, RayonCpuDomainExecutor,
+    ScopedCpuJob, ScopedCpuJobs,
 };
 pub use dot_runtime::{
     CpuProviderBundle, CpuProviderBundleBuildError, CpuProviderBundleBuilder,
@@ -171,7 +172,9 @@ pub use provider_capability::{
     CpuPlacementControl, CpuProviderDomainError, CpuProviderExecutionCapabilities,
     CpuThreadCountControl,
 };
-pub use resource_domain::{CpuDomainOwnership, ExternalCpuDomain, ExternalCpuDomainError};
+pub use resource_domain::{
+    CpuAdmissionMode, CpuDomainOwnership, ExternalCpuDomain, ExternalCpuDomainError,
+};
 pub use runtime_adapter::{
     runtime_engine_id, runtime_engine_registration, runtime_engine_registration_with_id,
     runtime_hardware_class,

--- a/crates/tenferro-cpu/src/placement.rs
+++ b/crates/tenferro-cpu/src/placement.rs
@@ -216,6 +216,12 @@ pub enum CpuPlacementError {
         /// The explicit registry-only placement request.
         requested: CpuPlacement,
     },
+    /// An externally managed coordinator has no domain with the requested ID.
+    #[error("externally managed CPU coordinator has no registered domain {domain:?}")]
+    UnregisteredExternalDomain {
+        /// Missing caller-stable domain identity.
+        domain: crate::CpuDomainId,
+    },
     /// A pinned engine could not be built for an otherwise valid placement.
     #[error("cannot resolve {requested:?} for {backend:?}: engine construction failed: {source}")]
     EngineConstruction {
@@ -244,6 +250,7 @@ pub(crate) enum ResolvedCpuExecution {
     Compatibility,
     Managed(ResolvedCpuPlacement),
     ExternalManaged(ResolvedCpuPlacement),
+    ExternalCallerManaged,
     ProviderDefaultExclusive,
 }
 

--- a/crates/tenferro-cpu/src/provider.rs
+++ b/crates/tenferro-cpu/src/provider.rs
@@ -183,18 +183,34 @@ impl<'a> CpuExecutionContext<'a> {
         self.domain.id()
     }
 
-    /// Return the selected domain's declared logical CPU set.
+    /// Return the selected domain's declared logical CPU set, when present.
     ///
     /// # Examples
     ///
     /// ```
     /// use tenferro_cpu::CpuExecutionContext;
     /// # fn inspect(context: &CpuExecutionContext<'_>) {
-    /// assert!(!context.cpus().is_empty());
+    /// if let Some(cpus) = context.cpus() {
+    ///     assert!(!cpus.is_empty());
+    /// }
     /// # }
     /// ```
-    pub fn cpus(&self) -> &CpuSet {
+    pub fn cpus(&self) -> Option<&CpuSet> {
         self.domain.cpus()
+    }
+
+    /// Return the selected domain's admission contract.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::{CpuAdmissionMode, CpuExecutionContext};
+    /// # fn inspect(context: &CpuExecutionContext<'_>) {
+    /// let _mode: CpuAdmissionMode = context.admission_mode();
+    /// # }
+    /// ```
+    pub fn admission_mode(&self) -> crate::CpuAdmissionMode {
+        self.domain.admission_mode()
     }
 
     /// Return the non-zero maximum participating-thread budget.
@@ -211,7 +227,7 @@ impl<'a> CpuExecutionContext<'a> {
         self.domain.thread_budget()
     }
 
-    /// Return the strength of the selected domain's placement guarantee.
+    /// Return the strength of the selected domain's placement guarantee, when present.
     ///
     /// # Examples
     ///
@@ -221,7 +237,7 @@ impl<'a> CpuExecutionContext<'a> {
     /// let _guarantee = context.placement_guarantee();
     /// # }
     /// ```
-    pub fn placement_guarantee(&self) -> CpuPlacementGuarantee {
+    pub fn placement_guarantee(&self) -> Option<CpuPlacementGuarantee> {
         self.domain.placement_guarantee()
     }
 

--- a/crates/tenferro-cpu/src/provider/tests.rs
+++ b/crates/tenferro-cpu/src/provider/tests.rs
@@ -205,11 +205,14 @@ fn provider_context_exposes_only_execution_policy() {
     let fixture = execution_context_fixture(4);
     fixture.with_context(ParallelMode::Inner, |provider_context| {
         assert_eq!(provider_context.domain_id(), CpuDomainId::new(9));
-        assert_eq!(provider_context.cpus().as_slice(), &[CpuId::new(0)]);
+        assert_eq!(
+            provider_context.cpus().map(|cpus| cpus.as_slice()),
+            Some(&[CpuId::new(0)][..])
+        );
         assert_eq!(provider_context.thread_budget().get(), 4);
         assert_eq!(
             provider_context.placement_guarantee(),
-            CpuPlacementGuarantee::AdvisoryDeclared
+            Some(CpuPlacementGuarantee::AdvisoryDeclared)
         );
         assert_eq!(provider_context.parallel_mode(), ParallelMode::Inner);
     });

--- a/crates/tenferro-cpu/src/provider_capability.rs
+++ b/crates/tenferro-cpu/src/provider_capability.rs
@@ -142,6 +142,16 @@ pub enum CpuProviderDomainError {
         /// Placement guarantee requested by the domain.
         guarantee: CpuPlacementGuarantee,
     },
+    /// The provider can leave the supplied executor in caller-managed mode.
+    #[error(
+        "provider placement control {placement:?} can leave the caller-managed executor for thread budget {thread_budget}"
+    )]
+    CallerManagedPlacementNotEnforceable {
+        /// Requested maximum number of participating threads.
+        thread_budget: usize,
+        /// Provider placement classification.
+        placement: CpuPlacementControl,
+    },
     /// The provider cannot honor the engine-selected fan-out mode.
     #[error("provider cannot honor requested CPU parallel mode {mode:?}")]
     ParallelModeNotSupported {
@@ -299,6 +309,27 @@ pub(crate) fn serial_capabilities() -> CpuProviderExecutionCapabilities {
 #[cfg(any(test, feature = "cpu-blas"))]
 pub(crate) fn builtin_blas_execution_capabilities() -> CpuProviderExecutionCapabilities {
     uncontrolled_external_capabilities()
+}
+
+pub(crate) fn validate_provider_for_caller_managed_domain(
+    capabilities: CpuProviderExecutionCapabilities,
+    thread_budget: NonZeroUsize,
+) -> Result<(), CpuProviderDomainError> {
+    if enforced_provider_thread_limit(capabilities.thread_count, thread_budget).is_none() {
+        return Err(CpuProviderDomainError::ThreadCountNotEnforceable {
+            thread_budget: thread_budget.get(),
+            control: capabilities.thread_count,
+        });
+    }
+    match capabilities.placement {
+        CpuPlacementControl::EngineWorkers | CpuPlacementControl::CallingThread => Ok(()),
+        CpuPlacementControl::ExternalWorkers | CpuPlacementControl::None => Err(
+            CpuProviderDomainError::CallerManagedPlacementNotEnforceable {
+                thread_budget: thread_budget.get(),
+                placement: capabilities.placement,
+            },
+        ),
+    }
 }
 
 pub(crate) fn validate_provider_for_domain(

--- a/crates/tenferro-cpu/src/resource_domain.rs
+++ b/crates/tenferro-cpu/src/resource_domain.rs
@@ -1,4 +1,5 @@
 use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use thiserror::Error;
@@ -26,6 +27,37 @@ pub enum CpuDomainOwnership {
     Managed,
     /// The application supplied and owns the executor resource policy.
     ExternalManaged,
+}
+
+/// Admission contract for one CPU resource domain.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuAdmissionMode;
+///
+/// assert_ne!(
+///     CpuAdmissionMode::CooperativeCpuSet,
+///     CpuAdmissionMode::CallerManaged,
+/// );
+/// ```
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CpuAdmissionMode {
+    /// tenferro arbitrates the domain's declared CPU set with other CPU work.
+    CooperativeCpuSet,
+    /// The caller owns cross-domain admission; tenferro guards only this domain.
+    CallerManaged,
+}
+
+#[derive(Debug)]
+enum CpuDomainAdmission {
+    CooperativeCpuSet {
+        placement: ResolvedCpuPlacement,
+        guarantee: CpuPlacementGuarantee,
+    },
+    CallerManaged {
+        active: Arc<AtomicBool>,
+    },
 }
 
 /// Typed failure to construct an externally managed CPU resource domain.
@@ -64,10 +96,9 @@ pub enum ExternalCpuDomainError {
 #[derive(Debug)]
 pub(crate) struct CpuResourceDomain {
     id: CpuDomainId,
-    placement: ResolvedCpuPlacement,
+    admission: CpuDomainAdmission,
     executor: Arc<dyn CpuDomainExecutor>,
     thread_budget: NonZeroUsize,
-    placement_guarantee: CpuPlacementGuarantee,
     ownership: CpuDomainOwnership,
 }
 
@@ -82,11 +113,29 @@ impl CpuResourceDomain {
     ) -> Self {
         Self {
             id,
-            placement,
+            admission: CpuDomainAdmission::CooperativeCpuSet {
+                placement,
+                guarantee: placement_guarantee,
+            },
             executor,
             thread_budget,
-            placement_guarantee,
             ownership,
+        }
+    }
+
+    fn new_caller_managed(
+        id: CpuDomainId,
+        executor: Arc<dyn CpuDomainExecutor>,
+        thread_budget: NonZeroUsize,
+    ) -> Self {
+        Self {
+            id,
+            admission: CpuDomainAdmission::CallerManaged {
+                active: Arc::new(AtomicBool::new(false)),
+            },
+            executor,
+            thread_budget,
+            ownership: CpuDomainOwnership::ExternalManaged,
         }
     }
 
@@ -94,12 +143,29 @@ impl CpuResourceDomain {
         self.id
     }
 
-    pub(crate) fn placement(&self) -> &ResolvedCpuPlacement {
-        &self.placement
+    pub(crate) fn admission_mode(&self) -> CpuAdmissionMode {
+        match self.admission {
+            CpuDomainAdmission::CooperativeCpuSet { .. } => CpuAdmissionMode::CooperativeCpuSet,
+            CpuDomainAdmission::CallerManaged { .. } => CpuAdmissionMode::CallerManaged,
+        }
     }
 
-    pub(crate) fn cpus(&self) -> &CpuSet {
-        self.placement.cpus()
+    pub(crate) fn placement(&self) -> Option<&ResolvedCpuPlacement> {
+        match &self.admission {
+            CpuDomainAdmission::CooperativeCpuSet { placement, .. } => Some(placement),
+            CpuDomainAdmission::CallerManaged { .. } => None,
+        }
+    }
+
+    pub(crate) fn cpus(&self) -> Option<&CpuSet> {
+        self.placement().map(ResolvedCpuPlacement::cpus)
+    }
+
+    pub(crate) fn caller_managed_active(&self) -> Option<Arc<AtomicBool>> {
+        match &self.admission {
+            CpuDomainAdmission::CallerManaged { active } => Some(Arc::clone(active)),
+            CpuDomainAdmission::CooperativeCpuSet { .. } => None,
+        }
     }
 
     pub(crate) fn executor(&self) -> &Arc<dyn CpuDomainExecutor> {
@@ -110,8 +176,11 @@ impl CpuResourceDomain {
         self.thread_budget
     }
 
-    pub(crate) fn placement_guarantee(&self) -> CpuPlacementGuarantee {
-        self.placement_guarantee
+    pub(crate) fn placement_guarantee(&self) -> Option<CpuPlacementGuarantee> {
+        match self.admission {
+            CpuDomainAdmission::CooperativeCpuSet { guarantee, .. } => Some(guarantee),
+            CpuDomainAdmission::CallerManaged { .. } => None,
+        }
     }
 
     pub(crate) fn ownership(&self) -> CpuDomainOwnership {
@@ -203,7 +272,7 @@ impl ExternalCpuDomain {
         placement_guarantee: CpuPlacementGuarantee,
     ) -> Result<Self, ExternalCpuDomainError> {
         let worker_count = executor.capabilities().worker_count.get();
-        validate_external_domain_config(placement.cpus().len(), worker_count, thread_budget)?;
+        validate_external_domain_config(Some(placement.cpus().len()), worker_count, thread_budget)?;
         Ok(Self {
             domain: CpuResourceDomain::new(
                 id,
@@ -213,6 +282,52 @@ impl ExternalCpuDomain {
                 placement_guarantee,
                 CpuDomainOwnership::ExternalManaged,
             ),
+        })
+    }
+
+    /// Construct a caller-managed domain without declaring a CPU set.
+    ///
+    /// The caller owns admission between distinct caller-managed domains. tenferro
+    /// retains `executor`, rejects concurrent public entry into this domain, and
+    /// never constructs or shuts down another executor.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::num::NonZeroUsize;
+    /// use std::sync::Arc;
+    /// use tenferro_cpu::{
+    ///     CpuAdmissionMode, ExternalCpuDomain, RayonCpuDomainExecutor,
+    /// };
+    /// use tenferro_tensor::CpuDomainId;
+    ///
+    /// let pool = Arc::new(rayon::ThreadPoolBuilder::new().num_threads(2).build()?);
+    /// let executor = Arc::new(RayonCpuDomainExecutor::new(Arc::clone(&pool)));
+    /// let domain = ExternalCpuDomain::new_caller_managed(
+    ///     CpuDomainId::new(9),
+    ///     executor,
+    ///     NonZeroUsize::new(2).unwrap(),
+    /// )?;
+    /// assert_eq!(domain.admission_mode(), CpuAdmissionMode::CallerManaged);
+    /// assert!(domain.placement().is_none());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExternalCpuDomainError::ZeroExecutorWorkers`] when the executor
+    /// reports no workers, or
+    /// [`ExternalCpuDomainError::ThreadBudgetExceedsWorkerCount`] when
+    /// `thread_budget` exceeds the executor worker count.
+    pub fn new_caller_managed(
+        id: CpuDomainId,
+        executor: Arc<dyn CpuDomainExecutor>,
+        thread_budget: NonZeroUsize,
+    ) -> Result<Self, ExternalCpuDomainError> {
+        let worker_count = executor.capabilities().worker_count.get();
+        validate_external_domain_config(None, worker_count, thread_budget)?;
+        Ok(Self {
+            domain: CpuResourceDomain::new_caller_managed(id, executor, thread_budget),
         })
     }
 
@@ -230,31 +345,70 @@ impl ExternalCpuDomain {
         self.domain.id()
     }
 
-    /// Return the declared resolved placement.
+    /// Return the declared resolved placement, if this domain uses CPU-set admission.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_cpu::{ExternalCpuDomain, ResolvedCpuPlacement};
+    /// use std::num::NonZeroUsize;
+    /// use std::sync::Arc;
+    /// use tenferro_cpu::{CpuContext, ExternalCpuDomain};
+    /// use tenferro_tensor::CpuDomainId;
     ///
-    /// let _placement: fn(&ExternalCpuDomain) -> &ResolvedCpuPlacement =
-    ///     ExternalCpuDomain::placement;
+    /// let domain = ExternalCpuDomain::new_caller_managed(
+    ///     CpuDomainId::new(1),
+    ///     Arc::new(CpuContext::with_threads(1)?),
+    ///     NonZeroUsize::MIN,
+    /// )?;
+    /// assert!(domain.placement().is_none());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn placement(&self) -> &ResolvedCpuPlacement {
+    pub fn placement(&self) -> Option<&ResolvedCpuPlacement> {
         self.domain.placement()
     }
 
-    /// Return the logical CPUs declared for this domain.
+    /// Return the logical CPUs declared for CPU-set admission.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_cpu::{CpuSet, ExternalCpuDomain};
+    /// use std::num::NonZeroUsize;
+    /// use std::sync::Arc;
+    /// use tenferro_cpu::{CpuContext, ExternalCpuDomain};
+    /// use tenferro_tensor::CpuDomainId;
     ///
-    /// let _cpus: fn(&ExternalCpuDomain) -> &CpuSet = ExternalCpuDomain::cpus;
+    /// let domain = ExternalCpuDomain::new_caller_managed(
+    ///     CpuDomainId::new(1),
+    ///     Arc::new(CpuContext::with_threads(1)?),
+    ///     NonZeroUsize::MIN,
+    /// )?;
+    /// assert!(domain.cpus().is_none());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn cpus(&self) -> &CpuSet {
+    pub fn cpus(&self) -> Option<&CpuSet> {
         self.domain.cpus()
+    }
+
+    /// Return this domain's admission contract.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::num::NonZeroUsize;
+    /// use std::sync::Arc;
+    /// use tenferro_cpu::{CpuAdmissionMode, CpuContext, ExternalCpuDomain};
+    /// use tenferro_tensor::CpuDomainId;
+    ///
+    /// let domain = ExternalCpuDomain::new_caller_managed(
+    ///     CpuDomainId::new(1),
+    ///     Arc::new(CpuContext::with_threads(1)?),
+    ///     NonZeroUsize::MIN,
+    /// )?;
+    /// assert_eq!(domain.admission_mode(), CpuAdmissionMode::CallerManaged);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn admission_mode(&self) -> CpuAdmissionMode {
+        self.domain.admission_mode()
     }
 
     /// Return the nonzero thread budget requested for tenferro work.
@@ -272,17 +426,25 @@ impl ExternalCpuDomain {
         self.domain.thread_budget()
     }
 
-    /// Return whether placement is an exact or advisory declaration.
+    /// Return whether cooperative placement is an exact or advisory declaration.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_cpu::{CpuPlacementGuarantee, ExternalCpuDomain};
+    /// use std::num::NonZeroUsize;
+    /// use std::sync::Arc;
+    /// use tenferro_cpu::{CpuContext, ExternalCpuDomain};
+    /// use tenferro_tensor::CpuDomainId;
     ///
-    /// let _guarantee: fn(&ExternalCpuDomain) -> CpuPlacementGuarantee =
-    ///     ExternalCpuDomain::placement_guarantee;
+    /// let domain = ExternalCpuDomain::new_caller_managed(
+    ///     CpuDomainId::new(1),
+    ///     Arc::new(CpuContext::with_threads(1)?),
+    ///     NonZeroUsize::MIN,
+    /// )?;
+    /// assert!(domain.placement_guarantee().is_none());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn placement_guarantee(&self) -> CpuPlacementGuarantee {
+    pub fn placement_guarantee(&self) -> Option<CpuPlacementGuarantee> {
         self.domain.placement_guarantee()
     }
 
@@ -322,11 +484,11 @@ impl From<ExternalCpuDomain> for CpuResourceDomain {
 }
 
 fn validate_external_domain_config(
-    cpu_count: usize,
+    cpu_count: Option<usize>,
     worker_count: usize,
     thread_budget: NonZeroUsize,
 ) -> Result<(), ExternalCpuDomainError> {
-    if cpu_count == 0 {
+    if cpu_count == Some(0) {
         return Err(ExternalCpuDomainError::EmptyPlacementCpuSet);
     }
     if worker_count == 0 {

--- a/crates/tenferro-cpu/src/resource_domain/tests.rs
+++ b/crates/tenferro-cpu/src/resource_domain/tests.rs
@@ -25,7 +25,7 @@ fn external_domain_guarantees_round_trip_without_upgrading_affinity() {
         )
         .unwrap();
 
-        assert_eq!(domain.placement_guarantee(), guarantee);
+        assert_eq!(domain.placement_guarantee(), Some(guarantee));
         assert_eq!(
             domain.executor_capabilities().affinity,
             CpuExecutorAffinity::CallerDeclaredUnverified
@@ -70,12 +70,12 @@ fn external_node_domain_reports_public_diagnostics() {
     .unwrap();
 
     assert_eq!(domain.id(), CpuDomainId::new(9));
-    assert_eq!(domain.placement(), &placement);
-    assert_eq!(domain.cpus().as_usize_vec(), vec![3, 5]);
+    assert_eq!(domain.placement(), Some(&placement));
+    assert_eq!(domain.cpus().map(CpuSet::as_usize_vec), Some(vec![3, 5]));
     assert_eq!(domain.thread_budget(), nonzero(2));
     assert_eq!(
         domain.placement_guarantee(),
-        CpuPlacementGuarantee::ExactDeclared
+        Some(CpuPlacementGuarantee::ExactDeclared)
     );
     assert_eq!(domain.ownership(), CpuDomainOwnership::ExternalManaged);
     assert_eq!(domain.executor_capabilities(), expected_capabilities);
@@ -93,14 +93,47 @@ fn external_all_allowed_domain_reports_public_diagnostics() {
     )
     .unwrap();
 
-    assert_eq!(domain.placement(), &placement);
-    assert_eq!(domain.placement().node_id(), None);
-    assert_eq!(domain.cpus().as_usize_vec(), vec![1, 8]);
+    assert_eq!(domain.placement(), Some(&placement));
+    assert_eq!(
+        domain.placement().and_then(ResolvedCpuPlacement::node_id),
+        None
+    );
+    assert_eq!(domain.cpus().map(CpuSet::as_usize_vec), Some(vec![1, 8]));
     assert_eq!(
         domain.placement_guarantee(),
-        CpuPlacementGuarantee::AdvisoryDeclared
+        Some(CpuPlacementGuarantee::AdvisoryDeclared)
     );
     assert_eq!(domain.ownership(), CpuDomainOwnership::ExternalManaged);
+}
+
+#[test]
+fn caller_managed_domain_has_no_fabricated_placement_and_validates_budget() {
+    let domain = ExternalCpuDomain::new_caller_managed(
+        CpuDomainId::new(12),
+        Arc::new(TestExecutor::new(3)),
+        nonzero(2),
+    )
+    .unwrap();
+    assert_eq!(domain.admission_mode(), CpuAdmissionMode::CallerManaged);
+    assert!(domain.placement().is_none());
+    assert!(domain.cpus().is_none());
+    assert!(domain.placement_guarantee().is_none());
+    assert_eq!(domain.executor_capabilities().worker_count.get(), 3);
+    assert_eq!(domain.thread_budget().get(), 2);
+
+    let error = ExternalCpuDomain::new_caller_managed(
+        CpuDomainId::new(13),
+        Arc::new(TestExecutor::new(2)),
+        nonzero(3),
+    )
+    .unwrap_err();
+    assert_eq!(
+        error,
+        ExternalCpuDomainError::ThreadBudgetExceedsWorkerCount {
+            thread_budget: 3,
+            worker_count: 2,
+        }
+    );
 }
 
 #[test]
@@ -133,7 +166,7 @@ fn zero_thread_budget_is_unrepresentable_at_the_safe_public_boundary() {
 #[test]
 fn defensive_validation_rejects_empty_placement() {
     assert_eq!(
-        validate_external_domain_config(0, 1, nonzero(1)),
+        validate_external_domain_config(Some(0), 1, nonzero(1)),
         Err(ExternalCpuDomainError::EmptyPlacementCpuSet)
     );
 }
@@ -141,7 +174,7 @@ fn defensive_validation_rejects_empty_placement() {
 #[test]
 fn defensive_validation_rejects_zero_executor_workers() {
     assert_eq!(
-        validate_external_domain_config(1, 0, nonzero(1)),
+        validate_external_domain_config(Some(1), 0, nonzero(1)),
         Err(ExternalCpuDomainError::ZeroExecutorWorkers)
     );
 }

--- a/docs/design/cpu-backend-execution.md
+++ b/docs/design/cpu-backend-execution.md
@@ -20,6 +20,65 @@ provider calls both cross the selected all-allowed domain executor exactly
 once. The executor entry owns admission and caller-thread placement; the BLAS
 runtime, rather than the executor's Rayon workers, owns provider fan-out.
 
+## Caller-managed external admission
+
+An external domain explicitly selects one of two admission contracts:
+
+- **cooperative CPU-set admission** retains the existing resolved placement,
+  placement guarantee, and process-wide overlap arbitration; or
+- **caller-managed admission** declares no CPU set. The supplied executor's
+  workers are the complete CPU universe for that domain, and the caller owns
+  admission and oversubscription across caller-managed domains.
+
+`ExternalCpuDomain::new` remains the cooperative constructor.
+`ExternalCpuDomain::new_caller_managed(id, executor, thread_budget)` selects the
+second contract. `ExternalCpuDomain::admission_mode()` and
+`CpuExecutionInfo::admission_mode()` expose the distinction. Placement and CPU
+set accessors on `ExternalCpuDomain`, `CpuExecutionInfo`, and provider-facing
+`CpuExecutionContext` return `None` for caller-managed domains rather than
+inventing a placement claim. `CpuBackend::for_domain(CpuDomainId)` selects any
+registered external domain by stable ID; placement selection remains available
+only for cooperative domains.
+
+Caller-managed execution never enters `ResourceArbiter`, so unrelated
+caller-managed domains do not conflict because their process affinity overlaps.
+Instead, each caller-managed domain owns a small RAII admission guard carrying
+tenferro's execution-owner identity. It rejects a second public backend entry
+while that domain is active, including entry from another worker of the same
+caller pool, and clears on success, error, or unwind. This preserves public
+`CpuBackend` recursive-entry rejection without requiring TLS installation on a
+pool built by the caller. The permit never reports arbiter re-entry, so the
+existing engine-resource lock continues to protect that domain's caches and
+buffer pool. Cooperative, managed, compatibility, and provider-exclusive
+permits are unchanged.
+
+The standard caller-owned Rayon adapter retains an `Arc<rayon::ThreadPool>` and
+implements the generic `CpuDomainExecutor` contract without constructing or
+shutting down a pool. Its synchronous `install` delegates to that exact pool,
+including when called by a worker already inside the same pool; inner faer and
+strided parallelism therefore sees only that pool and the validated domain
+thread budget. `submit` partitions only the indexed jobs supplied by tenferro.
+No path may fall back to ambient/global Rayon.
+
+Caller-managed domains explicitly select `CpuBackendKind::Faer`, independent of
+`CpuBackendKind::default_compiled()`; construction returns a typed unsupported
+configuration error when faer is not compiled. Provider-domain validation has a
+distinct caller-managed branch with no advisory or process-all-allowed bypass.
+It accepts only thread controls `PerCallUpperBound`, `Sequential`, or
+`BinaryClampToOne` and placement controls `EngineWorkers` or `CallingThread`.
+Caller-managed domains carry no `CpuPlacementGuarantee`. A bundle with external
+workers, uncontrolled thread count, or no placement control fails with a typed
+construction error before execution. The current BLAS/LAPACK operation-family
+path is unsupported because its process-global or provider-owned workers cannot
+be confined to the supplied executor. It must not run and then weaken
+isolation, mutate an output, or fall back silently.
+
+Diagnostics report caller-managed admission, absent verified placement, caller
+executor/shutdown ownership, worker count, and thread budget. Fresh output
+metadata may retain the stable CPU domain ID for routing, but it is not evidence
+of CPU affinity or NUMA residency. Executor ownership stays with the caller and
+is retained by the domain for every active synchronous job.
+
 The unentered crate-private `CpuOperationEntry` holds the selected domain and
 resource permit. It is the only CPU backend value allowed to call executor
 `install` or `submit`. Provider-facing `CpuExecutionContext` values are created

--- a/docs/guides/cpu-execution.md
+++ b/docs/guides/cpu-execution.md
@@ -83,7 +83,32 @@ waiting for it from the outer execution can deadlock. Finish the outer backend
 execution before launching new top-level backend calls. Ordinary Rayon work
 that does not re-enter a CPU backend remains supported.
 
-### Scoped direct faer calls
+## Caller-managed executor domains
+
+A host scheduler that already owns independent Rayon pools can register each
+pool as a caller-managed external domain. Use
+`RayonCpuDomainExecutor::new(Arc<rayon::ThreadPool>)` with
+`ExternalCpuDomain::new_caller_managed`; the generic `CpuDomainExecutor` trait
+remains available for non-Rayon executors. No CPU set is declared or inferred.
+Select a registered domain with `CpuBackend::for_domain(CpuDomainId)`.
+
+Caller-managed domains use faer and tenferro-native kernels only. tenferro
+retains the supplied executor, enters only that executor, applies the declared
+thread budget, and never creates or shuts down another pool. Entry from an
+exclusive coarse task already running on the same Rayon pool is supported.
+Distinct caller-managed domains do not enter the process-wide CPU-set arbiter,
+so their pools may overlap even when the process affinity mask is identical.
+The host owns cross-domain scheduling and oversubscription policy.
+
+A second public backend entry into the same active domain is rejected, including
+entry from another worker of that pool. Provider bundles with external workers
+or uncontrolled thread counts, and BLAS/LAPACK configurations that cannot stay
+inside the supplied executor, fail during backend construction. Diagnostics
+report `CpuAdmissionMode::CallerManaged`; resolved placement, domain CPUs, and
+placement guarantee are `None` because tenferro has no verified placement
+claim.
+
+## Scoped direct faer calls
 
 Downstream code that needs a faer routine not exposed by tenferro can use
 `tenferro_cpu::FaerParallelismExt` on the active `BackendSession`:

--- a/docs/guides/parallelism-and-caching.md
+++ b/docs/guides/parallelism-and-caching.md
@@ -179,6 +179,14 @@ let backend = CpuBackend::with_threads(1)?;
 For BLAS/LAPACK providers, apply the same rule to provider thread variables.
 For benchmarks, pin all relevant thread counts and report them with the result.
 
+When the host already partitions coarse work across caller-owned Rayon pools,
+use caller-managed external domains instead of fabricating disjoint CPU sets.
+Each domain's `worker_count` is the pool capacity visible to tenferro and its
+`thread_budget` is the maximum inner participation for one operation. Distinct
+domains may overlap in process affinity and execute concurrently; the host must
+admit at most one coarse tenferro operation per pool and account for any physical
+CPU oversubscription. See [CPU Execution and NUMA Placement](cpu-execution.md#caller-managed-executor-domains).
+
 ## Reuse Runtime State
 
 Reuse execution objects when you repeat related work:

--- a/docs/worklogs/2026-08-20-issue-1716-caller-managed-cpu-admission.md
+++ b/docs/worklogs/2026-08-20-issue-1716-caller-managed-cpu-admission.md
@@ -1,0 +1,85 @@
+# Issue #1716: caller-managed CPU admission
+
+## Summary
+
+Implemented explicit caller-managed admission for caller-owned CPU executors.
+Caller-managed domains declare no CPU set, bypass process-wide CPU-set
+arbitration, retain a per-domain public-entry guard, and execute faer/native work
+only through the supplied executor. Cooperative external domains retain their
+existing placement and arbitration behavior.
+
+## Context read
+
+- Issue #1716 and its acceptance criteria
+- `AGENTS.md`, `REPOSITORY_RULES.md`, workspace `CODING_RULES.md`, and the
+  relevant shared Rust, performance, documentation, and testing rules
+- `docs/design/cpu-backend-execution.md`
+- `docs/design/execution-engine-provider-architecture.md`
+- `docs/guides/cpu-execution.md`
+- `docs/guides/parallelism-and-caching.md`
+- CPU domain executor, resource domain, backend, arbiter, provider, provider
+  capability, engine, and existing external-managed tests
+- Rayon `ThreadPool::install` / registry same-pool entry behavior from the
+  installed Rayon source
+
+## Decisions
+
+- Kept `ExternalCpuDomain::new` as the cooperative CPU-set constructor and added
+  `new_caller_managed` rather than introducing a parallel domain type.
+- Added `CpuAdmissionMode` and made placement, CPU-set, and placement-guarantee
+  diagnostics optional. Caller-managed domains do not fabricate affinity facts.
+- Added `CpuBackend::for_domain(CpuDomainId)` because placement-free domains
+  cannot be selected through `CpuPlacement`.
+- Added a thin `RayonCpuDomainExecutor` adapter that retains exactly one
+  caller-owned `Arc<rayon::ThreadPool>`; the generic executor trait remains the
+  primary seam.
+- Used a per-domain RAII active-entry flag to reject recursive or simultaneous
+  public entry into one caller-managed domain across all caller-pool workers.
+  Distinct domains have independent flags and never enter `ResourceArbiter`.
+- Selected faer explicitly for caller-managed registries. Provider validation
+  has a caller-managed branch with no advisory/all-allowed bypass and rejects
+  external workers, missing placement control, or uncontrolled thread counts
+  before returning a backend.
+
+## Alternatives rejected
+
+- Fabricated `AllAllowed` placements: they would preserve the overlap conflict
+  and misreport a placement contract the caller did not make.
+- A global registry of external pools: unnecessary process-global state and
+  contrary to the accepted issue.
+- Worker TLS installation on caller-created Rayon pools: start handlers cannot
+  be retrofitted, and a per-domain entry guard enforces the public re-entry
+  contract without reconstructing the pool.
+- Allowing BLAS/LAPACK and documenting weaker isolation: provider-owned workers
+  cannot satisfy the supplied-executor boundary.
+
+## Review gates
+
+- Pre-implementation design: `reviewer-flash-opencode-go` requested changes to
+  provider validation, cross-worker re-entry, domain-ID selection, and optional
+  placement scope. The revised design received `Correct-to-implement`.
+- Post-implementation full-diff review: `reviewer-flash-opencode-go` reported
+  no Critical or Important findings and returned `Correct-to-merge`. Four Minor
+  cleanup findings (worklog verdict, caller affinity diagnostic, unreachable
+  diagnostic wording, and duplicate default-domain validation) were fixed and
+  re-reviewed before integration.
+
+## Verification
+
+- `cargo check --workspace`
+- `cargo check -p tenferro-cpu --no-default-features --features cpu-blas`
+- `cargo check -p tenferro-cpu --features cpu-blas`
+- `cargo test -p tenferro-cpu` — 805 passed
+- `cargo test -p tenferro-cpu --doc` — 217 passed
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+The BLAS-only unit-test binary cannot link without a concrete CBLAS provider in
+this environment; the BLAS-only compile check succeeds and the default faer
+suite covers the public typed rejection path.
+
+## Remaining risks
+
+Caller-managed admission cannot verify host scheduling or physical CPU
+oversubscription across distinct pools; that responsibility is intentionally
+owned by the caller and is reported in diagnostics and user documentation.

--- a/ext/sparse/src/sparse.rs
+++ b/ext/sparse/src/sparse.rs
@@ -294,7 +294,7 @@ pub(crate) fn validate_coordinates(
         ));
     }
     let mut entries = Vec::with_capacity(coord_shape[1]);
-    for pair in coordinates.as_slice::<i64>()?.chunks_exact(2) {
+    for pair in coordinates.as_slice::<i64>()?.as_chunks::<2>().0 {
         let row = usize::try_from(pair[0]).map_err(|_| {
             Error::invalid_argument(OP, "coordinates", "negative sparse row coordinate")
         })?;


### PR DESCRIPTION
## Summary

- add explicit caller-managed admission for externally supplied CPU executors without fabricated CPU sets
- add a thin caller-owned Rayon pool adapter, stable domain-ID selection, per-domain re-entry protection, and explicit diagnostics
- keep cooperative CPU-set arbitration unchanged and reject incompatible external-worker/provider configurations before execution
- document the execution contract and caller responsibilities
- refresh Rust 1.98 Clippy/trybuild compatibility artifacts (`as_chunks::<2>()` and one diagnostic snapshot; no semantic change)

Closes #1716

## Design and review

- Design: `docs/design/cpu-backend-execution.md`
- Worklog: `docs/worklogs/2026-08-20-issue-1716-caller-managed-cpu-admission.md`
- Pre-implementation design review: `Correct-to-implement`
- Post-implementation full-diff review: `Correct-to-merge` (no Critical or Important findings; Minor findings fixed and re-reviewed)

## Verification

- `cargo check --workspace`
- `cargo check -p tenferro-cpu --no-default-features --features cpu-blas`
- `cargo check -p tenferro-cpu --features cpu-blas`
- `cargo test -p tenferro-cpu` (805 passed)
- `cargo test -p tenferro-cpu --doc` (217 passed)
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/check-public-error-docs.py`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-cpu caller_managed'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1716.json --dry-run --llm-skipped-reason 'local deterministic review'` (pass)
