### PR TITLE
perf(gpu): cut per-operation cost on the CUDA path, and back BLAS-1 with cuBLAS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,14 +68,14 @@ lapack-src = "0.13"
 lapack-inject = "0.1.2"
 # Compile both CubeCL runtime paths with CUDA 12.8 bindings. Dynamic runtime
 # gating keeps the baseline compatible with CUDA 12.4 driver/NVRTC libraries.
-cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "cublas", "dynamic-loading", "cuda-12080"] }
+cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "dynamic-loading", "cuda-12080"] }
 # Pre-publish staging: Cargo uses these fork commits locally, while packaged
 # manifests retain only the crates.io version requirements.
-cubecl = { package = "t4a-cubecl", git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1", version = "=0.10.0", default-features = false }
-cubecl-cuda = { package = "t4a-cubecl-cuda", git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1", version = "=0.10.0" }
-cubecl-common = { package = "t4a-cubecl-common", git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1", version = "=0.10.0" }
-cubecl-runtime = { package = "t4a-cubecl-runtime", git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1", version = "=0.10.0" }
-cubecl-wgpu = { package = "t4a-cubecl-wgpu", git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1", version = "=0.10.0" }
+cubecl = { package = "t4a-cubecl", git = "https://github.com/tensor4all/cubecl.git", rev = "f274a76d8589d39fbbbcb4916b4f354f1c2447db", version = "=0.10.0", default-features = false }
+cubecl-cuda = { package = "t4a-cubecl-cuda", git = "https://github.com/tensor4all/cubecl.git", rev = "f274a76d8589d39fbbbcb4916b4f354f1c2447db", version = "=0.10.0" }
+cubecl-common = { package = "t4a-cubecl-common", git = "https://github.com/tensor4all/cubecl.git", rev = "f274a76d8589d39fbbbcb4916b4f354f1c2447db", version = "=0.10.0" }
+cubecl-runtime = { package = "t4a-cubecl-runtime", git = "https://github.com/tensor4all/cubecl.git", rev = "f274a76d8589d39fbbbcb4916b4f354f1c2447db", version = "=0.10.0" }
+cubecl-wgpu = { package = "t4a-cubecl-wgpu", git = "https://github.com/tensor4all/cubecl.git", rev = "f274a76d8589d39fbbbcb4916b4f354f1c2447db", version = "=0.10.0" }
 cubek-matmul = { package = "t4a-cubek-matmul", git = "https://github.com/tensor4all/cubek.git", rev = "5535bda85c68b1d286f1e4660fa15f7b0eb5cf04", version = "=0.2.0", default-features = false }
 cubek-std = { package = "t4a-cubek-std", git = "https://github.com/tensor4all/cubek.git", rev = "5535bda85c68b1d286f1e4660fa15f7b0eb5cf04", version = "=0.2.0", default-features = false }
 cubek-fft = { package = "cubek-fft", git = "https://github.com/tensor4all/cubek.git", rev = "5535bda85c68b1d286f1e4660fa15f7b0eb5cf04", version = "=0.2.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,14 +71,14 @@ lapack-inject = "0.1.2"
 cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "dynamic-loading", "cuda-12080"] }
 # Pre-publish staging: Cargo uses these fork commits locally, while packaged
 # manifests retain only the crates.io version requirements.
-cubecl = { package = "t4a-cubecl", git = "https://github.com/tensor4all/cubecl.git", rev = "f274a76d8589d39fbbbcb4916b4f354f1c2447db", version = "=0.10.0", default-features = false }
-cubecl-cuda = { package = "t4a-cubecl-cuda", git = "https://github.com/tensor4all/cubecl.git", rev = "f274a76d8589d39fbbbcb4916b4f354f1c2447db", version = "=0.10.0" }
-cubecl-common = { package = "t4a-cubecl-common", git = "https://github.com/tensor4all/cubecl.git", rev = "f274a76d8589d39fbbbcb4916b4f354f1c2447db", version = "=0.10.0" }
-cubecl-runtime = { package = "t4a-cubecl-runtime", git = "https://github.com/tensor4all/cubecl.git", rev = "f274a76d8589d39fbbbcb4916b4f354f1c2447db", version = "=0.10.0" }
-cubecl-wgpu = { package = "t4a-cubecl-wgpu", git = "https://github.com/tensor4all/cubecl.git", rev = "f274a76d8589d39fbbbcb4916b4f354f1c2447db", version = "=0.10.0" }
-cubek-matmul = { package = "t4a-cubek-matmul", git = "https://github.com/tensor4all/cubek.git", rev = "5535bda85c68b1d286f1e4660fa15f7b0eb5cf04", version = "=0.2.0", default-features = false }
-cubek-std = { package = "t4a-cubek-std", git = "https://github.com/tensor4all/cubek.git", rev = "5535bda85c68b1d286f1e4660fa15f7b0eb5cf04", version = "=0.2.0", default-features = false }
-cubek-fft = { package = "cubek-fft", git = "https://github.com/tensor4all/cubek.git", rev = "5535bda85c68b1d286f1e4660fa15f7b0eb5cf04", version = "=0.2.0", default-features = false }
+cubecl = { package = "t4a-cubecl", git = "https://github.com/tensor4all/cubecl.git", rev = "5939d8e3b1c479ed6db31de5f01cb6d432178f2d", version = "=0.10.0", default-features = false }
+cubecl-cuda = { package = "t4a-cubecl-cuda", git = "https://github.com/tensor4all/cubecl.git", rev = "5939d8e3b1c479ed6db31de5f01cb6d432178f2d", version = "=0.10.0" }
+cubecl-common = { package = "t4a-cubecl-common", git = "https://github.com/tensor4all/cubecl.git", rev = "5939d8e3b1c479ed6db31de5f01cb6d432178f2d", version = "=0.10.0" }
+cubecl-runtime = { package = "t4a-cubecl-runtime", git = "https://github.com/tensor4all/cubecl.git", rev = "5939d8e3b1c479ed6db31de5f01cb6d432178f2d", version = "=0.10.0" }
+cubecl-wgpu = { package = "t4a-cubecl-wgpu", git = "https://github.com/tensor4all/cubecl.git", rev = "5939d8e3b1c479ed6db31de5f01cb6d432178f2d", version = "=0.10.0" }
+cubek-matmul = { package = "t4a-cubek-matmul", git = "https://github.com/tensor4all/cubek.git", rev = "4daea6ab1bb36c6375134f1e589c9cf8645b7229", version = "=0.2.0", default-features = false }
+cubek-std = { package = "t4a-cubek-std", git = "https://github.com/tensor4all/cubek.git", rev = "4daea6ab1bb36c6375134f1e589c9cf8645b7229", version = "=0.2.0", default-features = false }
+cubek-fft = { package = "cubek-fft", git = "https://github.com/tensor4all/cubek.git", rev = "4daea6ab1bb36c6375134f1e589c9cf8645b7229", version = "=0.2.0", default-features = false }
 sha2 = "0.10"
 omeco = "0.2.4"
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ lapack-src = "0.13"
 lapack-inject = "0.1.2"
 # Compile both CubeCL runtime paths with CUDA 12.8 bindings. Dynamic runtime
 # gating keeps the baseline compatible with CUDA 12.4 driver/NVRTC libraries.
-cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "dynamic-loading", "cuda-12080"] }
+cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "cublas", "dynamic-loading", "cuda-12080"] }
 # Pre-publish staging: Cargo uses these fork commits locally, while packaged
 # manifests retain only the crates.io version requirements.
 cubecl = { package = "t4a-cubecl", git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1", version = "=0.10.0", default-features = false }

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -107,6 +107,14 @@ name = "integration"
 path = "tests/integration.rs"
 
 [[test]]
+name = "blas1_thread_counts"
+path = "tests/blas1_thread_counts.rs"
+
+[[test]]
+name = "blas1_pool_aliasing"
+path = "tests/blas1_pool_aliasing.rs"
+
+[[test]]
 name = "install_allocation_tests"
 path = "tests/install_allocation_tests/main.rs"
 required-features = ["cpu-faer"]

--- a/crates/tenferro-cpu/tests/blas1_pool_aliasing.rs
+++ b/crates/tenferro-cpu/tests/blas1_pool_aliasing.rs
@@ -1,0 +1,87 @@
+//! A BLAS1 scalar result must not alias a buffer that a live tensor still owns.
+//!
+//! `vdot_read` and `norm_squared_read` allocate their rank-0 output from the
+//! backend's buffer pool. Tensors returned by earlier session operations come
+//! from the same pool. If the pool can hand the same storage to both, a BLAS1
+//! call returns the correct scalar while silently overwriting data a caller is
+//! still holding — which is invisible to any test that only checks the scalar.
+//!
+//! This is the shape a Krylov loop produces: contraction results are kept alive
+//! as basis vectors across many interleaved inner products, each in its own
+//! session.
+
+use num_complex::Complex64;
+
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::backend::BackendSessionHost;
+use tenferro_tensor::{DotGeneralConfig, Tensor, TensorRead};
+
+fn matrix(rows: usize, columns: usize, seed: f64) -> Tensor {
+    let data: Vec<Complex64> = (0..rows * columns)
+        .map(|i| Complex64::new(seed + 0.5 * i as f64, 1.0 - 0.125 * i as f64))
+        .collect();
+    Tensor::from_vec_col_major(vec![rows, columns], data).unwrap()
+}
+
+#[test]
+fn blas1_scalars_do_not_overwrite_live_session_results() {
+    let mut backend = CpuBackend::new();
+
+    let lhs = matrix(8, 6, 0.25);
+    let rhs = matrix(6, 4, -1.5);
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+
+    // Several live results from the pool, exactly as a sweep accumulates a
+    // Krylov basis.
+    let mut live: Vec<Tensor> = Vec::new();
+    for _ in 0..4 {
+        let product = backend
+            .with_backend_session(|session| {
+                session.dot_general_read(
+                    TensorRead::from_tensor(&lhs),
+                    TensorRead::from_tensor(&rhs),
+                    &config,
+                )
+            })
+            .unwrap();
+        live.push(product);
+    }
+
+    let expected: Vec<Vec<Complex64>> = live
+        .iter()
+        .map(|tensor| tensor.as_slice::<Complex64>().unwrap().to_vec())
+        .collect();
+
+    // Interleave BLAS1 scalar reductions, each in its own session, while those
+    // results stay alive.
+    let operand = matrix(16, 1, 0.75);
+    for _ in 0..8 {
+        let _dot = backend
+            .with_backend_session(|session| {
+                session.vdot_read(
+                    TensorRead::from_tensor(&operand),
+                    TensorRead::from_tensor(&operand),
+                )
+            })
+            .unwrap();
+        let _norm = backend
+            .with_backend_session(|session| {
+                session.norm_squared_read(TensorRead::from_tensor(&operand))
+            })
+            .unwrap();
+    }
+
+    for (index, (tensor, expected)) in live.iter().zip(&expected).enumerate() {
+        let actual = tensor.as_slice::<Complex64>().unwrap();
+        assert_eq!(
+            actual,
+            expected.as_slice(),
+            "contraction result {index} changed while only BLAS1 scalars ran"
+        );
+    }
+}

--- a/crates/tenferro-cpu/tests/blas1_thread_counts.rs
+++ b/crates/tenferro-cpu/tests/blas1_thread_counts.rs
@@ -10,7 +10,7 @@ use num_complex::Complex64;
 
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::backend::BackendSessionHost;
-use tenferro_tensor::{BackendSession, Tensor, TensorRead, TensorView, TypedTensorView};
+use tenferro_tensor::{Tensor, TensorRead, TensorView, TypedTensorView};
 
 fn sample(len: usize) -> Vec<Complex64> {
     (0..len)
@@ -61,10 +61,7 @@ fn vdot_and_norm_squared_hold_across_thread_counts_and_lengths() {
             // Owned operands.
             let dot = backend
                 .with_backend_session(|session| {
-                    session.vdot_read(
-                        TensorRead::from_tensor(&lhs),
-                        TensorRead::from_tensor(&rhs),
-                    )
+                    session.vdot_read(TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs))
                 })
                 .unwrap();
             let dot = dot.as_slice::<Complex64>().unwrap()[0];

--- a/crates/tenferro-cpu/tests/blas1_thread_counts.rs
+++ b/crates/tenferro-cpu/tests/blas1_thread_counts.rs
@@ -1,0 +1,110 @@
+//! `vdot_read` and `norm_squared_read` against a scalar reference across
+//! thread counts and input lengths.
+//!
+//! The existing in-crate BLAS1 coverage exercises one and two worker threads.
+//! A default `CpuBackend` on a large host takes one worker per core, so a
+//! reduction whose chunking is wrong only when the worker count rivals or
+//! exceeds the element count is invisible to it. These cases sweep both.
+
+use num_complex::Complex64;
+
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::backend::BackendSessionHost;
+use tenferro_tensor::{BackendSession, Tensor, TensorRead, TensorView, TypedTensorView};
+
+fn sample(len: usize) -> Vec<Complex64> {
+    (0..len)
+        .map(|i| Complex64::new(0.25 + 0.5 * i as f64, 1.0 - 0.125 * i as f64))
+        .collect()
+}
+
+fn reference_vdot(lhs: &[Complex64], rhs: &[Complex64]) -> Complex64 {
+    lhs.iter().zip(rhs).map(|(a, b)| a.conj() * b).sum()
+}
+
+fn reference_norm_squared(input: &[Complex64]) -> f64 {
+    input.iter().map(|z| z.norm_sqr()).sum()
+}
+
+/// A flat view over an owned tensor, which is how a sweep hands a slice of a
+/// larger buffer to BLAS1 without materializing it.
+fn flat_view(tensor: &Tensor, len: usize) -> TensorRead<'_> {
+    let Tensor::C64(typed) = tensor else {
+        panic!("these cases are C64")
+    };
+    let view = TypedTensorView::from_slice(
+        vec![len],
+        vec![1_isize],
+        0,
+        typed.host_data().expect("host tensor"),
+    )
+    .expect("a flat view of the whole buffer is in bounds");
+    TensorRead::from_view(TensorView::C64(view))
+}
+
+#[test]
+fn vdot_and_norm_squared_hold_across_thread_counts_and_lengths() {
+    // Lengths that straddle the worker count, which is where a chunking bug
+    // lives: fewer elements than workers, exactly as many, and many more.
+    for threads in [1_usize, 2, 4, 16, 64, 128] {
+        let mut backend = CpuBackend::with_threads(threads).expect("backend builds");
+        for len in [1_usize, 3, 16, 17, 64, 128, 129, 4096] {
+            let lhs_host = sample(len);
+            let rhs_host: Vec<Complex64> = sample(len).iter().map(|z| z.conj() * 0.5).collect();
+            let lhs = Tensor::from_vec_col_major(vec![len], lhs_host.clone()).unwrap();
+            let rhs = Tensor::from_vec_col_major(vec![len], rhs_host.clone()).unwrap();
+
+            let expected_dot = reference_vdot(&lhs_host, &rhs_host);
+            let expected_norm = reference_norm_squared(&lhs_host);
+            let tolerance = 1e-9 * (1.0 + expected_norm);
+
+            // Owned operands.
+            let dot = backend
+                .with_backend_session(|session| {
+                    session.vdot_read(
+                        TensorRead::from_tensor(&lhs),
+                        TensorRead::from_tensor(&rhs),
+                    )
+                })
+                .unwrap();
+            let dot = dot.as_slice::<Complex64>().unwrap()[0];
+            assert!(
+                (dot - expected_dot).norm() <= tolerance,
+                "vdot(owned) threads={threads} len={len}: {dot} vs {expected_dot}"
+            );
+
+            let norm = backend
+                .with_backend_session(|session| {
+                    session.norm_squared_read(TensorRead::from_tensor(&lhs))
+                })
+                .unwrap();
+            let norm = norm.as_slice::<f64>().unwrap()[0];
+            assert!(
+                (norm - expected_norm).abs() <= tolerance,
+                "norm_squared(owned) threads={threads} len={len}: {norm} vs {expected_norm}"
+            );
+
+            // The same operands as views, which is the path a backend adapter
+            // takes when the buffer it holds is larger than the operand.
+            let dot = backend
+                .with_backend_session(|session| {
+                    session.vdot_read(flat_view(&lhs, len), flat_view(&rhs, len))
+                })
+                .unwrap();
+            let dot = dot.as_slice::<Complex64>().unwrap()[0];
+            assert!(
+                (dot - expected_dot).norm() <= tolerance,
+                "vdot(view) threads={threads} len={len}: {dot} vs {expected_dot}"
+            );
+
+            let norm = backend
+                .with_backend_session(|session| session.norm_squared_read(flat_view(&lhs, len)))
+                .unwrap();
+            let norm = norm.as_slice::<f64>().unwrap()[0];
+            assert!(
+                (norm - expected_norm).abs() <= tolerance,
+                "norm_squared(view) threads={threads} len={len}: {norm} vs {expected_norm}"
+            );
+        }
+    }
+}

--- a/crates/tenferro-fft/tests/apple_cpu.rs
+++ b/crates/tenferro-fft/tests/apple_cpu.rs
@@ -51,26 +51,21 @@ fn managed_cpu_fft_preserves_values_domain_and_transfer_counters() {
     assert_eq!(context.transfer_stats(), before);
 
     let host_f64 = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, -2.0, 0.5]).unwrap();
-    let (reference_spectrum, reference_round_trip) =
-        reference_cpu.with_backend_session(|session| {
-            let spectrum = host_f64
-                .rfft(Some(4), 0, FftNorm::Forward, session)
-                .unwrap();
-            let round_trip = spectrum
-                .irfft(Some(4), 0, FftNorm::Forward, session)
-                .unwrap();
-            (spectrum, round_trip)
-        });
+    let reference_round_trip = reference_cpu.with_backend_session(|session| {
+        host_f64
+            .rfft(Some(4), 0, FftNorm::Forward, session)
+            .unwrap()
+            .irfft(Some(4), 0, FftNorm::Forward, session)
+            .unwrap()
+    });
     let managed_f64 = context.upload_tensor(&host_f64).unwrap();
     let before = context.transfer_stats();
-    let (spectrum, round_trip) = apple_cpu.with_backend_session(|session| {
-        let spectrum = managed_f64
+    let round_trip = apple_cpu.with_backend_session(|session| {
+        managed_f64
             .rfft(Some(4), 0, FftNorm::Forward, session)
-            .unwrap();
-        let round_trip = spectrum
+            .unwrap()
             .irfft(Some(4), 0, FftNorm::Forward, session)
-            .unwrap();
-        (spectrum, round_trip)
+            .unwrap()
     });
     let Tensor::F64(round_trip) = round_trip else {
         panic!("expected F64 output")

--- a/crates/tenferro-fft/tests/webgpu_metal_fft.rs
+++ b/crates/tenferro-fft/tests/webgpu_metal_fft.rs
@@ -1,7 +1,6 @@
 #[cfg(target_os = "macos")]
 mod metal {
     use num_complex::{Complex32, Complex64};
-    use tenferro_cpu::CpuBackend;
     use tenferro_fft::{FftNorm, TensorFftExt};
     use tenferro_gpu::{
         apple::AppleContext, webgpu::interop as webgpu_interop, webgpu::upload_webgpu_tensor,

--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -89,6 +89,10 @@ name = "integration"
 path = "tests/integration.rs"
 
 [[test]]
+name = "blas1_cuda"
+path = "tests/blas1_cuda.rs"
+
+[[test]]
 name = "storage_provider_cuda_progress"
 path = "tests/storage_provider_cuda_progress.rs"
 

--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -32,6 +32,7 @@ blas-mkl = ["tenferro-cpu/blas-mkl"]
 cpu-reference = []
 cuda = [
     "dep:cubecl",
+    "dep:lru",
     "cubecl/std",
     "cubecl/stdlib",
     "cubecl/cuda",
@@ -68,6 +69,7 @@ cubek-std = { workspace = true, optional = true }
 cubek-fft = { workspace = true, optional = true }
 cudarc = { workspace = true, optional = true }
 libloading.workspace = true
+lru = { workspace = true, optional = true }
 num-complex.workspace = true
 num-traits.workspace = true
 smallvec.workspace = true

--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -67,7 +67,7 @@ cubecl-wgpu = { workspace = true, optional = true }
 cubek-matmul = { workspace = true, optional = true }
 cubek-std = { workspace = true, optional = true }
 cubek-fft = { workspace = true, optional = true }
-cudarc = { workspace = true, optional = true }
+cudarc = { workspace = true, optional = true, features = ["cublas"] }
 libloading.workspace = true
 lru = { workspace = true, optional = true }
 num-complex.workspace = true

--- a/crates/tenferro-gpu/src/cubecl/blas1.rs
+++ b/crates/tenferro-gpu/src/cubecl/blas1.rs
@@ -1,0 +1,649 @@
+//! cuBLAS-backed BLAS1 session operations for the CUDA backend.
+//!
+//! Implements the [`tenferro_tensor::backend::BackendSession`] BLAS1 hooks —
+//! `vdot_read`, `norm_squared_read`, and `axpby_read_into_accum` — as single
+//! cuBLAS calls on the runtime's CubeCL stream, so a TDVP/Krylov-style loop
+//! does not have to compose them from full `dot_general` contractions.
+//!
+//! Execution contract:
+//! - `vdot_read` enqueues `cublas{S,D}dot`/`cublas{C,Z}dotc` with the cuBLAS
+//!   **device pointer mode**, writing `sum(conj(lhs) * rhs)` into a freshly
+//!   allocated rank-0 device tensor. Success means the reduction was enqueued;
+//!   no host barrier is taken.
+//! - `norm_squared_read` reinterprets the (compact) input as a real component
+//!   span and enqueues a self-`dot`, writing `sum(|x|^2)` into a rank-0 F32 or
+//!   F64 device tensor, again in device pointer mode.
+//! - `axpby_read_into_accum` enqueues one in-place vector
+//!   `cublas{S,D,C,Z}geam` (`y <- alpha * x + beta * y`); the exact-dtype
+//!   coefficients are read from host memory at enqueue time (host pointer
+//!   mode), which does not block.
+//!
+//! Non-contiguous inputs are canonicalized on the device through the backend's
+//! existing `to_contiguous_read` path before the cuBLAS call; tensors never
+//! move between host and device here. Compact views with a nonzero offset are
+//! consumed in place via pointer arithmetic. The per-(device, stream) cuBLAS
+//! handle cache lives on [`CudaRuntime`].
+//!
+//! When the cuBLAS shared library cannot be loaded, these operations fail with
+//! a typed load error; they do not fall back to native CubeCL kernels.
+
+use std::ffi::c_void;
+
+use cubecl::prelude::{CubeElement, CubePrimitive};
+use cudarc::cublas::sys as cublas;
+use num_complex::{Complex32, Complex64};
+
+use tenferro_tensor::backend::{
+    validate_axpby_read_into_accum, validate_norm_squared_read, validate_vdot_read,
+};
+use tenferro_tensor::{ContractionScalar, DType, TensorRead, TensorWrite};
+
+use super::dispatch::{
+    alloc_output, ensure_resident_on_runtime, ensure_view_mut_resident_on_runtime,
+    ensure_view_resident_on_runtime, prepared_view_access, prepared_view_mut_access,
+};
+use super::error::unsupported_dtype;
+use super::gemm::typed_device_ptr;
+use super::interop::{cuda_device_ptr_from_addr, upload_typed_tensor};
+use super::runtime::check_cublas;
+use super::{CudaBackend, CudaRuntime};
+use crate::backend::TensorStructural;
+use crate::{
+    Error, Tensor, TensorScalar, TensorView, TensorViewMut, TypedTensor, TypedTensorView,
+    TypedTensorViewMut,
+};
+
+const VDOT_OP: &str = "BackendSession::vdot_read";
+const NORM_OP: &str = "BackendSession::norm_squared_read";
+const AXPBY_OP: &str = "BackendSession::axpby_read_into_accum";
+
+/// Compute `sum(conj(lhs) * rhs)` into a rank-0 device tensor via cuBLAS.
+///
+/// # Errors
+///
+/// See [`tenferro_tensor::backend::BackendSession::vdot_read`]; additionally
+/// returns [`Error::Io`] when the cuBLAS library cannot be loaded and
+/// [`Error::RuntimeState`] when an input is not resident on this runtime.
+pub(super) fn vdot_read(
+    backend: &mut CudaBackend,
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+) -> crate::Result<Tensor> {
+    validate_vdot_read(&lhs, &rhs)?;
+    let lhs = DeviceContiguous::prepare(backend, lhs)?;
+    let rhs = DeviceContiguous::prepare(backend, rhs)?;
+    let (lhs, rhs) = (lhs.read(), rhs.read());
+    match lhs.dtype() {
+        DType::F32 => vdot_typed::<f32>(backend, &lhs, &rhs),
+        DType::F64 => vdot_typed::<f64>(backend, &lhs, &rhs),
+        DType::C32 => vdot_typed::<Complex32>(backend, &lhs, &rhs),
+        DType::C64 => vdot_typed::<Complex64>(backend, &lhs, &rhs),
+        // INVARIANT: shared validation restricts the dtype to F32/F64/C32/C64.
+        dtype => Err(unsupported_dtype(VDOT_OP, dtype)),
+    }
+}
+
+/// Compute `sum(|x|^2)` into a rank-0 real device tensor via cuBLAS.
+///
+/// # Errors
+///
+/// See [`tenferro_tensor::backend::BackendSession::norm_squared_read`];
+/// additionally returns [`Error::Io`] when the cuBLAS library cannot be
+/// loaded and [`Error::RuntimeState`] when the input is not resident on this
+/// runtime.
+pub(super) fn norm_squared_read(
+    backend: &mut CudaBackend,
+    input: TensorRead<'_>,
+) -> crate::Result<Tensor> {
+    validate_norm_squared_read(&input)?;
+    let input = DeviceContiguous::prepare(backend, input)?;
+    let input = input.read();
+    match input.dtype() {
+        DType::F32 => norm_squared_typed::<f32>(backend, &input),
+        DType::F64 => norm_squared_typed::<f64>(backend, &input),
+        DType::C32 => norm_squared_typed::<Complex32>(backend, &input),
+        DType::C64 => norm_squared_typed::<Complex64>(backend, &input),
+        // INVARIANT: shared validation restricts the dtype to F32/F64/C32/C64.
+        dtype => Err(unsupported_dtype(NORM_OP, dtype)),
+    }
+}
+
+/// Apply `y <- alpha * x + beta * y` in place via one cuBLAS vector `geam`.
+///
+/// # Errors
+///
+/// See [`tenferro_tensor::backend::BackendSession::axpby_read_into_accum`];
+/// additionally returns [`Error::Io`] when the cuBLAS library cannot be
+/// loaded and [`Error::RuntimeState`] when an operand is not resident on this
+/// runtime.
+pub(super) fn axpby_read_into_accum(
+    backend: &mut CudaBackend,
+    alpha: ContractionScalar,
+    x: TensorRead<'_>,
+    beta: ContractionScalar,
+    mut y: TensorWrite<'_>,
+) -> crate::Result<()> {
+    validate_axpby_read_into_accum(alpha, &x, beta, &y)?;
+    let x = DeviceContiguous::prepare(backend, x)?;
+    let x = x.read();
+    match x.dtype() {
+        DType::F32 => axpby_typed::<f32>(backend, alpha, &x, beta, &mut y),
+        DType::F64 => axpby_typed::<f64>(backend, alpha, &x, beta, &mut y),
+        DType::C32 => axpby_typed::<Complex32>(backend, alpha, &x, beta, &mut y),
+        DType::C64 => axpby_typed::<Complex64>(backend, alpha, &x, beta, &mut y),
+        // INVARIANT: shared validation restricts the dtype to F32/F64/C32/C64.
+        dtype => Err(unsupported_dtype(AXPBY_OP, dtype)),
+    }
+}
+
+/// A borrowed read that is proven column-major contiguous on the device.
+///
+/// Non-contiguous inputs are canonicalized once through the backend's
+/// same-placement `to_contiguous_read` path; the materialized tensor is owned
+/// here so its device allocation outlives the enqueued cuBLAS call site.
+enum DeviceContiguous<'a> {
+    Borrowed(TensorRead<'a>),
+    Materialized(Tensor),
+}
+
+impl<'a> DeviceContiguous<'a> {
+    fn prepare(backend: &mut CudaBackend, read: TensorRead<'a>) -> crate::Result<Self> {
+        if read.is_col_major_contiguous()? {
+            Ok(Self::Borrowed(read))
+        } else {
+            // Same-placement canonicalization on the device; the typed source
+            // error (residency, dtype, allocation) propagates unchanged.
+            Ok(Self::Materialized(backend.to_contiguous_read(read)?))
+        }
+    }
+
+    fn read(&self) -> TensorRead<'_> {
+        match self {
+            Self::Borrowed(read) => read.clone(),
+            Self::Materialized(tensor) => TensorRead::from_tensor(tensor),
+        }
+    }
+}
+
+/// Read-slot operand: an owned compact tensor or a compact contiguous view.
+enum ReadRef<'a, 'b, T> {
+    Owned(&'a TypedTensor<T>),
+    View(&'a TypedTensorView<'b, T>),
+}
+
+impl<T: TensorScalar + 'static> ReadRef<'_, '_, T> {
+    fn n_elements(&self) -> usize {
+        match self {
+            Self::Owned(tensor) => tensor.n_elements(),
+            Self::View(view) => view.n_elements(),
+        }
+    }
+
+    fn ensure_resident(&self, rt: &CudaRuntime, op: &'static str) -> crate::Result<()> {
+        match self {
+            Self::Owned(tensor) => ensure_resident_on_runtime(rt, tensor, op),
+            Self::View(view) => ensure_view_resident_on_runtime(rt, view, op),
+        }
+    }
+
+    fn device_ptr(&self, rt: &CudaRuntime, op: &'static str) -> crate::Result<*mut c_void> {
+        match self {
+            Self::Owned(tensor) => typed_device_ptr(rt, tensor),
+            Self::View(view) => {
+                let prepared = prepared_view_access(view, op)?;
+                offset_device_ptr::<T>(rt, prepared, view.offset(), op)
+            }
+        }
+    }
+}
+
+/// Write-slot operand: an owned compact tensor or a compact contiguous view.
+enum WriteRef<'a, 'b, T> {
+    Owned(&'a mut TypedTensor<T>),
+    View(&'a mut TypedTensorViewMut<'b, T>),
+}
+
+impl<T: TensorScalar + 'static> WriteRef<'_, '_, T> {
+    fn ensure_resident(&self, rt: &CudaRuntime, op: &'static str) -> crate::Result<()> {
+        match self {
+            Self::Owned(tensor) => ensure_resident_on_runtime(rt, tensor, op),
+            Self::View(view) => ensure_view_mut_resident_on_runtime(rt, view, op),
+        }
+    }
+
+    fn device_ptr(&mut self, rt: &CudaRuntime, op: &'static str) -> crate::Result<*mut c_void> {
+        match self {
+            Self::Owned(tensor) => typed_device_ptr(rt, tensor),
+            Self::View(view) => {
+                let offset = view.offset();
+                let prepared = prepared_view_mut_access(view, op)?;
+                offset_device_ptr::<T>(rt, prepared, offset, op)
+            }
+        }
+    }
+}
+
+/// Resolve a compact view region to `base + offset * size_of::<T>()`.
+fn offset_device_ptr<T: 'static>(
+    rt: &CudaRuntime,
+    prepared: super::dispatch::CubeclPreparedAccess,
+    offset: isize,
+    op: &'static str,
+) -> crate::Result<*mut c_void> {
+    let offset = usize::try_from(offset)
+        .map_err(|_| Error::invalid_argument(op, "layout", "view offset must be nonnegative"))?;
+    let resource = rt
+        .client()
+        .get_resource(prepared.into_handle())
+        .map_err(|err| Error::backend_source(op, err))?;
+    let offset_bytes = offset
+        .checked_mul(std::mem::size_of::<T>())
+        .ok_or_else(|| Error::invalid_argument(op, "layout", "view byte offset overflows"))?;
+    let addr = resource
+        .resource()
+        .ptr
+        .checked_add(offset_bytes as u64)
+        .ok_or_else(|| Error::invalid_argument(op, "layout", "view device address overflows"))?;
+    cuda_device_ptr_from_addr(addr, op)
+}
+
+fn read_ref<'a, 'b, T: CublasScalar>(read: &'a TensorRead<'b>) -> Option<ReadRef<'a, 'b, T>> {
+    match read {
+        TensorRead::Tensor(tensor) => T::unwrap_tensor(tensor).map(ReadRef::Owned),
+        TensorRead::View(view) => T::unwrap_view(view).map(ReadRef::View),
+    }
+}
+
+fn write_ref<'a, 'b, T: CublasScalar>(write: &'a mut TensorWrite<'b>) -> Option<WriteRef<'a, 'b, T>> {
+    match write {
+        TensorWrite::Tensor(tensor) => T::unwrap_tensor_mut(tensor).map(WriteRef::Owned),
+        TensorWrite::View(view) => T::unwrap_view_mut(view).map(WriteRef::View),
+    }
+}
+
+fn validated_dtype_changed() -> Error {
+    // INVARIANT: shared validation proves all operands share one supported
+    // dtype before the typed dispatch; reaching this arm is an internal bug.
+    Error::Internal("validated BLAS1 dtype changed before execution".into())
+}
+
+/// Convert an element count to the cuBLAS 64-bit length parameter.
+pub(super) fn blas1_len(n: usize, op: &'static str) -> crate::Result<i64> {
+    i64::try_from(n).map_err(|_| {
+        Error::invalid_argument(op, "shape", format!("element count {n} exceeds i64::MAX"))
+    })
+}
+
+fn set_pointer_mode(
+    handle: cublas::cublasHandle_t,
+    mode: cublas::cublasPointerMode_t,
+    op: &'static str,
+) -> crate::Result<()> {
+    // SAFETY: `handle` is a live handle owned by the runtime's per-stream cache.
+    check_cublas(op, "cublasSetPointerMode", unsafe {
+        cublas::cublasSetPointerMode_v2(handle, mode)
+    })
+}
+
+fn vdot_typed<T: CublasScalar>(
+    backend: &CudaBackend,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
+) -> crate::Result<Tensor> {
+    let rt = backend.runtime();
+    let (Some(lhs), Some(rhs)) = (read_ref::<T>(lhs), read_ref::<T>(rhs)) else {
+        return Err(validated_dtype_changed());
+    };
+    lhs.ensure_resident(rt, VDOT_OP)?;
+    rhs.ensure_resident(rt, VDOT_OP)?;
+    rt.set_current_cuda_context(VDOT_OP)?;
+    let len = lhs.n_elements();
+    if len == 0 {
+        // Empty reduction: the rank-0 result is a semantic zero. This uploads
+        // the zero rather than calling `alloc_zero_output`, whose fill-zero
+        // kernel fails to compile for complex dtypes (CubeCL emits an invalid
+        // `cuDoubleComplex(uint32(0))` cast).
+        return Ok(T::wrap_tensor(upload_typed_tensor(
+            rt,
+            Vec::new(),
+            vec![T::default()],
+        )?));
+    }
+    let out = alloc_output::<T>(rt, &[])?;
+    let out_ptr = typed_device_ptr(rt, &out)?;
+    let x = lhs.device_ptr(rt, VDOT_OP)?;
+    let y = rhs.device_ptr(rt, VDOT_OP)?;
+    let n = blas1_len(len, VDOT_OP)?;
+    let handle = rt.cublas_handle(VDOT_OP)?;
+    set_pointer_mode(
+        handle,
+        cublas::cublasPointerMode_t::CUBLAS_POINTER_MODE_DEVICE,
+        VDOT_OP,
+    )?;
+    // SAFETY: residency checks above tie `x`, `y`, and `out_ptr` to this
+    // runtime's device; the shared validation proves both inputs are compact
+    // spans of exactly `n` elements and `out` is a fresh rank-0 allocation.
+    check_cublas(VDOT_OP, T::DOTC_NAME, unsafe {
+        T::dotc(handle, n, x, y, out_ptr)
+    })?;
+    Ok(T::wrap_tensor(out))
+}
+
+fn norm_squared_typed<T: CublasScalar>(
+    backend: &CudaBackend,
+    input: &TensorRead<'_>,
+) -> crate::Result<Tensor> {
+    let rt = backend.runtime();
+    let Some(input) = read_ref::<T>(input) else {
+        return Err(validated_dtype_changed());
+    };
+    input.ensure_resident(rt, NORM_OP)?;
+    rt.set_current_cuda_context(NORM_OP)?;
+    let len = input.n_elements();
+    if len == 0 {
+        // Empty reduction: see the note in `vdot_typed`.
+        return Ok(<T as CublasScalar>::Real::wrap_tensor(upload_typed_tensor(
+            rt,
+            Vec::new(),
+            vec![<T as CublasScalar>::Real::default()],
+        )?));
+    }
+    let out = alloc_output::<<T as CublasScalar>::Real>(rt, &[])?;
+    let out_ptr = typed_device_ptr(rt, &out)?;
+    let x = input.device_ptr(rt, NORM_OP)?;
+    let real_len = len.checked_mul(T::REAL_COMPONENTS).ok_or_else(|| {
+        Error::invalid_argument(NORM_OP, "shape", "real component count overflows")
+    })?;
+    let n = blas1_len(real_len, NORM_OP)?;
+    let handle = rt.cublas_handle(NORM_OP)?;
+    set_pointer_mode(
+        handle,
+        cublas::cublasPointerMode_t::CUBLAS_POINTER_MODE_DEVICE,
+        NORM_OP,
+    )?;
+    // INVARIANT: `Complex32`/`Complex64` are `repr(C)` `[re, im]` pairs, so a
+    // compact complex span of `len` elements reinterprets as `2 * len` reals
+    // whose self-dot equals `sum(|z|^2)`; real dtypes reinterpret as themselves.
+    // SAFETY: residency checks above tie `x` and `out_ptr` to this runtime's
+    // device; the span holds exactly `n` real components and `out` is a fresh
+    // rank-0 allocation of the matching real dtype.
+    check_cublas(NORM_OP, <T as CublasScalar>::Real::DOT_NAME, unsafe {
+        <T as CublasScalar>::Real::dot(handle, n, x, x, out_ptr)
+    })?;
+    Ok(<T as CublasScalar>::Real::wrap_tensor(out))
+}
+
+fn axpby_typed<T: CublasScalar>(
+    backend: &CudaBackend,
+    alpha: ContractionScalar,
+    x: &TensorRead<'_>,
+    beta: ContractionScalar,
+    y: &mut TensorWrite<'_>,
+) -> crate::Result<()> {
+    let rt = backend.runtime();
+    let Some(x) = read_ref::<T>(x) else {
+        return Err(validated_dtype_changed());
+    };
+    let Some(mut y) = write_ref::<T>(y) else {
+        return Err(validated_dtype_changed());
+    };
+    let (Some(alpha), Some(beta)) = (T::from_scalar(alpha), T::from_scalar(beta)) else {
+        return Err(validated_dtype_changed());
+    };
+    x.ensure_resident(rt, AXPBY_OP)?;
+    y.ensure_resident(rt, AXPBY_OP)?;
+    rt.set_current_cuda_context(AXPBY_OP)?;
+    let len = x.n_elements();
+    if len == 0 {
+        return Ok(());
+    }
+    let x_ptr = x.device_ptr(rt, AXPBY_OP)?;
+    let y_ptr = y.device_ptr(rt, AXPBY_OP)?;
+    let n = blas1_len(len, AXPBY_OP)?;
+    let handle = rt.cublas_handle(AXPBY_OP)?;
+    set_pointer_mode(
+        handle,
+        cublas::cublasPointerMode_t::CUBLAS_POINTER_MODE_HOST,
+        AXPBY_OP,
+    )?;
+    // SAFETY: residency checks above tie `x_ptr` and `y_ptr` to this runtime's
+    // device; shared validation proves compact same-shape spans of `n`
+    // elements, a compact injective destination, and x/y non-overlap, which
+    // matches the cuBLAS `geam` in-place contract (`C == B`, `ldb == ldc`).
+    // Host-mode coefficients are read at enqueue time from the live stack
+    // values `alpha` and `beta`.
+    check_cublas(AXPBY_OP, T::GEAM_NAME, unsafe {
+        T::geam_accum(handle, n, &alpha, x_ptr, &beta, y_ptr)
+    })?;
+    Ok(())
+}
+
+/// Scalar-family dispatch for the cuBLAS BLAS1 bindings.
+pub(super) trait CublasScalar:
+    CubeElement + CubePrimitive + TensorScalar + Clone + Default + Send + Sync + 'static
+{
+    /// Real accumulator scalar: `Self` for real dtypes, the underlying real
+    /// float for complex dtypes.
+    type Real: CublasRealScalar;
+    /// Real components per element (1 for real dtypes, 2 for complex).
+    const REAL_COMPONENTS: usize;
+    /// cuBLAS symbol name reported in provider errors for [`Self::dotc`].
+    const DOTC_NAME: &'static str;
+    /// cuBLAS symbol name reported in provider errors for [`Self::geam_accum`].
+    const GEAM_NAME: &'static str;
+
+    fn unwrap_tensor(tensor: &Tensor) -> Option<&TypedTensor<Self>>;
+    fn unwrap_view<'a, 'b>(view: &'a TensorView<'b>) -> Option<&'a TypedTensorView<'b, Self>>;
+    fn unwrap_tensor_mut(tensor: &mut Tensor) -> Option<&mut TypedTensor<Self>>;
+    fn unwrap_view_mut<'a, 'b>(
+        view: &'a mut TensorViewMut<'b>,
+    ) -> Option<&'a mut TypedTensorViewMut<'b, Self>>;
+    fn wrap_tensor(tensor: TypedTensor<Self>) -> Tensor;
+    fn from_scalar(value: ContractionScalar) -> Option<Self>;
+
+    /// Enqueue `result <- sum(conj(x) * y)` over `n` device elements.
+    ///
+    /// # Safety
+    ///
+    /// `x` and `y` must be live device pointers to at least `n` compact
+    /// elements of `Self` on the handle's device, and `result` must be a live
+    /// device pointer to one `Self` (device pointer mode).
+    unsafe fn dotc(
+        handle: cublas::cublasHandle_t,
+        n: i64,
+        x: *const c_void,
+        y: *const c_void,
+        result: *mut c_void,
+    ) -> cublas::cublasStatus_t;
+
+    /// Enqueue the in-place vector update `y <- alpha * x + beta * y`.
+    ///
+    /// # Safety
+    ///
+    /// `x` and `y` must be live non-overlapping device pointers to at least
+    /// `n` compact elements of `Self` on the handle's device; `alpha` and
+    /// `beta` must be live host pointers (host pointer mode).
+    unsafe fn geam_accum(
+        handle: cublas::cublasHandle_t,
+        n: i64,
+        alpha: *const Self,
+        x: *const c_void,
+        beta: *const Self,
+        y: *mut c_void,
+    ) -> cublas::cublasStatus_t;
+}
+
+/// Real scalar family used for norm-squared accumulation.
+pub(super) trait CublasRealScalar: CublasScalar {
+    /// cuBLAS symbol name reported in provider errors for [`Self::dot`].
+    const DOT_NAME: &'static str;
+
+    /// Enqueue `result <- sum(x * y)` over `n` device elements.
+    ///
+    /// # Safety
+    ///
+    /// Same contract as [`CublasScalar::dotc`].
+    unsafe fn dot(
+        handle: cublas::cublasHandle_t,
+        n: i64,
+        x: *const c_void,
+        y: *const c_void,
+        result: *mut c_void,
+    ) -> cublas::cublasStatus_t;
+}
+
+macro_rules! impl_cublas_scalar {
+    (
+        $ty:ty, $variant:ident, $real:ty, $components:expr, $ffi:ty,
+        $dotc:ident, $geam:ident
+    ) => {
+        impl CublasScalar for $ty {
+            type Real = $real;
+            const REAL_COMPONENTS: usize = $components;
+            const DOTC_NAME: &'static str = stringify!($dotc);
+            const GEAM_NAME: &'static str = stringify!($geam);
+
+            fn unwrap_tensor(tensor: &Tensor) -> Option<&TypedTensor<Self>> {
+                match tensor {
+                    Tensor::$variant(tensor) => Some(tensor),
+                    _ => None,
+                }
+            }
+
+            fn unwrap_view<'a, 'b>(
+                view: &'a TensorView<'b>,
+            ) -> Option<&'a TypedTensorView<'b, Self>> {
+                match view {
+                    TensorView::$variant(view) => Some(view),
+                    _ => None,
+                }
+            }
+
+            fn unwrap_tensor_mut(tensor: &mut Tensor) -> Option<&mut TypedTensor<Self>> {
+                match tensor {
+                    Tensor::$variant(tensor) => Some(tensor),
+                    _ => None,
+                }
+            }
+
+            fn unwrap_view_mut<'a, 'b>(
+                view: &'a mut TensorViewMut<'b>,
+            ) -> Option<&'a mut TypedTensorViewMut<'b, Self>> {
+                match view {
+                    TensorViewMut::$variant(view) => Some(view),
+                    _ => None,
+                }
+            }
+
+            fn wrap_tensor(tensor: TypedTensor<Self>) -> Tensor {
+                Tensor::$variant(tensor)
+            }
+
+            fn from_scalar(value: ContractionScalar) -> Option<Self> {
+                match value {
+                    ContractionScalar::$variant(value) => Some(value),
+                    _ => None,
+                }
+            }
+
+            unsafe fn dotc(
+                handle: cublas::cublasHandle_t,
+                n: i64,
+                x: *const c_void,
+                y: *const c_void,
+                result: *mut c_void,
+            ) -> cublas::cublasStatus_t {
+                // INVARIANT: `Complex32`/`Complex64` are `repr(C)` re/im pairs
+                // with the same layout as `cuComplex`/`cuDoubleComplex`.
+                cublas::$dotc(
+                    handle,
+                    n,
+                    x.cast::<$ffi>(),
+                    1,
+                    y.cast::<$ffi>(),
+                    1,
+                    result.cast::<$ffi>(),
+                )
+            }
+
+            unsafe fn geam_accum(
+                handle: cublas::cublasHandle_t,
+                n: i64,
+                alpha: *const Self,
+                x: *const c_void,
+                beta: *const Self,
+                y: *mut c_void,
+            ) -> cublas::cublasStatus_t {
+                let ld = n.max(1);
+                // In-place `geam` form 2: `C = alpha * op(A) + beta * C` with
+                // `B == C`, `ldb == ldc`, and `transb == N`, treating the
+                // vectors as `n x 1` column-major matrices.
+                cublas::$geam(
+                    handle,
+                    cublas::cublasOperation_t::CUBLAS_OP_N,
+                    cublas::cublasOperation_t::CUBLAS_OP_N,
+                    n,
+                    1,
+                    alpha.cast::<$ffi>(),
+                    x.cast::<$ffi>(),
+                    ld,
+                    beta.cast::<$ffi>(),
+                    y.cast::<$ffi>().cast_const(),
+                    ld,
+                    y.cast::<$ffi>(),
+                    ld,
+                )
+            }
+        }
+    };
+}
+
+impl_cublas_scalar!(f32, F32, f32, 1, f32, cublasSdot_v2_64, cublasSgeam_64);
+impl_cublas_scalar!(f64, F64, f64, 1, f64, cublasDdot_v2_64, cublasDgeam_64);
+impl_cublas_scalar!(
+    Complex32,
+    C32,
+    f32,
+    2,
+    cublas::cuComplex,
+    cublasCdotc_v2_64,
+    cublasCgeam_64
+);
+impl_cublas_scalar!(
+    Complex64,
+    C64,
+    f64,
+    2,
+    cublas::cuDoubleComplex,
+    cublasZdotc_v2_64,
+    cublasZgeam_64
+);
+
+impl CublasRealScalar for f32 {
+    const DOT_NAME: &'static str = "cublasSdot_v2_64";
+
+    unsafe fn dot(
+        handle: cublas::cublasHandle_t,
+        n: i64,
+        x: *const c_void,
+        y: *const c_void,
+        result: *mut c_void,
+    ) -> cublas::cublasStatus_t {
+        <f32 as CublasScalar>::dotc(handle, n, x, y, result)
+    }
+}
+
+impl CublasRealScalar for f64 {
+    const DOT_NAME: &'static str = "cublasDdot_v2_64";
+
+    unsafe fn dot(
+        handle: cublas::cublasHandle_t,
+        n: i64,
+        x: *const c_void,
+        y: *const c_void,
+        result: *mut c_void,
+    ) -> cublas::cublasStatus_t {
+        <f64 as CublasScalar>::dotc(handle, n, x, y, result)
+    }
+}
+

--- a/crates/tenferro-gpu/src/cubecl/blas1.rs
+++ b/crates/tenferro-gpu/src/cubecl/blas1.rs
@@ -39,12 +39,13 @@ use tenferro_tensor::backend::{
 use tenferro_tensor::{ContractionScalar, DType, TensorRead, TensorWrite};
 
 use super::dispatch::{
-    alloc_output, ensure_resident_on_runtime, ensure_view_mut_resident_on_runtime,
+    alloc_output, cubecl_buffer, cubecl_view_buffer, cubecl_view_mut_buffer,
+    ensure_resident_on_runtime, ensure_view_mut_resident_on_runtime,
     ensure_view_resident_on_runtime, prepared_view_access, prepared_view_mut_access,
 };
 use super::error::unsupported_dtype;
 use super::gemm::typed_device_ptr;
-use super::interop::{cuda_device_ptr_from_addr, upload_typed_tensor};
+use super::interop::{alloc_zero_output, cuda_device_ptr_from_addr};
 use super::runtime::check_cublas;
 use super::{CudaBackend, CudaRuntime};
 use crate::backend::TensorStructural;
@@ -70,9 +71,24 @@ pub(super) fn vdot_read(
     rhs: TensorRead<'_>,
 ) -> crate::Result<Tensor> {
     validate_vdot_read(&lhs, &rhs)?;
-    let lhs = DeviceContiguous::prepare(backend, lhs)?;
-    let rhs = DeviceContiguous::prepare(backend, rhs)?;
-    let (lhs, rhs) = (lhs.read(), rhs.read());
+    let lhs_materialized = if lhs.is_col_major_contiguous()? {
+        None
+    } else {
+        Some(Box::new(backend.to_contiguous_read(lhs.clone())?))
+    };
+    let rhs_materialized = if rhs.is_col_major_contiguous()? {
+        None
+    } else {
+        Some(Box::new(backend.to_contiguous_read(rhs.clone())?))
+    };
+    let lhs = lhs_materialized
+        .as_deref()
+        .map(TensorRead::from_tensor)
+        .unwrap_or(lhs);
+    let rhs = rhs_materialized
+        .as_deref()
+        .map(TensorRead::from_tensor)
+        .unwrap_or(rhs);
     match lhs.dtype() {
         DType::F32 => vdot_typed::<f32>(backend, &lhs, &rhs),
         DType::F64 => vdot_typed::<f64>(backend, &lhs, &rhs),
@@ -96,8 +112,15 @@ pub(super) fn norm_squared_read(
     input: TensorRead<'_>,
 ) -> crate::Result<Tensor> {
     validate_norm_squared_read(&input)?;
-    let input = DeviceContiguous::prepare(backend, input)?;
-    let input = input.read();
+    let materialized = if input.is_col_major_contiguous()? {
+        None
+    } else {
+        Some(Box::new(backend.to_contiguous_read(input.clone())?))
+    };
+    let input = materialized
+        .as_deref()
+        .map(TensorRead::from_tensor)
+        .unwrap_or(input);
     match input.dtype() {
         DType::F32 => norm_squared_typed::<f32>(backend, &input),
         DType::F64 => norm_squared_typed::<f64>(backend, &input),
@@ -124,8 +147,15 @@ pub(super) fn axpby_read_into_accum(
     mut y: TensorWrite<'_>,
 ) -> crate::Result<()> {
     validate_axpby_read_into_accum(alpha, &x, beta, &y)?;
-    let x = DeviceContiguous::prepare(backend, x)?;
-    let x = x.read();
+    let materialized = if x.is_col_major_contiguous()? {
+        None
+    } else {
+        Some(Box::new(backend.to_contiguous_read(x.clone())?))
+    };
+    let x = materialized
+        .as_deref()
+        .map(TensorRead::from_tensor)
+        .unwrap_or(x);
     match x.dtype() {
         DType::F32 => axpby_typed::<f32>(backend, alpha, &x, beta, &mut y),
         DType::F64 => axpby_typed::<f64>(backend, alpha, &x, beta, &mut y),
@@ -133,35 +163,6 @@ pub(super) fn axpby_read_into_accum(
         DType::C64 => axpby_typed::<Complex64>(backend, alpha, &x, beta, &mut y),
         // INVARIANT: shared validation restricts the dtype to F32/F64/C32/C64.
         dtype => Err(unsupported_dtype(AXPBY_OP, dtype)),
-    }
-}
-
-/// A borrowed read that is proven column-major contiguous on the device.
-///
-/// Non-contiguous inputs are canonicalized once through the backend's
-/// same-placement `to_contiguous_read` path; the materialized tensor is owned
-/// here so its device allocation outlives the enqueued cuBLAS call site.
-enum DeviceContiguous<'a> {
-    Borrowed(TensorRead<'a>),
-    Materialized(Tensor),
-}
-
-impl<'a> DeviceContiguous<'a> {
-    fn prepare(backend: &mut CudaBackend, read: TensorRead<'a>) -> crate::Result<Self> {
-        if read.is_col_major_contiguous()? {
-            Ok(Self::Borrowed(read))
-        } else {
-            // Same-placement canonicalization on the device; the typed source
-            // error (residency, dtype, allocation) propagates unchanged.
-            Ok(Self::Materialized(backend.to_contiguous_read(read)?))
-        }
-    }
-
-    fn read(&self) -> TensorRead<'_> {
-        match self {
-            Self::Borrowed(read) => read.clone(),
-            Self::Materialized(tensor) => TensorRead::from_tensor(tensor),
-        }
     }
 }
 
@@ -188,11 +189,18 @@ impl<T: TensorScalar + 'static> ReadRef<'_, '_, T> {
 
     fn device_ptr(&self, rt: &CudaRuntime, op: &'static str) -> crate::Result<*mut c_void> {
         match self {
-            Self::Owned(tensor) => typed_device_ptr(rt, tensor),
+            Self::Owned(tensor) => typed_device_ptr(rt, tensor, op),
             Self::View(view) => {
                 let prepared = prepared_view_access(view, op)?;
                 offset_device_ptr::<T>(rt, prepared, view.offset(), op)
             }
+        }
+    }
+
+    fn handle<'a>(&'a self, op: &'static str) -> crate::Result<&'a cubecl_runtime::server::Handle> {
+        match self {
+            Self::Owned(tensor) => Ok(cubecl_buffer(tensor, op)?.handle()),
+            Self::View(view) => Ok(cubecl_view_buffer(view, op)?.handle()),
         }
     }
 }
@@ -213,7 +221,7 @@ impl<T: TensorScalar + 'static> WriteRef<'_, '_, T> {
 
     fn device_ptr(&mut self, rt: &CudaRuntime, op: &'static str) -> crate::Result<*mut c_void> {
         match self {
-            Self::Owned(tensor) => typed_device_ptr(rt, tensor),
+            Self::Owned(tensor) => typed_device_ptr(rt, tensor, op),
             Self::View(view) => {
                 let offset = view.offset();
                 let prepared = prepared_view_mut_access(view, op)?;
@@ -221,6 +229,24 @@ impl<T: TensorScalar + 'static> WriteRef<'_, '_, T> {
             }
         }
     }
+
+    fn handle<'a>(&'a self, op: &'static str) -> crate::Result<&'a cubecl_runtime::server::Handle> {
+        match self {
+            Self::Owned(tensor) => Ok(cubecl_buffer(tensor, op)?.handle()),
+            Self::View(view) => Ok(cubecl_view_mut_buffer(view, op)?.handle()),
+        }
+    }
+}
+
+fn cross_stream_handles<'a>(
+    rt: &CudaRuntime,
+    handles: impl IntoIterator<Item = &'a cubecl_runtime::server::Handle>,
+) -> Vec<cubecl_runtime::server::Handle> {
+    handles
+        .into_iter()
+        .filter(|handle| !rt.is_current_stream_slot(handle))
+        .cloned()
+        .collect()
 }
 
 /// Resolve a compact view region to `base + offset * size_of::<T>()`.
@@ -254,7 +280,9 @@ fn read_ref<'a, 'b, T: CublasScalar>(read: &'a TensorRead<'b>) -> Option<ReadRef
     }
 }
 
-fn write_ref<'a, 'b, T: CublasScalar>(write: &'a mut TensorWrite<'b>) -> Option<WriteRef<'a, 'b, T>> {
+fn write_ref<'a, 'b, T: CublasScalar>(
+    write: &'a mut TensorWrite<'b>,
+) -> Option<WriteRef<'a, 'b, T>> {
     match write {
         TensorWrite::Tensor(tensor) => T::unwrap_tensor_mut(tensor).map(WriteRef::Owned),
         TensorWrite::View(view) => T::unwrap_view_mut(view).map(WriteRef::View),
@@ -274,17 +302,6 @@ pub(super) fn blas1_len(n: usize, op: &'static str) -> crate::Result<i64> {
     })
 }
 
-fn set_pointer_mode(
-    handle: cublas::cublasHandle_t,
-    mode: cublas::cublasPointerMode_t,
-    op: &'static str,
-) -> crate::Result<()> {
-    // SAFETY: `handle` is a live handle owned by the runtime's per-stream cache.
-    check_cublas(op, "cublasSetPointerMode", unsafe {
-        cublas::cublasSetPointerMode_v2(handle, mode)
-    })
-}
-
 fn vdot_typed<T: CublasScalar>(
     backend: &CudaBackend,
     lhs: &TensorRead<'_>,
@@ -299,33 +316,34 @@ fn vdot_typed<T: CublasScalar>(
     rt.set_current_cuda_context(VDOT_OP)?;
     let len = lhs.n_elements();
     if len == 0 {
-        // Empty reduction: the rank-0 result is a semantic zero. This uploads
-        // the zero rather than calling `alloc_zero_output`, whose fill-zero
-        // kernel fails to compile for complex dtypes (CubeCL emits an invalid
-        // `cuDoubleComplex(uint32(0))` cast).
-        return Ok(T::wrap_tensor(upload_typed_tensor(
-            rt,
-            Vec::new(),
-            vec![T::default()],
-        )?));
+        return Ok(T::wrap_tensor(alloc_zero_output::<T>(rt, &[])?));
     }
     let out = alloc_output::<T>(rt, &[])?;
-    let out_ptr = typed_device_ptr(rt, &out)?;
+    let out_ptr = typed_device_ptr(rt, &out, VDOT_OP)?;
     let x = lhs.device_ptr(rt, VDOT_OP)?;
     let y = rhs.device_ptr(rt, VDOT_OP)?;
     let n = blas1_len(len, VDOT_OP)?;
-    let handle = rt.cublas_handle(VDOT_OP)?;
-    set_pointer_mode(
-        handle,
-        cublas::cublasPointerMode_t::CUBLAS_POINTER_MODE_DEVICE,
+    let cross_stream_handles = cross_stream_handles(
+        rt,
+        [
+            lhs.handle(VDOT_OP)?,
+            rhs.handle(VDOT_OP)?,
+            cubecl_buffer(&out, VDOT_OP)?.handle(),
+        ],
+    );
+    rt.with_cublas_handle(
         VDOT_OP,
+        cublas::cublasPointerMode_t::CUBLAS_POINTER_MODE_DEVICE,
+        cross_stream_handles,
+        |handle| {
+            // SAFETY: residency checks above tie `x`, `y`, and `out_ptr` to this
+            // runtime's device; shared validation proves compact spans of `n`
+            // elements and `out` is a fresh rank-0 allocation.
+            check_cublas(VDOT_OP, T::DOTC_NAME, unsafe {
+                T::dotc(handle, n, x, y, out_ptr)
+            })
+        },
     )?;
-    // SAFETY: residency checks above tie `x`, `y`, and `out_ptr` to this
-    // runtime's device; the shared validation proves both inputs are compact
-    // spans of exactly `n` elements and `out` is a fresh rank-0 allocation.
-    check_cublas(VDOT_OP, T::DOTC_NAME, unsafe {
-        T::dotc(handle, n, x, y, out_ptr)
-    })?;
     Ok(T::wrap_tensor(out))
 }
 
@@ -341,35 +359,38 @@ fn norm_squared_typed<T: CublasScalar>(
     rt.set_current_cuda_context(NORM_OP)?;
     let len = input.n_elements();
     if len == 0 {
-        // Empty reduction: see the note in `vdot_typed`.
-        return Ok(<T as CublasScalar>::Real::wrap_tensor(upload_typed_tensor(
-            rt,
-            Vec::new(),
-            vec![<T as CublasScalar>::Real::default()],
-        )?));
+        return Ok(<T as CublasScalar>::Real::wrap_tensor(alloc_zero_output::<
+            <T as CublasScalar>::Real,
+        >(rt, &[])?));
     }
     let out = alloc_output::<<T as CublasScalar>::Real>(rt, &[])?;
-    let out_ptr = typed_device_ptr(rt, &out)?;
+    let out_ptr = typed_device_ptr(rt, &out, NORM_OP)?;
     let x = input.device_ptr(rt, NORM_OP)?;
     let real_len = len.checked_mul(T::REAL_COMPONENTS).ok_or_else(|| {
         Error::invalid_argument(NORM_OP, "shape", "real component count overflows")
     })?;
     let n = blas1_len(real_len, NORM_OP)?;
-    let handle = rt.cublas_handle(NORM_OP)?;
-    set_pointer_mode(
-        handle,
-        cublas::cublasPointerMode_t::CUBLAS_POINTER_MODE_DEVICE,
+    let cross_stream_handles = cross_stream_handles(
+        rt,
+        [
+            input.handle(NORM_OP)?,
+            cubecl_buffer(&out, NORM_OP)?.handle(),
+        ],
+    );
+    rt.with_cublas_handle(
         NORM_OP,
+        cublas::cublasPointerMode_t::CUBLAS_POINTER_MODE_DEVICE,
+        cross_stream_handles,
+        |handle| {
+            // INVARIANT: `Complex32`/`Complex64` are `repr(C)` `[re, im]`
+            // pairs, so `2 * len` real components self-dot to `sum(|z|^2)`.
+            // SAFETY: residency checks tie `x`/`out_ptr` to this runtime; the
+            // spans hold `n` real components and one output scalar.
+            check_cublas(NORM_OP, <T as CublasScalar>::Real::DOT_NAME, unsafe {
+                <T as CublasScalar>::Real::dot(handle, n, x, x, out_ptr)
+            })
+        },
     )?;
-    // INVARIANT: `Complex32`/`Complex64` are `repr(C)` `[re, im]` pairs, so a
-    // compact complex span of `len` elements reinterprets as `2 * len` reals
-    // whose self-dot equals `sum(|z|^2)`; real dtypes reinterpret as themselves.
-    // SAFETY: residency checks above tie `x` and `out_ptr` to this runtime's
-    // device; the span holds exactly `n` real components and `out` is a fresh
-    // rank-0 allocation of the matching real dtype.
-    check_cublas(NORM_OP, <T as CublasScalar>::Real::DOT_NAME, unsafe {
-        <T as CublasScalar>::Real::dot(handle, n, x, x, out_ptr)
-    })?;
     Ok(<T as CublasScalar>::Real::wrap_tensor(out))
 }
 
@@ -400,21 +421,21 @@ fn axpby_typed<T: CublasScalar>(
     let x_ptr = x.device_ptr(rt, AXPBY_OP)?;
     let y_ptr = y.device_ptr(rt, AXPBY_OP)?;
     let n = blas1_len(len, AXPBY_OP)?;
-    let handle = rt.cublas_handle(AXPBY_OP)?;
-    set_pointer_mode(
-        handle,
-        cublas::cublasPointerMode_t::CUBLAS_POINTER_MODE_HOST,
+    let cross_stream_handles = cross_stream_handles(rt, [x.handle(AXPBY_OP)?, y.handle(AXPBY_OP)?]);
+    rt.with_cublas_handle(
         AXPBY_OP,
+        cublas::cublasPointerMode_t::CUBLAS_POINTER_MODE_HOST,
+        cross_stream_handles,
+        |handle| {
+            // SAFETY: residency checks tie both pointers to this runtime;
+            // shared validation proves compact same-shape, non-overlapping
+            // spans matching in-place geam (`C == B`, `ldb == ldc`). Host-mode
+            // coefficients are consumed synchronously during enqueue.
+            check_cublas(AXPBY_OP, T::GEAM_NAME, unsafe {
+                T::geam_accum(handle, n, &alpha, x_ptr, &beta, y_ptr)
+            })
+        },
     )?;
-    // SAFETY: residency checks above tie `x_ptr` and `y_ptr` to this runtime's
-    // device; shared validation proves compact same-shape spans of `n`
-    // elements, a compact injective destination, and x/y non-overlap, which
-    // matches the cuBLAS `geam` in-place contract (`C == B`, `ldb == ldc`).
-    // Host-mode coefficients are read at enqueue time from the live stack
-    // values `alpha` and `beta`.
-    check_cublas(AXPBY_OP, T::GEAM_NAME, unsafe {
-        T::geam_accum(handle, n, &alpha, x_ptr, &beta, y_ptr)
-    })?;
     Ok(())
 }
 
@@ -646,4 +667,3 @@ impl CublasRealScalar for f64 {
         <f64 as CublasScalar>::dotc(handle, n, x, y, result)
     }
 }
-

--- a/crates/tenferro-gpu/src/cubecl/blas1.rs
+++ b/crates/tenferro-gpu/src/cubecl/blas1.rs
@@ -295,10 +295,10 @@ fn validated_dtype_changed() -> Error {
     Error::Internal("validated BLAS1 dtype changed before execution".into())
 }
 
-/// Convert an element count to the cuBLAS 64-bit length parameter.
-pub(super) fn blas1_len(n: usize, op: &'static str) -> crate::Result<i64> {
-    i64::try_from(n).map_err(|_| {
-        Error::invalid_argument(op, "shape", format!("element count {n} exceeds i64::MAX"))
+/// Convert an element count to the portable cuBLAS length parameter.
+pub(super) fn blas1_len(n: usize, op: &'static str) -> crate::Result<i32> {
+    i32::try_from(n).map_err(|_| {
+        Error::invalid_argument(op, "shape", format!("element count {n} exceeds i32::MAX"))
     })
 }
 
@@ -471,7 +471,7 @@ pub(super) trait CublasScalar:
     /// device pointer to one `Self` (device pointer mode).
     unsafe fn dotc(
         handle: cublas::cublasHandle_t,
-        n: i64,
+        n: i32,
         x: *const c_void,
         y: *const c_void,
         result: *mut c_void,
@@ -486,7 +486,7 @@ pub(super) trait CublasScalar:
     /// `beta` must be live host pointers (host pointer mode).
     unsafe fn geam_accum(
         handle: cublas::cublasHandle_t,
-        n: i64,
+        n: i32,
         alpha: *const Self,
         x: *const c_void,
         beta: *const Self,
@@ -506,7 +506,7 @@ pub(super) trait CublasRealScalar: CublasScalar {
     /// Same contract as [`CublasScalar::dotc`].
     unsafe fn dot(
         handle: cublas::cublasHandle_t,
-        n: i64,
+        n: i32,
         x: *const c_void,
         y: *const c_void,
         result: *mut c_void,
@@ -569,7 +569,7 @@ macro_rules! impl_cublas_scalar {
 
             unsafe fn dotc(
                 handle: cublas::cublasHandle_t,
-                n: i64,
+                n: i32,
                 x: *const c_void,
                 y: *const c_void,
                 result: *mut c_void,
@@ -589,7 +589,7 @@ macro_rules! impl_cublas_scalar {
 
             unsafe fn geam_accum(
                 handle: cublas::cublasHandle_t,
-                n: i64,
+                n: i32,
                 alpha: *const Self,
                 x: *const c_void,
                 beta: *const Self,
@@ -619,16 +619,16 @@ macro_rules! impl_cublas_scalar {
     };
 }
 
-impl_cublas_scalar!(f32, F32, f32, 1, f32, cublasSdot_v2_64, cublasSgeam_64);
-impl_cublas_scalar!(f64, F64, f64, 1, f64, cublasDdot_v2_64, cublasDgeam_64);
+impl_cublas_scalar!(f32, F32, f32, 1, f32, cublasSdot_v2, cublasSgeam);
+impl_cublas_scalar!(f64, F64, f64, 1, f64, cublasDdot_v2, cublasDgeam);
 impl_cublas_scalar!(
     Complex32,
     C32,
     f32,
     2,
     cublas::cuComplex,
-    cublasCdotc_v2_64,
-    cublasCgeam_64
+    cublasCdotc_v2,
+    cublasCgeam
 );
 impl_cublas_scalar!(
     Complex64,
@@ -636,16 +636,16 @@ impl_cublas_scalar!(
     f64,
     2,
     cublas::cuDoubleComplex,
-    cublasZdotc_v2_64,
-    cublasZgeam_64
+    cublasZdotc_v2,
+    cublasZgeam
 );
 
 impl CublasRealScalar for f32 {
-    const DOT_NAME: &'static str = "cublasSdot_v2_64";
+    const DOT_NAME: &'static str = "cublasSdot_v2";
 
     unsafe fn dot(
         handle: cublas::cublasHandle_t,
-        n: i64,
+        n: i32,
         x: *const c_void,
         y: *const c_void,
         result: *mut c_void,
@@ -655,11 +655,11 @@ impl CublasRealScalar for f32 {
 }
 
 impl CublasRealScalar for f64 {
-    const DOT_NAME: &'static str = "cublasDdot_v2_64";
+    const DOT_NAME: &'static str = "cublasDdot_v2";
 
     unsafe fn dot(
         handle: cublas::cublasHandle_t,
-        n: i64,
+        n: i32,
         x: *const c_void,
         y: *const c_void,
         result: *mut c_void,

--- a/crates/tenferro-gpu/src/cubecl/exec_session.rs
+++ b/crates/tenferro-gpu/src/cubecl/exec_session.rs
@@ -592,6 +592,24 @@ delegate_cached! {
 }
 
 impl BackendSession for CudaExecSession<'_> {
+    fn vdot_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
+        BackendSession::vdot_read(self.backend, lhs, rhs)
+    }
+
+    fn norm_squared_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
+        BackendSession::norm_squared_read(self.backend, input)
+    }
+
+    fn axpby_read_into_accum(
+        &mut self,
+        alpha: tenferro_tensor::ContractionScalar,
+        x: TensorRead<'_>,
+        beta: tenferro_tensor::ContractionScalar,
+        y: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        BackendSession::axpby_read_into_accum(self.backend, alpha, x, beta, y)
+    }
+
     fn session_type_id(&self) -> TypeId {
         TypeId::of::<CudaExecSessionMarker>()
     }

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -1001,15 +1001,26 @@ where
         return Ok(output);
     }
     if layout.contracting_elements == 0 {
-        return zero_alloc::<T>(backend.runtime(), &layout.output_shape);
+        // The contraction sum is empty: fill the already-allocated output with
+        // zeros instead of allocating a second output tensor.
+        launch_nullary_into(
+            backend.runtime(),
+            &output,
+            OP,
+            cube_count_for_len(output.n_elements())?,
+            cube_dim_1d(),
+            |client, count, dim, out| unsafe {
+                structural::fill_zero_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
+                    client, count, dim, out,
+                );
+            },
+        )?;
+        return Ok(output);
     }
 
     let lhs_ptr = typed_device_ptr(backend.runtime(), lhs)?;
     let rhs_ptr = typed_device_ptr(backend.runtime(), rhs)?;
     let output_ptr = typed_device_ptr(backend.runtime(), &output)?;
-
-    let accumulator = alloc_output::<T>(backend.runtime(), &layout.output_shape)?;
-    let accumulator_ptr = typed_device_ptr(backend.runtime(), &accumulator)?;
 
     let alpha = T::one();
     let beta = T::zero();
@@ -1026,6 +1037,9 @@ where
         rhs_conj,
         workspace_preference: CutensorWorksizePreference::Default,
     };
+    // C = D = output: cuTENSOR never reads the accumulator slot when
+    // beta == 0, so the freshly allocated output serves as both C and D and
+    // no separate accumulator tensor is needed.
     cached_cutensor_contraction::<T, _>(backend, &spec, |cutensor, plan, workspace| unsafe {
         cutensor.contract(
             plan,
@@ -1033,7 +1047,7 @@ where
             lhs_ptr as *const c_void,
             rhs_ptr as *const c_void,
             &beta as *const T as *const c_void,
-            accumulator_ptr as *const c_void,
+            output_ptr as *const c_void,
             output_ptr,
             workspace.ptr,
             workspace.size,
@@ -1205,26 +1219,6 @@ fn typed_device_ptr<T: TensorScalar + 'static>(
         .map_err(|err| crate::Error::backend_source(OP, err))?;
     // The residency check above ties this raw FFI pointer to the caller's runtime/device.
     cuda_device_ptr_from_addr(resource.resource().ptr, OP)
-}
-
-fn zero_alloc<T>(rt: &CudaRuntime, shape: &[usize]) -> crate::Result<TypedTensor<T>>
-where
-    T: CutensorScalar,
-{
-    let output = alloc_output::<T>(rt, shape)?;
-    launch_nullary_into(
-        rt,
-        &output,
-        OP,
-        cube_count_for_len(output.n_elements())?,
-        cube_dim_1d(),
-        |client, count, dim, out| unsafe {
-            structural::fill_zero_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
-                client, count, dim, out,
-            );
-        },
-    )?;
-    Ok(output)
 }
 
 fn build_layout(

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -1,4 +1,3 @@
-use std::collections::{HashMap, VecDeque};
 use std::ffi::c_void;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
@@ -21,6 +20,7 @@ use super::ffi::cutensor::{
     CutensorWorksizePreference, OperationDescriptor, Plan, PlanPreference, TensorDescriptor,
 };
 use super::interop::cuda_device_ptr_from_addr;
+use super::plan_cache::LruPlanCache;
 use super::{CudaBackend, CudaRuntime};
 use crate::config::DotGeneralConfig;
 use crate::kernels::structural;
@@ -33,6 +33,7 @@ use tenferro_tensor::{
 const OP: &str = "dot_general";
 const CUDA_ALLOCATION_ALIGNMENT: u32 = 256;
 const DEFAULT_CUTENSOR_PLAN_CACHE_MAX_ENTRIES: usize = 64;
+type CutensorContractionPlanCache = LruPlanCache<CutensorContractionKey, CachedCutensorContraction>;
 type CutensorPlanCacheState = Arc<Mutex<CutensorContractionPlanCache>>;
 
 trait CutensorScalar: CubeElement + TensorScalar + CubePrimitive + Clone + One + Zero {
@@ -437,104 +438,53 @@ impl CachedCutensorContraction {
     }
 }
 
-struct CutensorContractionPlanCache {
-    max_entries: NonZeroUsize,
-    entries: HashMap<CutensorContractionKey, CachedCutensorContraction>,
-    order: VecDeque<CutensorContractionKey>,
-    stats: CacheStats,
+/// Hash `spec` into the plan-cache key hash without materializing an owned
+/// key. Field order mirrors [`CutensorContractionKey::from_spec`]; the stored
+/// key is compared with [`key_matches_spec`] on lookup, so a 64-bit collision
+/// degrades to a plan rebuild instead of a wrong plan.
+fn spec_hash<T: CutensorScalar>(spec: &CutensorContractionSpec<'_>) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    T::DTYPE.hash(&mut hasher);
+    spec.layout.lhs_extents.hash(&mut hasher);
+    spec.lhs_strides.hash(&mut hasher);
+    spec.layout.lhs_modes.hash(&mut hasher);
+    spec.layout.rhs_extents.hash(&mut hasher);
+    spec.rhs_strides.hash(&mut hasher);
+    spec.layout.rhs_modes.hash(&mut hasher);
+    spec.layout.output_extents.hash(&mut hasher);
+    spec.output_strides.hash(&mut hasher);
+    spec.layout.output_modes.hash(&mut hasher);
+    spec.lhs_alignment_requirement.hash(&mut hasher);
+    spec.rhs_alignment_requirement.hash(&mut hasher);
+    spec.output_alignment_requirement.hash(&mut hasher);
+    cutensor_conj_op::<T>(spec.lhs_conj).hash(&mut hasher);
+    cutensor_conj_op::<T>(spec.rhs_conj).hash(&mut hasher);
+    spec.workspace_preference.hash(&mut hasher);
+    hasher.finish()
 }
 
-impl CutensorContractionPlanCache {
-    fn new(max_entries: NonZeroUsize) -> Self {
-        Self {
-            max_entries,
-            entries: HashMap::new(),
-            order: VecDeque::new(),
-            stats: CacheStats::empty(),
-        }
-    }
-
-    fn ensure<T>(
-        &mut self,
-        rt: &CudaRuntime,
-        cutensor: &CutensorHandle,
-        key: &CutensorContractionKey,
-        spec: &CutensorContractionSpec<'_>,
-    ) -> crate::Result<()>
-    where
-        T: CutensorScalar,
-    {
-        if self.entries.contains_key(key) {
-            self.stats.hits = self.stats.hits.saturating_add(1);
-            self.touch(key);
-            return Ok(());
-        }
-        self.stats.misses = self.stats.misses.saturating_add(1);
-        let cached = CachedCutensorContraction::new::<T>(rt, cutensor, spec)?;
-        self.entries.insert(key.clone(), cached);
-        self.touch(key);
-        self.evict_to_limit();
-        Ok(())
-    }
-
-    fn get(&self, key: &CutensorContractionKey) -> crate::Result<&CachedCutensorContraction> {
-        self.entries.get(key).ok_or_else(|| {
-            Error::runtime_state(
-                "cutensor_plan_cache",
-                "cached cuTENSOR contraction was evicted before use",
-            )
-        })
-    }
-
-    fn touch(&mut self, key: &CutensorContractionKey) {
-        // INVARIANT: the LRU order is bounded by configured `max_entries`, so
-        // this retain scan has a constant configured ceiling.
-        self.order.retain(|existing| existing != key);
-        self.order.push_back(key.clone());
-    }
-
-    fn evict_to_limit(&mut self) {
-        while self.entries.len() > self.max_entries.get() {
-            let Some(oldest) = self.order.pop_front() else {
-                break;
-            };
-            if self.entries.remove(&oldest).is_some() {
-                self.stats.evictions = self.stats.evictions.saturating_add(1);
-            }
-        }
-    }
-
-    fn max_entries(&self) -> NonZeroUsize {
-        self.max_entries
-    }
-
-    fn set_max_entries(&mut self, max_entries: NonZeroUsize) {
-        self.max_entries = max_entries;
-        self.evict_to_limit();
-    }
-
-    fn stats(&self) -> CacheStats {
-        CacheStats {
-            entries: self.entries.len(),
-            retained_bytes: self.retained_bytes(),
-            ..self.stats
-        }
-    }
-
-    fn retained_bytes(&self) -> usize {
-        // INVARIANT: retained entries are bounded by configured `max_entries`,
-        // so this retained-byte fold has a constant configured ceiling.
-        let entries_bytes =
-            self.entries
-                .iter()
-                .fold(std::mem::size_of::<Self>(), |total, (key, cached)| {
-                    total
-                        .saturating_add(key.retained_bytes())
-                        .saturating_add(cached.retained_bytes())
-                });
-        entries_bytes
-            .saturating_add(self.order.capacity() * std::mem::size_of::<CutensorContractionKey>())
-    }
+/// Verify a stored materialized key against a borrowed spec.
+fn key_matches_spec<T: CutensorScalar>(
+    key: &CutensorContractionKey,
+    spec: &CutensorContractionSpec<'_>,
+) -> bool {
+    key.dtype == T::DTYPE
+        && key.lhs.extents == spec.layout.lhs_extents
+        && key.lhs.strides == spec.lhs_strides
+        && key.lhs.modes == spec.layout.lhs_modes
+        && key.rhs.extents == spec.layout.rhs_extents
+        && key.rhs.strides == spec.rhs_strides
+        && key.rhs.modes == spec.layout.rhs_modes
+        && key.output.extents == spec.layout.output_extents
+        && key.output.strides == spec.output_strides
+        && key.output.modes == spec.layout.output_modes
+        && key.lhs_alignment_requirement == spec.lhs_alignment_requirement
+        && key.rhs_alignment_requirement == spec.rhs_alignment_requirement
+        && key.output_alignment_requirement == spec.output_alignment_requirement
+        && key.lhs_op == cutensor_conj_op::<T>(spec.lhs_conj)
+        && key.rhs_op == cutensor_conj_op::<T>(spec.rhs_conj)
+        && key.workspace_preference == spec.workspace_preference
 }
 
 pub(super) fn dot_general(
@@ -1116,7 +1066,7 @@ pub(super) fn cutensor_plan_cache_workspace_bytes(backend: &CudaBackend) -> crat
         return Ok(0);
     };
     let plan_cache = lock_cutensor_plan_cache(&plan_cache)?;
-    Ok(plan_cache.entries.values().fold(0, |total, cached| {
+    Ok(plan_cache.values().fold(0, |total, cached| {
         total.saturating_add(cached.workspace.size)
     }))
 }
@@ -1156,15 +1106,35 @@ where
     T: CutensorScalar,
 {
     let cutensor = backend.cutensor_handle()?;
-    let key = CutensorContractionKey::from_spec::<T>(spec);
+    let hash = spec_hash::<T>(spec);
     let plan_cache = get_or_init_cutensor_plan_cache(backend)?;
     let mut plan_cache = lock_cutensor_plan_cache(&plan_cache)?;
-    plan_cache.ensure::<T>(backend.runtime(), cutensor, &key, spec)?;
-    let retained_bytes = plan_cache.retained_bytes();
-    backend
-        .cuda_extension_cache()
-        .update_retained_bytes::<CutensorPlanCacheState>(retained_bytes)?;
-    let cached = plan_cache.get(&key)?;
+    let entries_changed = plan_cache.ensure(
+        hash,
+        |key| key_matches_spec::<T>(key, spec),
+        || {
+            let cached = CachedCutensorContraction::new::<T>(backend.runtime(), cutensor, spec)?;
+            let key = CutensorContractionKey::from_spec::<T>(spec);
+            let retained_bytes = key.retained_bytes().saturating_add(cached.retained_bytes());
+            Ok((key, cached, retained_bytes))
+        },
+    )?;
+    if entries_changed {
+        // Retained bytes only move on insert/evict, so cache hits skip the
+        // extension-cache accounting write entirely.
+        let retained_bytes = plan_cache.retained_bytes();
+        backend
+            .cuda_extension_cache()
+            .update_retained_bytes::<CutensorPlanCacheState>(retained_bytes)?;
+    }
+    let cached = plan_cache
+        .get(hash, |key| key_matches_spec::<T>(key, spec))
+        .ok_or_else(|| {
+            Error::runtime_state(
+                "cutensor_plan_cache",
+                "cached cuTENSOR contraction was evicted before use",
+            )
+        })?;
     execute(cutensor, &cached.plan, &cached.workspace)
 }
 

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -9,10 +9,10 @@ use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 
 use super::dispatch::{
-    alloc_output, cube_count_for_len, cube_dim_1d, cubecl_buffer, dtype_mismatch,
-    ensure_resident_on_runtime, ensure_view_mut_resident_on_runtime,
-    ensure_view_resident_on_runtime, launch_nullary_into, prepared_tensor_access,
-    prepared_view_access, prepared_view_mut_access, CubeclPreparedAccess,
+    alloc_output, cube_count_for_len, cube_dim_1d, cubecl_buffer, cubecl_view_buffer,
+    cubecl_view_mut_buffer, dtype_mismatch, ensure_resident_on_runtime,
+    ensure_view_mut_resident_on_runtime, ensure_view_resident_on_runtime, launch_nullary_into,
+    prepared_tensor_access, prepared_view_access, prepared_view_mut_access, CubeclPreparedAccess,
 };
 use super::error::{unsupported_dtype, unsupported_operation, workspace_size_overflow};
 use super::ffi::cutensor::{
@@ -240,14 +240,13 @@ struct DotGeneralLayout {
 }
 
 struct Workspace {
-    // INVARIANT: in pinned CubeCL rev 1c88bb6, CUDA storage records handle
-    // deallocation and matches async allocations with `cuMemFreeAsync` on the
-    // allocation stream (or sync allocations with `cuMemFree`). Dropping an
-    // evicted handle therefore follows CubeCL's stream-owned release contract;
-    // this cache does not free the device pointer directly.
+    // CubeCL owns the allocation. `Drop` retires the stream on which cuTENSOR
+    // used it before releasing this handle.
     _handle: Option<cubecl_runtime::server::Handle>,
     ptr: *mut c_void,
     size: u64,
+    runtime: Option<CudaRuntime>,
+    stream: u64,
 }
 
 impl Workspace {
@@ -256,6 +255,24 @@ impl Workspace {
             _handle: None,
             ptr: std::ptr::null_mut(),
             size: 0,
+            runtime: None,
+            stream: 0,
+        }
+    }
+}
+
+impl Drop for Workspace {
+    fn drop(&mut self) {
+        let (Some(runtime), Some(handle)) = (self.runtime.as_ref(), self._handle.take()) else {
+            return;
+        };
+        if runtime
+            .synchronize_raw_stream(self.stream, "cutensor_workspace_drop")
+            .is_err()
+        {
+            // Without a proven barrier the evicted workspace may still be in
+            // use. Leak its CubeCL handle rather than race device reclamation.
+            std::mem::forget(handle);
         }
     }
 }
@@ -353,6 +370,12 @@ struct CutensorContractionSpec<'a> {
 }
 
 struct CachedCutensorContraction {
+    // INVARIANT: Rust drops fields in declaration order. Workspaces retire
+    // their owning streams before the plan and descriptors used by queued
+    // contractions are destroyed. Each slot has one workspace and one lock,
+    // so teardown cannot synchronize the same allocation twice.
+    workspaces: Box<[Mutex<Option<Workspace>>]>,
+    workspace_size: u64,
     // Drop the cuTENSOR plan before the descriptor objects it was built from.
     plan: Plan,
     _plan_preference: PlanPreference,
@@ -360,7 +383,6 @@ struct CachedCutensorContraction {
     _output_descriptor: TensorDescriptor,
     _rhs_descriptor: TensorDescriptor,
     _lhs_descriptor: TensorDescriptor,
-    workspace: Workspace,
 }
 
 // SAFETY: cached cuTENSOR state is tied to one `CudaBackend` and is only used
@@ -420,21 +442,36 @@ impl CachedCutensorContraction {
         let workspace_size =
             cutensor.estimate_workspace_size(&op_desc, &pref, spec.workspace_preference, OP)?;
         let plan = Plan::new(cutensor, &op_desc, &pref, workspace_size, OP)?;
-        let workspace = alloc_workspace(rt, workspace_size)?;
         Ok(Self {
+            workspaces: (0..rt.stream_slot_count())
+                .map(|_| Mutex::new(None))
+                .collect(),
+            workspace_size,
             plan,
             _plan_preference: pref,
             _operation_descriptor: op_desc,
             _output_descriptor: desc_out,
             _rhs_descriptor: desc_b,
             _lhs_descriptor: desc_a,
-            workspace,
         })
     }
 
     fn retained_bytes(&self) -> usize {
-        std::mem::size_of::<Self>()
-            .saturating_add(usize::try_from(self.workspace.size).unwrap_or(usize::MAX))
+        std::mem::size_of::<Self>().saturating_add(
+            self.workspaces
+                .len()
+                .saturating_mul(std::mem::size_of::<Mutex<Option<Workspace>>>()),
+        )
+    }
+
+    #[cfg(test)]
+    fn workspace_bytes(&self) -> crate::Result<u64> {
+        self.workspaces.iter().try_fold(0_u64, |total, slot| {
+            let workspace = slot
+                .lock()
+                .map_err(|_| Error::runtime_state(OP, "cuTENSOR workspace lock poisoned"))?;
+            Ok(total.saturating_add(workspace.as_ref().map_or(0, |workspace| workspace.size)))
+        })
     }
 }
 
@@ -581,6 +618,13 @@ impl<T: 'static> ReadOperand<'_, '_, T> {
             Self::View(view) => view.shape(),
         }
     }
+
+    fn handle(&self) -> crate::Result<&cubecl_runtime::server::Handle> {
+        match self {
+            Self::Owned(tensor) => Ok(cubecl_buffer(tensor, OP)?.handle()),
+            Self::View(view) => Ok(cubecl_view_buffer(view, OP)?.handle()),
+        }
+    }
 }
 
 fn read_operand_alignment_requirement<T: CutensorScalar>(operand: &ReadOperand<'_, '_, T>) -> u32 {
@@ -610,6 +654,24 @@ impl<T: 'static> WriteOperand<'_, '_, T> {
             Self::View(view) => view.n_elements(),
         }
     }
+
+    fn handle(&self) -> crate::Result<&cubecl_runtime::server::Handle> {
+        match self {
+            Self::Owned(tensor) => Ok(cubecl_buffer(tensor, OP)?.handle()),
+            Self::View(view) => Ok(cubecl_view_mut_buffer(view, OP)?.handle()),
+        }
+    }
+}
+
+fn cross_stream_handles<'a>(
+    rt: &CudaRuntime,
+    handles: impl IntoIterator<Item = &'a cubecl_runtime::server::Handle>,
+) -> Vec<cubecl_runtime::server::Handle> {
+    handles
+        .into_iter()
+        .filter(|handle| !rt.is_current_stream_slot(handle))
+        .cloned()
+        .collect()
 }
 
 fn write_operand_alignment_requirement<T: CutensorScalar>(
@@ -740,6 +802,10 @@ where
             layout.output_shape.clone(),
         ));
     }
+    let cross_stream_handles = cross_stream_handles(
+        backend.runtime(),
+        [lhs.handle()?, rhs.handle()?, out.handle()?],
+    );
     // Residency, buffer-family, stride-sign, and bounds validation for all
     // three slots happens here, before any degenerate-case early return.
     let lhs_res = resolve_read_operand(backend.runtime(), &lhs, &layout.lhs_strides)?;
@@ -787,21 +853,26 @@ where
     // by cuTENSOR itself when beta == 0) and writes the result in place.
     // Overlap between the out region and the lhs/rhs regions is the caller's
     // responsibility, as with BLAS-style in-place update APIs.
-    cached_cutensor_contraction::<T, _>(backend, &spec, |cutensor, plan, workspace| unsafe {
-        cutensor.contract(
-            plan,
-            &alpha as *const T as *const c_void,
-            lhs_res.ptr as *const c_void,
-            rhs_res.ptr as *const c_void,
-            &beta as *const T as *const c_void,
-            out_res.ptr as *const c_void,
-            out_res.ptr,
-            workspace.ptr,
-            workspace.size,
-            stream,
-            OP,
-        )
-    })
+    cached_cutensor_contraction::<T, _>(
+        backend,
+        &spec,
+        cross_stream_handles,
+        |cutensor, plan, workspace| unsafe {
+            cutensor.contract(
+                plan,
+                &alpha as *const T as *const c_void,
+                lhs_res.ptr as *const c_void,
+                rhs_res.ptr as *const c_void,
+                &beta as *const T as *const c_void,
+                out_res.ptr as *const c_void,
+                out_res.ptr,
+                workspace.ptr,
+                workspace.size,
+                stream,
+                OP,
+            )
+        },
+    )
 }
 
 fn resolve_read_operand<'a, T>(
@@ -814,7 +885,7 @@ where
 {
     match operand {
         ReadOperand::Owned(tensor) => Ok(ResolvedOperand {
-            ptr: typed_device_ptr(rt, tensor)?,
+            ptr: typed_device_ptr(rt, tensor, OP)?,
             strides: std::borrow::Cow::Borrowed(compact_strides),
             alignment: CUDA_ALLOCATION_ALIGNMENT,
         }),
@@ -836,7 +907,7 @@ where
 {
     match operand {
         WriteOperand::Owned(tensor) => Ok(ResolvedOperand {
-            ptr: typed_device_ptr(rt, tensor)?,
+            ptr: typed_device_ptr(rt, tensor, OP)?,
             strides: std::borrow::Cow::Borrowed(compact_strides),
             alignment: CUDA_ALLOCATION_ALIGNMENT,
         }),
@@ -972,9 +1043,9 @@ where
         return Ok(output);
     }
 
-    let lhs_ptr = typed_device_ptr(backend.runtime(), lhs)?;
-    let rhs_ptr = typed_device_ptr(backend.runtime(), rhs)?;
-    let output_ptr = typed_device_ptr(backend.runtime(), &output)?;
+    let lhs_ptr = typed_device_ptr(backend.runtime(), lhs, OP)?;
+    let rhs_ptr = typed_device_ptr(backend.runtime(), rhs, OP)?;
+    let output_ptr = typed_device_ptr(backend.runtime(), &output, OP)?;
 
     let alpha = T::one();
     let beta = T::zero();
@@ -994,21 +1065,34 @@ where
     // C = D = output: cuTENSOR never reads the accumulator slot when
     // beta == 0, so the freshly allocated output serves as both C and D and
     // no separate accumulator tensor is needed.
-    cached_cutensor_contraction::<T, _>(backend, &spec, |cutensor, plan, workspace| unsafe {
-        cutensor.contract(
-            plan,
-            &alpha as *const T as *const c_void,
-            lhs_ptr as *const c_void,
-            rhs_ptr as *const c_void,
-            &beta as *const T as *const c_void,
-            output_ptr as *const c_void,
-            output_ptr,
-            workspace.ptr,
-            workspace.size,
-            stream,
-            OP,
-        )
-    })?;
+    let cross_stream_handles = cross_stream_handles(
+        backend.runtime(),
+        [
+            cubecl_buffer(lhs, OP)?.handle(),
+            cubecl_buffer(rhs, OP)?.handle(),
+            cubecl_buffer(&output, OP)?.handle(),
+        ],
+    );
+    cached_cutensor_contraction::<T, _>(
+        backend,
+        &spec,
+        cross_stream_handles,
+        |cutensor, plan, workspace| unsafe {
+            cutensor.contract(
+                plan,
+                &alpha as *const T as *const c_void,
+                lhs_ptr as *const c_void,
+                rhs_ptr as *const c_void,
+                &beta as *const T as *const c_void,
+                output_ptr as *const c_void,
+                output_ptr,
+                workspace.ptr,
+                workspace.size,
+                stream,
+                OP,
+            )
+        },
+    )?;
 
     Ok(output)
 }
@@ -1068,9 +1152,11 @@ pub(super) fn cutensor_plan_cache_workspace_bytes(backend: &CudaBackend) -> crat
         return Ok(0);
     };
     let plan_cache = lock_cutensor_plan_cache(&plan_cache)?;
-    Ok(plan_cache.values().fold(0, |total, cached| {
-        total.saturating_add(cached.workspace.size)
-    }))
+    let mut total = 0_u64;
+    for cached in plan_cache.values() {
+        total = total.saturating_add(cached.workspace_bytes()?);
+    }
+    Ok(total)
 }
 
 pub(super) fn cutensor_plan_cache_max_entries(
@@ -1102,6 +1188,7 @@ pub(super) fn set_cutensor_plan_cache_max_entries(
 fn cached_cutensor_contraction<T, R>(
     backend: &CudaBackend,
     spec: &CutensorContractionSpec<'_>,
+    cross_stream_handles: Vec<cubecl_runtime::server::Handle>,
     execute: impl FnOnce(&CutensorHandle, &Plan, &Workspace) -> crate::Result<R>,
 ) -> crate::Result<R>
 where
@@ -1129,15 +1216,50 @@ where
             .cuda_extension_cache()
             .update_retained_bytes::<CutensorPlanCacheState>(retained_bytes)?;
     }
-    let cached = plan_cache
-        .get(hash, |key| key_matches_spec::<T>(key, spec))
-        .ok_or_else(|| {
-            Error::runtime_state(
+    let (result, added_workspace_bytes) = {
+        let cached = plan_cache
+            .get(hash, |key| key_matches_spec::<T>(key, spec))
+            .ok_or_else(|| {
+                Error::runtime_state(
+                    "cutensor_plan_cache",
+                    "cached cuTENSOR contraction was evicted before use",
+                )
+            })?;
+        let mut workspace = cached.workspaces[backend.runtime().stream_slot()]
+            .lock()
+            .map_err(|_| Error::runtime_state(OP, "cuTENSOR workspace lock poisoned"))?;
+        let added_workspace_bytes = if workspace.is_none() {
+            *workspace = Some(alloc_workspace(backend.runtime(), cached.workspace_size)?);
+            usize::try_from(cached.workspace_size).unwrap_or(usize::MAX)
+        } else {
+            0
+        };
+        let workspace = workspace
+            .as_ref()
+            .ok_or_else(|| Error::runtime_state(OP, "cuTENSOR workspace is unavailable"))?;
+        let execute_result = execute(cutensor, &cached.plan, workspace);
+        let result =
+            backend
+                .runtime()
+                .finish_vendor_enqueue(OP, cross_stream_handles, execute_result);
+        (result, added_workspace_bytes)
+    };
+    if added_workspace_bytes != 0 {
+        if !plan_cache.add_retained_bytes(
+            hash,
+            |key| key_matches_spec::<T>(key, spec),
+            added_workspace_bytes,
+        ) {
+            return Err(Error::runtime_state(
                 "cutensor_plan_cache",
-                "cached cuTENSOR contraction was evicted before use",
-            )
-        })?;
-    execute(cutensor, &cached.plan, &cached.workspace)
+                "cached cuTENSOR contraction disappeared during accounting",
+            ));
+        }
+        backend
+            .cuda_extension_cache()
+            .update_retained_bytes::<CutensorPlanCacheState>(plan_cache.retained_bytes())?;
+    }
+    result
 }
 
 fn validate_descriptor_alignment(
@@ -1173,20 +1295,24 @@ fn alloc_workspace(rt: &CudaRuntime, workspace_size: u64) -> crate::Result<Works
         .client()
         .get_resource(handle.clone())
         .map_err(|err| crate::Error::backend_source(OP, err))?;
+    let stream = rt.raw_cuda_stream()?;
     Ok(Workspace {
         _handle: Some(handle),
         ptr: cuda_device_ptr_from_addr(resource.resource().ptr, OP)?,
         size: workspace_size,
+        runtime: Some(rt.clone()),
+        stream,
     })
 }
 
 pub(super) fn typed_device_ptr<T: TensorScalar + 'static>(
     rt: &CudaRuntime,
     tensor: &TypedTensor<T>,
+    op: &'static str,
 ) -> crate::Result<*mut c_void> {
-    ensure_resident_on_runtime(rt, tensor, OP)?;
-    let prepared = prepared_tensor_access(tensor, OP)?;
-    let buffer = cubecl_buffer(tensor, OP)?;
+    ensure_resident_on_runtime(rt, tensor, op)?;
+    let prepared = prepared_tensor_access(tensor, op)?;
+    let buffer = cubecl_buffer(tensor, op)?;
     // Fast path: reuse the buffer's memoized device address when executing on
     // the stream that created the allocation. In that case `get_resource` is
     // only a pointer lookup — CubeCL's cross-stream alignment pass skips
@@ -1198,19 +1324,19 @@ pub(super) fn typed_device_ptr<T: TensorScalar + 'static>(
         if let Some(addr) = buffer.cached_device_addr() {
             // The residency check above ties this raw FFI pointer to the
             // caller's runtime/device.
-            return cuda_device_ptr_from_addr(addr, OP);
+            return cuda_device_ptr_from_addr(addr, op);
         }
     }
     let handle = prepared.into_handle();
     let resource = rt
         .client()
         .get_resource(handle)
-        .map_err(|err| crate::Error::backend_source(OP, err))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
     let addr = resource.resource().ptr;
     // See `CubeclBuffer::device_addr` for the address-stability invariant.
     buffer.memoize_device_addr(addr);
     // The residency check above ties this raw FFI pointer to the caller's runtime/device.
-    cuda_device_ptr_from_addr(addr, OP)
+    cuda_device_ptr_from_addr(addr, op)
 }
 
 fn build_layout(

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -4,14 +4,16 @@ use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 
 use cubecl::prelude::{CubeElement, CubePrimitive};
+use cubecl::stream_id::StreamId;
 use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 
 use super::dispatch::{
-    alloc_output, cube_count_for_len, cube_dim_1d, dtype_mismatch, ensure_resident_on_runtime,
-    ensure_view_mut_resident_on_runtime, ensure_view_resident_on_runtime, launch_nullary_into,
-    prepared_tensor_access, prepared_view_access, prepared_view_mut_access, CubeclPreparedAccess,
+    alloc_output, cube_count_for_len, cube_dim_1d, cubecl_buffer, dtype_mismatch,
+    ensure_resident_on_runtime, ensure_view_mut_resident_on_runtime,
+    ensure_view_resident_on_runtime, launch_nullary_into, prepared_tensor_access,
+    prepared_view_access, prepared_view_mut_access, CubeclPreparedAccess,
 };
 use super::error::{unsupported_dtype, unsupported_operation, workspace_size_overflow};
 use super::ffi::cutensor::{
@@ -1212,13 +1214,31 @@ fn typed_device_ptr<T: TensorScalar + 'static>(
 ) -> crate::Result<*mut c_void> {
     ensure_resident_on_runtime(rt, tensor, OP)?;
     let prepared = prepared_tensor_access(tensor, OP)?;
+    let buffer = cubecl_buffer(tensor, OP)?;
+    // Fast path: reuse the buffer's memoized device address when executing on
+    // the stream that created the allocation. In that case `get_resource` is
+    // only a pointer lookup — CubeCL's cross-stream alignment pass skips
+    // bindings whose creation stream equals the current stream — so no
+    // synchronization is lost. Any other stream takes the full `get_resource`
+    // round trip below, preserving CubeCL's cross-stream alignment.
+    let same_stream = StreamId::current() == buffer.handle().stream;
+    if same_stream {
+        if let Some(addr) = buffer.cached_device_addr() {
+            // The residency check above ties this raw FFI pointer to the
+            // caller's runtime/device.
+            return cuda_device_ptr_from_addr(addr, OP);
+        }
+    }
     let handle = prepared.into_handle();
     let resource = rt
         .client()
         .get_resource(handle)
         .map_err(|err| crate::Error::backend_source(OP, err))?;
+    let addr = resource.resource().ptr;
+    // See `CubeclBuffer::device_addr` for the address-stability invariant.
+    buffer.memoize_device_addr(addr);
     // The residency check above ties this raw FFI pointer to the caller's runtime/device.
-    cuda_device_ptr_from_addr(resource.resource().ptr, OP)
+    cuda_device_ptr_from_addr(addr, OP)
 }
 
 fn build_layout(

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -1180,7 +1180,7 @@ fn alloc_workspace(rt: &CudaRuntime, workspace_size: u64) -> crate::Result<Works
     })
 }
 
-fn typed_device_ptr<T: TensorScalar + 'static>(
+pub(super) fn typed_device_ptr<T: TensorScalar + 'static>(
     rt: &CudaRuntime,
     tensor: &TypedTensor<T>,
 ) -> crate::Result<*mut c_void> {

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -626,9 +626,11 @@ fn view_descriptor_alignment_requirement<T: CutensorScalar>() -> u32 {
 }
 
 /// Device pointer plus cuTENSOR descriptor metadata for one operand.
-struct ResolvedOperand {
+/// Compact owned operands borrow the layout's precomputed strides; strided
+/// views own their converted strides.
+struct ResolvedOperand<'a> {
     ptr: *mut c_void,
-    strides: Vec<i64>,
+    strides: std::borrow::Cow<'a, [i64]>,
     alignment: u32,
 }
 
@@ -802,18 +804,18 @@ where
     })
 }
 
-fn resolve_read_operand<T>(
+fn resolve_read_operand<'a, T>(
     rt: &CudaRuntime,
     operand: &ReadOperand<'_, '_, T>,
-    compact_strides: &[i64],
-) -> crate::Result<ResolvedOperand>
+    compact_strides: &'a [i64],
+) -> crate::Result<ResolvedOperand<'a>>
 where
     T: CutensorScalar + 'static,
 {
     match operand {
         ReadOperand::Owned(tensor) => Ok(ResolvedOperand {
             ptr: typed_device_ptr(rt, tensor)?,
-            strides: compact_strides.to_vec(),
+            strides: std::borrow::Cow::Borrowed(compact_strides),
             alignment: CUDA_ALLOCATION_ALIGNMENT,
         }),
         ReadOperand::View(view) => {
@@ -824,18 +826,18 @@ where
     }
 }
 
-fn resolve_write_operand<T>(
+fn resolve_write_operand<'a, T>(
     rt: &CudaRuntime,
     operand: &mut WriteOperand<'_, '_, T>,
-    compact_strides: &[i64],
-) -> crate::Result<ResolvedOperand>
+    compact_strides: &'a [i64],
+) -> crate::Result<ResolvedOperand<'a>>
 where
     T: CutensorScalar + 'static,
 {
     match operand {
         WriteOperand::Owned(tensor) => Ok(ResolvedOperand {
             ptr: typed_device_ptr(rt, tensor)?,
-            strides: compact_strides.to_vec(),
+            strides: std::borrow::Cow::Borrowed(compact_strides),
             alignment: CUDA_ALLOCATION_ALIGNMENT,
         }),
         WriteOperand::View(view) => {
@@ -855,7 +857,7 @@ fn resolve_prepared_device_region<T: CutensorScalar + 'static>(
     prepared: CubeclPreparedAccess,
     strides: &[isize],
     offset: isize,
-) -> crate::Result<ResolvedOperand> {
+) -> crate::Result<ResolvedOperand<'static>> {
     let mut strides_i64 = Vec::with_capacity(strides.len());
     for &stride in strides {
         if stride < 0 {
@@ -890,7 +892,7 @@ fn resolve_prepared_device_region<T: CutensorScalar + 'static>(
     // even when the view starts inside the root allocation.
     Ok(ResolvedOperand {
         ptr: cuda_device_ptr_from_addr(addr, OP)?,
-        strides: strides_i64,
+        strides: std::borrow::Cow::Owned(strides_i64),
         alignment: view_descriptor_alignment_requirement::<T>(),
     })
 }

--- a/crates/tenferro-gpu/src/cubecl/memory.rs
+++ b/crates/tenferro-gpu/src/cubecl/memory.rs
@@ -146,12 +146,13 @@ fn download_typed<T: CubeElement + TensorScalar + Clone + 'static>(
     }
 
     // Small-payload fast path. A Krylov loop reads back one reduction result
-    // per iteration. Both this path and the general one below synchronize the
-    // same single stream, so the saving is in staging, not in the barrier:
-    // CubeCL's `read_one` allocates and copies through pageable host memory,
-    // while this copies those 8-16 bytes through the runtime's pinned slot.
-    // The gate is a byte length, so a short vector takes it too, not only a
-    // scalar.
+    // per iteration. CubeCL's `read_one` already stages through pinned memory,
+    // so this is not a pageable-to-pinned conversion; what it avoids is
+    // CubeCL's staging-reservation machinery and one of two barriers. The
+    // general path below synchronizes the stream and then lets `read_one` wait
+    // on its own fence after the copy, while this issues the copy and waits
+    // once. Neither path synchronizes the device. The gate is a byte length, so
+    // a short vector takes it too, not only a scalar.
     let byte_len = typed
         .n_elements()
         .checked_mul(size_of::<T>())

--- a/crates/tenferro-gpu/src/cubecl/memory.rs
+++ b/crates/tenferro-gpu/src/cubecl/memory.rs
@@ -109,7 +109,8 @@ fn upload_typed<T: CubeElement + TensorScalar + Clone + Send + Sync + 'static>(
     )
 }
 
-/// Read a scalar-sized compact tensor through the runtime's pinned staging slot.
+/// Read a compact tensor of at most `PINNED_SCALAR_BYTES` through the runtime's
+/// pinned staging slot.
 fn download_scalar<T: CubeElement + TensorScalar + Clone + 'static>(
     rt: &CudaRuntime,
     typed: &TypedTensor<T>,
@@ -144,10 +145,13 @@ fn download_typed<T: CubeElement + TensorScalar + Clone + 'static>(
         );
     }
 
-    // Scalar fast path. A Krylov loop reads back one reduction result per
-    // iteration, and the general path below pays a device-wide synchronize
-    // plus CubeCL's pageable staging for those 8-16 bytes. Copy them through
-    // the runtime's pinned slot instead and synchronize only this stream.
+    // Small-payload fast path. A Krylov loop reads back one reduction result
+    // per iteration. Both this path and the general one below synchronize the
+    // same single stream, so the saving is in staging, not in the barrier:
+    // CubeCL's `read_one` allocates and copies through pageable host memory,
+    // while this copies those 8-16 bytes through the runtime's pinned slot.
+    // The gate is a byte length, so a short vector takes it too, not only a
+    // scalar.
     let byte_len = typed
         .n_elements()
         .checked_mul(size_of::<T>())

--- a/crates/tenferro-gpu/src/cubecl/memory.rs
+++ b/crates/tenferro-gpu/src/cubecl/memory.rs
@@ -6,7 +6,7 @@ use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 use num_complex::{Complex32, Complex64};
 
 use super::dispatch;
-use crate::cubecl::runtime::CudaRuntime;
+use crate::cubecl::runtime::{CudaRuntime, PINNED_SCALAR_BYTES};
 use crate::types::{
     CubeclBuffer, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, StorageBuffer,
     Tensor, TensorScalar, TypedTensor,
@@ -109,6 +109,23 @@ fn upload_typed<T: CubeElement + TensorScalar + Clone + Send + Sync + 'static>(
     )
 }
 
+/// Read a scalar-sized compact tensor through the runtime's pinned staging slot.
+///
+/// Returns `Ok(None)` when the tensor's layout has no directly addressable
+/// device pointer, so the caller falls back to the general download.
+fn download_scalar<T: CubeElement + TensorScalar + Clone + 'static>(
+    rt: &CudaRuntime,
+    typed: &TypedTensor<T>,
+    byte_len: usize,
+) -> crate::Result<Option<Vec<T>>> {
+    let Ok(ptr) = super::gemm::typed_device_ptr(rt, typed) else {
+        return Ok(None);
+    };
+    let mut bytes = vec![0_u8; byte_len];
+    rt.download_scalar_bytes(ptr as u64, &mut bytes, "download")?;
+    Ok(Some(T::from_bytes(&bytes).to_vec()))
+}
+
 fn download_typed<T: CubeElement + TensorScalar + Clone + 'static>(
     rt: &CudaRuntime,
     typed: &TypedTensor<T>,
@@ -129,6 +146,21 @@ fn download_typed<T: CubeElement + TensorScalar + Clone + 'static>(
             StorageBuffer::Host(Vec::new()),
             Placement::default(),
         );
+    }
+
+    // Scalar fast path. A Krylov loop reads back one reduction result per
+    // iteration, and the general path below pays a device-wide synchronize
+    // plus CubeCL's pageable staging for those 8-16 bytes. Copy them through
+    // the runtime's pinned slot instead and synchronize only this stream.
+    let byte_len = typed.n_elements() * size_of::<T>();
+    if byte_len <= PINNED_SCALAR_BYTES {
+        if let Some(data) = download_scalar(rt, typed, byte_len)? {
+            return TypedTensor::from_buffer_col_major(
+                typed.shape().to_vec(),
+                StorageBuffer::Host(data),
+                Placement::default(),
+            );
+        }
     }
 
     rt.synchronize()?;

--- a/crates/tenferro-gpu/src/cubecl/memory.rs
+++ b/crates/tenferro-gpu/src/cubecl/memory.rs
@@ -110,20 +110,16 @@ fn upload_typed<T: CubeElement + TensorScalar + Clone + Send + Sync + 'static>(
 }
 
 /// Read a scalar-sized compact tensor through the runtime's pinned staging slot.
-///
-/// Returns `Ok(None)` when the tensor's layout has no directly addressable
-/// device pointer, so the caller falls back to the general download.
 fn download_scalar<T: CubeElement + TensorScalar + Clone + 'static>(
     rt: &CudaRuntime,
     typed: &TypedTensor<T>,
     byte_len: usize,
-) -> crate::Result<Option<Vec<T>>> {
-    let Ok(ptr) = super::gemm::typed_device_ptr(rt, typed) else {
-        return Ok(None);
-    };
+) -> crate::Result<Vec<T>> {
+    let ptr = super::gemm::typed_device_ptr(rt, typed, "download")?;
+    let retained = dispatch::cubecl_buffer(typed, "download")?.handle().clone();
     let mut bytes = vec![0_u8; byte_len];
-    rt.download_scalar_bytes(ptr as u64, &mut bytes, "download")?;
-    Ok(Some(T::from_bytes(&bytes).to_vec()))
+    rt.download_scalar_bytes(ptr as u64, &mut bytes, "download", retained)?;
+    Ok(T::from_bytes(&bytes).to_vec())
 }
 
 fn download_typed<T: CubeElement + TensorScalar + Clone + 'static>(
@@ -152,15 +148,19 @@ fn download_typed<T: CubeElement + TensorScalar + Clone + 'static>(
     // iteration, and the general path below pays a device-wide synchronize
     // plus CubeCL's pageable staging for those 8-16 bytes. Copy them through
     // the runtime's pinned slot instead and synchronize only this stream.
-    let byte_len = typed.n_elements() * size_of::<T>();
+    let byte_len = typed
+        .n_elements()
+        .checked_mul(size_of::<T>())
+        .ok_or_else(|| {
+            crate::Error::invalid_argument("download", "shape", "byte length overflows")
+        })?;
     if byte_len <= PINNED_SCALAR_BYTES {
-        if let Some(data) = download_scalar(rt, typed, byte_len)? {
-            return TypedTensor::from_buffer_col_major(
-                typed.shape().to_vec(),
-                StorageBuffer::Host(data),
-                Placement::default(),
-            );
-        }
+        let data = download_scalar(rt, typed, byte_len)?;
+        return TypedTensor::from_buffer_col_major(
+            typed.shape().to_vec(),
+            StorageBuffer::Host(data),
+            Placement::default(),
+        );
     }
 
     rt.synchronize()?;

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -79,7 +79,7 @@ use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 use num_complex::{Complex32, Complex64};
 use tenferro_core_ops::PrimitiveOpKind;
 use tenferro_tensor::CacheStats;
-use tenferro_tensor::{DotGeneralAccumulation, TensorRead, TensorWrite};
+use tenferro_tensor::{ContractionScalar, DotGeneralAccumulation, TensorRead, TensorWrite};
 
 use crate::backend::{
     BackendCachedDot, BackendRuntimeCache, BackendSession, TensorAnalytic, TensorBackend,
@@ -100,6 +100,7 @@ use crate::{
     TypedTensorView, TypedTensorViewMut,
 };
 
+mod blas1;
 mod capability;
 mod device;
 pub(crate) mod dispatch;
@@ -5708,6 +5709,24 @@ impl TensorFusion for CudaBackend {
 }
 
 impl BackendSession for CudaBackend {
+    fn vdot_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
+        blas1::vdot_read(self, lhs, rhs)
+    }
+
+    fn norm_squared_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
+        blas1::norm_squared_read(self, input)
+    }
+
+    fn axpby_read_into_accum(
+        &mut self,
+        alpha: ContractionScalar,
+        x: TensorRead<'_>,
+        beta: ContractionScalar,
+        y: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        blas1::axpby_read_into_accum(self, alpha, x, beta, y)
+    }
+
     fn session_type_id(&self) -> TypeId {
         TypeId::of::<CudaBackendSessionMarker>()
     }

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -114,6 +114,7 @@ pub(crate) mod interop;
 mod memory;
 pub(crate) mod op_descriptor;
 mod permutation;
+mod plan_cache;
 pub(crate) mod raw;
 mod runtime;
 mod runtime_adapter;

--- a/crates/tenferro-gpu/src/cubecl/plan_cache.rs
+++ b/crates/tenferro-gpu/src/cubecl/plan_cache.rs
@@ -96,6 +96,24 @@ impl<K, V> LruPlanCache<K, V> {
         matches(&entry.key).then_some(&entry.value)
     }
 
+    /// Add retained bytes lazily allocated by an existing cache value.
+    pub(super) fn add_retained_bytes(
+        &mut self,
+        hash: u64,
+        matches: impl FnOnce(&K) -> bool,
+        added: usize,
+    ) -> bool {
+        let Some(entry) = self.entries.get_mut(&hash) else {
+            return false;
+        };
+        if !matches(&entry.key) {
+            return false;
+        }
+        entry.retained_bytes = entry.retained_bytes.saturating_add(added);
+        self.entry_retained_bytes = self.entry_retained_bytes.saturating_add(added);
+        true
+    }
+
     pub(super) fn max_entries(&self) -> NonZeroUsize {
         self.entries.cap()
     }

--- a/crates/tenferro-gpu/src/cubecl/plan_cache.rs
+++ b/crates/tenferro-gpu/src/cubecl/plan_cache.rs
@@ -1,0 +1,136 @@
+//! Hash-keyed LRU core shared by cuTENSOR plan caches.
+//!
+//! The cache is keyed by a caller-computed 64-bit hash of the borrowed plan
+//! spec, so cache hits never materialize an owned key. The fully materialized
+//! key is retained inside each entry and verified on lookup, so a 64-bit hash
+//! collision degrades to a plan rebuild instead of a wrong plan.
+
+use std::num::NonZeroUsize;
+
+use lru::LruCache;
+use tenferro_tensor::CacheStats;
+
+/// One retained entry: the materialized key for collision verification, the
+/// cached value, and the entry's logical retained-byte estimate.
+struct PlanCacheEntry<K, V> {
+    key: K,
+    value: V,
+    retained_bytes: usize,
+}
+
+/// Bounded LRU plan cache with O(1) hits and incrementally maintained
+/// retained-byte accounting.
+///
+/// Retained bytes are the cache's owned/logical payload estimate: the sum of
+/// the per-entry estimates supplied at insertion plus the cache struct
+/// itself. The estimate changes only on insertion and eviction, so lookups
+/// stay allocation-free.
+pub(super) struct LruPlanCache<K, V> {
+    entries: LruCache<u64, PlanCacheEntry<K, V>>,
+    stats: CacheStats,
+    entry_retained_bytes: usize,
+}
+
+impl<K, V> LruPlanCache<K, V> {
+    pub(super) fn new(max_entries: NonZeroUsize) -> Self {
+        Self {
+            entries: LruCache::new(max_entries),
+            stats: CacheStats::empty(),
+            entry_retained_bytes: 0,
+        }
+    }
+
+    /// Ensure an entry for `hash` exists, building it on a miss.
+    ///
+    /// A hit promotes the entry to most-recently-used in O(1). `matches`
+    /// verifies the stored key against the caller's borrowed spec; a same-hash
+    /// entry for a different spec (a 64-bit hash collision) is rebuilt and
+    /// replaces the colliding entry. `build` returns the materialized key, the
+    /// value, and the entry's logical retained-byte estimate.
+    ///
+    /// Returns `true` when the retained entries changed (insert, eviction, or
+    /// collision replacement) so callers can refresh external accounting only
+    /// when needed.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the `build` error on a miss; the cache is unchanged in that
+    /// case.
+    pub(super) fn ensure(
+        &mut self,
+        hash: u64,
+        matches: impl FnOnce(&K) -> bool,
+        build: impl FnOnce() -> crate::Result<(K, V, usize)>,
+    ) -> crate::Result<bool> {
+        if let Some(entry) = self.entries.get(&hash) {
+            if matches(&entry.key) {
+                self.stats.hits = self.stats.hits.saturating_add(1);
+                return Ok(false);
+            }
+        }
+        self.stats.misses = self.stats.misses.saturating_add(1);
+        let (key, value, retained_bytes) = build()?;
+        self.entry_retained_bytes = self.entry_retained_bytes.saturating_add(retained_bytes);
+        if let Some((_, removed)) = self.entries.push(
+            hash,
+            PlanCacheEntry {
+                key,
+                value,
+                retained_bytes,
+            },
+        ) {
+            // Either the least-recently-used entry was evicted at capacity or
+            // a same-hash collision entry was replaced; both drop one entry.
+            self.entry_retained_bytes = self
+                .entry_retained_bytes
+                .saturating_sub(removed.retained_bytes);
+            self.stats.evictions = self.stats.evictions.saturating_add(1);
+        }
+        Ok(true)
+    }
+
+    /// Return the value for `hash` when the stored key matches, promoting the
+    /// entry to most-recently-used.
+    pub(super) fn get(&mut self, hash: u64, matches: impl FnOnce(&K) -> bool) -> Option<&V> {
+        let entry = self.entries.get(&hash)?;
+        matches(&entry.key).then_some(&entry.value)
+    }
+
+    pub(super) fn max_entries(&self) -> NonZeroUsize {
+        self.entries.cap()
+    }
+
+    /// Replace the entry bound, evicting least-recently-used entries first.
+    pub(super) fn set_max_entries(&mut self, max_entries: NonZeroUsize) {
+        while self.entries.len() > max_entries.get() {
+            let Some((_, removed)) = self.entries.pop_lru() else {
+                break;
+            };
+            self.entry_retained_bytes = self
+                .entry_retained_bytes
+                .saturating_sub(removed.retained_bytes);
+            self.stats.evictions = self.stats.evictions.saturating_add(1);
+        }
+        self.entries.resize(max_entries);
+    }
+
+    pub(super) fn stats(&self) -> CacheStats {
+        CacheStats {
+            entries: self.entries.len(),
+            retained_bytes: self.retained_bytes(),
+            ..self.stats
+        }
+    }
+
+    /// The cache's owned/logical retained-byte estimate, maintained
+    /// incrementally on insert and evict.
+    pub(super) fn retained_bytes(&self) -> usize {
+        std::mem::size_of::<Self>().saturating_add(self.entry_retained_bytes)
+    }
+
+    /// Iterate the retained values in most- to least-recently-used order.
+    #[cfg(test)]
+    pub(super) fn values(&self) -> impl Iterator<Item = &V> {
+        self.entries.iter().map(|(_, entry)| &entry.value)
+    }
+}

--- a/crates/tenferro-gpu/src/cubecl/runtime.rs
+++ b/crates/tenferro-gpu/src/cubecl/runtime.rs
@@ -1,15 +1,15 @@
 //! CubeCL CUDA runtime initialization and synchronization.
 
-use std::collections::HashMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use cubecl::client::ComputeClient;
 use cubecl::stream_id::StreamId;
 use cubecl::Runtime;
 use cubecl_cuda::{CudaDevice, CudaRuntime as CubeclCudaRuntime};
+use cubecl_runtime::config::{CubeClRuntimeConfig, RuntimeConfig};
 use cudarc::cublas::sys as cublas_sys;
 use cudarc::driver::result::DriverError;
 use cudarc::driver::sys::{CUcontext, CUdevice, CUresult};
@@ -203,24 +203,21 @@ struct CudaRuntimeState {
     primary_context: CudaPrimaryContext,
     identity: CudaRuntimeIdentity,
     allocation_domain: AllocationDomainId,
-    // Memoized raw CUDA stream handles keyed by CubeCL [`StreamId`] value.
+    // Memoized raw CUDA stream handles keyed by the bounded CubeCL stream-pool
+    // slot, not the process-global and monotonically increasing `StreamId`.
     //
-    // INVARIANT: in pinned CubeCL rev 1c88bb6, the CUDA server maps each
+    // INVARIANT: in pinned CubeCL rev f274a76, the CUDA server maps each
     // `StreamId` to a fixed `StreamPool` slot whose `CUstream` is created once
     // and never destroyed or replaced while the server is alive, and the
-    // server outlives the `ComputeClient` clone owned by this state. The map
+    // server outlives the `ComputeClient` clone owned by this state. The table
     // is owned by this runtime object (not thread-local/global), holds one
-    // entry per thread that has executed on the runtime, and is dropped with
-    // the runtime.
-    raw_streams: Mutex<HashMap<u64, u64>>,
-    // cuBLAS handles keyed by CubeCL [`StreamId`] value, mirroring the
-    // `raw_streams` cache: one handle per (device, stream), created lazily on
-    // the first BLAS1 call and bound to that stream via `cublasSetStream`.
-    // The map is runtime-owned (not thread-local/global), holds at most one
-    // entry per thread that has executed BLAS1 work on the runtime, and every
-    // handle is destroyed in this state's `Drop` while the primary context is
-    // still retained.
-    cublas_handles: Mutex<HashMap<u64, CublasStreamHandle>>,
+    // entry per CubeCL stream slot, and is dropped with the runtime.
+    raw_streams: Box<[OnceLock<u64>]>,
+    // One lazily created cuBLAS handle per bounded CubeCL stream-pool slot.
+    // Each slot lock covers pointer-mode selection and the enqueue itself:
+    // distinct `StreamId`s can map to the same physical stream, and cuBLAS
+    // handle configuration is mutable.
+    cublas_handles: Box<[Mutex<Option<CublasStreamHandle>>]>,
     // Lazily allocated pinned-host staging slot for single-scalar downloads
     // (`cudaHostAlloc`, `PINNED_SCALAR_BYTES` bytes). Freed in `Drop` with
     // `cudaFreeHost` while the primary context is still retained.
@@ -247,8 +244,8 @@ pub(crate) const PINNED_SCALAR_BYTES: usize = 16;
 unsafe impl Send for CudaRuntimeState {}
 // SAFETY: Shared state access exposes immutable runtime handles; synchronization
 // and stream queries use explicit CUDA/CubeCL handles and do not mutate Rust
-// aliasing-visible fields. cuBLAS handles are per-stream (per-thread) and the
-// pinned staging slot is used only while its mutex is held.
+// aliasing-visible fields. cuBLAS handles are locked per bounded physical
+// stream slot, and the pinned staging slot is used only while its mutex is held.
 unsafe impl Sync for CudaRuntimeState {}
 
 impl fmt::Debug for CudaRuntime {
@@ -359,8 +356,12 @@ impl CudaRuntime {
                 primary_context,
                 identity: CudaRuntimeIdentity::fresh(),
                 allocation_domain: AllocationDomainId::fresh(),
-                raw_streams: Mutex::new(HashMap::new()),
-                cublas_handles: Mutex::new(HashMap::new()),
+                raw_streams: (0..cubecl_stream_slots())
+                    .map(|_| OnceLock::new())
+                    .collect(),
+                cublas_handles: (0..cubecl_stream_slots())
+                    .map(|_| Mutex::new(None))
+                    .collect(),
                 pinned_scalar: Mutex::new(PinnedScalarSlot {
                     ptr: std::ptr::null_mut(),
                 }),
@@ -516,13 +517,49 @@ impl CudaRuntime {
         self.inner.raw_cuda_stream()
     }
 
-    /// Return the cuBLAS handle bound to the current thread's CubeCL stream,
-    /// creating and caching it on first use.
+    pub(crate) fn synchronize_raw_stream(
+        &self,
+        stream: u64,
+        op: &'static str,
+    ) -> crate::Result<()> {
+        self.inner.synchronize_raw_stream(stream, op)
+    }
+
+    /// Run one cuBLAS enqueue with the handle for the current CubeCL stream.
     ///
     /// The caller must have the tenferro primary context current on this
     /// thread (see [`CudaRuntimeState::set_current_cuda_context`]).
-    pub(crate) fn cublas_handle(&self, op: &'static str) -> crate::Result<cublas_sys::cublasHandle_t> {
-        self.inner.cublas_handle(op)
+    pub(crate) fn with_cublas_handle<R>(
+        &self,
+        op: &'static str,
+        pointer_mode: cublas_sys::cublasPointerMode_t,
+        cross_stream_handles: Vec<cubecl_runtime::server::Handle>,
+        execute: impl FnOnce(cublas_sys::cublasHandle_t) -> crate::Result<R>,
+    ) -> crate::Result<R> {
+        self.inner
+            .with_cublas_handle(op, pointer_mode, cross_stream_handles, execute)
+    }
+
+    pub(crate) fn finish_vendor_enqueue<R>(
+        &self,
+        op: &'static str,
+        cross_stream_handles: Vec<cubecl_runtime::server::Handle>,
+        result: crate::Result<R>,
+    ) -> crate::Result<R> {
+        self.inner
+            .finish_vendor_enqueue(op, cross_stream_handles, result)
+    }
+
+    pub(crate) fn stream_slot(&self) -> usize {
+        self.inner.stream_slot()
+    }
+
+    pub(crate) fn stream_slot_count(&self) -> usize {
+        self.inner.raw_streams.len()
+    }
+
+    pub(crate) fn is_current_stream_slot(&self, handle: &cubecl_runtime::server::Handle) -> bool {
+        self.inner.stream_slot_for(handle.stream) == self.inner.stream_slot()
     }
 
     /// Download up to [`PINNED_SCALAR_BYTES`] bytes from a device address
@@ -536,8 +573,10 @@ impl CudaRuntime {
         device_addr: u64,
         out: &mut [u8],
         op: &'static str,
+        retained: cubecl_runtime::server::Handle,
     ) -> crate::Result<()> {
-        self.inner.download_scalar_bytes(device_addr, out, op)
+        self.inner
+            .download_scalar_bytes(device_addr, out, op, retained)
     }
 
     /// Block the current thread until work submitted to the current CUDA stream completes.
@@ -562,6 +601,14 @@ impl CudaRuntime {
 }
 
 impl CudaRuntimeState {
+    fn stream_slot(&self) -> usize {
+        self.stream_slot_for(StreamId::current())
+    }
+
+    fn stream_slot_for(&self, stream_id: StreamId) -> usize {
+        stream_id.value as usize % self.raw_streams.len()
+    }
+
     fn set_current_cuda_context(&self, op: &'static str) -> crate::Result<()> {
         // Fast path: the tenferro primary context is already current on this
         // thread. `cuCtxGetCurrent` only reads driver thread state, so this
@@ -585,14 +632,8 @@ impl CudaRuntimeState {
 
     fn raw_cuda_stream(&self) -> crate::Result<u64> {
         let stream_id = StreamId::current();
-        let poisoned =
-            || crate::Error::runtime_state("raw_cuda_stream", "raw stream cache lock poisoned");
-        if let Some(&stream) = self
-            .raw_streams
-            .lock()
-            .map_err(|_| poisoned())?
-            .get(&stream_id.value)
-        {
+        let slot = self.stream_slot();
+        if let Some(&stream) = self.raw_streams[slot].get() {
             return Ok(stream);
         }
         let stream = self
@@ -606,56 +647,113 @@ impl CudaRuntimeState {
             .ok_or_else(|| {
                 crate::Error::runtime_state("raw_cuda_stream", "CubeCL server is unavailable")
             })??;
-        self.raw_streams
-            .lock()
-            .map_err(|_| poisoned())?
-            .insert(stream_id.value, stream);
-        Ok(stream)
+        Ok(*self.raw_streams[slot].get_or_init(|| stream))
     }
 
     fn synchronize(&self) -> crate::Result<()> {
         const OP: &str = "cubecl_runtime_synchronize";
-        self.set_current_cuda_context(OP)?;
-        let stream = self.raw_cuda_stream()? as usize as cudaStream_t;
-        unsafe { cuda_result::stream::synchronize(stream) }
-            .map_err(|err| crate::Error::backend_source(OP, err))
+        let stream = self.raw_cuda_stream()?;
+        self.synchronize_raw_stream(stream, OP)
     }
 
-    fn cublas_handle(&self, op: &'static str) -> crate::Result<cublas_sys::cublasHandle_t> {
-        let stream_id = StreamId::current();
+    fn synchronize_raw_stream(&self, stream: u64, op: &'static str) -> crate::Result<()> {
+        self.set_current_cuda_context(op)?;
+        unsafe { cuda_result::stream::synchronize(stream as usize as cudaStream_t) }
+            .map_err(|err| crate::Error::backend_source(op, err))
+    }
+
+    fn retire_initialized_streams(&self) -> bool {
+        const OP: &str = "cuda_runtime_drop";
+        if let Err(error) = self.set_current_cuda_context(OP) {
+            report_cuda_runtime_drop_error(&error);
+            return false;
+        }
+        let mut retired = true;
+        for stream in &self.raw_streams {
+            let Some(&stream) = stream.get() else {
+                continue;
+            };
+            // SAFETY: every initialized entry is a CubeCL-owned stream that
+            // remains live until this runtime state and its client are dropped.
+            if let Err(source) =
+                unsafe { cuda_result::stream::synchronize(stream as usize as cudaStream_t) }
+            {
+                retired = false;
+                report_cuda_runtime_drop_error(&crate::Error::backend_source(OP, source));
+            }
+        }
+        retired
+    }
+
+    fn with_cublas_handle<R>(
+        &self,
+        op: &'static str,
+        pointer_mode: cublas_sys::cublasPointerMode_t,
+        cross_stream_handles: Vec<cubecl_runtime::server::Handle>,
+        execute: impl FnOnce(cublas_sys::cublasHandle_t) -> crate::Result<R>,
+    ) -> crate::Result<R> {
         let poisoned = || crate::Error::runtime_state(op, "cuBLAS handle cache lock poisoned");
-        if let Some(handle) = self
-            .cublas_handles
-            .lock()
-            .map_err(|_| poisoned())?
-            .get(&stream_id.value)
-        {
-            return Ok(handle.0);
-        }
-        if !cublas_library_present() {
-            return Err(crate::Error::io_source(op, CublasLibraryMissing));
-        }
-        let stream = self.raw_cuda_stream()? as usize as cublas_sys::cudaStream_t;
-        let mut raw = std::ptr::null_mut();
-        // SAFETY: the caller holds the tenferro primary context current; the
-        // handle is created on this device and bound to this runtime's stream.
-        check_cublas(op, "cublasCreate", unsafe {
-            cublas_sys::cublasCreate_v2(&mut raw)
+        let slot = self.stream_slot();
+        let mut cached = self.cublas_handles[slot].lock().map_err(|_| poisoned())?;
+        let handle = match *cached {
+            Some(ref handle) => handle.0,
+            None => {
+                if !cublas_library_present() {
+                    return Err(crate::Error::io_source(op, CublasLibraryMissing));
+                }
+                let stream = self.raw_cuda_stream()? as usize as cublas_sys::cudaStream_t;
+                let mut raw = std::ptr::null_mut();
+                // SAFETY: the caller holds the tenferro primary context current;
+                // the handle is created on this device and bound to this stream.
+                check_cublas(op, "cublasCreate", unsafe {
+                    cublas_sys::cublasCreate_v2(&mut raw)
+                })?;
+                // SAFETY: `raw` was just created and `stream` is owned by this
+                // runtime for the lifetime of the cached handle.
+                if let Err(err) = check_cublas(op, "cublasSetStream", unsafe {
+                    cublas_sys::cublasSetStream_v2(raw, stream)
+                }) {
+                    // SAFETY: `raw` is live and not stored anywhere else.
+                    let _ = unsafe { cublas_sys::cublasDestroy_v2(raw) };
+                    return Err(err);
+                }
+                *cached = Some(CublasStreamHandle(raw));
+                raw
+            }
+        };
+        // SAFETY: the per-stream slot lock is held across configuration and
+        // enqueue, so no caller can race this mutable handle state.
+        check_cublas(op, "cublasSetPointerMode", unsafe {
+            cublas_sys::cublasSetPointerMode_v2(handle, pointer_mode)
         })?;
-        // SAFETY: `raw` was just created; `stream` is the memoized CubeCL
-        // stream for the current thread (see the `raw_streams` invariant).
-        if let Err(err) = check_cublas(op, "cublasSetStream", unsafe {
-            cublas_sys::cublasSetStream_v2(raw, stream)
-        }) {
-            // SAFETY: `raw` is live and not stored anywhere else.
-            let _ = unsafe { cublas_sys::cublasDestroy_v2(raw) };
-            return Err(err);
+        let result = execute(handle);
+        self.finish_vendor_enqueue(op, cross_stream_handles, result)
+    }
+
+    fn finish_vendor_enqueue<R>(
+        &self,
+        op: &'static str,
+        cross_stream_handles: Vec<cubecl_runtime::server::Handle>,
+        result: crate::Result<R>,
+    ) -> crate::Result<R> {
+        if cross_stream_handles.is_empty() {
+            return result;
         }
-        self.cublas_handles
-            .lock()
-            .map_err(|_| poisoned())?
-            .insert(stream_id.value, CublasStreamHandle(raw));
-        Ok(raw)
+        let retirement = self.synchronize();
+        match (result, retirement) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(error), Ok(())) => Err(error),
+            (Ok(_), Err(retirement)) => {
+                // No completion barrier was proven. Retain the foreign-stream
+                // allocations so their owners cannot reclaim or mutate them.
+                std::mem::forget(cross_stream_handles);
+                Err(crate::Error::backend_source(op, retirement))
+            }
+            (Err(error), Err(_retirement)) => {
+                std::mem::forget(cross_stream_handles);
+                Err(error)
+            }
+        }
     }
 
     fn download_scalar_bytes(
@@ -663,6 +761,7 @@ impl CudaRuntimeState {
         device_addr: u64,
         out: &mut [u8],
         op: &'static str,
+        retained: cubecl_runtime::server::Handle,
     ) -> crate::Result<()> {
         if out.len() > PINNED_SCALAR_BYTES {
             return Err(crate::Error::Internal(format!(
@@ -682,35 +781,48 @@ impl CudaRuntimeState {
             let mut ptr = std::ptr::null_mut();
             // SAFETY: the primary context is current; the allocation is freed
             // in this state's `Drop` with `cudaFreeHost`.
-            unsafe { cuda_sys::cudaHostAlloc(&mut ptr, PINNED_SCALAR_BYTES, cuda_sys::cudaHostAllocDefault) }
-                .result()
-                .map_err(|err| crate::Error::backend_source(op, err))?;
+            unsafe {
+                cuda_sys::cudaHostAlloc(
+                    &mut ptr,
+                    PINNED_SCALAR_BYTES,
+                    cuda_sys::cudaHostAllocDefault,
+                )
+            }
+            .result()
+            .map_err(|err| crate::Error::backend_source(op, err))?;
             slot.ptr = ptr;
         }
         let src = super::interop::cuda_device_ptr_from_addr(device_addr, op)?;
         // SAFETY: `slot.ptr` is a live pinned allocation of PINNED_SCALAR_BYTES
         // bytes, `out.len()` is validated above, and the mutex guard keeps the
         // slot exclusive until the stream synchronization below completes.
-        let staging =
-            unsafe { std::slice::from_raw_parts_mut(slot.ptr.cast::<u8>(), out.len()) };
+        let staging = unsafe { std::slice::from_raw_parts_mut(slot.ptr.cast::<u8>(), out.len()) };
         // SAFETY: `src` is a residency-checked device address owned by this
         // runtime and the copy length equals the destination slice length.
         unsafe { cuda_result::memcpy_dtoh_async(staging, src, stream) }
             .map_err(|err| crate::Error::backend_source(op, err))?;
         // SAFETY: `stream` is the memoized CubeCL stream the copy was enqueued on.
-        unsafe { cuda_result::stream::synchronize(stream) }
-            .map_err(|err| crate::Error::backend_source(op, err))?;
+        if let Err(err) = unsafe { cuda_result::stream::synchronize(stream) } {
+            // The stream did not provide a proven completion barrier. Keep the
+            // source allocation alive rather than letting an async copy or the
+            // preceding scalar-producing kernel race reclamation.
+            std::mem::forget(retained);
+            return Err(crate::Error::backend_source(op, err));
+        }
         out.copy_from_slice(staging);
         Ok(())
     }
 
     /// Destroy cached cuBLAS handles and free the pinned staging slot.
     ///
-    /// Called from `Drop` after `synchronize`, which leaves the primary
-    /// context current on the dropping thread.
+    /// Called from `Drop` after all initialized streams have retired, which
+    /// leaves the primary context current on the dropping thread.
     fn release_cuda_library_resources(&mut self) {
-        if let Ok(mut handles) = self.cublas_handles.lock() {
-            for (_, handle) in handles.drain() {
+        for cached in &self.cublas_handles {
+            if let Ok(mut handle) = cached.lock() {
+                let Some(handle) = handle.take() else {
+                    continue;
+                };
                 // SAFETY: each stored handle is live and no longer reachable.
                 if let Err(err) = unsafe { cublas_sys::cublasDestroy_v2(handle.0) }.result() {
                     report_cuda_resource_release_error("cuBLAS handle", &err);
@@ -727,6 +839,10 @@ impl CudaRuntimeState {
             }
         }
     }
+}
+
+fn cubecl_stream_slots() -> usize {
+    usize::from(CubeClRuntimeConfig::get().streaming.max_streams.max(1))
 }
 
 /// Typed load failure for the dynamically loaded cuBLAS library.
@@ -754,7 +870,12 @@ pub(super) fn check_cublas(
     if matches!(status, cublas_sys::cublasStatus_t::CUBLAS_STATUS_SUCCESS) {
         Ok(())
     } else {
-        Err(super::error::provider_status(op, "cuBLAS", call, status as i32))
+        Err(super::error::provider_status(
+            op,
+            "cuBLAS",
+            call,
+            status as i32,
+        ))
     }
 }
 
@@ -795,13 +916,16 @@ where
 impl Drop for CudaRuntimeState {
     fn drop(&mut self) {
         // Drop cannot surface errors, but the runtime must not release the
-        // primary context while queued kernels may still reference it.
-        if let Err(err) = self.synchronize() {
-            report_cuda_runtime_drop_error(&err);
+        // primary context while queued kernels on any initialized slot may
+        // still reference it.
+        if self.retire_initialized_streams() {
+            // Retirement left the primary context current; release CUDA
+            // library resources before the retained primary context drops.
+            self.release_cuda_library_resources();
         }
-        // `synchronize` left the primary context current; release CUDA library
-        // resources before the retained primary context drops with this state.
-        self.release_cuda_library_resources();
+        // On retirement failure, raw library resources intentionally leak:
+        // their pointer-only owners have no Drop implementation, so Rust does
+        // not reclaim resources that may still be in use asynchronously.
     }
 }
 

--- a/crates/tenferro-gpu/src/cubecl/runtime.rs
+++ b/crates/tenferro-gpu/src/cubecl/runtime.rs
@@ -795,7 +795,9 @@ impl CudaRuntimeState {
         let src = super::interop::cuda_device_ptr_from_addr(device_addr, op)?;
         // SAFETY: `slot.ptr` is a live pinned allocation of PINNED_SCALAR_BYTES
         // bytes, `out.len()` is validated above, and the mutex guard keeps the
-        // slot exclusive until the stream synchronization below completes.
+        // slot exclusive until the stream synchronization below completes. If
+        // that synchronization fails the slot is abandoned rather than reused,
+        // so exclusivity never depends on an unproven barrier.
         let staging = unsafe { std::slice::from_raw_parts_mut(slot.ptr.cast::<u8>(), out.len()) };
         // SAFETY: `src` is a residency-checked device address owned by this
         // runtime and the copy length equals the destination slice length.
@@ -803,10 +805,16 @@ impl CudaRuntimeState {
             .map_err(|err| crate::Error::backend_source(op, err))?;
         // SAFETY: `stream` is the memoized CubeCL stream the copy was enqueued on.
         if let Err(err) = unsafe { cuda_result::stream::synchronize(stream) } {
-            // The stream did not provide a proven completion barrier. Keep the
-            // source allocation alive rather than letting an async copy or the
-            // preceding scalar-producing kernel race reclamation.
+            // The stream did not provide a proven completion barrier, so the
+            // device-to-host copy may still be in flight. Keep the source
+            // allocation alive rather than letting that copy or the preceding
+            // scalar-producing kernel race reclamation, and abandon the pinned
+            // staging slot for the same reason: no later download may reuse a
+            // destination the device might still write, and `Drop` must not
+            // `cudaFreeHost` it. Both leaks are bounded and the next call
+            // allocates a fresh slot.
             std::mem::forget(retained);
+            slot.ptr = std::ptr::null_mut();
             return Err(crate::Error::backend_source(op, err));
         }
         out.copy_from_slice(staging);

--- a/crates/tenferro-gpu/src/cubecl/runtime.rs
+++ b/crates/tenferro-gpu/src/cubecl/runtime.rs
@@ -795,24 +795,24 @@ impl CudaRuntimeState {
         let src = super::interop::cuda_device_ptr_from_addr(device_addr, op)?;
         // SAFETY: `slot.ptr` is a live pinned allocation of PINNED_SCALAR_BYTES
         // bytes, `out.len()` is validated above, and the mutex guard keeps the
-        // slot exclusive until the stream synchronization below completes. If
-        // that synchronization fails the slot is abandoned rather than reused,
-        // so exclusivity never depends on an unproven barrier.
+        // slot exclusive until the copy below is known to have completed. Every
+        // exit that cannot prove completion abandons the slot instead of
+        // returning it, so exclusivity never rests on an unproven barrier.
         let staging = unsafe { std::slice::from_raw_parts_mut(slot.ptr.cast::<u8>(), out.len()) };
+        // Neither submitting the copy nor waiting on it proves the device is
+        // done with `staging` and `retained` once it reports an error: an async
+        // CUDA call can surface a failure from an earlier launch on the stream,
+        // so a non-success return says nothing about what is still running.
+        // Both paths therefore leak the source allocation and abandon the
+        // staging slot rather than let a later download reuse a destination the
+        // device may still write, or let `Drop` `cudaFreeHost` it. Each failure
+        // leaks one slot and one handle; the next call allocates fresh ones.
         // SAFETY: `src` is a residency-checked device address owned by this
-        // runtime and the copy length equals the destination slice length.
-        unsafe { cuda_result::memcpy_dtoh_async(staging, src, stream) }
-            .map_err(|err| crate::Error::backend_source(op, err))?;
-        // SAFETY: `stream` is the memoized CubeCL stream the copy was enqueued on.
-        if let Err(err) = unsafe { cuda_result::stream::synchronize(stream) } {
-            // The stream did not provide a proven completion barrier, so the
-            // device-to-host copy may still be in flight. Keep the source
-            // allocation alive rather than letting that copy or the preceding
-            // scalar-producing kernel race reclamation, and abandon the pinned
-            // staging slot for the same reason: no later download may reuse a
-            // destination the device might still write, and `Drop` must not
-            // `cudaFreeHost` it. Both leaks are bounded and the next call
-            // allocates a fresh slot.
+        // runtime, the copy length equals the destination slice length, and
+        // `stream` is the memoized CubeCL stream the copy is enqueued on.
+        let completed = unsafe { cuda_result::memcpy_dtoh_async(staging, src, stream) }
+            .and_then(|()| unsafe { cuda_result::stream::synchronize(stream) });
+        if let Err(err) = completed {
             std::mem::forget(retained);
             slot.ptr = std::ptr::null_mut();
             return Err(crate::Error::backend_source(op, err));

--- a/crates/tenferro-gpu/src/cubecl/runtime.rs
+++ b/crates/tenferro-gpu/src/cubecl/runtime.rs
@@ -10,9 +10,10 @@ use cubecl::client::ComputeClient;
 use cubecl::stream_id::StreamId;
 use cubecl::Runtime;
 use cubecl_cuda::{CudaDevice, CudaRuntime as CubeclCudaRuntime};
+use cudarc::cublas::sys as cublas_sys;
 use cudarc::driver::result::DriverError;
 use cudarc::driver::sys::{CUcontext, CUdevice, CUresult};
-use cudarc::runtime::{result as cuda_result, sys::cudaStream_t};
+use cudarc::runtime::{result as cuda_result, sys as cuda_sys, sys::cudaStream_t};
 use tenferro_tensor::AllocationDomainId;
 
 use super::device::{
@@ -212,15 +213,42 @@ struct CudaRuntimeState {
     // entry per thread that has executed on the runtime, and is dropped with
     // the runtime.
     raw_streams: Mutex<HashMap<u64, u64>>,
+    // cuBLAS handles keyed by CubeCL [`StreamId`] value, mirroring the
+    // `raw_streams` cache: one handle per (device, stream), created lazily on
+    // the first BLAS1 call and bound to that stream via `cublasSetStream`.
+    // The map is runtime-owned (not thread-local/global), holds at most one
+    // entry per thread that has executed BLAS1 work on the runtime, and every
+    // handle is destroyed in this state's `Drop` while the primary context is
+    // still retained.
+    cublas_handles: Mutex<HashMap<u64, CublasStreamHandle>>,
+    // Lazily allocated pinned-host staging slot for single-scalar downloads
+    // (`cudaHostAlloc`, `PINNED_SCALAR_BYTES` bytes). Freed in `Drop` with
+    // `cudaFreeHost` while the primary context is still retained.
+    pinned_scalar: Mutex<PinnedScalarSlot>,
 }
+
+/// One cached cuBLAS handle bound to a fixed CUDA stream.
+struct CublasStreamHandle(cublas_sys::cublasHandle_t);
+
+/// Pinned-host staging slot; `ptr` is null until the first scalar download.
+struct PinnedScalarSlot {
+    ptr: *mut std::ffi::c_void,
+}
+
+/// Size of the runtime-owned pinned staging slot: large enough for the widest
+/// supported scalar (`Complex64`, 16 bytes).
+pub(crate) const PINNED_SCALAR_BYTES: usize = 16;
 
 // SAFETY: `CudaRuntimeState` owns a retained CUDA primary context and a CubeCL
 // client for one device ordinal. Methods set the context current before raw CUDA
-// calls, and backend/executor layers serialize mutating tensor execution.
+// calls, and backend/executor layers serialize mutating tensor execution. The
+// raw cuBLAS handles and the pinned staging pointer are plain CUDA resource
+// addresses owned by this state and released in `Drop`.
 unsafe impl Send for CudaRuntimeState {}
 // SAFETY: Shared state access exposes immutable runtime handles; synchronization
 // and stream queries use explicit CUDA/CubeCL handles and do not mutate Rust
-// aliasing-visible fields.
+// aliasing-visible fields. cuBLAS handles are per-stream (per-thread) and the
+// pinned staging slot is used only while its mutex is held.
 unsafe impl Sync for CudaRuntimeState {}
 
 impl fmt::Debug for CudaRuntime {
@@ -332,6 +360,10 @@ impl CudaRuntime {
                 identity: CudaRuntimeIdentity::fresh(),
                 allocation_domain: AllocationDomainId::fresh(),
                 raw_streams: Mutex::new(HashMap::new()),
+                cublas_handles: Mutex::new(HashMap::new()),
+                pinned_scalar: Mutex::new(PinnedScalarSlot {
+                    ptr: std::ptr::null_mut(),
+                }),
             }),
         })
     }
@@ -484,6 +516,30 @@ impl CudaRuntime {
         self.inner.raw_cuda_stream()
     }
 
+    /// Return the cuBLAS handle bound to the current thread's CubeCL stream,
+    /// creating and caching it on first use.
+    ///
+    /// The caller must have the tenferro primary context current on this
+    /// thread (see [`CudaRuntimeState::set_current_cuda_context`]).
+    pub(crate) fn cublas_handle(&self, op: &'static str) -> crate::Result<cublas_sys::cublasHandle_t> {
+        self.inner.cublas_handle(op)
+    }
+
+    /// Download up to [`PINNED_SCALAR_BYTES`] bytes from a device address
+    /// through the runtime-owned pinned staging slot.
+    ///
+    /// Enqueues an async device-to-host copy on the current thread's CubeCL
+    /// stream and synchronizes only that stream, so previously enqueued work
+    /// on the stream is observed without a device-wide barrier.
+    pub(crate) fn download_scalar_bytes(
+        &self,
+        device_addr: u64,
+        out: &mut [u8],
+        op: &'static str,
+    ) -> crate::Result<()> {
+        self.inner.download_scalar_bytes(device_addr, out, op)
+    }
+
     /// Block the current thread until work submitted to the current CUDA stream completes.
     ///
     /// # Examples
@@ -564,6 +620,147 @@ impl CudaRuntimeState {
         unsafe { cuda_result::stream::synchronize(stream) }
             .map_err(|err| crate::Error::backend_source(OP, err))
     }
+
+    fn cublas_handle(&self, op: &'static str) -> crate::Result<cublas_sys::cublasHandle_t> {
+        let stream_id = StreamId::current();
+        let poisoned = || crate::Error::runtime_state(op, "cuBLAS handle cache lock poisoned");
+        if let Some(handle) = self
+            .cublas_handles
+            .lock()
+            .map_err(|_| poisoned())?
+            .get(&stream_id.value)
+        {
+            return Ok(handle.0);
+        }
+        if !cublas_library_present() {
+            return Err(crate::Error::io_source(op, CublasLibraryMissing));
+        }
+        let stream = self.raw_cuda_stream()? as usize as cublas_sys::cudaStream_t;
+        let mut raw = std::ptr::null_mut();
+        // SAFETY: the caller holds the tenferro primary context current; the
+        // handle is created on this device and bound to this runtime's stream.
+        check_cublas(op, "cublasCreate", unsafe {
+            cublas_sys::cublasCreate_v2(&mut raw)
+        })?;
+        // SAFETY: `raw` was just created; `stream` is the memoized CubeCL
+        // stream for the current thread (see the `raw_streams` invariant).
+        if let Err(err) = check_cublas(op, "cublasSetStream", unsafe {
+            cublas_sys::cublasSetStream_v2(raw, stream)
+        }) {
+            // SAFETY: `raw` is live and not stored anywhere else.
+            let _ = unsafe { cublas_sys::cublasDestroy_v2(raw) };
+            return Err(err);
+        }
+        self.cublas_handles
+            .lock()
+            .map_err(|_| poisoned())?
+            .insert(stream_id.value, CublasStreamHandle(raw));
+        Ok(raw)
+    }
+
+    fn download_scalar_bytes(
+        &self,
+        device_addr: u64,
+        out: &mut [u8],
+        op: &'static str,
+    ) -> crate::Result<()> {
+        if out.len() > PINNED_SCALAR_BYTES {
+            return Err(crate::Error::Internal(format!(
+                "pinned scalar staging supports at most {PINNED_SCALAR_BYTES} bytes, got {}",
+                out.len()
+            )));
+        }
+        self.set_current_cuda_context(op)?;
+        let stream = self.raw_cuda_stream()? as usize as cudaStream_t;
+        // ponytail: one shared staging slot serializes concurrent scalar
+        // downloads per runtime; add per-thread slots if that lock contends.
+        let mut slot = self
+            .pinned_scalar
+            .lock()
+            .map_err(|_| crate::Error::runtime_state(op, "pinned scalar staging lock poisoned"))?;
+        if slot.ptr.is_null() {
+            let mut ptr = std::ptr::null_mut();
+            // SAFETY: the primary context is current; the allocation is freed
+            // in this state's `Drop` with `cudaFreeHost`.
+            unsafe { cuda_sys::cudaHostAlloc(&mut ptr, PINNED_SCALAR_BYTES, cuda_sys::cudaHostAllocDefault) }
+                .result()
+                .map_err(|err| crate::Error::backend_source(op, err))?;
+            slot.ptr = ptr;
+        }
+        let src = super::interop::cuda_device_ptr_from_addr(device_addr, op)?;
+        // SAFETY: `slot.ptr` is a live pinned allocation of PINNED_SCALAR_BYTES
+        // bytes, `out.len()` is validated above, and the mutex guard keeps the
+        // slot exclusive until the stream synchronization below completes.
+        let staging =
+            unsafe { std::slice::from_raw_parts_mut(slot.ptr.cast::<u8>(), out.len()) };
+        // SAFETY: `src` is a residency-checked device address owned by this
+        // runtime and the copy length equals the destination slice length.
+        unsafe { cuda_result::memcpy_dtoh_async(staging, src, stream) }
+            .map_err(|err| crate::Error::backend_source(op, err))?;
+        // SAFETY: `stream` is the memoized CubeCL stream the copy was enqueued on.
+        unsafe { cuda_result::stream::synchronize(stream) }
+            .map_err(|err| crate::Error::backend_source(op, err))?;
+        out.copy_from_slice(staging);
+        Ok(())
+    }
+
+    /// Destroy cached cuBLAS handles and free the pinned staging slot.
+    ///
+    /// Called from `Drop` after `synchronize`, which leaves the primary
+    /// context current on the dropping thread.
+    fn release_cuda_library_resources(&mut self) {
+        if let Ok(mut handles) = self.cublas_handles.lock() {
+            for (_, handle) in handles.drain() {
+                // SAFETY: each stored handle is live and no longer reachable.
+                if let Err(err) = unsafe { cublas_sys::cublasDestroy_v2(handle.0) }.result() {
+                    report_cuda_resource_release_error("cuBLAS handle", &err);
+                }
+            }
+        }
+        if let Ok(mut slot) = self.pinned_scalar.lock() {
+            if !slot.ptr.is_null() {
+                // SAFETY: the slot owns exactly one live cudaHostAlloc allocation.
+                if let Err(err) = unsafe { cuda_sys::cudaFreeHost(slot.ptr) }.result() {
+                    report_cuda_resource_release_error("pinned scalar staging", &err);
+                }
+                slot.ptr = std::ptr::null_mut();
+            }
+        }
+    }
+}
+
+/// Typed load failure for the dynamically loaded cuBLAS library.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "cuBLAS shared library not found; ensure `LD_LIBRARY_PATH` includes the CUDA toolkit library directory"
+)]
+struct CublasLibraryMissing;
+
+/// Report whether the cuBLAS shared library can be dynamically loaded.
+fn cublas_library_present() -> bool {
+    use std::sync::OnceLock;
+    static PRESENT: OnceLock<bool> = OnceLock::new();
+    // SAFETY: `is_culib_present` only probes candidate library names and does
+    // not call cuBLAS function pointers or retain a library handle.
+    *PRESENT.get_or_init(|| unsafe { cublas_sys::is_culib_present() })
+}
+
+/// Map a non-success cuBLAS status to a typed provider error.
+pub(super) fn check_cublas(
+    op: &'static str,
+    call: &'static str,
+    status: cublas_sys::cublasStatus_t,
+) -> crate::Result<()> {
+    if matches!(status, cublas_sys::cublasStatus_t::CUBLAS_STATUS_SUCCESS) {
+        Ok(())
+    } else {
+        Err(super::error::provider_status(op, "cuBLAS", call, status as i32))
+    }
+}
+
+#[cold]
+fn report_cuda_resource_release_error(what: &'static str, err: &impl fmt::Debug) {
+    eprintln!("tenferro-gpu: failed to release {what} during Drop: {err:?}");
 }
 
 fn is_invalid_device_lookup(source: DriverError) -> bool {
@@ -602,6 +799,9 @@ impl Drop for CudaRuntimeState {
         if let Err(err) = self.synchronize() {
             report_cuda_runtime_drop_error(&err);
         }
+        // `synchronize` left the primary context current; release CUDA library
+        // resources before the retained primary context drops with this state.
+        self.release_cuda_library_resources();
     }
 }
 

--- a/crates/tenferro-gpu/src/cubecl/runtime.rs
+++ b/crates/tenferro-gpu/src/cubecl/runtime.rs
@@ -206,7 +206,7 @@ struct CudaRuntimeState {
     // Memoized raw CUDA stream handles keyed by the bounded CubeCL stream-pool
     // slot, not the process-global and monotonically increasing `StreamId`.
     //
-    // INVARIANT: in pinned CubeCL rev f274a76, the CUDA server maps each
+    // INVARIANT: in pinned CubeCL rev 5939d8e, the CUDA server maps each
     // `StreamId` to a fixed `StreamPool` slot whose `CUstream` is created once
     // and never destroyed or replaced while the server is alive, and the
     // server outlives the `ComputeClient` clone owned by this state. The table

--- a/crates/tenferro-gpu/src/cubecl/runtime.rs
+++ b/crates/tenferro-gpu/src/cubecl/runtime.rs
@@ -1,9 +1,10 @@
 //! CubeCL CUDA runtime initialization and synchronization.
 
+use std::collections::HashMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use cubecl::client::ComputeClient;
 use cubecl::stream_id::StreamId;
@@ -201,6 +202,16 @@ struct CudaRuntimeState {
     primary_context: CudaPrimaryContext,
     identity: CudaRuntimeIdentity,
     allocation_domain: AllocationDomainId,
+    // Memoized raw CUDA stream handles keyed by CubeCL [`StreamId`] value.
+    //
+    // INVARIANT: in pinned CubeCL rev 1c88bb6, the CUDA server maps each
+    // `StreamId` to a fixed `StreamPool` slot whose `CUstream` is created once
+    // and never destroyed or replaced while the server is alive, and the
+    // server outlives the `ComputeClient` clone owned by this state. The map
+    // is owned by this runtime object (not thread-local/global), holds one
+    // entry per thread that has executed on the runtime, and is dropped with
+    // the runtime.
+    raw_streams: Mutex<HashMap<u64, u64>>,
 }
 
 // SAFETY: `CudaRuntimeState` owns a retained CUDA primary context and a CubeCL
@@ -320,6 +331,7 @@ impl CudaRuntime {
                 primary_context,
                 identity: CudaRuntimeIdentity::fresh(),
                 allocation_domain: AllocationDomainId::fresh(),
+                raw_streams: Mutex::new(HashMap::new()),
             }),
         })
     }
@@ -495,6 +507,16 @@ impl CudaRuntime {
 
 impl CudaRuntimeState {
     fn set_current_cuda_context(&self, op: &'static str) -> crate::Result<()> {
+        // Fast path: the tenferro primary context is already current on this
+        // thread. `cuCtxGetCurrent` only reads driver thread state, so this
+        // skips the per-op `cudaSetDevice` + `cuCtxSetCurrent` round trips.
+        // Runtime-API calls made afterwards operate on the current driver
+        // context, so no separate runtime-API device activation is needed.
+        if let Ok(Some(current)) = cudarc::driver::result::ctx::get_current() {
+            if current == self.primary_context.context() {
+                return Ok(());
+            }
+        }
         // INVARIANT: CUDA ordinals are device identifiers; bad ordinals are
         // reported by CUDA instead of indexing memory in tenferro.
         let device_ordinal = i32::try_from(self.device_id.ordinal())
@@ -506,16 +528,33 @@ impl CudaRuntimeState {
     }
 
     fn raw_cuda_stream(&self) -> crate::Result<u64> {
-        self.client
-            .with_server(|server| {
+        let stream_id = StreamId::current();
+        let poisoned =
+            || crate::Error::runtime_state("raw_cuda_stream", "raw stream cache lock poisoned");
+        if let Some(&stream) = self
+            .raw_streams
+            .lock()
+            .map_err(|_| poisoned())?
+            .get(&stream_id.value)
+        {
+            return Ok(stream);
+        }
+        let stream = self
+            .client
+            .with_server(move |server| {
                 server
-                    .raw_stream(StreamId::current())
+                    .raw_stream(stream_id)
                     .map(|stream| stream as u64)
                     .map_err(|err| crate::Error::backend_source("raw_cuda_stream", err))
             })
             .ok_or_else(|| {
                 crate::Error::runtime_state("raw_cuda_stream", "CubeCL server is unavailable")
-            })?
+            })??;
+        self.raw_streams
+            .lock()
+            .map_err(|_| poisoned())?
+            .insert(stream_id.value, stream);
+        Ok(stream)
     }
 
     fn synchronize(&self) -> crate::Result<()> {

--- a/crates/tenferro-gpu/src/cubecl/tests/blas1_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/blas1_tests.rs
@@ -1,0 +1,8 @@
+use super::super::blas1::blas1_len;
+
+#[test]
+fn blas1_length_stays_within_the_portable_cublas_interface() {
+    assert_eq!(blas1_len(i32::MAX as usize, "test").unwrap(), i32::MAX);
+    let error = blas1_len(i32::MAX as usize + 1, "test").unwrap_err();
+    assert!(error.to_string().contains("exceeds i32::MAX"));
+}

--- a/crates/tenferro-gpu/src/cubecl/tests/gemm_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/gemm_tests.rs
@@ -63,8 +63,8 @@ fn cuda_cutensor_cache_eviction_keeps_inflight_workspace_valid() {
         "second contraction must evict the first plan"
     );
 
-    // Eviction drops the first plan while its launch may still be queued. The
-    // pinned CubeCL CUDA allocator retires async frees on the owning stream.
+    // Eviction retires the workspace's owning stream before releasing its
+    // CubeCL allocation handle, so the first queued launch remains valid.
     gpu.runtime().synchronize().unwrap();
     assert_tensor_close(&download(&gpu, &actual_a), &expected_a, 1e-4);
     assert_tensor_close(&download(&gpu, &actual_b), &expected_b, 1e-4);

--- a/crates/tenferro-gpu/src/cubecl/tests/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/mod.rs
@@ -11,6 +11,7 @@ use crate::{DType, Error, Tensor, TypedTensor};
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{backend::BackendSessionHost, ErrorKind, ValidationError, ValidationKind};
 
+mod blas1_tests;
 mod capability_tests;
 mod cubecl_session_tests;
 mod device_tests;

--- a/crates/tenferro-gpu/src/cubecl/tests/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/mod.rs
@@ -20,6 +20,7 @@ mod gemm_accum_tests;
 mod gemm_tests;
 mod indexing_tests;
 mod metadata_tests;
+mod plan_cache_tests;
 mod raw_launch_tests;
 mod raw_session_tests;
 mod reduction_tests;

--- a/crates/tenferro-gpu/src/cubecl/tests/plan_cache_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/plan_cache_tests.rs
@@ -94,6 +94,19 @@ fn plan_cache_retained_bytes_track_insert_and_evict() {
 }
 
 #[test]
+fn plan_cache_retained_bytes_include_lazy_value_allocations() {
+    let base = std::mem::size_of::<TestCache>();
+    let mut cache = cache_with(2);
+    insert(&mut cache, 1, vec![1], "a", 10);
+
+    assert!(cache.add_retained_bytes(1, |stored| stored == &[1], 7));
+    assert_eq!(cache.retained_bytes(), base + 17);
+    assert!(!cache.add_retained_bytes(2, |_| true, 5));
+    assert!(!cache.add_retained_bytes(1, |stored| stored == &[2], 5));
+    assert_eq!(cache.stats().retained_bytes, base + 17);
+}
+
+#[test]
 fn plan_cache_hash_collision_replaces_entry() {
     let mut cache = cache_with(4);
     insert(&mut cache, 7, vec![1], "a", 10);

--- a/crates/tenferro-gpu/src/cubecl/tests/plan_cache_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/plan_cache_tests.rs
@@ -1,0 +1,146 @@
+//! Pure-logic tests for the hash-keyed LRU plan-cache core. No CUDA hardware
+//! is required: the entry type is a plain value standing in for a cached
+//! cuTENSOR plan.
+
+use std::num::NonZeroUsize;
+
+use super::super::plan_cache::LruPlanCache;
+
+type TestCache = LruPlanCache<Vec<i64>, &'static str>;
+
+fn cache_with(max_entries: usize) -> TestCache {
+    LruPlanCache::new(NonZeroUsize::new(max_entries).unwrap())
+}
+
+fn insert(cache: &mut TestCache, hash: u64, key: Vec<i64>, value: &'static str, bytes: usize) {
+    cache
+        .ensure(
+            hash,
+            |stored| *stored == key,
+            || Ok((key.clone(), value, bytes)),
+        )
+        .unwrap();
+}
+
+#[test]
+fn plan_cache_hits_and_misses_are_counted() {
+    let mut cache = cache_with(4);
+    insert(&mut cache, 1, vec![1], "a", 10);
+    assert!(!cache
+        .ensure(
+            1,
+            |stored| stored == &[1],
+            || panic!("hit must not rebuild")
+        )
+        .unwrap());
+    let stats = cache.stats();
+    assert_eq!(stats.entries, 1);
+    assert_eq!(stats.hits, 1);
+    assert_eq!(stats.misses, 1);
+    assert_eq!(stats.evictions, 0);
+    assert_eq!(cache.get(1, |stored| stored == &[1]), Some(&"a"));
+    assert_eq!(cache.get(2, |_| true), None);
+}
+
+#[test]
+fn plan_cache_build_error_leaves_cache_unchanged() {
+    let mut cache = cache_with(4);
+    let result = cache.ensure(
+        9,
+        |_| false,
+        || {
+            Err(crate::Error::runtime_state(
+                "test_plan_cache",
+                "build failed",
+            ))
+        },
+    );
+    assert!(result.is_err());
+    let stats = cache.stats();
+    assert_eq!(stats.entries, 0);
+    assert_eq!(stats.misses, 1);
+    assert_eq!(cache.retained_bytes(), std::mem::size_of::<TestCache>());
+}
+
+#[test]
+fn plan_cache_evicts_least_recently_used_entry() {
+    let mut cache = cache_with(2);
+    insert(&mut cache, 1, vec![1], "a", 10);
+    insert(&mut cache, 2, vec![2], "b", 20);
+    // Touch entry 1 so entry 2 becomes least recently used.
+    assert!(cache.get(1, |stored| stored == &[1]).is_some());
+    insert(&mut cache, 3, vec![3], "c", 30);
+    let stats = cache.stats();
+    assert_eq!(stats.entries, 2);
+    assert_eq!(stats.evictions, 1);
+    assert!(cache.get(2, |stored| stored == &[2]).is_none());
+    assert!(cache.get(1, |stored| stored == &[1]).is_some());
+    assert!(cache.get(3, |stored| stored == &[3]).is_some());
+}
+
+#[test]
+fn plan_cache_retained_bytes_track_insert_and_evict() {
+    let base = std::mem::size_of::<TestCache>();
+    let mut cache = cache_with(2);
+    assert_eq!(cache.retained_bytes(), base);
+    insert(&mut cache, 1, vec![1], "a", 10);
+    assert_eq!(cache.retained_bytes(), base + 10);
+    insert(&mut cache, 2, vec![2], "b", 20);
+    assert_eq!(cache.retained_bytes(), base + 30);
+    // Evicts entry 1 (least recently used): 10 bytes leave, 40 arrive.
+    insert(&mut cache, 3, vec![3], "c", 40);
+    assert_eq!(cache.retained_bytes(), base + 60);
+    assert_eq!(cache.stats().retained_bytes, base + 60);
+}
+
+#[test]
+fn plan_cache_hash_collision_replaces_entry() {
+    let mut cache = cache_with(4);
+    insert(&mut cache, 7, vec![1], "a", 10);
+    // Same hash, different materialized key: the lookup must reject the
+    // stored entry and the rebuild must replace it.
+    insert(&mut cache, 7, vec![2], "b", 20);
+    let stats = cache.stats();
+    assert_eq!(stats.entries, 1);
+    assert_eq!(stats.misses, 2);
+    assert_eq!(stats.evictions, 1);
+    assert_eq!(cache.get(7, |stored| stored == &[2]), Some(&"b"));
+    assert_eq!(
+        cache.retained_bytes(),
+        std::mem::size_of::<TestCache>() + 20
+    );
+}
+
+#[test]
+fn plan_cache_shrinking_max_entries_evicts_and_reaccounts() {
+    let base = std::mem::size_of::<TestCache>();
+    let mut cache = cache_with(3);
+    insert(&mut cache, 1, vec![1], "a", 10);
+    insert(&mut cache, 2, vec![2], "b", 20);
+    insert(&mut cache, 3, vec![3], "c", 40);
+    assert_eq!(cache.max_entries().get(), 3);
+
+    cache.set_max_entries(NonZeroUsize::new(1).unwrap());
+    assert_eq!(cache.max_entries().get(), 1);
+    let stats = cache.stats();
+    assert_eq!(stats.entries, 1);
+    assert_eq!(stats.evictions, 2);
+    assert_eq!(cache.retained_bytes(), base + 40);
+    // Only the most recently used entry survives.
+    assert!(cache.get(3, |stored| stored == &[3]).is_some());
+
+    // Growing the bound back keeps the retained entry and evicts nothing.
+    cache.set_max_entries(NonZeroUsize::new(4).unwrap());
+    assert_eq!(cache.stats().entries, 1);
+    assert_eq!(cache.stats().evictions, 2);
+}
+
+#[test]
+fn plan_cache_values_iterates_retained_entries() {
+    let mut cache = cache_with(3);
+    insert(&mut cache, 1, vec![1], "a", 1);
+    insert(&mut cache, 2, vec![2], "b", 1);
+    let mut values: Vec<&&str> = cache.values().collect();
+    values.sort();
+    assert_eq!(values, [&"a", &"b"]);
+}

--- a/crates/tenferro-gpu/src/lib.rs
+++ b/crates/tenferro-gpu/src/lib.rs
@@ -105,7 +105,7 @@ pub(crate) struct CubeclBuffer {
     allocation_id: AllocationId,
     // Memoized device address resolved by the first raw-FFI access.
     //
-    // INVARIANT: in pinned CubeCL rev 1c88bb6, a retained handle's memory
+    // INVARIANT: in pinned CubeCL rev f274a76, a retained handle's memory
     // slice keeps its storage offset (pool coalescing merges only free
     // slices) and its backing storage is never deallocated while any of its
     // slices is live, so the resolved address is stable for this buffer's

--- a/crates/tenferro-gpu/src/lib.rs
+++ b/crates/tenferro-gpu/src/lib.rs
@@ -105,7 +105,7 @@ pub(crate) struct CubeclBuffer {
     allocation_id: AllocationId,
     // Memoized device address resolved by the first raw-FFI access.
     //
-    // INVARIANT: in pinned CubeCL rev f274a76, a retained handle's memory
+    // INVARIANT: in pinned CubeCL rev 5939d8e, a retained handle's memory
     // slice keeps its storage offset (pool coalescing merges only free
     // slices) and its backing storage is never deallocated while any of its
     // slices is live, so the resolved address is stable for this buffer's

--- a/crates/tenferro-gpu/src/lib.rs
+++ b/crates/tenferro-gpu/src/lib.rs
@@ -103,6 +103,15 @@ pub(crate) struct CubeclBuffer {
     device_ordinal: usize,
     allocation_domain: AllocationDomainId,
     allocation_id: AllocationId,
+    // Memoized device address resolved by the first raw-FFI access.
+    //
+    // INVARIANT: in pinned CubeCL rev 1c88bb6, a retained handle's memory
+    // slice keeps its storage offset (pool coalescing merges only free
+    // slices) and its backing storage is never deallocated while any of its
+    // slices is live, so the resolved address is stable for this buffer's
+    // lifetime. Raw-FFI callers must still route cross-stream accesses
+    // through `get_resource` for CubeCL's stream alignment.
+    device_addr: std::sync::OnceLock<u64>,
 }
 
 #[cfg(feature = "cuda")]
@@ -136,11 +145,23 @@ impl CubeclBuffer {
             allocation_id: AllocationId::from_backend_id(
                 NEXT_CUDA_ALLOCATION_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             ),
+            device_addr: std::sync::OnceLock::new(),
         }
     }
 
     pub(crate) fn handle(&self) -> &cubecl_runtime::server::Handle {
         &self.handle
+    }
+
+    /// Return the memoized device address, if one was resolved.
+    pub(crate) fn cached_device_addr(&self) -> Option<u64> {
+        self.device_addr.get().copied()
+    }
+
+    /// Memoize the device address resolved through `get_resource` for this
+    /// buffer's handle; later calls keep the first stored value.
+    pub(crate) fn memoize_device_addr(&self, addr: u64) {
+        let _ = self.device_addr.set(addr);
     }
 
     pub(crate) fn element_len<T: 'static>(&self) -> usize {

--- a/crates/tenferro-gpu/tests/blas1_cuda.rs
+++ b/crates/tenferro-gpu/tests/blas1_cuda.rs
@@ -309,10 +309,7 @@ fn cuda_vdot_accepts_two_strided_operands() {
     let lhs = upload_tensor(cuda.runtime(), &host_lhs).unwrap();
     let rhs = upload_tensor(cuda.runtime(), &host_rhs).unwrap();
     let got = cuda
-        .vdot_read(
-            transposed_device_view(&lhs),
-            transposed_device_view(&rhs),
-        )
+        .vdot_read(transposed_device_view(&lhs), transposed_device_view(&rhs))
         .unwrap();
     let got = download_tensor(cuda.runtime(), &got).unwrap();
 

--- a/crates/tenferro-gpu/tests/blas1_cuda.rs
+++ b/crates/tenferro-gpu/tests/blas1_cuda.rs
@@ -1,0 +1,276 @@
+#![cfg(feature = "cuda")]
+
+//! Hardware parity gate for the cuBLAS-backed BLAS1 session hooks.
+//!
+//! `vdot_read`, `norm_squared_read`, and `axpby_read_into_accum` on
+//! [`CudaBackend`] bypass the generic `dot_general`/elementwise composition and
+//! call cuBLAS directly. These tests pin the numerics against the CPU backend,
+//! which keeps the composed reference semantics. They are no-ops on machines
+//! without an available CUDA device.
+//!
+//! The conjugation convention in `vdot_read` is the reason this file exists: a
+//! `dotu`-for-`dotc` slip is invisible on real inputs and silently wrong on the
+//! complex ones a Krylov loop actually feeds it.
+
+use num_complex::Complex64;
+
+use tenferro_cpu::CpuBackend;
+use tenferro_gpu::cuda::{download_tensor, gpu_available, upload_tensor, CudaBackend, CudaDeviceId};
+use tenferro_tensor::backend::BackendSession;
+use tenferro_tensor::{
+    ContractionScalar, Tensor, TensorRead, TensorView, TensorWrite, TypedTensorView,
+};
+
+fn c64(re: f64, im: f64) -> Complex64 {
+    Complex64::new(re, im)
+}
+
+/// Deterministic, non-degenerate complex data: distinct real and imaginary
+/// parts so a conjugation or transposition error cannot cancel out.
+fn sample(len: usize, seed: f64) -> Tensor {
+    let data: Vec<Complex64> = (0..len)
+        .map(|i| {
+            let x = i as f64;
+            c64(seed + 0.5 * x, 1.0 - 0.25 * x + seed)
+        })
+        .collect();
+    Tensor::from_vec_col_major(vec![len], data).unwrap()
+}
+
+fn backends() -> Option<(CudaBackend, CpuBackend)> {
+    if !gpu_available() {
+        return None;
+    }
+    let cuda = CudaBackend::new(CudaDeviceId::from_ordinal(0)).unwrap();
+    Some((cuda, CpuBackend::default()))
+}
+
+fn assert_close_c64(actual: &Tensor, expected: &Tensor, what: &str) {
+    let a = actual.as_slice::<Complex64>().unwrap();
+    let e = expected.as_slice::<Complex64>().unwrap();
+    assert_eq!(a.len(), e.len(), "{what}: length mismatch");
+    for (i, (a, e)) in a.iter().zip(e.iter()).enumerate() {
+        let tol = 1e-12 * (1.0 + e.norm());
+        assert!(
+            (a - e).norm() <= tol,
+            "{what}: element {i} is {a} but CPU says {e}"
+        );
+    }
+}
+
+fn assert_close_f64(actual: &Tensor, expected: &Tensor, what: &str) {
+    let a = actual.as_slice::<f64>().unwrap();
+    let e = expected.as_slice::<f64>().unwrap();
+    assert_eq!(a.len(), e.len(), "{what}: length mismatch");
+    for (i, (a, e)) in a.iter().zip(e.iter()).enumerate() {
+        let tol = 1e-12 * (1.0 + e.abs());
+        assert!(
+            (a - e).abs() <= tol,
+            "{what}: element {i} is {a} but CPU says {e}"
+        );
+    }
+}
+
+#[test]
+fn cuda_vdot_matches_cpu_and_conjugates_the_left_operand() {
+    let Some((mut cuda, mut cpu)) = backends() else {
+        return;
+    };
+
+    for len in [1_usize, 7, 1024] {
+        let host_lhs = sample(len, 0.25);
+        let host_rhs = sample(len, -1.5);
+
+        let expected = cpu
+            .vdot_read(
+                TensorRead::from_tensor(&host_lhs),
+                TensorRead::from_tensor(&host_rhs),
+            )
+            .unwrap();
+
+        let lhs = upload_tensor(cuda.runtime(), &host_lhs).unwrap();
+        let rhs = upload_tensor(cuda.runtime(), &host_rhs).unwrap();
+        let got = cuda
+            .vdot_read(TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs))
+            .unwrap();
+        let got = download_tensor(cuda.runtime(), &got).unwrap();
+
+        assert_close_c64(&got, &expected, &format!("vdot len={len}"));
+
+        // Independent check of the convention itself, not just CPU agreement.
+        let manual: Complex64 = host_lhs
+            .as_slice::<Complex64>()
+            .unwrap()
+            .iter()
+            .zip(host_rhs.as_slice::<Complex64>().unwrap())
+            .map(|(l, r)| l.conj() * r)
+            .sum();
+        let got = got.as_slice::<Complex64>().unwrap()[0];
+        assert!(
+            (got - manual).norm() <= 1e-12 * (1.0 + manual.norm()),
+            "vdot len={len} is {got} but sum(conj(l)*r) is {manual}"
+        );
+    }
+}
+
+/// A row-major-strided `[3, 4]` view over a column-major `[4, 3]` buffer, i.e.
+/// the transpose, expressed the way the sweep code builds strided operands.
+///
+/// Device and host tensors take different view constructors: `backend_region_view`
+/// requires a device allocation, and host storage goes through `from_slice`.
+fn transposed_device_view(tensor: &Tensor) -> TensorRead<'_> {
+    let Tensor::C64(typed) = tensor else {
+        panic!("blas1 parity tests use C64 tensors")
+    };
+    let view = typed
+        .backend_region_view(vec![3, 4], vec![4, 1], 0)
+        .unwrap();
+    TensorRead::from_view(TensorView::C64(view))
+}
+
+fn transposed_host_view(tensor: &Tensor) -> TensorRead<'_> {
+    let view = TypedTensorView::from_slice(
+        vec![3, 4],
+        vec![4_isize, 1],
+        0,
+        tensor.as_slice::<Complex64>().unwrap(),
+    )
+    .unwrap();
+    TensorRead::from_view(TensorView::C64(view))
+}
+
+#[test]
+fn cuda_vdot_accepts_a_non_contiguous_read() {
+    let Some((mut cuda, mut cpu)) = backends() else {
+        return;
+    };
+
+    // The cuBLAS path must canonicalize a strided operand on the device rather
+    // than reading the underlying storage order.
+    let host = Tensor::from_vec_col_major(
+        vec![4, 3],
+        (0..12)
+            .map(|i| c64(i as f64, 3.0 - 0.5 * i as f64))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+    let other = Tensor::from_vec_col_major(
+        vec![3, 4],
+        (0..12)
+            .map(|i| c64(0.75 + 0.5 * i as f64, 1.0 - 0.25 * i as f64))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+
+    let expected = cpu
+        .vdot_read(transposed_host_view(&host), TensorRead::from_tensor(&other))
+        .unwrap();
+
+    let device = upload_tensor(cuda.runtime(), &host).unwrap();
+    let device_other = upload_tensor(cuda.runtime(), &other).unwrap();
+    let got = cuda
+        .vdot_read(
+            transposed_device_view(&device),
+            TensorRead::from_tensor(&device_other),
+        )
+        .unwrap();
+    let got = download_tensor(cuda.runtime(), &got).unwrap();
+
+    assert_close_c64(&got, &expected, "vdot transposed");
+}
+
+#[test]
+fn cuda_norm_squared_matches_cpu() {
+    let Some((mut cuda, mut cpu)) = backends() else {
+        return;
+    };
+
+    for len in [1_usize, 5, 4096] {
+        let host = sample(len, 0.125);
+        let expected = cpu
+            .norm_squared_read(TensorRead::from_tensor(&host))
+            .unwrap();
+
+        let device = upload_tensor(cuda.runtime(), &host).unwrap();
+        let got = cuda
+            .norm_squared_read(TensorRead::from_tensor(&device))
+            .unwrap();
+        let got = download_tensor(cuda.runtime(), &got).unwrap();
+
+        assert_close_f64(&got, &expected, &format!("norm_squared len={len}"));
+
+        let manual: f64 = host
+            .as_slice::<Complex64>()
+            .unwrap()
+            .iter()
+            .map(|z| z.norm_sqr())
+            .sum();
+        let got = got.as_slice::<f64>().unwrap()[0];
+        assert!(
+            (got - manual).abs() <= 1e-12 * (1.0 + manual),
+            "norm_squared len={len} is {got} but sum(|z|^2) is {manual}"
+        );
+    }
+}
+
+#[test]
+fn cuda_axpby_matches_cpu_with_complex_coefficients() {
+    let Some((mut cuda, mut cpu)) = backends() else {
+        return;
+    };
+
+    let alpha = ContractionScalar::C64(c64(0.75, -1.25));
+    let beta = ContractionScalar::C64(c64(-0.5, 2.0));
+
+    for len in [1_usize, 9, 2048] {
+        let host_x = sample(len, 0.5);
+        let host_y = sample(len, -0.25);
+
+        let mut expected = sample(len, -0.25);
+        cpu.axpby_read_into_accum(
+            alpha,
+            TensorRead::from_tensor(&host_x),
+            beta,
+            TensorWrite::from_tensor(&mut expected),
+        )
+        .unwrap();
+
+        let x = upload_tensor(cuda.runtime(), &host_x).unwrap();
+        let mut y = upload_tensor(cuda.runtime(), &host_y).unwrap();
+        cuda.axpby_read_into_accum(
+            alpha,
+            TensorRead::from_tensor(&x),
+            beta,
+            TensorWrite::from_tensor(&mut y),
+        )
+        .unwrap();
+        let got = download_tensor(cuda.runtime(), &y).unwrap();
+
+        assert_close_c64(&got, &expected, &format!("axpby len={len}"));
+    }
+}
+
+#[test]
+fn cuda_blas1_handles_empty_inputs() {
+    let Some((mut cuda, _)) = backends() else {
+        return;
+    };
+
+    let host = Tensor::from_vec_col_major(vec![0], Vec::<Complex64>::new()).unwrap();
+    let device = upload_tensor(cuda.runtime(), &host).unwrap();
+
+    let dot = cuda
+        .vdot_read(
+            TensorRead::from_tensor(&device),
+            TensorRead::from_tensor(&device),
+        )
+        .unwrap();
+    let dot = download_tensor(cuda.runtime(), &dot).unwrap();
+    assert_eq!(dot.as_slice::<Complex64>().unwrap(), &[c64(0.0, 0.0)]);
+
+    let norm = cuda
+        .norm_squared_read(TensorRead::from_tensor(&device))
+        .unwrap();
+    let norm = download_tensor(cuda.runtime(), &norm).unwrap();
+    assert_eq!(norm.as_slice::<f64>().unwrap(), &[0.0]);
+}

--- a/crates/tenferro-gpu/tests/blas1_cuda.rs
+++ b/crates/tenferro-gpu/tests/blas1_cuda.rs
@@ -12,13 +12,15 @@
 //! `dotu`-for-`dotc` slip is invisible on real inputs and silently wrong on the
 //! complex ones a Krylov loop actually feeds it.
 
-use num_complex::Complex64;
+use num_complex::{Complex32, Complex64};
 
 use tenferro_cpu::CpuBackend;
-use tenferro_gpu::cuda::{download_tensor, gpu_available, upload_tensor, CudaBackend, CudaDeviceId};
+use tenferro_gpu::cuda::{
+    download_tensor, gpu_available, upload_tensor, CudaBackend, CudaDeviceId,
+};
 use tenferro_tensor::backend::BackendSession;
 use tenferro_tensor::{
-    ContractionScalar, Tensor, TensorRead, TensorView, TensorWrite, TypedTensorView,
+    ContractionScalar, Tensor, TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensorView,
 };
 
 fn c64(re: f64, im: f64) -> Complex64 {
@@ -69,6 +71,104 @@ fn assert_close_f64(actual: &Tensor, expected: &Tensor, what: &str) {
             "{what}: element {i} is {a} but CPU says {e}"
         );
     }
+}
+
+#[test]
+fn cuda_blas1_covers_all_supported_dtypes() {
+    let Some((mut cuda, mut cpu)) = backends() else {
+        return;
+    };
+
+    macro_rules! check {
+        ($ty:ty, $scalar:ident, $real:ty, $alpha:expr, $beta:expr, $x:expr, $y:expr) => {{
+            let host_x = Tensor::from_vec_col_major(vec![2], $x).unwrap();
+            let host_y = Tensor::from_vec_col_major(vec![2], $y).unwrap();
+            let expected_dot = cpu
+                .vdot_read(
+                    TensorRead::from_tensor(&host_x),
+                    TensorRead::from_tensor(&host_y),
+                )
+                .unwrap();
+            let expected_norm = cpu
+                .norm_squared_read(TensorRead::from_tensor(&host_x))
+                .unwrap();
+            let mut expected_y = host_y.duplicate().unwrap();
+            cpu.axpby_read_into_accum(
+                ContractionScalar::$scalar($alpha),
+                TensorRead::from_tensor(&host_x),
+                ContractionScalar::$scalar($beta),
+                TensorWrite::from_tensor(&mut expected_y),
+            )
+            .unwrap();
+
+            let x = upload_tensor(cuda.runtime(), &host_x).unwrap();
+            let mut y = upload_tensor(cuda.runtime(), &host_y).unwrap();
+            let dot = cuda
+                .vdot_read(TensorRead::from_tensor(&x), TensorRead::from_tensor(&y))
+                .unwrap();
+            let norm = cuda.norm_squared_read(TensorRead::from_tensor(&x)).unwrap();
+            cuda.axpby_read_into_accum(
+                ContractionScalar::$scalar($alpha),
+                TensorRead::from_tensor(&x),
+                ContractionScalar::$scalar($beta),
+                TensorWrite::from_tensor(&mut y),
+            )
+            .unwrap();
+
+            let dot = download_tensor(cuda.runtime(), &dot).unwrap();
+            let norm = download_tensor(cuda.runtime(), &norm).unwrap();
+            let y = download_tensor(cuda.runtime(), &y).unwrap();
+            assert_eq!(
+                dot.as_slice::<$ty>().unwrap(),
+                expected_dot.as_slice::<$ty>().unwrap()
+            );
+            assert_eq!(
+                norm.as_slice::<$real>().unwrap(),
+                expected_norm.as_slice::<$real>().unwrap()
+            );
+            assert_eq!(
+                y.as_slice::<$ty>().unwrap(),
+                expected_y.as_slice::<$ty>().unwrap()
+            );
+        }};
+    }
+
+    check!(
+        f32,
+        F32,
+        f32,
+        2.0,
+        0.5,
+        vec![1.0_f32, -2.0],
+        vec![3.0_f32, 4.0]
+    );
+    check!(
+        f64,
+        F64,
+        f64,
+        2.0,
+        0.5,
+        vec![1.0_f64, -2.0],
+        vec![3.0_f64, 4.0]
+    );
+    check!(
+        Complex32,
+        C32,
+        f32,
+        Complex32::new(2.0, -0.5),
+        Complex32::new(0.5, 0.25),
+        vec![Complex32::new(1.0, 2.0), Complex32::new(-2.0, 0.5)],
+        vec![Complex32::new(3.0, -1.0), Complex32::new(4.0, 2.0)]
+    );
+    check!(
+        Complex64,
+        C64,
+        f64,
+        Complex64::new(2.0, -0.5),
+        Complex64::new(0.5, 0.25),
+        vec![Complex64::new(1.0, 2.0), Complex64::new(-2.0, 0.5)],
+        vec![Complex64::new(3.0, -1.0), Complex64::new(4.0, 2.0)]
+    );
 }
 
 #[test]
@@ -140,7 +240,7 @@ fn transposed_host_view(tensor: &Tensor) -> TensorRead<'_> {
 }
 
 #[test]
-fn cuda_vdot_accepts_a_non_contiguous_read() {
+fn cuda_reductions_accept_a_non_contiguous_read() {
     let Some((mut cuda, mut cpu)) = backends() else {
         return;
     };
@@ -177,6 +277,13 @@ fn cuda_vdot_accepts_a_non_contiguous_read() {
     let got = download_tensor(cuda.runtime(), &got).unwrap();
 
     assert_close_c64(&got, &expected, "vdot transposed");
+
+    let expected = cpu.norm_squared_read(transposed_host_view(&host)).unwrap();
+    let got = cuda
+        .norm_squared_read(transposed_device_view(&device))
+        .unwrap();
+    let got = download_tensor(cuda.runtime(), &got).unwrap();
+    assert_close_f64(&got, &expected, "norm_squared transposed");
 }
 
 #[test]
@@ -251,6 +358,100 @@ fn cuda_axpby_matches_cpu_with_complex_coefficients() {
 }
 
 #[test]
+fn cuda_axpby_accepts_compact_views_with_offsets() {
+    let Some((mut cuda, _)) = backends() else {
+        return;
+    };
+
+    let host_x = Tensor::from_vec_col_major(
+        vec![4],
+        vec![
+            c64(99.0, 0.0),
+            c64(1.0, 2.0),
+            c64(-3.0, 4.0),
+            c64(98.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let host_y = Tensor::from_vec_col_major(
+        vec![4],
+        vec![
+            c64(97.0, 0.0),
+            c64(5.0, -1.0),
+            c64(2.0, 3.0),
+            c64(96.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let x = upload_tensor(cuda.runtime(), &host_x).unwrap();
+    let mut y = upload_tensor(cuda.runtime(), &host_y).unwrap();
+    let Tensor::C64(x) = &x else {
+        unreachable!("test input is C64")
+    };
+    let Tensor::C64(y_typed) = &mut y else {
+        unreachable!("test output is C64")
+    };
+    let x_view = x.backend_region_view(vec![2], vec![1], 1).unwrap();
+    let y_view = y_typed
+        .backend_region_view_mut(vec![2], vec![1], 1)
+        .unwrap();
+    cuda.axpby_read_into_accum(
+        ContractionScalar::C64(c64(2.0, 0.0)),
+        TensorRead::from_view(TensorView::C64(x_view)),
+        ContractionScalar::C64(c64(0.5, 0.0)),
+        TensorWrite::from_view(TensorViewMut::C64(y_view)),
+    )
+    .unwrap();
+
+    let got = download_tensor(cuda.runtime(), &y).unwrap();
+    assert_eq!(
+        got.as_slice::<Complex64>().unwrap(),
+        &[
+            c64(97.0, 0.0),
+            c64(4.5, 3.5),
+            c64(-5.0, 9.5),
+            c64(96.0, 0.0)
+        ]
+    );
+}
+
+#[test]
+fn cuda_blas1_cross_thread_operands_observe_vendor_writes() {
+    let Some((cuda, _)) = backends() else {
+        return;
+    };
+
+    let host_x = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, -2.0]).unwrap();
+    let host_y = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
+    let x = upload_tensor(cuda.runtime(), &host_x).unwrap();
+    let mut y = upload_tensor(cuda.runtime(), &host_y).unwrap();
+    let mut worker = cuda.clone();
+
+    let (dot, y) = std::thread::spawn(move || {
+        let dot = worker
+            .vdot_read(TensorRead::from_tensor(&x), TensorRead::from_tensor(&y))
+            .unwrap();
+        worker
+            .axpby_read_into_accum(
+                ContractionScalar::F64(2.0),
+                TensorRead::from_tensor(&x),
+                ContractionScalar::F64(0.5),
+                TensorWrite::from_tensor(&mut y),
+            )
+            .unwrap();
+        (
+            download_tensor(worker.runtime(), &dot).unwrap(),
+            download_tensor(worker.runtime(), &y).unwrap(),
+        )
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(dot.as_slice::<f64>().unwrap(), &[-5.0]);
+    assert_eq!(y.as_slice::<f64>().unwrap(), &[3.5, -2.0]);
+}
+
+#[test]
 fn cuda_blas1_handles_empty_inputs() {
     let Some((mut cuda, _)) = backends() else {
         return;
@@ -273,4 +474,15 @@ fn cuda_blas1_handles_empty_inputs() {
         .unwrap();
     let norm = download_tensor(cuda.runtime(), &norm).unwrap();
     assert_eq!(norm.as_slice::<f64>().unwrap(), &[0.0]);
+
+    let mut out = upload_tensor(cuda.runtime(), &host).unwrap();
+    cuda.axpby_read_into_accum(
+        ContractionScalar::C64(c64(2.0, -1.0)),
+        TensorRead::from_tensor(&device),
+        ContractionScalar::C64(c64(0.5, 1.0)),
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+    let out = download_tensor(cuda.runtime(), &out).unwrap();
+    assert!(out.as_slice::<Complex64>().unwrap().is_empty());
 }

--- a/crates/tenferro-gpu/tests/blas1_cuda.rs
+++ b/crates/tenferro-gpu/tests/blas1_cuda.rs
@@ -6,7 +6,9 @@
 //! [`CudaBackend`] bypass the generic `dot_general`/elementwise composition and
 //! call cuBLAS directly. These tests pin the numerics against the CPU backend,
 //! which keeps the composed reference semantics. They are no-ops on machines
-//! without an available CUDA device.
+//! without an available CUDA device, and report the same `ok` when they skip as
+//! when they pass, so set `TENFERRO_REQUIRE_GPU=1` wherever a device is
+//! expected to turn that silent skip into a failure.
 //!
 //! The conjugation convention in `vdot_read` is the reason this file exists: a
 //! `dotu`-for-`dotc` slip is invisible on real inputs and silently wrong on the
@@ -41,6 +43,17 @@ fn sample(len: usize, seed: f64) -> Tensor {
 
 fn backends() -> Option<(CudaBackend, CpuBackend)> {
     if !gpu_available() {
+        // Every case below returns without asserting anything when this is
+        // `None`, and the harness still prints `ok`. A green run therefore
+        // means nothing unless the reader independently knows a device was
+        // visible. On a machine that is supposed to have one, say so and let
+        // the absence fail loudly instead.
+        assert!(
+            std::env::var_os("TENFERRO_REQUIRE_GPU").is_none(),
+            "TENFERRO_REQUIRE_GPU is set but no CUDA device is available: this \
+             hardware parity gate would have reported success without executing \
+             a single cuBLAS call"
+        );
         return None;
     }
     let cuda = CudaBackend::new(CudaDeviceId::from_ordinal(0)).unwrap();
@@ -237,6 +250,198 @@ fn transposed_host_view(tensor: &Tensor) -> TensorRead<'_> {
     )
     .unwrap();
     TensorRead::from_view(TensorView::C64(view))
+}
+
+/// The middle three elements of a length-5 buffer: compact, but starting at a
+/// nonzero offset, which is the layout a Krylov basis slice has.
+fn offset_host_view(tensor: &Tensor) -> TensorRead<'_> {
+    let view = TypedTensorView::from_slice(
+        vec![3],
+        vec![1_isize],
+        1,
+        tensor.as_slice::<Complex64>().unwrap(),
+    )
+    .unwrap();
+    TensorRead::from_view(TensorView::C64(view))
+}
+
+fn offset_device_view(tensor: &Tensor) -> TensorRead<'_> {
+    let Tensor::C64(typed) = tensor else {
+        panic!("blas1 parity tests use C64 tensors")
+    };
+    let view = typed.backend_region_view(vec![3], vec![1], 1).unwrap();
+    TensorRead::from_view(TensorView::C64(view))
+}
+
+/// A `[4, 3]` column-major buffer of distinct complex entries, seeded so two
+/// such buffers cannot accidentally agree.
+fn grid(seed: f64) -> Tensor {
+    Tensor::from_vec_col_major(
+        vec![4, 3],
+        (0..12)
+            .map(|i| {
+                let x = i as f64;
+                c64(seed + 0.5 * x, 1.0 - 0.25 * x - seed)
+            })
+            .collect::<Vec<_>>(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn cuda_vdot_accepts_two_strided_operands() {
+    let Some((mut cuda, mut cpu)) = backends() else {
+        return;
+    };
+
+    // The existing strided case leaves the right operand owned and compact, so
+    // it cannot catch a materialization that only ever runs on the left slot.
+    let host_lhs = grid(0.25);
+    let host_rhs = grid(-1.5);
+
+    let expected = cpu
+        .vdot_read(
+            transposed_host_view(&host_lhs),
+            transposed_host_view(&host_rhs),
+        )
+        .unwrap();
+
+    let lhs = upload_tensor(cuda.runtime(), &host_lhs).unwrap();
+    let rhs = upload_tensor(cuda.runtime(), &host_rhs).unwrap();
+    let got = cuda
+        .vdot_read(
+            transposed_device_view(&lhs),
+            transposed_device_view(&rhs),
+        )
+        .unwrap();
+    let got = download_tensor(cuda.runtime(), &got).unwrap();
+
+    assert_close_c64(&got, &expected, "vdot both operands transposed");
+
+    // The convention again, independently: transposing both operands must not
+    // silently cancel a conjugation error the way matched layouts can.
+    let lhs_elems = host_lhs.as_slice::<Complex64>().unwrap();
+    let rhs_elems = host_rhs.as_slice::<Complex64>().unwrap();
+    let mut manual = c64(0.0, 0.0);
+    for row in 0..3 {
+        for col in 0..4 {
+            let index = row * 4 + col;
+            manual += lhs_elems[index].conj() * rhs_elems[index];
+        }
+    }
+    let got = got.as_slice::<Complex64>().unwrap()[0];
+    assert!(
+        (got - manual).norm() <= 1e-12 * (1.0 + manual.norm()),
+        "vdot both transposed is {got} but sum(conj(l)*r) is {manual}"
+    );
+}
+
+#[test]
+fn cuda_axpby_accepts_a_non_contiguous_read() {
+    let Some((mut cuda, mut cpu)) = backends() else {
+        return;
+    };
+
+    // `axpby` requires a compact destination, so only the read slot can be
+    // strided. That slot has no coverage otherwise: the offset-view case is
+    // compact, and the length-swept case is owned.
+    let alpha = ContractionScalar::C64(c64(0.75, -1.25));
+    let beta = ContractionScalar::C64(c64(-0.5, 2.0));
+
+    let host_x = grid(0.5);
+    let host_y = Tensor::from_vec_col_major(
+        vec![3, 4],
+        (0..12)
+            .map(|i| c64(2.0 - 0.125 * i as f64, 0.5 + 0.375 * i as f64))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+
+    let mut expected = host_y.duplicate().unwrap();
+    cpu.axpby_read_into_accum(
+        alpha,
+        transposed_host_view(&host_x),
+        beta,
+        TensorWrite::from_tensor(&mut expected),
+    )
+    .unwrap();
+
+    let x = upload_tensor(cuda.runtime(), &host_x).unwrap();
+    let mut y = upload_tensor(cuda.runtime(), &host_y).unwrap();
+    cuda.axpby_read_into_accum(
+        alpha,
+        transposed_device_view(&x),
+        beta,
+        TensorWrite::from_tensor(&mut y),
+    )
+    .unwrap();
+    let got = download_tensor(cuda.runtime(), &y).unwrap();
+
+    assert_close_c64(&got, &expected, "axpby transposed read");
+}
+
+#[test]
+fn cuda_reductions_accept_compact_views_with_offsets() {
+    let Some((mut cuda, mut cpu)) = backends() else {
+        return;
+    };
+
+    // A compact view at a nonzero offset is the shape a Krylov basis slice
+    // takes. It is contiguous, so it skips the materialization path and hands
+    // cuBLAS an offset pointer directly: the arithmetic that offset needs is
+    // what this pins. The sentinel ends must not enter either result.
+    let host = Tensor::from_vec_col_major(
+        vec![5],
+        vec![
+            c64(99.0, -99.0),
+            c64(1.0, 2.0),
+            c64(-3.0, 4.0),
+            c64(0.5, -1.5),
+            c64(98.0, -98.0),
+        ],
+    )
+    .unwrap();
+    let host_other = Tensor::from_vec_col_major(
+        vec![5],
+        vec![
+            c64(-97.0, 97.0),
+            c64(2.0, -0.5),
+            c64(1.5, 3.0),
+            c64(-2.5, 0.25),
+            c64(-96.0, 96.0),
+        ],
+    )
+    .unwrap();
+
+    let expected_dot = cpu
+        .vdot_read(offset_host_view(&host), offset_host_view(&host_other))
+        .unwrap();
+    let expected_norm = cpu.norm_squared_read(offset_host_view(&host)).unwrap();
+
+    let device = upload_tensor(cuda.runtime(), &host).unwrap();
+    let device_other = upload_tensor(cuda.runtime(), &host_other).unwrap();
+
+    let dot = cuda
+        .vdot_read(
+            offset_device_view(&device),
+            offset_device_view(&device_other),
+        )
+        .unwrap();
+    let dot = download_tensor(cuda.runtime(), &dot).unwrap();
+    assert_close_c64(&dot, &expected_dot, "vdot compact offset view");
+
+    let norm = cuda.norm_squared_read(offset_device_view(&device)).unwrap();
+    let norm = download_tensor(cuda.runtime(), &norm).unwrap();
+    assert_close_f64(&norm, &expected_norm, "norm_squared compact offset view");
+
+    // A wrong offset would fold a sentinel in; both results are far too small
+    // for that to hide inside the tolerance above.
+    let norm = norm.as_slice::<f64>().unwrap()[0];
+    assert!(
+        norm < 100.0,
+        "norm_squared over the offset slice is {norm}, which means a sentinel \
+         element outside the view was read"
+    );
 }
 
 #[test]

--- a/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
@@ -1200,8 +1200,8 @@ fn cubecl_raw_device_pointer_paths_are_not_public() {
         "gemm::typed_device_ptr",
         gemm_ptr,
         &[
-            "ensure_resident_on_runtime(rt, tensor, OP)?;",
-            "let prepared = prepared_tensor_access(tensor, OP)?;",
+            "ensure_resident_on_runtime(rt, tensor, op)?;",
+            "let prepared = prepared_tensor_access(tensor, op)?;",
             "let handle = prepared.into_handle();",
             ".get_resource(handle)",
         ],
@@ -1437,7 +1437,7 @@ fn cubecl_scatter_reports_unsupported_integer_operand_dtypes() {
 }
 
 #[test]
-fn cubecl_runtime_initializes_context_before_client_and_syncs_on_drop() {
+fn cubecl_runtime_initializes_context_before_client_and_retires_streams_on_drop() {
     let runtime_source = cubecl_source("runtime.rs");
     let new_source = source_section(
         &runtime_source,
@@ -1463,8 +1463,8 @@ fn cubecl_runtime_initializes_context_before_client_and_syncs_on_drop() {
         "CudaRuntime::drop",
         drop_source,
         &[
-            "if let Err(err) = self.synchronize()",
-            "report_cuda_runtime_drop_error(&err);",
+            "if self.retire_initialized_streams()",
+            "self.release_cuda_library_resources();",
         ],
     );
 }

--- a/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
@@ -1194,7 +1194,7 @@ fn cubecl_raw_device_pointer_paths_are_not_public() {
     let gemm_ptr = source_section(
         &gemm_source,
         "fn typed_device_ptr<T: TensorScalar + 'static>(",
-        "fn zero_alloc<T>",
+        "fn build_layout(",
     );
     assert_ordered_needles(
         "gemm::typed_device_ptr",
@@ -1472,22 +1472,27 @@ fn cubecl_runtime_initializes_context_before_client_and_syncs_on_drop() {
 #[test]
 fn cubecl_gemm_zero_contracting_path_stays_device_native() {
     let gemm_source = cubecl_source("gemm.rs");
-    let zero_alloc_source = source_section(&gemm_source, "fn zero_alloc<", "fn build_layout<");
+    let alloc_path_source = source_section(
+        &gemm_source,
+        "fn dot_general_typed_with_conj<",
+        "fn cutensor_conj_op<",
+    );
 
     for banned in [
         "vec![T::zero(); len]",
         "create_from_slice(T::as_bytes(&zeros))",
     ] {
         assert!(
-            !zero_alloc_source.contains(banned),
+            !alloc_path_source.contains(banned),
             "CubeCL GEMM zero-contracting fast path must not materialize host zeros: {banned}"
         );
     }
     assert_ordered_needles(
-        "gemm::zero_alloc",
-        zero_alloc_source,
+        "gemm::dot_general_typed_with_conj",
+        alloc_path_source,
         &[
-            "alloc_output::<T>(rt, shape)",
+            "alloc_output::<T>(backend.runtime(), &layout.output_shape)",
+            "layout.contracting_elements == 0",
             "structural::fill_zero_kernel",
         ],
     );

--- a/crates/tenferro-gpu/tests/integration/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/public_surface_contract.rs
@@ -246,7 +246,7 @@ fn cuda_dot_general_stays_cutensor_backed_and_not_cubek_rewired() {
     );
     assert!(
         cuda_gemm.contains("cached_cutensor_contraction::<")
-            && cuda_gemm.contains("alloc_workspace(rt, workspace_size)")
+            && cuda_gemm.contains("alloc_workspace(backend.runtime(), cached.workspace_size)")
             && cuda_gemm.contains("Plan::new(cutensor, &op_desc"),
         "CUDA workspace and plan flow must remain visible through the cuTENSOR cache helper"
     );

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -192,6 +192,9 @@ owned by another physical stream synchronizes the enqueue stream before its
 retention guards are released; same-stream calls remain asynchronous. Runtime
 teardown retires every initialized physical stream before destroying library
 handles or releasing the retained primary context.
+The direct cuBLAS BLAS-1 hooks use the standard 32-bit interfaces for CUDA
+11/12 library compatibility and reject element counts above `i32::MAX` before
+enqueue.
 
 cuTENSOR, cuSOLVER, and cuBLAS are CUDA-only and are loaded lazily through the
 CUDA FFI layer. cuFFT follows a different ownership boundary: `tenferro-fft`

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -185,6 +185,14 @@ WebGPU queue/device barrier. Higher-level eager GPU execution exposes the same
 barrier through `EagerRuntime::synchronize()`, with CPU eager runtimes treating
 the call as a no-op.
 
+CUDA vendor-library handles are indexed by CubeCL's bounded physical stream
+pool, not by process-global logical `StreamId` values. A cuBLAS handle is locked
+across pointer-mode selection and enqueue. A vendor call using an allocation
+owned by another physical stream synchronizes the enqueue stream before its
+retention guards are released; same-stream calls remain asynchronous. Runtime
+teardown retires every initialized physical stream before destroying library
+handles or releasing the retained primary context.
+
 cuTENSOR, cuSOLVER, and cuBLAS are CUDA-only and are loaded lazily through the
 CUDA FFI layer. cuFFT follows a different ownership boundary: `tenferro-fft`
 loads it and owns its opaque plans and `cufft-plans` cache entries;
@@ -253,15 +261,17 @@ logical retained bytes, and event counters with
 Retained bytes are estimates of cache-owned payloads, not process RSS or
 allocator arena usage.
 
-CUDA `dot_general` stores cuTENSOR contraction descriptors, plans, and device
-workspace inside this backend-owned extension cache. The cuTENSOR plan key is
+CUDA `dot_general` stores cuTENSOR contraction descriptors, plans, and lazy
+per-physical-stream device workspaces inside this backend-owned extension
+cache. A workspace is locked through enqueue, and eviction retires its owning
+stream before releasing the workspace, plan, or descriptors. The cuTENSOR plan key is
 structural: dtype, extents, strides, modes, conjugation flags, descriptor
 alignment requirements, and workspace preference. It must not include
 allocation addresses or actual pointer-specific alignment. Whole-allocation
 operands keep the CUDA allocation alignment requirement; borrowed views use a
 conservative dtype-size descriptor alignment requirement so the cached plan
 remains valid across different view offsets without using pointer-specific
-alignment. Cached device workspace bytes are included in the logical
+alignment. Lazily allocated device workspace bytes are included in the logical
 retained-byte estimate and are released by normal extension-cache eviction or
 `CudaBackend::clear_cuda_extension_cache`. The overall extension cache stats
 report the retained typed cache entry. Use

--- a/docs/worklogs/2026-08-29-cuda-dispatch-cublas.md
+++ b/docs/worklogs/2026-08-29-cuda-dispatch-cublas.md
@@ -12,9 +12,10 @@ cuTENSOR plan one lazy workspace per physical stream, and retires all relevant
 streams before releasing resources.
 
 The complex zero-fill workaround was removed. CubeCL PR #17 fixes complex cast
-lowering at the emitter and this PR pins that fix. The independently observed
-cuTENSOR/Volta wrong-result boundary is handled separately by tenferro PR
-#1734.
+lowering at the emitter and this PR pins that fix. CubeK PR #12 advances its
+CubeCL pins to the same revision so workspace feature unions use one compatible
+type universe. The independently observed cuTENSOR/Volta wrong-result boundary
+is handled separately by tenferro PR #1734.
 
 ## Context read
 

--- a/docs/worklogs/2026-08-29-cuda-dispatch-cublas.md
+++ b/docs/worklogs/2026-08-29-cuda-dispatch-cublas.md
@@ -1,0 +1,78 @@
+# CUDA dispatch and cuBLAS BLAS-1
+
+## Session summary
+
+PR #1733 reduces fixed CUDA issue overhead and adds cuBLAS-backed `vdot`,
+`norm_squared`, and `axpby`. Review then found that the first implementation
+cached by unbounded logical stream IDs, allowed shared cuBLAS handle state to
+race, and did not retain cross-stream allocations until vendor work completed.
+The final implementation keys fixed tables by CubeCL's physical stream pool,
+locks each cuBLAS handle through configuration and enqueue, gives each
+cuTENSOR plan one lazy workspace per physical stream, and retires all relevant
+streams before releasing resources.
+
+The complex zero-fill workaround was removed. CubeCL PR #17 fixes complex cast
+lowering at the emitter and this PR pins that fix. The independently observed
+cuTENSOR/Volta wrong-result boundary is handled separately by tenferro PR
+#1734.
+
+## Context read
+
+- `AGENTS.md`, `REPOSITORY_RULES.md`, `CONTRIBUTING.md`, and the shared common,
+  Rust, performance, numerical, documentation, and test rules
+- `docs/design/gpu-backend-design.md`
+- CubeCL CUDA stream-pool, event, allocation, and C++ emitter implementations
+- cuBLAS stream/pointer-mode and cuTENSOR workspace lifecycle call sites
+- PR #1733 review comments and hosted-CI failures
+
+## Measurement record
+
+- baseline source: `8e8d879da79d5dfac573cf52924f84d4bb903c48`
+- originally measured candidate: `30151a5a6dc689e952e32b5daee39b55a4c6a5ce`
+- hardware: NVIDIA A800
+- software: Rust 1.96, CUDA 12, cuTENSOR 2.3.1
+- cases: C64 `dot_general` at `256x192x64`, allocating and preallocated enqueue,
+  per-operation synchronization, empty-queue synchronization, a dimension-4096
+  conjugated self-dot plus scalar readback, and two-site TDVP at bond dimensions
+  64, 128, and 256 against a 16-thread CPU baseline
+
+The original measurement session did not record warmup count, repetition
+count, sample dispersion, exact CUDA minor version, or benchmark harness SHA.
+The reported medians remain useful directional evidence, but are not treated as
+a reproducible performance gate. The review correctness changes were not
+remeasured locally because this machine has no CUDA GPU.
+
+## Decisions
+
+1. Match CubeCL's configured physical stream count and modulo mapping. This is
+   bounded and avoids an LRU whose eviction would add synchronization to thread
+   churn.
+2. Keep the same-physical-stream path asynchronous. Synchronize only when raw
+   vendor work borrows an allocation owned by another physical stream.
+3. Hold the per-slot cuBLAS mutex across pointer-mode selection and enqueue.
+4. Allocate cuTENSOR workspaces lazily per physical stream and count them in
+   retained-byte limits. Drop workspaces first so their stream barriers precede
+   plan and descriptor destruction.
+5. Propagate scalar pointer-resolution failures. If a completion barrier fails,
+   retain the involved allocation handle instead of permitting unproven reuse.
+6. Keep compact BLAS-1 inputs allocation-free; box only the noncontiguous
+   materialization slow path.
+
+## Verification
+
+- CUDA-feature library tests, including plan-cache accounting
+- CUDA-feature clippy with warnings denied
+- CUDA integration source-contract tests
+- CPU BLAS-1 thread-count and pool-aliasing tests
+- build-artifact dependency-contract tests
+- formatting and diff checks
+- expanded CUDA hardware tests compile locally; execution remains hosted-CI
+  owned
+
+## Remaining risks
+
+- Same-stream performance after the correctness patch has not been remeasured.
+- Cross-stream raw vendor calls intentionally pay a stream barrier.
+- CUDA and V100 hardware validation depend on hosted or maintainer hardware.
+- The temporary CubeCL Git pin should be replaced by a published dependency
+  once the emitter fix is released.

--- a/docs/worklogs/2026-08-29-cuda-dispatch-cublas.md
+++ b/docs/worklogs/2026-08-29-cuda-dispatch-cublas.md
@@ -58,6 +58,9 @@ remeasured locally because this machine has no CUDA GPU.
    retain the involved allocation handle instead of permitting unproven reuse.
 6. Keep compact BLAS-1 inputs allocation-free; box only the noncontiguous
    materialization slow path.
+7. Use cuBLAS's standard 32-bit BLAS-1 interfaces. The CUDA 11.8 library on
+   hosted GPU CI does not export the optional `_64` symbols; calls with more
+   than `i32::MAX` elements return a shape error before enqueue.
 
 ## Verification
 

--- a/samples/cubecl-kernel/Cargo.toml
+++ b/samples/cubecl-kernel/Cargo.toml
@@ -23,11 +23,11 @@ tenferro-tensor = { path = "../../crates/tenferro-tensor" }
 # revision the tenferro workspace deps pin, keeping a single CubeCL runtime
 # type across the sample and tenferro-gpu.
 [patch.crates-io]
-t4a-cubecl = { git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1" }
-t4a-cubecl-cuda = { git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1" }
-t4a-cubecl-common = { git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1" }
-t4a-cubecl-runtime = { git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1" }
-t4a-cubecl-wgpu = { git = "https://github.com/tensor4all/cubecl.git", rev = "1c88bb6f1a47ffb11755e05048b7828a743f53e1" }
+t4a-cubecl = { git = "https://github.com/tensor4all/cubecl.git", rev = "5939d8e3b1c479ed6db31de5f01cb6d432178f2d" }
+t4a-cubecl-cuda = { git = "https://github.com/tensor4all/cubecl.git", rev = "5939d8e3b1c479ed6db31de5f01cb6d432178f2d" }
+t4a-cubecl-common = { git = "https://github.com/tensor4all/cubecl.git", rev = "5939d8e3b1c479ed6db31de5f01cb6d432178f2d" }
+t4a-cubecl-runtime = { git = "https://github.com/tensor4all/cubecl.git", rev = "5939d8e3b1c479ed6db31de5f01cb6d432178f2d" }
+t4a-cubecl-wgpu = { git = "https://github.com/tensor4all/cubecl.git", rev = "5939d8e3b1c479ed6db31de5f01cb6d432178f2d" }
 
 # Match workspace [profile.ci] used by scripts/ci/run_profile.py extensions.
 [profile.ci]

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -135,7 +135,7 @@ class BuildArtifactContracts(unittest.TestCase):
         manifest = tomllib.loads((ROOT / "Cargo.toml").read_text())
         dependencies = manifest["workspace"]["dependencies"]
 
-        revision = "1c88bb6f1a47ffb11755e05048b7828a743f53e1"
+        revision = "f274a76d8589d39fbbbcb4916b4f354f1c2447db"
         for name in (
             "cubecl",
             "cubecl-cuda",

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -135,7 +135,7 @@ class BuildArtifactContracts(unittest.TestCase):
         manifest = tomllib.loads((ROOT / "Cargo.toml").read_text())
         dependencies = manifest["workspace"]["dependencies"]
 
-        revision = "f274a76d8589d39fbbbcb4916b4f354f1c2447db"
+        revision = "5939d8e3b1c479ed6db31de5f01cb6d432178f2d"
         for name in (
             "cubecl",
             "cubecl-cuda",

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -163,5 +163,41 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertIn("dep:cubek-matmul", features["webgpu"])
         self.assertIn("dep:cubek-std", features["webgpu"])
 
+    def test_sample_workspaces_patch_cubecl_to_the_workspace_revision(self) -> None:
+        """`samples/cubecl-kernel` sits outside the root workspace, so its
+        `[patch.crates-io]` block is the only thing holding it to the same
+        CubeCL fork revision `tenferro-gpu` pins. When the two drift apart both
+        revisions land in one dependency graph, and the sample fails against
+        same-named types from different crate versions: an `E0308` mismatch on
+        `ComputeClient` and `CubeDim` rather than a legible version conflict.
+        Comparing the manifests catches that at the source.
+        """
+        workspace = tomllib.loads((ROOT / "Cargo.toml").read_text())
+        expected = workspace["workspace"]["dependencies"]["cubecl"]["rev"]
+
+        for sample in ("cubecl-kernel",):
+            manifest = tomllib.loads(
+                (ROOT / "samples" / sample / "Cargo.toml").read_text()
+            )
+            patches = manifest.get("patch", {}).get("crates-io", {})
+            cubecl_patches = {
+                name: spec
+                for name, spec in patches.items()
+                if name.startswith("t4a-cubecl")
+            }
+            self.assertTrue(
+                cubecl_patches,
+                f"samples/{sample} should patch its CubeCL line to the fork",
+            )
+            for name, spec in cubecl_patches.items():
+                self.assertEqual(
+                    spec.get("rev"),
+                    expected,
+                    f"samples/{sample} patches {name} at {spec.get('rev')}, but the "
+                    f"workspace pins CubeCL at {expected}; both revisions would end "
+                    "up in one dependency graph",
+                )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This PR reduces fixed per-operation CUDA overhead for the many-small-operations
regime used by Krylov, TDVP, and DMRG workloads. It also adds direct cuBLAS
implementations of `vdot`, `norm_squared`, and `axpby`, plus a pinned
small-payload readback path.

The review follow-up fixes the correctness bugs found in the first version:

- `cudarc/cublas` is enabled only by `tenferro-gpu`, preserving the workspace
  CubeCL dependency contract.
- scalar device-pointer errors propagate instead of silently falling back.
- raw CUDA stream and cuBLAS handle tables are bounded by CubeCL's configured
  physical stream pool rather than process-global logical `StreamId`s.
- each cuBLAS handle is locked across pointer-mode selection and enqueue.
- cross-physical-stream vendor calls retain allocations through a completion
  barrier; same-stream calls remain asynchronous.
- cuTENSOR workspaces are lazy and per physical stream, counted in retained
  bytes, and retired before cached plans/descriptors are destroyed.
- runtime teardown retires every initialized stream before releasing CUDA
  library resources; failed retirement leaks pointer-only resources rather than
  reclaiming potentially live asynchronous state.
- compact BLAS-1 operands stay allocation-free; only noncontiguous
  materialization takes the boxed slow path.
- every failing exit from the pinned readback now abandons the staging slot as
  well as retaining the source allocation. An async CUDA call can surface a
  failure from an earlier launch on the stream, so neither submitting the copy
  nor waiting on it proves the device is finished when it returns an error.
  Previously both paths left the slot installed, so a later download could reuse
  a buffer the device might still be writing, and `Drop` could `cudaFreeHost` it
  with the copy in flight.

## What the change actually does

All three hooks get direct cuBLAS implementations, but they are not replacing
the same thing. `vdot_read` and `norm_squared_read` replace a caller-composed
contraction reduction with a cuBLAS dot. `axpby_read_into_accum` replaces a
composed pointwise update with an in-place GEAM. The two reductions run in
`CUBLAS_POINTER_MODE_DEVICE`; AXPBY uses host pointer mode for its coefficients.

Two details matter when reading the numbers below:

- The reductions leave their result on the device and transfer nothing. The
  device-to-host copy happens later, when the consumer calls `download_tensor`.
- Noncontiguous **read** operands are canonicalized through `to_contiguous_read`
  before the cuBLAS call, which is another `O(n)` device copy and allocation. A
  noncontiguous AXPBY destination is rejected rather than materialized.

So this is not the removal of a constant per-call transfer. Old path and new are
both `O(n)`; what changes is which vendor kernel runs and how much host-side
setup precedes it. Whether the relative gain grows, flattens, or reverses with
vector length depends on the cuBLAS-versus-cuTENSOR bandwidth ratio and on where
each provider's kernels cross over. That has not been measured across lengths,
and this PR makes no claim about it.

The pinned readback is a separate, smaller change, and it is not a
pageable-to-pinned conversion: CubeCL's `read_one` already stages through pinned
memory at the revision pinned here, falling back to pageable only if the
reservation fails. What the small path avoids is CubeCL's staging-reservation
machinery and one of two barriers, since the general path synchronizes the
stream and then lets `read_one` wait on its own fence after the copy. Neither
path synchronizes the device. The gate is a byte length, so short vectors take
it too, not only scalars.

## Why this matters

A two-site TDVP step issues roughly 10,000 contractions and 47,000 BLAS-1
operations. At modest bond dimension the kernels are short, so host issue cost
dominates. The original A800 measurement found about 200 us to issue a C64
`256x192x64` `dot_general`, versus single-digit microseconds of kernel work.

The performance changes remove repeated context/stream resolution, memoize
stable device addresses, make cuTENSOR plan-cache hits O(1) and allocation-free,
avoid cloning compact strides and allocating an unused accumulator, and route
BLAS-1 directly to cuBLAS.

## Measurements

Original candidate `30151a5a`, NVIDIA A800, Rust 1.96, CUDA 12, cuTENSOR 2.3.1:

| case | before | original candidate |
| --- | ---: | ---: |
| C64 contraction enqueue, session re-entered | ~200 us | 15.4-18.3 us |
| C64 contraction enqueue, preallocated output | - | 6.4-9.7 us |
| synchronized contraction | - | 31.3-34.5 us |
| empty-queue synchronize | - | 1.2-1.9 us |
| dim-4096 conjugated self-dot + scalar readback | 63 us | 38.5 us |

Two-site TDVP, same workload before and after:

| bond dimension | before | original candidate |
| ---: | ---: | ---: |
| 64 | 0.33x | 1.33x |
| 128 | 0.62x | 1.33x |
| 256 | 1.15x | 1.68x |

Read that table with three caveats. The baseline is a 16-thread CPU run, not the
single-core reference this project uses elsewhere, so the ratios are not
comparable to other CPU-relative figures. The rows bundle every optimization in
this PR, so they do not isolate the BLAS-1 substitution. And no bond dimension
above 256 was measured, so nothing here supports a claim at 512 or beyond.

The original session also did not record warmup and repetition counts,
dispersion, exact CUDA minor version, or benchmark harness SHA. The correctness
follow-up has not been remeasured locally because this machine has no CUDA GPU.
Cross-stream vendor calls now intentionally pay a stream barrier; the hot
same-stream path does not.

**Downstream TDVP performance is inconclusive at this commit.** The isolating
experiment is a runtime switch between the former composition and the cuBLAS
path inside one build, replaying a real Krylov call trace with its actual
shapes, strides, and readback cadence. That experiment has not been run. It
should also record Krylov iteration counts and residuals, not only wall time,
since cuBLAS and cuTENSOR reduce in different orders and a changed iteration
count would move step time for reasons unrelated to throughput.

## Validation

- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-gpu --features cuda --test integration cubecl_launch_contract'`
- CUDA-feature library tests: 116 passed, 129 hardware tests ignored
- CUDA source contracts: 37 passed
- full root and standalone-extension clippy profiles: passed
- CPU BLAS-1 thread-count and pool-aliasing tests: passed
- deterministic repository-rules review: pass

Executed on an NVIDIA A800 (cuTENSOR 2.3.1, CUDA 12.1, Rust 1.96, single GPU,
`RAYON_NUM_THREADS=1`), which is the first time these assertions have run
against real cuBLAS rather than only compiled:

- `blas1_cuda`: 11 passed, 0 failed, with `TENFERRO_REQUIRE_GPU=1`
- `integration`: 70 passed, 0 failed

These tests assert nothing when no device is visible and still print `ok`, so a
green run was previously indistinguishable from a vacuous one. `backends()` now
fails instead when `TENFERRO_REQUIRE_GPU` is set, and GPU runners should set it.
Default behaviour on a device-less machine is unchanged.

Three coverage gaps are closed by new cases: a strided read operand for AXPBY,
compact offset views for both reductions, and a VDOT with both operands strided
(the previous strided case left the right operand owned, so a materialization
bug confined to one slot could not fail it).

Remaining gaps: runtime drop with work in flight, and the failed-readback paths
themselves, which need injected CUDA failures rather than hardware.

The refreshed performance measurement remains maintainer-hardware work.

## Related root-cause fixes

- [CubeCL #17](https://github.com/tensor4all/cubecl/pull/17) fixes scalar/complex
  and complex-precision casts in the C++ emitter. This PR pins that fix and uses
  device-native complex zero fill; the host-upload workaround is gone.
- [CubeK #12](https://github.com/tensor4all/cubek/pull/12) advances CubeK to the
  same CubeCL revision so CUDA, WebGPU, matmul, and FFT share one type universe.
- [tenferro #1734](https://github.com/tensor4all/tenferro-rs/pull/1734) fails
  closed for cuTENSOR >=2.2 on SM 7.0, based on the version-bisected V100 silent
  wrong-result matrix. Its docs record that this empirical boundary is stricter
  than NVIDIA's advertised cuTENSOR 2.2 SM 7.0 support.

Design and reproduction details are recorded in
[`docs/worklogs/2026-08-29-cuda-dispatch-cublas.md`](https://github.com/tensor4all/tenferro-rs/blob/perf/cuda-dot-dispatch/docs/worklogs/2026-08-29-cuda-dispatch-cublas.md).

*(Implementation and measurements assisted by Claude.)*
