### PR TITLE
Remediate tensor, CPU, docs, and CUDA issues

### DIFF
--- a/.agents/skills/tenferro-compute/references/pitfalls.md
+++ b/.agents/skills/tenferro-compute/references/pitfalls.md
@@ -11,11 +11,13 @@ cheatsheet](api-cheatsheet.md#direct-concrete-tensors).
 
 ## Einsum syntax
 
-Use the explicit arrow in every equation: `"ij,jk->ik"`. Flat notation
+**Warning:** use the explicit arrow in every equation: `"ij,jk->ik"`.
+Omitting it returns `Error::InvalidSubscripts` during parsing. Flat notation
 supports one right-aligned, broadcastable `...` ellipsis per term, and
-`EinsumNotation` is the programmatic form. Parenthesized ellipsis remains
-unsupported; `"i->ii"` is a tenferro extension rather than a general NumPy
-spelling. Read the `tenferro-einsum` guide before porting a large equation.
+`EinsumNotation` is the programmatic form. Parenthesized contraction order
+containing ellipsis is also rejected during parsing; `"i->ii"` is a tenferro
+extension rather than a general NumPy spelling. Read the `tenferro-einsum`
+guide before porting a large equation.
 
 ## Extension registration
 
@@ -72,8 +74,10 @@ Same traps, keyed by the priors you arrived with.
 
 - Trace one level of `?`: traced operators return `Result`; `a.matmul(&b)` is
   a `Result`, unlike `torch.matmul` / `jnp.matmul`.
-- Einsum needs the explicit arrow; flat `...` ellipsis is supported, while
-  parenthesized ellipsis is deferred (see [Einsum syntax](#einsum-syntax)).
+- Einsum needs the explicit arrow; omitting it is a parse-time
+  `Error::InvalidSubscripts`. Flat `...` ellipsis is supported, while
+  parenthesized ellipsis is rejected during parsing (see
+  [Einsum syntax](#einsum-syntax)).
 - The backend is not ambient: eager code must own an `EagerRuntime`, traced
   code must register an engine plus extension modules (see
   [Extension registration](#extension-registration)).

--- a/.claude/skills/tenferro-compute/references/pitfalls.md
+++ b/.claude/skills/tenferro-compute/references/pitfalls.md
@@ -11,11 +11,13 @@ cheatsheet](api-cheatsheet.md#direct-concrete-tensors).
 
 ## Einsum syntax
 
-Use the explicit arrow in every equation: `"ij,jk->ik"`. Flat notation
+**Warning:** use the explicit arrow in every equation: `"ij,jk->ik"`.
+Omitting it returns `Error::InvalidSubscripts` during parsing. Flat notation
 supports one right-aligned, broadcastable `...` ellipsis per term, and
-`EinsumNotation` is the programmatic form. Parenthesized ellipsis remains
-unsupported; `"i->ii"` is a tenferro extension rather than a general NumPy
-spelling. Read the `tenferro-einsum` guide before porting a large equation.
+`EinsumNotation` is the programmatic form. Parenthesized contraction order
+containing ellipsis is also rejected during parsing; `"i->ii"` is a tenferro
+extension rather than a general NumPy spelling. Read the `tenferro-einsum`
+guide before porting a large equation.
 
 ## Extension registration
 
@@ -72,8 +74,10 @@ Same traps, keyed by the priors you arrived with.
 
 - Trace one level of `?`: traced operators return `Result`; `a.matmul(&b)` is
   a `Result`, unlike `torch.matmul` / `jnp.matmul`.
-- Einsum needs the explicit arrow; flat `...` ellipsis is supported, while
-  parenthesized ellipsis is deferred (see [Einsum syntax](#einsum-syntax)).
+- Einsum needs the explicit arrow; omitting it is a parse-time
+  `Error::InvalidSubscripts`. Flat `...` ellipsis is supported, while
+  parenthesized ellipsis is rejected during parsing (see
+  [Einsum syntax](#einsum-syntax)).
 - The backend is not ambient: eager code must own an `EagerRuntime`, traced
   code must register an engine plus extension modules (see
   [Extension registration](#extension-registration)).

--- a/.kimi/skills/tenferro-compute/references/pitfalls.md
+++ b/.kimi/skills/tenferro-compute/references/pitfalls.md
@@ -11,11 +11,13 @@ cheatsheet](api-cheatsheet.md#direct-concrete-tensors).
 
 ## Einsum syntax
 
-Use the explicit arrow in every equation: `"ij,jk->ik"`. Flat notation
+**Warning:** use the explicit arrow in every equation: `"ij,jk->ik"`.
+Omitting it returns `Error::InvalidSubscripts` during parsing. Flat notation
 supports one right-aligned, broadcastable `...` ellipsis per term, and
-`EinsumNotation` is the programmatic form. Parenthesized ellipsis remains
-unsupported; `"i->ii"` is a tenferro extension rather than a general NumPy
-spelling. Read the `tenferro-einsum` guide before porting a large equation.
+`EinsumNotation` is the programmatic form. Parenthesized contraction order
+containing ellipsis is also rejected during parsing; `"i->ii"` is a tenferro
+extension rather than a general NumPy spelling. Read the `tenferro-einsum`
+guide before porting a large equation.
 
 ## Extension registration
 
@@ -72,8 +74,10 @@ Same traps, keyed by the priors you arrived with.
 
 - Trace one level of `?`: traced operators return `Result`; `a.matmul(&b)` is
   a `Result`, unlike `torch.matmul` / `jnp.matmul`.
-- Einsum needs the explicit arrow; flat `...` ellipsis is supported, while
-  parenthesized ellipsis is deferred (see [Einsum syntax](#einsum-syntax)).
+- Einsum needs the explicit arrow; omitting it is a parse-time
+  `Error::InvalidSubscripts`. Flat `...` ellipsis is supported, while
+  parenthesized ellipsis is rejected during parsing (see
+  [Einsum syntax](#einsum-syntax)).
 - The backend is not ambient: eager code must own an `EagerRuntime`, traced
   code must register an engine plus extension modules (see
   [Extension registration](#extension-registration)).

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -1034,6 +1034,9 @@ fn typed_reduce_sum_wrapping<T>(
 where
     T: WrappingReductionElem + TensorScalar,
 {
+    // INVARIANT: the pinned strided-kernel `ErasedReduceScalar` implementation
+    // for i32/i64 uses `wrapping_add`; the CPU overflow regression test pins
+    // this delegated two's-complement contract.
     typed_reduce_erased(input, axes, ReduceOp::Sum, "reduce_sum", exec_context)
 }
 
@@ -1061,6 +1064,9 @@ fn typed_reduce_prod_wrapping<T>(
 where
     T: WrappingReductionElem + TensorScalar,
 {
+    // INVARIANT: the pinned strided-kernel `ErasedReduceScalar` implementation
+    // for i32/i64 uses `wrapping_mul`; the CPU overflow regression test pins
+    // this delegated two's-complement contract.
     typed_reduce_erased(input, axes, ReduceOp::Product, "reduce_prod", exec_context)
 }
 

--- a/crates/tenferro-cpu/tests/integration/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/integration/runtime_error_tests.rs
@@ -312,6 +312,29 @@ fn cpu_reductions_use_common_empty_axes_validation_helpers() {
 }
 
 #[test]
+fn integer_reductions_record_the_delegated_wrapping_contract() {
+    let reduction = include_str!("../../src/reduction.rs");
+
+    for (start, end, operation) in [
+        (
+            "fn typed_reduce_sum_wrapping",
+            "pub(crate) fn typed_reduce_prod",
+            "wrapping_add",
+        ),
+        (
+            "fn typed_reduce_prod_wrapping",
+            "pub fn typed_reduce_max",
+            "wrapping_mul",
+        ),
+    ] {
+        let section = source_section(reduction, start, end);
+        assert!(section.contains("// INVARIANT:"));
+        assert!(section.contains("pinned strided-kernel"));
+        assert!(section.contains(operation));
+    }
+}
+
+#[test]
 fn cpu_backend_with_threads_rejects_zero_without_panicking() {
     let err = match CpuBackend::with_threads(0) {
         Ok(_) => panic!("zero threads should be rejected"),

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -753,6 +753,23 @@ fn backend_buffer_handle_metadata_and_host_export_errors_are_explicit() {
     assert!(col_err
         .to_string()
         .contains("backend buffers cannot be exported"));
+
+    let tensor = TypedTensor::<f64>::from_buffer_col_major(
+        vec![2],
+        StorageBuffer::Backend(Box::new(BackendStorageHandle::<f64>::new_with_len(43, 2))),
+        Placement {
+            memory_kind: MemoryKind::Device,
+            device: Some(DeviceId {
+                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+                ordinal: 0,
+            }),
+            cpu_affinity: None,
+        },
+    )
+    .unwrap();
+    let parts_err = tensor.into_parts().unwrap_err();
+
+    assert!(matches!(parts_err, Error::RuntimeState { .. }));
 }
 
 #[test]

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -6904,13 +6904,21 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// use tenferro_tensor::{StorageBuffer, TypedTensor};
     ///
-    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
-    /// let (buffer, layout, placement) = t.into_parts();
+    /// # fn main() -> tenferro_tensor::Result<()> {
+    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0])?;
+    /// let (buffer, layout, placement) = t.into_parts()?;
     /// assert!(matches!(buffer, StorageBuffer::Host(_)));
     /// assert_eq!(layout.shape(), &[2]);
     /// assert!(placement.device.is_none());
+    /// # Ok(())
+    /// # }
     /// ```
-    pub fn into_parts(self) -> (StorageBuffer<T>, TensorLayout<R>, Placement)
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] when this tensor uses backend
+    /// storage; download it before extracting host storage.
+    pub fn into_parts(self) -> crate::Result<(StorageBuffer<T>, TensorLayout<R>, Placement)>
     where
         T: TensorScalar,
     {
@@ -6920,11 +6928,8 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
             placement,
             ..
         } = self;
-        let buffer = match group.into_host_vec::<T>() {
-            Ok(data) => StorageBuffer::Host(data),
-            Err(_) => StorageBuffer::Host(Vec::new()),
-        };
-        (buffer, layout, placement)
+        let data = group.into_host_vec::<T>()?;
+        Ok((StorageBuffer::Host(data), layout, placement))
     }
 }
 
@@ -8192,8 +8197,8 @@ impl Tensor {
     }
 }
 
-// Kept for crate-local layout tests while tensor indexing helpers remain split
-// across tensor and CPU crates.
+// INVARIANT: retained for crate-local layout tests while tensor indexing
+// helpers remain split across the tensor and CPU crates.
 #[allow(dead_code)]
 pub(crate) fn flat_to_multi(mut flat: usize, shape: &[usize], out: &mut [usize]) {
     for i in 0..shape.len() {

--- a/docs/PROVENANCE_AND_CITATION_POLICY.md
+++ b/docs/PROVENANCE_AND_CITATION_POLICY.md
@@ -25,6 +25,11 @@ addition to, not in place of, the upstream citations.
   "Algorithm origins" below).
 - Check the citation policies of the upstream projects listed in the
   component table and apply them recursively.
+- If a calculation uses the faer backend for dense CPU linear algebra, cite
+  Sarah Quiñones El Kazdadi, “faer: A linear algebra library for the Rust
+  programming language,” *Journal of Open Source Software* 11(123), 6099
+  (2026), [doi:10.21105/joss.06099](https://doi.org/10.21105/joss.06099), in
+  addition to tenferro-rs and method-specific references.
 - tenferro-rs itself does not yet have a software paper; if you need to
   reference it directly, cite the repository URL and the version or commit
   you used.

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -498,7 +498,7 @@ Error behavior:
 | --- | --- |
 | GPU op receives a CPU tensor | `Error::BackendFailure` with an upload hint |
 | CPU op receives a GPU tensor | `Error::BackendFailure` with a download hint for `Result` APIs |
-| `TypedTensor::host_data()` on a GPU buffer | panic with a diagnostic |
+| `TypedTensor::host_data()` or `host_data_mut()` on a GPU buffer | `Error::RuntimeState` with a download hint |
 | CUDA op receives a WebGPU tensor, or WebGPU op receives a CUDA tensor | `Error::BackendFailure` naming the expected provider |
 
 ## Implemented Coverage

--- a/docs/design/gpu-extension-api.md
+++ b/docs/design/gpu-extension-api.md
@@ -295,6 +295,8 @@ independent API/unsafe/lifetime/retirement/multi-GPU audit complete.
 
 - [gpu-backend-design.md](./gpu-backend-design.md) — backend provider model,
   runtime ownership, and cache ownership.
+- [Custom CUDA kernels](../guides/custom-cuda-kernels.md) — downstream PTX,
+  CUBIN, NVRTC, tensor-borrowing, launch, and lifetime cookbook.
 - `docs/design/storage-contract-freeze.md` — the frozen layout/storage contract.
 - `crates/tenferro-gpu/src/cubecl/` — implementation.
 - Plan: `docs/superpowers/plans/2026-08-09-gpu-extension-api.md`.

--- a/docs/design/tensor.md
+++ b/docs/design/tensor.md
@@ -85,6 +85,6 @@ Callers upload CPU tensors before CUDA backend execution and download CUDA
 tensors before CPU execution or host value inspection.
 
 Result-returning backend APIs report placement mismatches with
-`BackendFailure` diagnostics. Direct host-inspection methods that return
-slices, such as `TypedTensor::host_data()`, may panic on backend buffers because
-they cannot return a `Result`.
+`BackendFailure` diagnostics. Direct host-inspection methods such as
+`TypedTensor::host_data()` and `host_data_mut()` return `Result` and report
+backend buffers as runtime-state failures.

--- a/docs/getting-started/ndarray-nalgebra-mapping.md
+++ b/docs/getting-started/ndarray-nalgebra-mapping.md
@@ -16,9 +16,11 @@ The short version is the five conventions every tenferro program must follow:
 - **Explicit backend.** Direct operations take an explicit backend argument;
   construct the backend/runtime once and reuse it — per-call construction
   discards the buffer pool.
-- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`).
-  Flat notation supports one right-aligned, broadcastable `...` ellipsis per
-  term; use `EinsumNotation` for programmatic notation.
+- **WARNING — einsum dialect.** Equations need the explicit arrow
+  (`"ij,jk->ik"`); omitting it returns `Error::InvalidSubscripts` during
+  parsing. Flat notation supports one right-aligned, broadcastable `...`
+  ellipsis per term; parenthesized ellipsis is also rejected during parsing.
+  Use `EinsumNotation` for programmatic notation.
 - **Result-returning operators.** Traced operators return `Result`; propagate
   with `?`.
 

--- a/docs/guides/custom-cuda-kernels.md
+++ b/docs/guides/custom-cuda-kernels.md
@@ -1,0 +1,251 @@
+# Custom CUDA kernels
+
+External crates can launch CUDA kernels against tenferro-owned tensors through
+the public `tenferro_gpu::cuda::raw` API. The supported path is always:
+
+```text
+CudaBackend::with_backend_session
+  -> with_cuda_exec_session
+  -> CudaExecSession::with_raw
+  -> load PTX/CUBIN or compile with NVRTC
+  -> launch on the session stream
+```
+
+Do not extract pointers or streams from `CudaRuntime` directly. The raw session
+is the scoped execution authority that keeps the tenferro CUDA context, stream,
+and allocation ownership aligned.
+
+## Dependencies
+
+```toml
+[dependencies]
+tenferro-gpu = { version = "...", default-features = false, features = ["cuda"] }
+tenferro-tensor = "..."
+```
+
+For a local checkout, replace the versions with matching `path` dependencies.
+
+## Kernel
+
+Both examples use the same kernel:
+
+```cuda
+// kernel.cu
+extern "C" __global__ void add_kernel(
+    float* out,
+    const float* lhs,
+    const float* rhs,
+    int n
+) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        out[i] = lhs[i] + rhs[i];
+    }
+}
+```
+
+## Precompile with `nvcc`
+
+PTX is portable across compatible CUDA devices; CUBIN is specific to the
+selected architecture. A minimal `build.rs` can emit both:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/custom_cuda_kernels.rs#custom_cuda_nvcc_build -->
+```rust
+    use std::{env, path::PathBuf, process::Command};
+
+    fn run(args: &[&str]) {
+        let status = Command::new("nvcc").args(args).status().expect("run nvcc");
+        assert!(status.success(), "nvcc failed: {args:?}");
+    }
+
+    fn main() {
+        let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        let ptx = out.join("add.ptx");
+        let cubin = out.join("add.cubin");
+        let arch = env::var("CUDA_ARCH").unwrap_or_else(|_| "sm_80".into());
+
+        run(&["--ptx", "kernel.cu", "-o", ptx.to_str().unwrap()]);
+        run(&[
+            "--cubin",
+            "kernel.cu",
+            "-arch",
+            &arch,
+            "-o",
+            cubin.to_str().unwrap(),
+        ]);
+        println!("cargo:rerun-if-changed=kernel.cu");
+    }
+```
+<!-- end-snippet-source -->
+
+Set `CUDA_ARCH` to the deployment GPU, for example `sm_86` for an RTX 3060.
+Embed or read the generated files and load exactly one image:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/custom_cuda_kernels.rs#custom_cuda_precompiled -->
+```rust
+    use std::ffi::CString;
+    use tenferro_gpu::cuda::raw;
+
+    fn load_nvcc_module(
+        session: &raw::Session<'_>,
+        ptx_bytes: &[u8],
+        cubin_bytes: &[u8],
+        use_cubin: bool,
+    ) -> tenferro_tensor::Result<raw::Module> {
+        if use_cubin {
+            session.load_cubin(cubin_bytes)
+        } else {
+            let ptx = CString::new(ptx_bytes).map_err(|_| {
+                tenferro_tensor::Error::invalid_argument(
+                    "custom_cuda.load",
+                    "ptx",
+                    "nvcc PTX contains an interior NUL",
+                )
+            })?;
+            session.load_ptx(&ptx)
+        }
+    }
+```
+<!-- end-snippet-source -->
+
+Use PTX unless architecture-specific CUBIN startup or code generation has been
+measured to matter.
+
+## Compile at runtime with NVRTC
+
+NVRTC needs no `build.rs`. Pass CUDA source directly to the raw session:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/custom_cuda_kernels.rs#custom_cuda_nvrtc -->
+```rust
+    use tenferro_gpu::cuda::raw::{self, NvrtcOptions};
+
+    const CUDA_SOURCE: &str = r#"
+extern "C" __global__ void add_kernel(
+    float* out, const float* lhs, const float* rhs, int n
+) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) out[i] = lhs[i] + rhs[i];
+}
+"#;
+
+    fn load_nvrtc_module(session: &raw::Session<'_>) -> tenferro_tensor::Result<raw::Module> {
+        session.compile_nvrtc(CUDA_SOURCE, &NvrtcOptions::default())
+    }
+```
+<!-- end-snippet-source -->
+
+`compile_nvrtc` returns a typed backend error containing the compiler log when
+compilation fails. Cache reusable modules with `raw::Session::resource` rather
+than compiling on every call.
+
+## Borrow tensors and launch
+
+The launch code is identical for PTX, CUBIN, and NVRTC modules:
+
+<!-- snippet-source: docs/tutorial-code/src/bin/custom_cuda_kernels.rs#custom_cuda_launch -->
+```rust
+    use tenferro_gpu::cuda::{raw, with_cuda_exec_session, CudaBackend};
+    use tenferro_tensor::{BackendSessionHost, Error, TypedTensor};
+
+    fn launch_add(
+        backend: &mut CudaBackend,
+        lhs: &TypedTensor<f32>,
+        rhs: &TypedTensor<f32>,
+    ) -> tenferro_tensor::Result<TypedTensor<f32>> {
+        backend.with_backend_session(|backend_session| {
+            with_cuda_exec_session(backend_session, |cuda| {
+                cuda.with_raw("custom_cuda.add", |session| {
+                    let lhs = session.tensor(lhs)?;
+                    let rhs = session.tensor(rhs)?;
+                    let mut output = session.alloc_output::<f32>(&[8])?;
+                    let output_ref = session.tensor_mut(&mut output)?;
+
+                    let module =
+                        session.compile_nvrtc(CUDA_SOURCE, &raw::NvrtcOptions::default())?;
+                    let function = module.function("add_kernel")?;
+                    let config = raw::LaunchConfig::flat(8, 128, 0)?;
+
+                    // SAFETY: the kernel ABI is (float*, const float*, const float*,
+                    // int); all three tensors contain at least 8 f32 values; output
+                    // is exclusively borrowed and does not alias either input; the
+                    // kernel bounds-checks i < n; module and tensor borrows remain
+                    // live until the explicit synchronization below.
+                    unsafe {
+                        session.launch(
+                            &function,
+                            config,
+                            &[
+                                raw::KernelArg::tensor_mut(&output_ref),
+                                raw::KernelArg::tensor(&lhs),
+                                raw::KernelArg::tensor(&rhs),
+                                raw::KernelArg::i32(8),
+                            ],
+                        )?;
+                    }
+
+                    session.synchronize()?;
+                    Ok(output)
+                })
+            })
+            .ok_or_else(|| Error::runtime_state("custom_cuda.add", "backend session is not CUDA"))?
+        })
+    }
+```
+<!-- end-snippet-source -->
+
+Inputs must already be uploaded to the same `CudaBackend` runtime. The safe
+`tensor` and `tensor_mut` methods validate residency and return bounded device
+spans. `tensor_mut` requires an exclusive tensor borrow; a fresh
+`alloc_output` is the simplest output path. Owned `TypedTensor` values are
+compact column-major. Canonicalize a non-contiguous CUDA view through the
+backend before entering this compact-only raw path; do not download it.
+
+`session.stream()` exposes the same captured stream for a foreign CUDA library.
+Its native handle and `TensorRef::raw_ptr` / `TensorMut::raw_ptr` are unsafe FFI
+escapes: use them only inside the callback and never retain or destroy them.
+
+## Ordering, synchronization, and safety
+
+- Launch on the stream owned by the active raw session. Do not create a second
+  stream behind tenferro's scheduler.
+- Raw pointers, native stream handles, tensor spans, and workspace spans must
+  not escape the session callback.
+- A successful launch only enqueues work. Call `session.synchronize()` only
+  when the host must wait; later work on the same stream is already ordered.
+- Keep modules, inputs, outputs, and external-library resources alive until the
+  last asynchronous use completes.
+- Every `unsafe session.launch` must state the kernel ABI, argument order,
+  element/span bounds, aliasing, initialization, and asynchronous lifetime
+  proof.
+- Mutable/output arguments must be exclusively borrowed and fully initialized
+  before safe Rust reads them.
+- There is no implicit CPU/GPU transfer or device-wide synchronization.
+
+Compile-check the source-backed snippets without a GPU:
+
+```bash
+cargo check -p tenferro-tutorial-code --no-default-features \
+  --features cuda,cpu-faer --bin custom_cuda_kernels
+```
+
+The CUDA tests `raw_ptx_load_launch_roundtrip` and
+`raw_nvrtc_launch_roundtrip` compile these public loading and launch paths on
+the non-GPU CUDA lane and execute them on CUDA hardware. CUBIN execution must
+use a CI runner whose compute capability matches `CUDA_ARCH`.
+
+## Device-side libraries
+
+A downstream kernel may call device-side libraries such as cuSOLVERDx or
+cuBLASDx:
+
+```text
+external CUDA kernel
+  -> cuSOLVERDx/cuBLASDx device call
+  -> nvcc or NVRTC
+  -> raw Session module loading
+  -> launch on the tenferro session stream
+```
+
+The library headers, link-time device code, architecture flags, and licenses
+remain the downstream crate's responsibility. The tenferro ownership and
+stream rules above do not change.

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -37,7 +37,7 @@ plugins at runtime. See [XLA and PJRT](xla.md).
 | CUDA tensor to CPU backend | `Result`-returning CPU backend ops fail; download first |
 | Ordinary WebGPU tensor to CPU backend | `Result`-returning CPU backend ops fail; download first |
 | Apple managed tensor to its paired CPU backend | Guarded RustFFT and rank-2 Cholesky run without a transfer; other operations are not implied |
-| GPU tensor to host inspection | Direct host slice APIs panic; download first |
+| GPU tensor to host inspection | Direct host slice APIs return `Error::RuntimeState`; download first |
 | Unsupported CUDA op or dtype | Error, not silent CPU fallback |
 | Unsupported WebGPU op or dtype | Error, not silent CPU fallback |
 
@@ -132,6 +132,10 @@ cargo build -p tenferro-tutorial-code --no-default-features \
 ```
 
 The example downloads the result back to CPU and asserts the expected values.
+For downstream PTX, CUBIN, NVRTC, or device-library kernels, see
+[Custom CUDA kernels](custom-cuda-kernels.md). That guide uses only the public
+`CudaExecSession` and `cuda::raw` extension boundary.
+
 `TensorStructural::copy_read_into` can reuse an already allocated CUDA
 destination; for supported floating and complex permutation layouts it uses
 the backend-owned cuTENSOR permutation plan cache. The source and destination

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -144,6 +144,11 @@ Flat string notation supports one NumPy-style ellipsis per term. Ellipsis
 axes right-align and broadcast dimensions of size one. The programmatic
 `EinsumNotation` form resolves to the same canonical labels before planning.
 
+> **Warning:** string equations require exactly one explicit `->`. Omitting it
+> returns `Error::InvalidSubscripts` during parsing. Parenthesized contraction
+> order containing ellipsis is also rejected during parsing; use flat `...`
+> notation or `EinsumNotation` instead.
+
 <!-- snippet-source: docs/tutorial-code/src/bin/math_snippets.rs#einsum_20 -->
 ```rust
 use tenferro_cpu::CpuBackend;

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,7 +7,7 @@
 - **Column-major storage.** Dense buffers are column-major: the leftmost dimension varies fastest. Row-major data passed to `from_vec_col_major` is silently reinterpreted as column-major — permuted/wrong values, never rejected.
 - **No facade crate.** `cargo add tenferro` fails by design; depend on the crates you need (`tenferro-runtime`, `tenferro-cpu`, and operation crates).
 - **Explicit backend.** Direct operations take an explicit backend argument; construct the backend/runtime once and reuse it — per-call construction discards the buffer pool.
-- **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`). Flat notation supports one right-aligned, broadcastable `...` ellipsis per term; `EinsumNotation` is the programmatic form. Parenthesized ellipsis remains unsupported.
+- **WARNING — einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`); omitting it is rejected during parsing with `Error::InvalidSubscripts`. Flat notation supports one right-aligned, broadcastable `...` ellipsis per term, and `EinsumNotation` is the programmatic form. Parenthesized contraction order containing ellipsis is also rejected during parsing.
 - **Result-returning operators.** Traced operators return `Result`; propagate with `?`.
 
 ## Recipes and references
@@ -28,13 +28,14 @@
 
 ## Guides
 
-- [Einsum](https://tensor4all.org/tenferro-rs/guides/einsum.html): Requires the explicit arrow; documents flat `...` ellipsis and `EinsumNotation` semantics plus the parenthesized-ellipsis limitation.
+- [Einsum](https://tensor4all.org/tenferro-rs/guides/einsum.html): WARNING — missing arrows and parenthesized ellipses are parse-time `Error::InvalidSubscripts` failures; use flat `...` ellipsis or `EinsumNotation`.
 - [Linear Algebra](https://tensor4all.org/tenferro-rs/guides/linear-algebra.html): Covers the `tenferro-linalg` operation crate and its direct, eager, and traced execution surfaces.
 - [External Linear Algebra Interop](https://tensor4all.org/tenferro-rs/guides/external-linalg-interop.html): Calling faer or BLAS/LAPACK directly on tenferro-owned storage: the direct-dependency contract, column-major leading dimensions, non-contiguous/non-host rejection, and provider thread control.
 - [Autodiff](https://tensor4all.org/tenferro-rs/guides/autodiff.html): Describes eager `backward()` and functional or traced `grad`, `vjp`, and `jvp` workflows.
 - [Parallelism and Caching](https://tensor4all.org/tenferro-rs/guides/parallelism-and-caching.html): WARNING — backend/runtime instances own thread pools and caches; per-call construction throws them away.
 - [Memory Order](https://tensor4all.org/tenferro-rs/guides/memory-order.html): WARNING — buffers are column-major; row-major data passed to `from_vec_col_major` is silently reinterpreted as column-major (wrong values), never rejected.
 - [Devices and GPU](https://tensor4all.org/tenferro-rs/guides/devices-and-gpu.html): Documents explicit CPU/GPU placement and transfer boundaries plus CUDA and WebGPU capability coverage.
+- [Custom CUDA kernels](https://tensor4all.org/tenferro-rs/guides/custom-cuda-kernels.html): Downstream PTX, CUBIN, NVRTC, raw tensor borrowing, stream ordering, and launch safety through the public CUDA extension API.
 - [Troubleshooting](https://tensor4all.org/tenferro-rs/guides/troubleshooting.html): Covers feature selection, BLAS providers, CUDA setup, workspace traps, and common runtime failures.
 
 ## Specification

--- a/docs/tutorial-code/Cargo.toml
+++ b/docs/tutorial-code/Cargo.toml
@@ -170,6 +170,11 @@ name = "cuda_tutorial"
 path = "src/bin/cuda_tutorial.rs"
 required-features = ["cuda"]
 
+[[bin]]
+name = "custom_cuda_kernels"
+path = "src/bin/custom_cuda_kernels.rs"
+required-features = ["cuda"]
+
 [[test]]
 name = "tutorial_binaries"
 path = "tests/tutorial_binaries.rs"

--- a/docs/tutorial-code/src/bin/custom_cuda_kernels.rs
+++ b/docs/tutorial-code/src/bin/custom_cuda_kernels.rs
@@ -1,0 +1,140 @@
+// INVARIANT: this compile-only binary keeps independent downstream snippets
+// type-checked without executing CUDA or nvcc on ordinary documentation CI.
+#![allow(dead_code)]
+
+mod nvcc_build_script {
+    // snippet-start:custom_cuda_nvcc_build
+    use std::{env, path::PathBuf, process::Command};
+
+    fn run(args: &[&str]) {
+        let status = Command::new("nvcc").args(args).status().expect("run nvcc");
+        assert!(status.success(), "nvcc failed: {args:?}");
+    }
+
+    fn main() {
+        let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        let ptx = out.join("add.ptx");
+        let cubin = out.join("add.cubin");
+        let arch = env::var("CUDA_ARCH").unwrap_or_else(|_| "sm_80".into());
+
+        run(&["--ptx", "kernel.cu", "-o", ptx.to_str().unwrap()]);
+        run(&[
+            "--cubin",
+            "kernel.cu",
+            "-arch",
+            &arch,
+            "-o",
+            cubin.to_str().unwrap(),
+        ]);
+        println!("cargo:rerun-if-changed=kernel.cu");
+    }
+    // snippet-end:custom_cuda_nvcc_build
+}
+
+mod precompiled {
+    // snippet-start:custom_cuda_precompiled
+    use std::ffi::CString;
+    use tenferro_gpu::cuda::raw;
+
+    fn load_nvcc_module(
+        session: &raw::Session<'_>,
+        ptx_bytes: &[u8],
+        cubin_bytes: &[u8],
+        use_cubin: bool,
+    ) -> tenferro_tensor::Result<raw::Module> {
+        if use_cubin {
+            session.load_cubin(cubin_bytes)
+        } else {
+            let ptx = CString::new(ptx_bytes).map_err(|_| {
+                tenferro_tensor::Error::invalid_argument(
+                    "custom_cuda.load",
+                    "ptx",
+                    "nvcc PTX contains an interior NUL",
+                )
+            })?;
+            session.load_ptx(&ptx)
+        }
+    }
+    // snippet-end:custom_cuda_precompiled
+}
+
+mod nvrtc {
+    // snippet-start:custom_cuda_nvrtc
+    use tenferro_gpu::cuda::raw::{self, NvrtcOptions};
+
+    const CUDA_SOURCE: &str = r#"
+extern "C" __global__ void add_kernel(
+    float* out, const float* lhs, const float* rhs, int n
+) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) out[i] = lhs[i] + rhs[i];
+}
+"#;
+
+    fn load_nvrtc_module(session: &raw::Session<'_>) -> tenferro_tensor::Result<raw::Module> {
+        session.compile_nvrtc(CUDA_SOURCE, &NvrtcOptions::default())
+    }
+    // snippet-end:custom_cuda_nvrtc
+}
+
+mod launch {
+    const CUDA_SOURCE: &str = r#"
+extern "C" __global__ void add_kernel(
+    float* out, const float* lhs, const float* rhs, int n
+) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) out[i] = lhs[i] + rhs[i];
+}
+"#;
+
+    // snippet-start:custom_cuda_launch
+    use tenferro_gpu::cuda::{raw, with_cuda_exec_session, CudaBackend};
+    use tenferro_tensor::{BackendSessionHost, Error, TypedTensor};
+
+    fn launch_add(
+        backend: &mut CudaBackend,
+        lhs: &TypedTensor<f32>,
+        rhs: &TypedTensor<f32>,
+    ) -> tenferro_tensor::Result<TypedTensor<f32>> {
+        backend.with_backend_session(|backend_session| {
+            with_cuda_exec_session(backend_session, |cuda| {
+                cuda.with_raw("custom_cuda.add", |session| {
+                    let lhs = session.tensor(lhs)?;
+                    let rhs = session.tensor(rhs)?;
+                    let mut output = session.alloc_output::<f32>(&[8])?;
+                    let output_ref = session.tensor_mut(&mut output)?;
+
+                    let module =
+                        session.compile_nvrtc(CUDA_SOURCE, &raw::NvrtcOptions::default())?;
+                    let function = module.function("add_kernel")?;
+                    let config = raw::LaunchConfig::flat(8, 128, 0)?;
+
+                    // SAFETY: the kernel ABI is (float*, const float*, const float*,
+                    // int); all three tensors contain at least 8 f32 values; output
+                    // is exclusively borrowed and does not alias either input; the
+                    // kernel bounds-checks i < n; module and tensor borrows remain
+                    // live until the explicit synchronization below.
+                    unsafe {
+                        session.launch(
+                            &function,
+                            config,
+                            &[
+                                raw::KernelArg::tensor_mut(&output_ref),
+                                raw::KernelArg::tensor(&lhs),
+                                raw::KernelArg::tensor(&rhs),
+                                raw::KernelArg::i32(8),
+                            ],
+                        )?;
+                    }
+
+                    session.synchronize()?;
+                    Ok(output)
+                })
+            })
+            .ok_or_else(|| Error::runtime_state("custom_cuda.add", "backend session is not CUDA"))?
+        })
+    }
+    // snippet-end:custom_cuda_launch
+}
+
+fn main() {}

--- a/docs/worklogs/2026-08-28-open-issue-remediation.md
+++ b/docs/worklogs/2026-08-28-open-issue-remediation.md
@@ -1,0 +1,70 @@
+# Open issue remediation
+
+## Summary
+
+Base: `origin/main` at `8e8d879d`.
+
+This batch resolves verified documentation, invariant-marker, and public tensor
+ownership defects from issues #1707, #1715, #1718, #1724, #1728, #1729, and
+#1730. It does not implement the two design-gated performance investigations.
+
+## Classification ledger
+
+| Issue | Classification | Current evidence and disposition | Verification target |
+| --- | --- | --- | --- |
+| #1706 | Design Gate | The issue explicitly requires maintainer acceptance before implementation and predeclared cold-build experiments. Deferred unchanged. | Accepted design plus paired cold-build protocol |
+| #1707 | Verify First | The pinned `strided-kernel` revision implements `i32`/`i64` erased sum/product with `wrapping_add`/`wrapping_mul`, and existing CPU overflow tests pass. Added adjacent tenferro invariants and a source-contract test rather than duplicating the optimized reduction traversal. | CPU overflow behavior and source-contract tests |
+| #1715 | Auto Fix | Active agent-facing docs described syntax neutrally. They now name parse-time `Error::InvalidSubscripts` failures for omitted arrows and parenthesized ellipses. | Docs checks and mirror consistency |
+| #1718 | Auto Fix | `flat_to_multi` retained a deliberate `dead_code` allowance without the required marker. Replaced its prose with the canonical adjacent `// INVARIANT:` marker. | Tensor tests and repository-rules review |
+| #1720 | Design Gate | The proposed SVD policy depends on GPU-model measurements and an accepted selection policy. Deferred unchanged. | Accepted policy plus RTX/A100 benchmark matrix |
+| #1724 | Auto Fix | The public raw CUDA API already supports PTX, CUBIN, NVRTC, scoped tensor borrowing, and launch. Added a downstream guide using only that surface and linked it from active GPU docs. | Docs checks and CUDA raw launch tests |
+| #1728 | Auto Fix | JOSS publishes the faer paper as DOI `10.21105/joss.06099`. Added the backend-dependent citation requirement and full reference. | Link/docs checks |
+| #1729 | Auto Fix | Two design docs and one neighboring active GPU guide still claimed host slice access panicked. Updated all three to the current `Error::RuntimeState` contract. | Stale-language scan and docs checks |
+| #1730 | Auto Fix | `TypedTensor::into_parts` replaced backend extraction failure with an empty host vector. Made the canonical method fallible and added backend-storage regression coverage. | Focused tenferro-tensor test and doctest |
+
+## Context reviewed
+
+- `AGENTS.md`, `REPOSITORY_RULES.md`, `CONTRIBUTING.md`
+- shared tensor4all repository, Rust, performance, documentation, and provenance rules
+- bug-fix and repository-remediation workflows
+- `docs/design/gpu-extension-api.md` and the public `cuda::raw` implementation/tests
+- einsum parser implementation and rejection tests
+- JOSS faer article metadata and upstream `CITATION.cff`
+
+## Decisions
+
+- Kept integer reductions on the existing optimized `strided-kernel` plan. A
+  second tenferro-owned scalar traversal would violate the CPU-kernel ownership
+  contract and duplicate code; the exact dependency pin, runtime overflow
+  tests, invariant markers, and source-contract test make the delegated
+  wrapping contract explicit.
+- Changed `TypedTensor::into_parts` directly to return `Result`; no compatibility
+  shim was retained because the existing infallible behavior silently lost
+  backend data.
+- Reused the already hardware-exercised PTX/NVRTC public API rather than adding
+  another CUDA runtime abstraction or dependency.
+
+## Verification
+
+Passed locally:
+
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --doc-snippets` with the
+  focused tensor regression, CPU source-contract and overflow tests, and CUDA
+  tutorial compile check;
+- workspace plus standalone-extension formatting and clippy from the fast gate;
+- the full local `docs` CI profile, including source-backed snippet checks,
+  faer/BLAS interop examples, CUDA example compilation, rustdoc, and rendered
+  site link/inventory validation;
+- `cargo test -p tenferro-tensor --doc` (330 doctests);
+- compile-only CUDA raw PTX/NVRTC tests and the source-backed custom-kernel
+  tutorial binary; the docs CI profile now runs that compile check on GPU-less
+  runners.
+
+CUDA hardware execution was not run locally. Existing GPU tests cover PTX,
+NVRTC, and CPU/CUDA integer-reduction parity when a CUDA device is available.
+
+## Residual risks
+
+- CUBIN execution remains architecture-specific and must be run with a matching
+  `CUDA_ARCH`; the guide states this boundary.
+- #1706 and #1720 remain open until their design and hardware gates are met.

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -88,6 +88,10 @@ PROFILE_COMMANDS: dict[str, tuple[str, ...]] = {
         "--features cpu-faer --bin faer_interop",
         f"RUSTFLAGS='-l dylib=openblas -l dylib=lapack' cargo run -p tenferro-tutorial-code "
         f"{_CARGO_TEST_PROFILE} --no-default-features --features cpu-blas --bin blas_interop",
+        # Issue #1724: compile the source-backed raw CUDA examples on GPU-less
+        # docs CI; hardware execution remains in the CUDA test lane.
+        f"cargo check -p tenferro-tutorial-code {_CARGO_TEST_PROFILE} --no-default-features "
+        "--features cuda,cpu-faer --bin custom_cuda_kernels",
         "bash scripts/build_docs_site.sh",
     ),
     "coverage": (

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -156,6 +156,20 @@ class RunProfileTests(unittest.TestCase):
             commands.index("bash scripts/build_docs_site.sh"),
         )
 
+    def test_docs_profile_compile_checks_custom_cuda_kernel_examples(self) -> None:
+        commands = commands_for("docs")
+        command = (
+            "cargo check -p tenferro-tutorial-code --profile ci "
+            "--no-default-features --features cuda,cpu-faer "
+            "--bin custom_cuda_kernels"
+        )
+
+        self.assertIn(command, commands)
+        self.assertLess(
+            commands.index(command),
+            commands.index("bash scripts/build_docs_site.sh"),
+        )
+
     def test_ci_config_runs_release_publication_checks(self) -> None:
         commands = commands_for("ci-config")
         for command in (


### PR DESCRIPTION
> [!IMPORTANT]
> New features must start as a feature request issue.
> Please do not open a new-feature implementation PR before maintainers accept
> the issue and agree that implementation should start.
>
> If you already have prototype code, link to a fork branch, gist, or
> repository from the feature request issue instead of opening a PR.
>
> New-feature PRs opened before an accepted issue may be closed and redirected
> to an issue.
>
> If you are using an AI agent for a bug-fix PR, use or follow the
> repository-local `tenferro-bugfix-pr` workflow before editing code.

## Type

- [x] Bug fix
- [x] Documentation
- [x] Refactor / cleanup
- [x] Implementation of accepted issue

## Related issue

Closes #1707
Closes #1715
Closes #1718
Closes #1724
Closes #1728
Closes #1729
Closes #1730

Refs #1706; its pin-isolated cold-build attempt was posted to the issue and remains open because the shared-host noise gate made the result inconclusive.

Refs #1720; closed without code changes because the current CUDA SVD policy intentionally matches JAX/PyTorch defaults.

## Summary

- Make `TypedTensor::into_parts` return a typed error instead of silently replacing backend storage with an empty host vector; update stale host-access docs and the missing `flat_to_multi` invariant marker.
- Record the pinned `strided-kernel` wrapping contract for CPU integer reductions and guard it with source and overflow tests.
- Turn einsum dialect restrictions into explicit parse-failure warnings across active agent/user docs and add the verified faer JOSS citation requirement.
- Add a source-backed downstream CUDA kernel guide covering nvcc PTX/CUBIN, NVRTC, scoped tensor/stream borrowing, launch safety, and device-side libraries; compile-check it in the docs CI profile.

The remediation classification ledger, neighborhood scans, decisions, and residual risks are in the work log. Four coherent commits preserve the review units; this batch should use non-squash merge. The incomplete #1706 experiment is kept on a separate local investigation branch and is not part of this PR.

## Work log

[`docs/worklogs/2026-08-28-open-issue-remediation.md`](docs/worklogs/2026-08-28-open-issue-remediation.md)

## Verification

- `bash scripts/check-pr-fast.sh --coverage-reviewed --doc-snippets` with focused tensor, CPU wrapping, CI-profile, and CUDA tutorial checks
- `python3 scripts/ci/run_profile.py docs`
- `cargo test -p tenferro-tensor --doc`
- committed-head deterministic repository-rules review: pass (external LLM intentionally skipped)

CUDA hardware was not available locally; existing CUDA PTX/NVRTC and CPU/CUDA reduction parity tests execute in the hardware lane.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules review (deterministic; the external LLM
      review is permanently disabled) and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by
      maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from
      `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and
      linked it above.
