### PR TITLE
ci: restore required macOS workspace tests

### DIFF
--- a/.github/workflows/ci-pr-workspace-tests.yml
+++ b/.github/workflows/ci-pr-workspace-tests.yml
@@ -23,6 +23,7 @@ jobs:
       backends: ${{ steps.select.outputs.backends }}
       run_workspace: ${{ steps.policy.outputs.run_rust }}
       run_extensions: ${{ steps.policy.outputs.run_extensions }}
+      run_macos: ${{ steps.policy.outputs.run_macos }}
       reason: ${{ steps.policy.outputs.reason }}
     steps:
       - uses: actions/checkout@v5
@@ -180,3 +181,33 @@ jobs:
             exit 1
           fi
           echo "Selected policy satisfied: workspace=${RUN_WORKSPACE} extensions=${RUN_EXTENSIONS}"
+
+  macos:
+    name: macOS workspace tests
+    needs: [changes, ci-gate]
+    if: always()
+    runs-on: ${{ needs.ci-gate.result == 'success' && needs.changes.outputs.run_macos == 'true' && 'macos-15' || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v5
+        if: needs.ci-gate.result == 'success' && needs.changes.outputs.run_macos == 'true'
+      - uses: dtolnay/rust-toolchain@stable
+        if: needs.ci-gate.result == 'success' && needs.changes.outputs.run_macos == 'true'
+      - uses: Swatinem/rust-cache@v2
+        if: needs.ci-gate.result == 'success' && needs.changes.outputs.run_macos == 'true'
+      - uses: taiki-e/install-action@nextest
+        if: needs.ci-gate.result == 'success' && needs.changes.outputs.run_macos == 'true'
+      - name: Run macOS workspace profile
+        if: needs.ci-gate.result == 'success' && needs.changes.outputs.run_macos == 'true'
+        run: python3 scripts/ci/run_profile.py workspace-faer
+      - name: Report macOS disposition
+        if: always()
+        env:
+          LINUX_GATE_RESULT: ${{ needs.ci-gate.result }}
+          RUN_MACOS: ${{ needs.changes.outputs.run_macos }}
+          REASON: ${{ needs.changes.outputs.reason }}
+        run: |
+          if [ "${LINUX_GATE_RESULT}" != success ]; then
+            echo "Linux workspace gate failed: ${LINUX_GATE_RESULT}"
+            exit 1
+          fi
+          if [ "${RUN_MACOS}" != true ]; then echo "macOS tests not required - ${REASON}"; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,33 +168,6 @@ jobs:
           if [ "${POLICY_RESULT}" != success ]; then echo "Change classification failed"; exit 1; fi
           if [ "${REQUIRED}" != true ]; then echo "dependency check not required: ${REASON}"; fi
 
-  macos-gated-check:
-    name: macOS-gated GPU type-check
-    needs: policy
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
-      - uses: dtolnay/rust-toolchain@stable
-        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
-        with:
-          targets: aarch64-apple-darwin
-      - uses: Swatinem/rust-cache@v2
-        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
-      - name: Type-check macOS-gated GPU tests
-        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
-        run: cargo check -p tenferro-gpu --features webgpu --test integration --target aarch64-apple-darwin
-      - name: Report macOS-gated check disposition
-        if: always()
-        env:
-          POLICY_RESULT: ${{ needs.policy.result }}
-          REQUIRED: ${{ needs.policy.outputs.run_rust }}
-          REASON: ${{ needs.policy.outputs.reason }}
-        run: |
-          if [ "${POLICY_RESULT}" != success ]; then echo "Change classification failed"; exit 1; fi
-          if [ "${REQUIRED}" != true ]; then echo "macOS-gated GPU check not required: ${REASON}"; fi
-
   coverage:
     name: coverage
     needs: policy

--- a/crates/tenferro-fft/src/cpu.rs
+++ b/crates/tenferro-fft/src/cpu.rs
@@ -5,8 +5,7 @@ use num_traits::{Float, FromPrimitive, Zero};
 use tenferro_cpu::CpuExecSession;
 use tenferro_tensor::{
     AllocationDomainId, DType, DeviceKind, HostAccessError, MemoryKind, Placement,
-    SharedTensorAllocationDomain, StorageBuffer, Tensor, TensorRead, TensorScalar, TensorView,
-    TypedTensor,
+    SharedTensorAllocationDomain, Tensor, TensorRead, TensorScalar, TensorView, TypedTensor,
 };
 
 use crate::backend::FftExecutionCache;
@@ -242,15 +241,24 @@ fn with_managed_read<T, R>(
     execute: impl FnOnce(&[T]) -> tenferro_tensor::Result<R>,
 ) -> tenferro_tensor::Result<R>
 where
-    T: Send + Sync + 'static,
+    T: TensorScalar + Send + Sync + 'static,
 {
-    let StorageBuffer::Backend(buffer) = input.buffer() else {
+    if input.placement().memory_kind != MemoryKind::Managed {
         return Err(tenferro_tensor::Error::host_access(
             op,
-            HostAccessError::Unsupported { backend: "host" },
+            HostAccessError::Unsupported {
+                backend: if matches!(
+                    input.placement().memory_kind,
+                    MemoryKind::PinnedHost | MemoryKind::UnpinnedHost
+                ) {
+                    "host"
+                } else {
+                    "backend"
+                },
+            },
         ));
-    };
-    match buffer.allocation_domain() {
+    }
+    match input.allocation_domain() {
         Some(actual) if actual == expected_domain => {}
         Some(actual) => {
             return Err(tenferro_tensor::Error::host_access(
@@ -264,24 +272,18 @@ where
         None => {
             return Err(tenferro_tensor::Error::host_access(
                 op,
-                HostAccessError::Unsupported {
-                    backend: buffer.backend_family(),
-                },
+                HostAccessError::Unsupported { backend: "backend" },
             ));
         }
     }
-    if input.placement().memory_kind != MemoryKind::Managed {
-        return Err(tenferro_tensor::Error::host_access(
-            op,
-            HostAccessError::Unsupported {
-                backend: buffer.backend_family(),
-            },
-        ));
+    if let Some(buffer) = input.backend_buffer() {
+        let read = buffer
+            .map_read()
+            .map_err(|source| tenferro_tensor::Error::host_access(op, source))?;
+        execute(&read)
+    } else {
+        input.with_host_read(execute)?
     }
-    let read = buffer
-        .map_read()
-        .map_err(|source| tenferro_tensor::Error::host_access(op, source))?;
-    execute(&read)
 }
 
 fn write_managed_output<T>(
@@ -291,7 +293,7 @@ fn write_managed_output<T>(
     values: &[T],
 ) -> tenferro_tensor::Result<()>
 where
-    T: Send + Sync + 'static,
+    T: TensorScalar + Send + Sync + 'static,
 {
     if output.allocation_domain() != Some(expected_domain) {
         return Err(tenferro_tensor::Error::runtime_state(
@@ -305,18 +307,24 @@ where
             "shared allocation owner returned a non-managed output",
         ));
     }
-    let Some(buffer) = output.backend_buffer_mut() else {
-        return Err(tenferro_tensor::Error::runtime_state(
-            op,
-            "shared allocation owner returned a host output",
-        ));
-    };
-    let mut write = buffer
-        .map_write()
-        .map_err(|source| tenferro_tensor::Error::host_access(op, source))?;
-    write
-        .copy_from_slice(values)
-        .map_err(|source| tenferro_tensor::Error::host_access(op, source))
+    if let Some(buffer) = output.backend_buffer_mut() {
+        let mut write = buffer
+            .map_write()
+            .map_err(|source| tenferro_tensor::Error::host_access(op, source))?;
+        return write
+            .copy_from_slice(values)
+            .map_err(|source| tenferro_tensor::Error::host_access(op, source));
+    }
+    output.with_host_write(|write| {
+        if write.len() != values.len() {
+            return Err(tenferro_tensor::Error::runtime_state(
+                op,
+                "shared allocation owner returned an output with the wrong length",
+            ));
+        }
+        write.copy_from_slice(values);
+        Ok(())
+    })?
 }
 
 macro_rules! write_managed_output {

--- a/crates/tenferro-fft/tests/apple_cpu.rs
+++ b/crates/tenferro-fft/tests/apple_cpu.rs
@@ -3,7 +3,7 @@
 use num_complex::{Complex32, Complex64};
 use tenferro_fft::{FftExecutor, FftNorm, TensorFftExt};
 use tenferro_gpu::{apple::AppleContext, webgpu::upload_webgpu_tensor, webgpu::WebGpuRuntime};
-use tenferro_tensor::{BackendSessionHost, HostAccessError, StorageBuffer, Tensor};
+use tenferro_tensor::{BackendSessionHost, HostAccessError, Tensor, TensorScalar};
 
 fn apple_context() -> Option<AppleContext> {
     match AppleContext::new() {
@@ -15,13 +15,10 @@ fn apple_context() -> Option<AppleContext> {
     }
 }
 
-fn mapped_slice<T: Copy + Send + Sync + 'static>(
+fn mapped_slice<T: TensorScalar + Copy + Send + Sync + 'static>(
     tensor: &tenferro_tensor::TypedTensor<T>,
 ) -> Vec<T> {
-    let StorageBuffer::Backend(buffer) = tensor.buffer() else {
-        panic!("expected managed backend output")
-    };
-    buffer.map_read().unwrap().to_vec()
+    tensor.with_host_read(<[T]>::to_vec).unwrap()
 }
 
 #[test]
@@ -163,21 +160,20 @@ fn managed_cpu_fft_rejects_foreign_and_device_local_buffers_without_transfers() 
     let foreign = first.upload_tensor(&host).unwrap();
     let first_before = first.transfer_stats();
     let second_before = second.transfer_stats();
-    let error = foreign
-        .fft(
-            None,
-            -1,
-            FftNorm::Backward,
-            &mut second.cpu_backend().clone(),
-        )
+    let mut second_cpu = second.cpu_backend().clone();
+    let error = second_cpu
+        .with_backend_session(|session| foreign.fft(None, -1, FftNorm::Backward, session))
         .unwrap_err();
-    assert!(matches!(
-        error,
-        tenferro_tensor::Error::HostAccess {
-            source: HostAccessError::ForeignDomain { .. },
-            ..
-        }
-    ));
+    assert!(
+        matches!(
+            error,
+            tenferro_tensor::Error::HostAccess {
+                source: HostAccessError::ForeignDomain { .. },
+                ..
+            }
+        ),
+        "unexpected foreign-domain error: {error:?}"
+    );
     assert_eq!(first.transfer_stats(), first_before);
     assert_eq!(second.transfer_stats(), second_before);
 
@@ -187,13 +183,9 @@ fn managed_cpu_fft_rejects_foreign_and_device_local_buffers_without_transfers() 
     let device_local = upload_webgpu_tensor(&runtime, &host).unwrap();
     runtime.synchronize().unwrap();
     let before = first.transfer_stats();
-    let error = device_local
-        .fft(
-            None,
-            -1,
-            FftNorm::Backward,
-            &mut first.cpu_backend().clone(),
-        )
+    let mut first_cpu = first.cpu_backend().clone();
+    let error = first_cpu
+        .with_backend_session(|session| device_local.fft(None, -1, FftNorm::Backward, session))
         .unwrap_err();
     assert!(matches!(
         error,

--- a/crates/tenferro-fft/tests/webgpu_metal_fft.rs
+++ b/crates/tenferro-fft/tests/webgpu_metal_fft.rs
@@ -8,7 +8,7 @@ mod metal {
         webgpu::with_webgpu_exec_session, webgpu::WebGpuBackend, webgpu::WebGpuExecSession,
         webgpu::WebGpuRuntime,
     };
-    use tenferro_tensor::{BackendSessionHost, Error, StorageBuffer, Tensor};
+    use tenferro_tensor::{BackendSessionHost, Error, HostAccessError, Tensor, TensorScalar};
 
     /// Visit the concrete WebGPU session for SPI-level behavior only: stream
     /// synchronization and backend-interop limits. Concrete FFT trait calls
@@ -26,11 +26,10 @@ mod metal {
         })
     }
 
-    fn mapped<T: Copy + Send + Sync + 'static>(tensor: &tenferro_tensor::TypedTensor<T>) -> Vec<T> {
-        let StorageBuffer::Backend(buffer) = tensor.buffer() else {
-            panic!("expected managed backend buffer")
-        };
-        buffer.map_read().unwrap().to_vec()
+    fn mapped<T: TensorScalar + Copy + Send + Sync + 'static>(
+        tensor: &tenferro_tensor::TypedTensor<T>,
+    ) -> Vec<T> {
+        tensor.with_host_read(<[T]>::to_vec).unwrap()
     }
 
     fn c32_values(tensor: &Tensor) -> Vec<Complex32> {
@@ -316,7 +315,16 @@ mod metal {
         let error = metal
             .with_backend_session(|session| device_local.fft(None, 0, FftNorm::Backward, session))
             .unwrap_err();
-        assert!(matches!(error, Error::RuntimeState { .. }));
+        assert!(
+            matches!(
+                error,
+                Error::HostAccess {
+                    source: HostAccessError::ForeignDomain { .. },
+                    ..
+                }
+            ),
+            "unexpected device-local error: {error:?}"
+        );
         assert_eq!(context.transfer_stats(), before);
     }
 }

--- a/crates/tenferro-gpu/src/webgpu/runtime.rs
+++ b/crates/tenferro-gpu/src/webgpu/runtime.rs
@@ -238,9 +238,10 @@ mod identity_tests {
             return;
         }
 
-        let first = WebGpuBackend::new(0).expect("WebGPU backend should initialize");
+        let first = WebGpuBackend::new_default().expect("WebGPU backend should initialize");
         let clone = first.clone();
-        let independent = WebGpuBackend::new(0).expect("second WebGPU backend should initialize");
+        let independent =
+            WebGpuBackend::new_default().expect("second WebGPU backend should initialize");
 
         assert_eq!(first.runtime_identity(), clone.runtime_identity());
         assert_ne!(first.runtime_identity(), independent.runtime_identity());

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -7,8 +7,8 @@ use tenferro_cpu::linalg_interop::BufferPool;
 use tenferro_cpu::{CpuBackendKind, CpuExecSession, CpuExecutionContext};
 use tenferro_tensor::{
     validate::validate_nonsingular_u, AllocationDomainId, DType, Error, HostAccessError,
-    MemoryKind, SharedTensorAllocationDomain, StorageBuffer, Tensor, TensorElementwise, TensorRead,
-    TensorScalar, TensorStructural, TensorView, TensorViewMut, TensorWrite, TypedTensor,
+    MemoryKind, SharedTensorAllocationDomain, Tensor, TensorElementwise, TensorRead, TensorScalar,
+    TensorStructural, TensorView, TensorViewMut, TensorWrite, TypedTensor,
 };
 
 trait FreshLinalgOutput {
@@ -733,15 +733,7 @@ fn solve_shape_direct_eligible(a_shape: &[usize], b_shape: &[usize]) -> bool {
 }
 
 fn tensor_uses_backend_storage(input: &Tensor) -> bool {
-    match input {
-        Tensor::F32(input) => matches!(input.buffer(), StorageBuffer::Backend(_)),
-        Tensor::F64(input) => matches!(input.buffer(), StorageBuffer::Backend(_)),
-        Tensor::I32(input) => matches!(input.buffer(), StorageBuffer::Backend(_)),
-        Tensor::I64(input) => matches!(input.buffer(), StorageBuffer::Backend(_)),
-        Tensor::Bool(input) => matches!(input.buffer(), StorageBuffer::Backend(_)),
-        Tensor::C32(input) => matches!(input.buffer(), StorageBuffer::Backend(_)),
-        Tensor::C64(input) => matches!(input.buffer(), StorageBuffer::Backend(_)),
-    }
+    input.is_backend_buffer()
 }
 
 fn managed_cholesky(
@@ -851,19 +843,15 @@ where
     T: ManagedCholeskyScalar,
 {
     let n = validate_managed_cholesky_input(input, domain.id())?;
-    let StorageBuffer::Backend(buffer) = input.buffer() else {
-        return Err(tenferro_tensor::Error::host_access(
-            "cholesky",
-            HostAccessError::Unsupported { backend: "host" },
-        ));
-    };
     let values = if n == 0 {
         Vec::new()
-    } else {
+    } else if let Some(buffer) = input.backend_buffer() {
         let read = buffer
             .map_read()
             .map_err(|source| tenferro_tensor::Error::host_access("cholesky", source))?;
         T::factor(context, buffers, &read, n, provider)?
+    } else {
+        input.with_host_read(|read| T::factor(context, buffers, read, n, provider))??
     };
     let mut typed = T::take_output(domain.allocate(T::DTYPE, &[n, n])?)?;
     write_managed_cholesky_output(&mut typed, domain.id(), &values)?;
@@ -897,20 +885,29 @@ fn validate_managed_cholesky_input<T: Copy + Send + Sync + TensorScalar + 'stati
             "managed rank-2 Cholesky requires compact column-major full-allocation storage",
         ));
     }
-    let expected_len = rows.checked_mul(cols).ok_or_else(|| {
+    rows.checked_mul(cols).ok_or_else(|| {
         tenferro_tensor::Error::invalid_argument(
             "cholesky",
             "input shape",
             "matrix element count overflows usize",
         )
     })?;
-    let StorageBuffer::Backend(buffer) = input.buffer() else {
+    if input.placement().memory_kind != MemoryKind::Managed {
         return Err(tenferro_tensor::Error::host_access(
             "cholesky",
-            HostAccessError::Unsupported { backend: "host" },
+            HostAccessError::Unsupported {
+                backend: if matches!(
+                    input.placement().memory_kind,
+                    MemoryKind::PinnedHost | MemoryKind::UnpinnedHost
+                ) {
+                    "host"
+                } else {
+                    "backend"
+                },
+            },
         ));
-    };
-    match buffer.allocation_domain() {
+    }
+    match input.allocation_domain() {
         Some(actual) if actual == expected_domain => {}
         Some(actual) => {
             return Err(tenferro_tensor::Error::host_access(
@@ -924,24 +921,14 @@ fn validate_managed_cholesky_input<T: Copy + Send + Sync + TensorScalar + 'stati
         None => {
             return Err(tenferro_tensor::Error::host_access(
                 "cholesky",
-                HostAccessError::Unsupported {
-                    backend: buffer.backend_family(),
-                },
+                HostAccessError::Unsupported { backend: "backend" },
             ));
         }
-    }
-    if input.placement().memory_kind != MemoryKind::Managed || buffer.len() != expected_len {
-        return Err(tenferro_tensor::Error::host_access(
-            "cholesky",
-            HostAccessError::Unsupported {
-                backend: buffer.backend_family(),
-            },
-        ));
     }
     Ok(rows)
 }
 
-fn write_managed_cholesky_output<T: Copy + Send + Sync + 'static>(
+fn write_managed_cholesky_output<T: TensorScalar + Copy + Send + Sync + 'static>(
     output: &mut TypedTensor<T>,
     expected_domain: AllocationDomainId,
     values: &[T],
@@ -954,18 +941,24 @@ fn write_managed_cholesky_output<T: Copy + Send + Sync + 'static>(
             "shared allocation owner returned an output outside its managed domain",
         ));
     }
-    let Some(buffer) = output.backend_buffer_mut() else {
-        return Err(tenferro_tensor::Error::runtime_state(
-            "cholesky",
-            "shared allocation owner returned a host output",
-        ));
-    };
-    let mut write = buffer
-        .map_write()
-        .map_err(|source| tenferro_tensor::Error::host_access("cholesky", source))?;
-    write
-        .copy_from_slice(values)
-        .map_err(|source| tenferro_tensor::Error::host_access("cholesky", source))
+    if let Some(buffer) = output.backend_buffer_mut() {
+        let mut write = buffer
+            .map_write()
+            .map_err(|source| tenferro_tensor::Error::host_access("cholesky", source))?;
+        return write
+            .copy_from_slice(values)
+            .map_err(|source| tenferro_tensor::Error::host_access("cholesky", source));
+    }
+    output.with_host_write(|write| {
+        if write.len() != values.len() {
+            return Err(tenferro_tensor::Error::runtime_state(
+                "cholesky",
+                "shared allocation owner returned an output with the wrong length",
+            ));
+        }
+        write.copy_from_slice(values);
+        Ok(())
+    })?
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -6519,9 +6519,9 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     where
         T: 'static,
     {
-        match self.buffer() {
-            StorageBuffer::Host(_) => None,
-            StorageBuffer::Backend(buffer) => Some(buffer.as_ref()),
+        match self.group.backend_buffer::<T>() {
+            Some(StorageBuffer::Backend(buffer)) => Some(buffer.as_ref()),
+            Some(StorageBuffer::Host(_)) | None => None,
         }
     }
 

--- a/docs/design/change-aware-ci.md
+++ b/docs/design/change-aware-ci.md
@@ -45,8 +45,8 @@ changes and `main` pushes. It runs the shared `workspace-faer` profile on
 `macos-15`, covering workspace tests and doctests including macOS-only
 Apple/Metal paths. The job starts only after `CI gate (PR workspace tests)` has
 accepted the selected Linux workspace and extension lanes. This keeps macOS
-runner use off failed Linux revisions; the RunPod GPU workflow may start from
-the same Linux gate in parallel.
+runner use off failed Linux revisions. The RunPod GPU workflow remains further
+downstream, so a failed macOS run also prevents paid GPU allocation.
 
 The change policy also runs this gate when its workflow, shared profile, or
 classifier changes, so CI-only edits can validate the native lane. Other

--- a/docs/design/change-aware-ci.md
+++ b/docs/design/change-aware-ci.md
@@ -20,8 +20,8 @@ Pull requests have one primary class and independent lane flags:
 
 Mixed docs and CI changes are CI-only with both lightweight flags enabled.
 Unknown paths always fall back to code. Pushes to `main` force the
-comprehensive non-GPU matrix; they do not add a second paid GPU run after the
-pull-request gate.
+comprehensive Linux and macOS matrix; they do not add a second paid RunPod GPU
+run after the pull-request gate.
 
 Required job names do not disappear when work is unnecessary. Each required
 job either runs its selected profile or publishes an explicit successful
@@ -37,6 +37,24 @@ CI configuration. Local and hosted execution call the same profile names.
 execute once. Hosted Rust compile/test commands use workspace `[profile.ci]`
 (`opt-level=0`, `debug=0`, `incremental=false`, `strip="symbols"`) rather than
 `--release`; local `dev`/`test` profiles stay incremental.
+
+## macOS support gate
+
+`macOS workspace tests` is a required Apple Silicon execution gate for code
+changes and `main` pushes. It runs the shared `workspace-faer` profile on
+`macos-15`, covering workspace tests and doctests including macOS-only
+Apple/Metal paths. The job starts only after `CI gate (PR workspace tests)` has
+accepted the selected Linux workspace and extension lanes. This keeps macOS
+runner use off failed Linux revisions; the RunPod GPU workflow may start from
+the same Linux gate in parallel.
+
+The change policy also runs this gate when its workflow, shared profile, or
+classifier changes, so CI-only edits can validate the native lane. Other
+CI-only and docs-only changes run an explicit successful no-op on
+`ubuntu-latest` instead of allocating a macOS runner. A Linux gate failure also
+stays on Ubuntu and fails closed. The older Linux-hosted Apple cross-target
+type-check is removed because the real macOS workspace run compiles and
+executes the same target-gated code.
 
 ## RunPod trust boundary
 

--- a/docs/guides/cpu-execution.md
+++ b/docs/guides/cpu-execution.md
@@ -29,8 +29,12 @@ for node in backend.topology().nodes() {
     println!("OS node {}: {:?}", node.id(), node.cpus().as_usize_vec());
 }
 
-let all = backend.for_placement(CpuPlacement::AllAllowed)?;
-println!("{:?}", all.execution_info());
+if backend.supports_placement(CpuPlacement::AllAllowed) {
+    let all = backend.for_placement(CpuPlacement::AllAllowed)?;
+    println!("{:?}", all.execution_info());
+} else {
+    println!("{:?}", backend.execution_info());
+}
 ```
 <!-- end-snippet-source -->
 

--- a/docs/tutorial-code/src/bin/apple_shared_cholesky.rs
+++ b/docs/tutorial-code/src/bin/apple_shared_cholesky.rs
@@ -5,7 +5,7 @@ use tenferro_gpu::apple::AppleContext;
 #[cfg(target_os = "macos")]
 use tenferro_linalg::LinalgBackend;
 #[cfg(target_os = "macos")]
-use tenferro_tensor::{StorageBuffer, Tensor};
+use tenferro_tensor::Tensor;
 
 #[cfg(target_os = "macos")]
 fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -33,16 +33,14 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     };
     assert_eq!(factor.allocation_domain(), Some(context.domain_id()));
     assert_ne!(factor.allocation_id(), Some(input_allocation));
-    let StorageBuffer::Backend(buffer) = factor.buffer() else {
-        panic!("expected Apple managed output")
-    };
-    let l = buffer.map_read()?;
-    let reconstructed = [
-        l[0] * l[0] + l[2] * l[2],
-        l[1] * l[0] + l[3] * l[2],
-        l[0] * l[1] + l[2] * l[3],
-        l[1] * l[1] + l[3] * l[3],
-    ];
+    let reconstructed = factor.with_host_read(|l| {
+        [
+            l[0] * l[0] + l[2] * l[2],
+            l[1] * l[0] + l[3] * l[2],
+            l[0] * l[1] + l[2] * l[3],
+            l[1] * l[1] + l[3] * l[3],
+        ]
+    })?;
     let expected = [4.0_f32, 2.0, 2.0, 3.0];
     let residual = reconstructed
         .iter()

--- a/docs/tutorial-code/src/bin/apple_shared_fft.rs
+++ b/docs/tutorial-code/src/bin/apple_shared_fft.rs
@@ -8,15 +8,14 @@ use tenferro_fft::{FftNorm, TensorFftExt};
 use tenferro_gpu::apple::AppleContext;
 #[cfg(target_os = "macos")]
 use tenferro_tensor::{
-    AllocationDomainId, AllocationId, BackendSessionHost, Error, StorageBuffer, Tensor, TypedTensor,
+    AllocationDomainId, AllocationId, BackendSessionHost, Error, Tensor, TensorScalar, TypedTensor,
 };
 
 #[cfg(target_os = "macos")]
-fn managed_values<T: Copy + Send + Sync + 'static>(tensor: &TypedTensor<T>) -> Vec<T> {
-    let StorageBuffer::Backend(buffer) = tensor.buffer() else {
-        panic!("expected Apple managed storage")
-    };
-    buffer.map_read().unwrap().to_vec()
+fn managed_values<T: TensorScalar + Copy + Send + Sync + 'static>(
+    tensor: &TypedTensor<T>,
+) -> Vec<T> {
+    tensor.with_host_read(<[T]>::to_vec).unwrap()
 }
 
 #[cfg(target_os = "macos")]

--- a/docs/tutorial-code/src/bin/core_tensor_snippets.rs
+++ b/docs/tutorial-code/src/bin/core_tensor_snippets.rs
@@ -714,8 +714,12 @@ for node in backend.topology().nodes() {
     println!("OS node {}: {:?}", node.id(), node.cpus().as_usize_vec());
 }
 
-let all = backend.for_placement(CpuPlacement::AllAllowed)?;
-println!("{:?}", all.execution_info());
+if backend.supports_placement(CpuPlacement::AllAllowed) {
+    let all = backend.for_placement(CpuPlacement::AllAllowed)?;
+    println!("{:?}", all.execution_info());
+} else {
+    println!("{:?}", backend.execution_info());
+}
         // snippet-end:cpu_execution_28
         Ok(())
     }

--- a/docs/worklogs/2026-08-24-macos-ci-restoration.md
+++ b/docs/worklogs/2026-08-24-macos-ci-restoration.md
@@ -1,0 +1,39 @@
+# macOS CI restoration
+
+Date: 2026-08-24
+
+## Summary
+
+macOS is a supported tenferro platform, but pull requests previously only
+cross-compiled one Apple-gated GPU integration target from Linux. Issue #1721
+showed that this did not detect macOS-only Apple/Metal runtime failures.
+
+The PR workspace workflow now runs the existing `workspace-faer` profile on
+the GitHub-hosted Apple Silicon `macos-15` runner. The macOS job depends on the
+existing Linux workspace aggregate gate, so failed Linux revisions do not
+consume macOS runner time. RunPod GPU validation may proceed from the same
+Linux gate in parallel.
+
+## Decisions
+
+- Reuse `workspace-faer`; do not add a macOS-specific command profile.
+- Run full workspace tests and doctests rather than a Metal-only subset because
+  macOS is a supported host platform.
+- Run the native lane for code and macOS-control-plane changes; use
+  `ubuntu-latest` for other CI-only and docs-only no-ops, avoiding unnecessary
+  macOS allocation while preserving a stable required check name.
+- Remove the Linux cross-target Apple type-check because the native macOS run
+  supersedes it.
+- Keep the stable Linux aggregate check unchanged so RunPod ordering and
+  existing branch protection continue to work.
+
+## Verification
+
+- `python3 -m unittest scripts.ci.tests.test_change_policy scripts.ci.tests.test_workflow_contracts`
+- `python3 scripts/ci/run_profile.py ci-config`
+- `actionlint .github/workflows/ci.yml .github/workflows/ci-pr-workspace-tests.yml`
+
+The first hosted `macOS workspace tests` run is the native execution
+verification and may expose the currently reported macOS failures; those must
+be fixed rather than skipped or allowed to fail before the check becomes a
+merge requirement.

--- a/docs/worklogs/2026-08-24-macos-ci-restoration.md
+++ b/docs/worklogs/2026-08-24-macos-ci-restoration.md
@@ -11,8 +11,8 @@ showed that this did not detect macOS-only Apple/Metal runtime failures.
 The PR workspace workflow now runs the existing `workspace-faer` profile on
 the GitHub-hosted Apple Silicon `macos-15` runner. The macOS job depends on the
 existing Linux workspace aggregate gate, so failed Linux revisions do not
-consume macOS runner time. RunPod GPU validation may proceed from the same
-Linux gate in parallel.
+consume macOS runner time. RunPod GPU validation remains further downstream,
+so failed macOS revisions do not consume paid GPU time.
 
 ## Decisions
 
@@ -32,8 +32,26 @@ Linux gate in parallel.
 - `python3 -m unittest scripts.ci.tests.test_change_policy scripts.ci.tests.test_workflow_contracts`
 - `python3 scripts/ci/run_profile.py ci-config`
 - `actionlint .github/workflows/ci.yml .github/workflows/ci-pr-workspace-tests.yml`
+- `cargo test -p tenferro-fft --features webgpu --lib`
+- `cargo test -p tenferro-linalg --features webgpu managed_cholesky -- --nocapture`
+- `cargo test -p tenferro-gpu --features webgpu --lib webgpu::runtime::identity_tests::webgpu_backend_identity_tracks_the_exact_runtime_when_hardware_is_available -- --exact`
+- `cargo test -p tenferro-tutorial-code tutorial_binaries_run_successfully -- --exact`
+- Initial hosted evidence: [macOS workspace tests](https://github.com/tensor4all/tenferro-rs/actions/runs/32709423761/job/97377574384)
+- Independent read-only review: `reviewer-gpt`, verdict `Correct-to-merge` after tracing the CI policy/order and all three blocker-fix paths.
+- Deterministic repository-rules review: pass. It warned that the pre-existing 34-line WebGPU identity test module is inline; it remains in the 253-line leaf runtime module because this change only corrects one constructor call and moving the existing tests would be unrelated cleanup.
 
-The first hosted `macOS workspace tests` run is the native execution
-verification and may expose the currently reported macOS failures; those must
-be fixed rather than skipped or allowed to fail before the check becomes a
-merge requirement.
+## Hosted baseline and remediation
+
+The first hosted run executed 3,120 tests on GitHub's Apple Silicon runner:
+3,115 passed and five failed. No failure was skipped or allowed to fail.
+
+| Failure | Root cause | Fix |
+| --- | --- | --- |
+| Managed CPU/Metal FFT panics | Managed provider roots are scalar-independent, while the FFT path and test helpers still called the legacy scalar-typed `buffer()` accessor. | Validate placement/domain from tensor metadata and use guarded host mapping, retaining the legacy buffer path only for existing mock providers. |
+| FFT rejection assertions | The CPU rejection test passed a backend handle instead of entering its FFT-capable session; after the panic was fixed, the Metal test also exposed its stale expectation for a foreign device-local domain. | Enter the CPU backend session and assert the typed `HostAccessError::ForeignDomain` reported by both domain boundaries. |
+| WebGPU runtime identity test | Availability probed CubeCL's default adapter, but the test then requested discrete GPU ordinal 0; Apple Silicon exposes the supported integrated Metal adapter through default selection. | Construct both identity-test backends with `new_default()`. |
+| `core_tensor_snippets` tutorial | The tutorial unconditionally requested explicit managed `AllAllowed` affinity, which is intentionally unsupported on macOS. | Query `supports_placement` and retain the default compatibility context when explicit affinity is unavailable. |
+
+The same scalar-independent managed-root correction was applied to managed CPU
+Cholesky and the Apple FFT/Cholesky tutorials because they shared the exact
+storage contract and verification path.

--- a/scripts/ci/change_policy.py
+++ b/scripts/ci/change_policy.py
@@ -32,6 +32,7 @@ class ChangePolicy:
     run_docs: bool
     run_ci_config: bool
     run_gpu: bool
+    run_macos: bool
     reasons: tuple[str, ...]
 
     def as_output(self) -> dict[str, str | bool]:
@@ -45,6 +46,7 @@ class ChangePolicy:
             "run_docs": self.run_docs,
             "run_ci_config": self.run_ci_config,
             "run_gpu": self.run_gpu,
+            "run_macos": self.run_macos,
             "reason": "; ".join(self.reasons),
         }
 
@@ -66,6 +68,13 @@ _CI_FILES = frozenset(
     }
 )
 _CI_PREFIXES = (".github/workflows/", "scripts/ci/")
+_MACOS_CONTROL_FILES = frozenset(
+    {
+        ".github/workflows/ci-pr-workspace-tests.yml",
+        "scripts/ci/change_policy.py",
+        "scripts/ci/run_profile.py",
+    }
+)
 _GPU_CONTROL_FILES = frozenset(
     {
         ".github/workflows/CI_gpu.yml",
@@ -99,6 +108,10 @@ def _is_gpu_control_plane_path(path: str) -> bool:
     return path in _GPU_CONTROL_FILES
 
 
+def _is_macos_control_plane_path(path: str) -> bool:
+    return path in _MACOS_CONTROL_FILES
+
+
 def _full_policy(reason: str, *, run_gpu: bool = True) -> ChangePolicy:
     return ChangePolicy(
         change_class=ChangeClass.CODE,
@@ -108,6 +121,7 @@ def _full_policy(reason: str, *, run_gpu: bool = True) -> ChangePolicy:
         run_docs=True,
         run_ci_config=True,
         run_gpu=run_gpu,
+        run_macos=True,
         reasons=(reason,),
     )
 
@@ -155,6 +169,7 @@ def classify_paths(
         run_docs=bool(docs),
         run_ci_config=has_ci,
         run_gpu=any(_is_gpu_control_plane_path(path) for path in ci),
+        run_macos=any(_is_macos_control_plane_path(path) for path in ci),
         reasons=reasons,
     )
 

--- a/scripts/ci/tests/test_change_policy.py
+++ b/scripts/ci/tests/test_change_policy.py
@@ -22,6 +22,7 @@ class ChangePolicyTests(unittest.TestCase):
         self.assertFalse(policy.run_rust)
         self.assertFalse(policy.run_extensions)
         self.assertFalse(policy.run_gpu)
+        self.assertFalse(policy.run_macos)
 
     def test_ci_and_docs_runs_both_lightweight_suites(self) -> None:
         policy = classify_paths(
@@ -31,6 +32,23 @@ class ChangePolicyTests(unittest.TestCase):
         self.assertTrue(policy.run_ci_config)
         self.assertTrue(policy.run_docs)
         self.assertFalse(policy.run_rust)
+        self.assertFalse(policy.run_macos)
+
+    def test_macos_control_plane_requires_macos(self) -> None:
+        for path in (
+            ".github/workflows/ci-pr-workspace-tests.yml",
+            "scripts/ci/change_policy.py",
+            "scripts/ci/run_profile.py",
+        ):
+            with self.subTest(path=path):
+                policy = classify_paths([path])
+                self.assertIs(policy.change_class, ChangeClass.CI_ONLY)
+                self.assertTrue(policy.run_ci_config)
+                self.assertTrue(policy.run_macos)
+
+    def test_unrelated_ci_change_does_not_require_macos(self) -> None:
+        policy = classify_paths([".github/workflows/docs.yml"])
+        self.assertFalse(policy.run_macos)
 
     def test_runpod_control_plane_requires_gpu(self) -> None:
         for path in (
@@ -67,14 +85,16 @@ class ChangePolicyTests(unittest.TestCase):
                 self.assertTrue(policy.run_rust)
                 self.assertTrue(policy.run_extensions)
                 self.assertTrue(policy.run_gpu)
+                self.assertTrue(policy.run_macos)
 
-    def test_push_to_main_forces_comprehensive_non_gpu_lanes(self) -> None:
+    def test_push_to_main_forces_comprehensive_lanes(self) -> None:
         policy = classify_paths(["README.md"], event="push")
         self.assertIs(policy.change_class, ChangeClass.CODE)
         self.assertTrue(policy.run_rust)
         self.assertTrue(policy.run_extensions)
         self.assertTrue(policy.run_docs)
         self.assertTrue(policy.run_ci_config)
+        self.assertTrue(policy.run_macos)
 
     def test_paths_are_normalized_and_deduplicated(self) -> None:
         policy = classify_paths([" ./README.md ", "README.md", ""])
@@ -101,6 +121,7 @@ class ChangePolicyTests(unittest.TestCase):
             self.assertEqual(values["classification"], "docs-only")
             self.assertEqual(values["run_docs"], "true")
             self.assertEqual(values["run_rust"], "false")
+            self.assertEqual(values["run_macos"], "false")
             self.assertIn("README.md", values["reason"])
 
     def test_cli_classifies_deleted_documentation_as_docs_only(self) -> None:

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -26,19 +26,19 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("python3 scripts/ci/run_profile.py docs", text)
         self.assertIn("name: CI configuration checks", text)
 
-    def test_macos_gated_gpu_tests_are_cross_checked(self) -> None:
-        text = read(".github/workflows/ci.yml")
-        start = text.index("  macos-gated-check:")
-        end = text.index("\n  coverage:", start)
-        block = text[start:end]
-        self.assertIn("name: macOS-gated GPU type-check", block)
-        self.assertIn("targets: aarch64-apple-darwin", block)
-        self.assertIn(
-            "cargo check -p tenferro-gpu --features webgpu --test integration "
-            "--target aarch64-apple-darwin",
-            block,
-        )
-        self.assertIn("needs.policy.outputs.run_rust == 'true'", block)
+    def test_macos_workspace_tests_run_after_linux_gate(self) -> None:
+        text = read(".github/workflows/ci-pr-workspace-tests.yml")
+        start = text.index("  macos:")
+        block = text[start:]
+        self.assertIn("name: macOS workspace tests", block)
+        self.assertIn("needs: [changes, ci-gate]", block)
+        self.assertIn("run_macos: ${{ steps.policy.outputs.run_macos }}", text)
+        self.assertIn("'macos-15' || 'ubuntu-latest'", block)
+        self.assertIn("python3 scripts/ci/run_profile.py workspace-faer", block)
+        self.assertIn("Linux workspace gate failed", block)
+
+        fast = read(".github/workflows/ci.yml")
+        self.assertNotIn("macOS-gated GPU type-check", fast)
 
     def test_required_names_remain_stable(self) -> None:
         fast = read(".github/workflows/ci.yml")
@@ -53,6 +53,7 @@ class WorkflowContractTests(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertIn(f"name: {name}", fast)
         self.assertIn("name: CI gate (PR workspace tests)", heavy)
+        self.assertIn("name: macOS workspace tests", heavy)
 
     def test_fast_required_jobs_fail_if_policy_fails(self) -> None:
         text = read(".github/workflows/ci.yml")


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1721

## Summary

macOS is a supported tenferro platform, but PR CI only cross-compiled one Apple-gated target from Linux. This PR restores native Apple Silicon execution coverage and fixes every blocker found by the first hosted run.

### CI

- Run the existing `workspace-faer` profile on GitHub-hosted Apple Silicon `macos-15`.
- Start macOS only after the Linux workspace/extension aggregate succeeds.
- Keep RunPod GPU downstream, so Linux or macOS failures avoid paid GPU allocation.
- Use an Ubuntu no-op for docs-only and unrelated CI-only changes.
- Run macOS for changes to its workflow, shared profile, or classifier so the lane validates itself.
- Remove the superseded Linux-hosted Apple cross-target type-check.

### First hosted baseline: 3,115 passed / 5 failed

All five failures were fixed rather than skipped or allowed to fail:

- Apple/Metal FFT panics: replace legacy scalar-typed `buffer()` access with guarded mapping for scalar-independent managed roots, while retaining the legacy mock-provider path;
- FFT rejection assertions: enter the CPU backend's FFT-capable session and assert the typed foreign-domain error now exposed by both CPU and Metal boundaries;
- WebGPU identity failure: pair default-adapter availability probing with `WebGpuBackend::new_default()` instead of requesting a discrete adapter on Apple Silicon;
- tutorial failure: query `supports_placement(AllAllowed)` and retain the portable default context when explicit affinity is unavailable.

The same managed-root correction was applied to managed CPU Cholesky and the Apple FFT/Cholesky tutorials because they share the exact storage contract.

Bug-fix scope gate applied: no new API, backend, dependency, feature flag, or AD semantics. The neighborhood scan covered FFT and Cholesky managed providers, Apple tutorial readers, WebGPU adapter selection, affinity capability negotiation, change classification, required-check naming, and RunPod ordering. No new repository rule was added; existing CI design/contracts were tightened.

## Work log

- [`docs/worklogs/2026-08-24-macos-ci-restoration.md`](../blob/fix/1721-macos-ci/docs/worklogs/2026-08-24-macos-ci-restoration.md)

## Verification

- `bash scripts/check-pr-fast.sh --base origin/main --no-fetch --coverage-reviewed --doc-snippets` with focused FFT, managed-Cholesky, WebGPU identity, and tutorial-binary tests
- `python3 scripts/ci/run_profile.py ci-config`
- `actionlint .github/workflows/ci.yml .github/workflows/ci-pr-workspace-tests.yml`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --dry-run --llm-skipped-reason 'local deterministic review'` — pass; documented one pre-existing inline leaf-test warning
- independent read-only `reviewer-gpt` review — `Correct-to-merge`
- initial native macOS evidence: https://github.com/tensor4all/tenferro-rs/actions/runs/32709423761/job/97377574384

The refreshed required `macOS workspace tests` run is the final native verification.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules review (deterministic; the external LLM review is permanently disabled) and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
