### PR TITLE
fix(gpu): reject cuTENSOR 2.2+ on Volta

### DIFF
--- a/crates/tenferro-gpu/src/cubecl/ffi/cutensor.rs
+++ b/crates/tenferro-gpu/src/cubecl/ffi/cutensor.rs
@@ -3,6 +3,9 @@ use std::os::raw::c_char;
 use std::sync::Arc;
 
 use libloading::Library;
+use tenferro_tensor::ErrorKind;
+
+use super::super::CudaComputeCapability;
 
 const OP: &str = "cuda_cutensor";
 /// Default cuTENSOR search paths. Override with `TENFERRO_CUTENSOR_PATH` env var.
@@ -22,6 +25,7 @@ pub(crate) type CutensorCudaStream = *mut c_void;
 type CutensorStatus = i32;
 
 const CUTENSOR_STATUS_SUCCESS: CutensorStatus = 0;
+const CUTENSOR_VERSION_2_2_0: usize = 20_200;
 
 #[derive(Debug, thiserror::Error)]
 enum CutensorLoadError {
@@ -38,6 +42,43 @@ enum CutensorLoadError {
         #[source]
         source: libloading::Error,
     },
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "cuTENSOR {version_major}.{version_minor}.{version_patch} is unsupported by tenferro on SM {sm_major}.{sm_minor} because it can return incorrect results; use cuTENSOR 2.1.x on Volta"
+)]
+struct CutensorArchitectureError {
+    version_major: usize,
+    version_minor: usize,
+    version_patch: usize,
+    sm_major: u32,
+    sm_minor: u32,
+}
+
+fn validate_device_support(
+    version: usize,
+    compute_capability: CudaComputeCapability,
+) -> crate::Result<()> {
+    if compute_capability.major != 7
+        || compute_capability.minor != 0
+        || version < CUTENSOR_VERSION_2_2_0
+    {
+        return Ok(());
+    }
+
+    Err(crate::Error::extension(
+        OP,
+        "cuda",
+        ErrorKind::Unsupported,
+        CutensorArchitectureError {
+            version_major: version / 10_000,
+            version_minor: (version % 10_000) / 100,
+            version_patch: version % 100,
+            sm_major: compute_capability.major,
+            sm_minor: compute_capability.minor,
+        },
+    ))
 }
 
 #[repr(i32)]
@@ -160,6 +201,7 @@ type CutensorPermuteFn = unsafe extern "C" fn(
     CutensorCudaStream,
 ) -> CutensorStatus;
 type CutensorGetErrorStringFn = unsafe extern "C" fn(CutensorStatus) -> *const c_char;
+type CutensorGetVersionFn = unsafe extern "C" fn() -> usize;
 
 struct CutensorVtable {
     create: CutensorCreateFn,
@@ -177,6 +219,7 @@ struct CutensorVtable {
     contract: CutensorContractFn,
     permute: CutensorPermuteFn,
     get_error_string: CutensorGetErrorStringFn,
+    get_version: CutensorGetVersionFn,
     compute_desc_32f: CutensorComputeDescriptor,
     compute_desc_64f: CutensorComputeDescriptor,
 }
@@ -202,6 +245,7 @@ impl CutensorVtable {
             contract: load_symbol(lib, b"cutensorContract\0")?,
             permute: load_symbol(lib, b"cutensorPermute\0")?,
             get_error_string: load_symbol(lib, b"cutensorGetErrorString\0")?,
+            get_version: load_symbol(lib, b"cutensorGetVersion\0")?,
             compute_desc_32f: load_data_symbol(lib, b"CUTENSOR_COMPUTE_DESC_32F\0")?,
             compute_desc_64f: load_data_symbol(lib, b"CUTENSOR_COMPUTE_DESC_64F\0")?,
         })
@@ -371,8 +415,12 @@ unsafe impl Send for CutensorHandle {}
 unsafe impl Sync for CutensorHandle {}
 
 impl CutensorHandle {
-    pub(crate) fn load() -> crate::Result<Self> {
+    pub(crate) fn load(compute_capability: CudaComputeCapability) -> crate::Result<Self> {
         let lib = CutensorLibrary::load()?;
+        // SAFETY: `cutensorGetVersion` takes no arguments and only returns the
+        // version of the loaded library retained by `lib`.
+        let version = unsafe { (lib.vtable.get_version)() };
+        validate_device_support(version, compute_capability)?;
         let mut raw = std::ptr::null_mut();
         let status = unsafe { (lib.vtable.create)(&mut raw) };
         lib.check_status(status, OP, "cutensorCreate")?;

--- a/crates/tenferro-gpu/src/cubecl/ffi/cutensor/tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/ffi/cutensor/tests.rs
@@ -19,11 +19,11 @@ fn cutensor_loader_missing_library_is_typed_io_error() {
 }
 
 #[test]
-fn cutensor_volta_support_matches_vendor_version_boundary() {
+fn cutensor_sm70_guard_uses_reproduced_version_boundary() {
     let volta = super::CudaComputeCapability { major: 7, minor: 0 };
     let turing = super::CudaComputeCapability { major: 7, minor: 5 };
 
-    super::validate_device_support(20_100, volta).unwrap();
+    super::validate_device_support(20_199, volta).unwrap();
     super::validate_device_support(20_200, turing).unwrap();
 
     let error = super::validate_device_support(20_200, volta).unwrap_err();
@@ -31,4 +31,9 @@ fn cutensor_volta_support_matches_vendor_version_boundary() {
     assert!(error
         .to_string()
         .contains("cuTENSOR 2.2.0 is unsupported by tenferro on SM 7.0"));
+    assert!(matches!(
+        &error,
+        crate::Error::Extension { source, .. }
+            if source.downcast_ref::<super::CutensorArchitectureError>().is_some()
+    ));
 }

--- a/crates/tenferro-gpu/src/cubecl/ffi/cutensor/tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/ffi/cutensor/tests.rs
@@ -17,3 +17,18 @@ fn cutensor_loader_missing_library_is_typed_io_error() {
         other => panic!("expected typed cuTENSOR IoSource, got {other:?}"),
     }
 }
+
+#[test]
+fn cutensor_volta_support_matches_vendor_version_boundary() {
+    let volta = super::CudaComputeCapability { major: 7, minor: 0 };
+    let turing = super::CudaComputeCapability { major: 7, minor: 5 };
+
+    super::validate_device_support(20_100, volta).unwrap();
+    super::validate_device_support(20_200, turing).unwrap();
+
+    let error = super::validate_device_support(20_200, volta).unwrap_err();
+    assert_eq!(error.kind(), tenferro_tensor::ErrorKind::Unsupported);
+    assert!(error
+        .to_string()
+        .contains("cuTENSOR 2.2.0 is unsupported by tenferro on SM 7.0"));
+}

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -796,7 +796,8 @@ impl CudaBackend {
         if let Some(handle) = self.inner.cutensor.get() {
             return Ok(handle);
         }
-        let handle = ffi::cutensor::CutensorHandle::load()?;
+        let handle =
+            ffi::cutensor::CutensorHandle::load(self.inner.rt.device_info().compute_capability())?;
         let _ = self.inner.cutensor.set(handle);
         self.inner.cutensor.get().ok_or_else(|| {
             crate::Error::runtime_state(

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -194,12 +194,9 @@ session, so it is not owned by the cached plan entry. The CUDA provider first
 uses default soname/path candidates and allows explicit override with these
 variables:
 
-The cuTENSOR loader checks the loaded library version against the selected
-device before creating a handle. PR #1733 reproduced silent all-zero results
-from cuTENSOR 2.2 and newer on SM 7.0 despite success statuses. tenferro rejects
-that combination with a typed unsupported error. Volta requires cuTENSOR 2.1.x.
-NVIDIA's support table still lists SM 7.0 for cuTENSOR 2.2, then removes it in
-2.3; the stricter tenferro guard follows the observed numerical result.
+The cuTENSOR loader rejects version 2.2 and newer on SM 7.0 before creating a
+handle. PR #1733 reproduced silent wrong results for that combination, so
+cuTENSOR 2.1.x remains the supported Volta path.
 
 | Variable | Library |
 | --- | --- |

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -194,6 +194,13 @@ session, so it is not owned by the cached plan entry. The CUDA provider first
 uses default soname/path candidates and allows explicit override with these
 variables:
 
+The cuTENSOR loader checks the loaded library version against the selected
+device before creating a handle. PR #1733 reproduced silent all-zero results
+from cuTENSOR 2.2 and newer on SM 7.0 despite success statuses. tenferro rejects
+that combination with a typed unsupported error. Volta requires cuTENSOR 2.1.x.
+NVIDIA's support table still lists SM 7.0 for cuTENSOR 2.2, then removes it in
+2.3; the stricter tenferro guard follows the observed numerical result.
+
 | Variable | Library |
 | --- | --- |
 | `TENFERRO_CUTENSOR_PATH` | cuTENSOR |

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -171,10 +171,9 @@ CUDA operations implemented through NVIDIA libraries return typed load or
 provider errors when the required library is missing. They do not silently use
 a slower native CubeCL kernel as a CUDA fallback.
 
-cuTENSOR 2.2 and newer can return success with incorrect results on Volta
-(compute capability 7.0). On a Volta GPU, select a cuTENSOR 2.1.x library with
-`TENFERRO_CUTENSOR_PATH`; tenferro rejects newer cuTENSOR versions before
-creating a library handle.
+On compute capability 7.0, select cuTENSOR 2.1.x with
+`TENFERRO_CUTENSOR_PATH`. tenferro rejects cuTENSOR 2.2 and newer because that
+combination has returned success with incorrect results.
 
 For XLA/PJRT GPU verification, add the PJRT plugin path separately:
 

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -171,6 +171,11 @@ CUDA operations implemented through NVIDIA libraries return typed load or
 provider errors when the required library is missing. They do not silently use
 a slower native CubeCL kernel as a CUDA fallback.
 
+cuTENSOR 2.2 and newer can return success with incorrect results on Volta
+(compute capability 7.0). On a Volta GPU, select a cuTENSOR 2.1.x library with
+`TENFERRO_CUTENSOR_PATH`; tenferro rejects newer cuTENSOR versions before
+creating a library handle.
+
 For XLA/PJRT GPU verification, add the PJRT plugin path separately:
 
 ```bash

--- a/docs/worklogs/2026-08-29-cutensor-volta-version-guard.md
+++ b/docs/worklogs/2026-08-29-cutensor-volta-version-guard.md
@@ -1,0 +1,50 @@
+# 2026-08-29 cuTENSOR Volta version guard
+
+## Scope
+
+PR #1733 reported all-zero cuTENSOR contraction results on a V100 even though
+the provider calls returned success. This follow-up prevents tenferro from
+using a cuTENSOR release on an architecture that release does not support.
+
+## Context read
+
+- PR #1733's V100 result and version boundary
+- `REPOSITORY_RULES.md` and `docs/design/gpu-backend-design.md`
+- the CUDA device discovery, runtime metadata, lazy cuTENSOR loader, contraction,
+  and permutation paths
+- NVIDIA's cuTENSOR 2.2 and 2.3 support and release documentation
+
+## Evidence and decision
+
+The cuTENSOR 2.2 documentation lists SM 7.0 as supported and deprecates that
+support. PR #1733 nevertheless reports that 118 of 120 output-mode
+permutations returned all-zero results on a V100 with cuTENSOR 2.2 and newer,
+while every provider status reported success. The cuTENSOR 2.3 release notes
+then remove SM 7.0, and its support table starts at SM 7.5.
+
+The guard rejects version 2.2.0 and newer on compute capability 7.0. This is
+stricter than NVIDIA's 2.2 support table because silent wrong results violate
+the backend contract. cuTENSOR 2.1.x remains the documented Volta path.
+
+The loader resolves `cutensorGetVersion`, checks the pure version/device rule,
+and returns a typed unsupported error before `cutensorCreate`. Turing and newer
+devices, plus cuTENSOR 2.1.x on Volta, keep the existing path. No native CubeCL
+fallback was added.
+
+Rejecting only cuTENSOR 2.3 would match NVIDIA's published support table but
+would leave the reproduced 2.2 wrong-result path enabled. Falling back to a
+native CubeCL contraction would violate the accepted vendor-provider contract.
+
+## Verification
+
+- Pure unit coverage pins cuTENSOR 2.1.x acceptance on SM 7.0, cuTENSOR 2.2.0
+  rejection on SM 7.0, and cuTENSOR 2.2.0 acceptance on SM 7.5.
+- GPU execution remains hardware-gated. A V100 with both cuTENSOR 2.2.x and
+  2.3.x is still needed to verify the complete loader and contraction path.
+  Do not relax the guard without a numerical matrix that covers every output
+  mode on cuTENSOR 2.1.x and the candidate newer release.
+
+## References
+
+- [NVIDIA cuTENSOR 2.2 support table](https://docs.nvidia.com/cuda/cutensor/2.2.0/index.html)
+- [NVIDIA cuTENSOR 2.3 release notes](https://docs.nvidia.com/cuda/cutensor/2.3.0/release_notes.html)

--- a/docs/worklogs/2026-08-29-cutensor-volta-version-guard.md
+++ b/docs/worklogs/2026-08-29-cutensor-volta-version-guard.md
@@ -1,48 +1,33 @@
 # 2026-08-29 cuTENSOR Volta version guard
 
-## Scope
+## Session summary
 
 PR #1733 reported all-zero cuTENSOR contraction results on a V100 even though
-the provider calls returned success. This follow-up prevents tenferro from
-using a cuTENSOR release on an architecture that release does not support.
+provider calls returned success. This PR rejects cuTENSOR 2.2 and newer on SM
+7.0 before handle creation and keeps cuTENSOR 2.1.x as the Volta path.
 
 ## Context read
 
-- PR #1733's V100 result and version boundary
-- `REPOSITORY_RULES.md` and `docs/design/gpu-backend-design.md`
-- the CUDA device discovery, runtime metadata, lazy cuTENSOR loader, contraction,
-  and permutation paths
-- NVIDIA's cuTENSOR 2.2 and 2.3 support and release documentation
+- PR #1733's V100 version bisect
+- the device metadata, lazy loader, contraction, and permutation paths
+- `REPOSITORY_RULES.md`, the GPU design and guide, and NVIDIA's cuTENSOR 2.2
+  and 2.3 documentation
 
 ## Evidence and decision
 
-The cuTENSOR 2.2 documentation lists SM 7.0 as supported and deprecates that
-support. PR #1733 nevertheless reports that 118 of 120 output-mode
-permutations returned all-zero results on a V100 with cuTENSOR 2.2 and newer,
-while every provider status reported success. The cuTENSOR 2.3 release notes
-then remove SM 7.0, and its support table starts at SM 7.5.
-
-The guard rejects version 2.2.0 and newer on compute capability 7.0. This is
-stricter than NVIDIA's 2.2 support table because silent wrong results violate
-the backend contract. cuTENSOR 2.1.x remains the documented Volta path.
-
-The loader resolves `cutensorGetVersion`, checks the pure version/device rule,
-and returns a typed unsupported error before `cutensorCreate`. Turing and newer
-devices, plus cuTENSOR 2.1.x on Volta, keep the existing path. No native CubeCL
-fallback was added.
-
-Rejecting only cuTENSOR 2.3 would match NVIDIA's published support table but
-would leave the reproduced 2.2 wrong-result path enabled. Falling back to a
-native CubeCL contraction would violate the accepted vendor-provider contract.
+NVIDIA lists SM 7.0 as supported but deprecated in cuTENSOR 2.2 and removes it
+in 2.3. The reproduced 2.2 wrong-result path makes the empirical boundary the
+safer contract. The existing lazy loader is the single boundary shared by
+contraction and permutation, so the guard belongs there. No native fallback is
+added.
 
 ## Verification
 
-- Pure unit coverage pins cuTENSOR 2.1.x acceptance on SM 7.0, cuTENSOR 2.2.0
-  rejection on SM 7.0, and cuTENSOR 2.2.0 acceptance on SM 7.5.
-- GPU execution remains hardware-gated. A V100 with both cuTENSOR 2.2.x and
-  2.3.x is still needed to verify the complete loader and contraction path.
-  Do not relax the guard without a numerical matrix that covers every output
-  mode on cuTENSOR 2.1.x and the candidate newer release.
+- Unit coverage pins both sides of the 2.2 boundary on SM 7.0 and acceptance on
+  SM 7.5.
+- On an A800 (SM 8.0), CUDA 12.1 and cuTENSOR 2.3.1 passed targeted
+  `dot_general` and permutation tests through the real provider.
+- A V100 remains necessary for end-to-end rejection coverage.
 
 ## References
 


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs #1733

## Summary

PR #1733 reproduced silent all-zero contraction results on a V100 with
cuTENSOR 2.2 and newer while every provider call returned success. This PR:

- resolves `cutensorGetVersion` in the existing dynamic loader;
- rejects cuTENSOR 2.2 and newer on SM 7.0 before `cutensorCreate`;
- returns a typed `Unsupported` error that recommends cuTENSOR 2.1.x; and
- keeps cuTENSOR 2.2 and newer available on SM 7.5 and newer.

The guard is centralized in the lazy loader used by both contraction and
floating or complex permutation. No native CubeCL fallback was added.

NVIDIA still [lists SM 7.0 in the cuTENSOR 2.2 support
table](https://docs.nvidia.com/cuda/cutensor/2.2.0/index.html), then [removes it
in 2.3](https://docs.nvidia.com/cuda/cutensor/2.3.0/release_notes.html). The
stricter boundary follows the reproduced wrong-result matrix.

The bug-fix scope gate was applied. This changes no public API, dependency,
feature, backend, or operation family.

## Work log

[2026-08-29 cuTENSOR Volta version guard](docs/worklogs/2026-08-29-cutensor-volta-version-guard.md)

## Verification

Passed locally:

```text
python3 scripts/ci/run_profile.py fmt
cargo test -p tenferro-gpu --features cuda cubecl::ffi::cutensor::tests
cargo clippy -p tenferro-gpu --features cuda --all-targets -- -D warnings
python3 scripts/repository-rules-review.py --base origin/main --head HEAD \
  --output-json /tmp/repository-rules-review-cutensor-volta-cleanup.json \
  --dry-run --llm-skipped-reason "local deterministic review"
```

Passed over SSH on an A800 with CUDA 12.1 and cuTENSOR 2.3.1:

```text
cargo +1.96.0 test -p tenferro-gpu --features cuda \
  test_dot_general_matmul_f32 -- --ignored --nocapture
cargo +1.96.0 test -p tenferro-gpu --features cuda \
  cuda_cutensor_permutation_transpose_and_to_contiguous_match_cpu \
  -- --ignored --nocapture
```

The full local fast gate reaches workspace clippy, then fails on unchanged
macOS-only warnings in `tenferro-fft` tests: two unused variables in
`apple_cpu.rs` and one unused import in `webgpu_metal_fft.rs`.

Not run: end-to-end rejection on a V100. The pure regression test covers the
SM 7.0 version boundary; the A800 tests cover the accepted loader, contraction,
and permutation paths.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
