### PR TITLE
release: prepare tenferro v0.4.0

### DIFF
--- a/.agents/skills/tenferro-release-publish/SKILL.md
+++ b/.agents/skills/tenferro-release-publish/SKILL.md
@@ -21,9 +21,11 @@ Keep the interaction incremental:
 1. Derive and present the canonical workflow's SemVer proposal before editing;
    stop for explicit confirmation when the requested target differs.
 2. Phase 1: version-bump PR (workspace version plus every internal
-   cross-crate `version = "..."` requirement) and the full pre-push
-   checklist.
-3. Phase 2: tag the merged commit and push the tag.
+   cross-crate `version = "..."` requirement), curated user-facing GitHub
+   release notes, and the full pre-push checklist. Release notes describe only
+   shipped outcomes, never experiments or implementation history.
+3. Phase 2: tag the merged commit, push the tag, and create the GitHub release
+   from the reviewed notes file.
 4. At Phase 3, stop after validation; a human maintainer runs Phase 3
    publication from the tag. The maintainer can generate a guarded handoff
    script with

--- a/.claude/skills/tenferro-release-publish/SKILL.md
+++ b/.claude/skills/tenferro-release-publish/SKILL.md
@@ -21,9 +21,11 @@ Keep the interaction incremental:
 1. Derive and present the canonical workflow's SemVer proposal before editing;
    stop for explicit confirmation when the requested target differs.
 2. Phase 1: version-bump PR (workspace version plus every internal
-   cross-crate `version = "..."` requirement) and the full pre-push
-   checklist.
-3. Phase 2: tag the merged commit and push the tag.
+   cross-crate `version = "..."` requirement), curated user-facing GitHub
+   release notes, and the full pre-push checklist. Release notes describe only
+   shipped outcomes, never experiments or implementation history.
+3. Phase 2: tag the merged commit, push the tag, and create the GitHub release
+   from the reviewed notes file.
 4. At Phase 3, stop after validation; a human maintainer runs Phase 3
    publication from the tag. The maintainer can generate a guarded handoff
    script with

--- a/.github/releases/v0.4.0.md
+++ b/.github/releases/v0.4.0.md
@@ -1,0 +1,43 @@
+# tenferro v0.4.0
+
+v0.4.0 expands session-owned execution, downstream extension authoring, autodiff, and einsum while substantially improving CPU indexing and CUDA small-operation paths.
+
+## Upgrade notes
+
+- Direct tensor execution now centers on explicit backend sessions and operation-family extension traits. Code using removed free functions or older module paths should follow the [API migration guide](https://tensor4all.org/tenferro-rs/getting-started/api-migration.html).
+- Custom runtimes must install the extension modules they execute; missing registration reports a typed error rather than silently falling back.
+- Update tenferro dependencies together to `0.4` so internal crate versions remain aligned.
+
+## Highlights
+
+- Added a stable out-of-tree extension-authoring facade, generated runtime support, borrowed `TensorRead` execution, and structured runtime failure diagnostics ([#1714](https://github.com/tensor4all/tenferro-rs/pull/1714)).
+- Added ordered multi-input traced `jvp_many` and `vjp_many`, with shared derivative graphs and checked semantic residual access ([#1714](https://github.com/tensor4all/tenferro-rs/pull/1714)).
+- Added NumPy-style flat ellipsis notation to concrete, eager, traced, cached, and differentiable einsum paths ([#1705](https://github.com/tensor4all/tenferro-rs/pull/1705)).
+- Added caller-managed admission for externally supplied CPU executors while preserving explicit placement and re-entry checks ([#1717](https://github.com/tensor4all/tenferro-rs/pull/1717)).
+- Added values-only SVD APIs, borrowed linalg hooks, scoped faer parallelism, a CUDA execution tutorial, and expanded migration documentation ([#1703](https://github.com/tensor4all/tenferro-rs/pull/1703)).
+
+## Performance
+
+- CPU gather, scatter, dynamic slice/update, reductions, padding, and integer preflight now use the latest prepared strided replay paths. Paired repository benchmarks showed multi-fold improvements for representative high-rank workloads ([#1722](https://github.com/tensor4all/tenferro-rs/pull/1722), [#1725](https://github.com/tensor4all/tenferro-rs/pull/1725), [#1726](https://github.com/tensor4all/tenferro-rs/pull/1726), [#1727](https://github.com/tensor4all/tenferro-rs/pull/1727)).
+- Eager and session execution avoids several redundant engine, Rayon-pool, reshape, and extension-dispatch entries; linalg solve uses a single eager operation.
+- CUDA adds direct cuBLAS `vdot`, norm-squared, and fused AXPBY paths, bounded per-stream vendor resources, pinned small-payload readback, and lower cuTENSOR plan/launch overhead ([#1733](https://github.com/tensor4all/tenferro-rs/pull/1733)). Actual gains remain workload-, shape-, and device-dependent.
+
+## Fixes
+
+- Eager AD now preserves dtype promotion, concatenate shapes, semantic metadata scopes, and deferred graph state across the affected paths.
+- Faer full-pivot LU singularity detection is invariant under nonzero scaling for real and complex dtypes ([#1703](https://github.com/tensor4all/tenferro-rs/pull/1703)).
+- CUDA rejects cuTENSOR 2.2 and newer on Volta SM 7.0, where testing reproduced silent incorrect contraction results despite successful provider calls ([#1734](https://github.com/tensor4all/tenferro-rs/pull/1734)).
+- CUDA vendor-call buffer retention, stream retirement, handle locking, and scalar-readback failure paths now preserve asynchronous resource lifetimes ([#1733](https://github.com/tensor4all/tenferro-rs/pull/1733)).
+
+## Documentation
+
+- Added practical ndarray/nalgebra and faer/BLAS-LAPACK interoperability guidance, API-selection and migration guides, custom-extension examples, and CPU/CUDA tutorials.
+- Updated the bundled coding-agent skill and `llms.txt` routing to the current public API.
+
+## Known limitations
+
+- On Volta SM 7.0, use cuTENSOR 2.1.x; tenferro intentionally rejects cuTENSOR 2.2 and newer on that architecture.
+- HIP/ROCm remains unavailable. CUDA support still excludes the operation/dtype combinations documented in the [GPU guide](https://tensor4all.org/tenferro-rs/guides/devices-and-gpu.html).
+- Cross-stream raw CUDA vendor calls require a completion barrier; noncontiguous BLAS-1 read operands may require same-device canonicalization.
+
+**Full changelog:** https://github.com/tensor4all/tenferro-rs/compare/v0.3.0...v0.4.0

--- a/.kimi/skills/tenferro-release-publish/SKILL.md
+++ b/.kimi/skills/tenferro-release-publish/SKILL.md
@@ -21,9 +21,11 @@ Keep the interaction incremental:
 1. Derive and present the canonical workflow's SemVer proposal before editing;
    stop for explicit confirmation when the requested target differs.
 2. Phase 1: version-bump PR (workspace version plus every internal
-   cross-crate `version = "..."` requirement) and the full pre-push
-   checklist.
-3. Phase 2: tag the merged commit and push the tag.
+   cross-crate `version = "..."` requirement), curated user-facing GitHub
+   release notes, and the full pre-push checklist. Release notes describe only
+   shipped outcomes, never experiments or implementation history.
+3. Phase 2: tag the merged commit, push the tag, and create the GitHub release
+   from the reviewed notes file.
 4. At Phase 3, stop after validation; a human maintainer runs Phase 3
    publication from the tag. The maintainer can generate a guarded handoff
    script with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 rust-version = "1.96"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Add the runtime, CPU backend, and linear algebra extension crates:
 
 ```toml
 [dependencies]
-tenferro-runtime = "0.3"
-tenferro-cpu = "0.3"
-tenferro-linalg = "0.3"
+tenferro-runtime = "0.4"
+tenferro-cpu = "0.4"
+tenferro-linalg = "0.4"
 ```
 
 <!-- snippet-source: docs/tutorial-code/src/bin/direct_linalg_quickstart.rs -->
@@ -113,9 +113,9 @@ or `jvp`:
 
 ```toml
 [dependencies]
-tenferro-runtime = "0.3"
-tenferro-cpu = "0.3"
-tenferro-ad = "0.3"
+tenferro-runtime = "0.4"
+tenferro-cpu = "0.4"
+tenferro-ad = "0.4"
 ```
 
 <!-- snippet-source: docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs -->

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -79,7 +79,15 @@ Complete this phase before changing manifests or making any other release edit.
    must name the new version. A `"0.2"`-style pin never admits `0.3`, so a
    copy-paste user would resolve the previous minor against the current
    quickstart code.
-5. Verify locally:
+5. Add `.github/releases/vX.Y.Z.md` containing curated GitHub release notes
+   based on merged changes since the matching provenance tag. Describe only
+   shipped, user-visible outcomes: breaking changes and migration steps,
+   features, verified performance changes, fixes, documentation, and known
+   limitations. Do not include experiments, abandoned approaches, debugging or
+   CI history, agent activity, review rounds, or other implementation process.
+   Link relevant PRs for detail and include the full tag comparison URL. Review
+   this file as part of the version-bump PR.
+6. Verify locally:
 
    ```bash
    cargo metadata --format-version 1 > /dev/null   # resolution sanity
@@ -90,13 +98,23 @@ Complete this phase before changing manifests or making any other release edit.
    `cargo publish --dry-run` works only for crates whose internal
    dependencies are already on the registry at the new version, so deep
    crates are verified live in Phase 3; that is expected.
-6. Open the PR to `main` and merge it through the normal auto-merge flow.
+7. Open the PR to `main` and merge it through the normal auto-merge flow.
 
-## Phase 2 — Tag
+## Phase 2 — Tag And GitHub Release
 
 1. `git fetch origin main` and identify the merged bump commit.
 2. `git tag vX.Y.Z <merged-commit> && git push origin vX.Y.Z`.
-3. Recommended: `gh release create vX.Y.Z --generate-notes`.
+3. Publish the reviewed notes from the tagged tree:
+
+   ```bash
+   gh release create vX.Y.Z --verify-tag \
+     --title "tenferro vX.Y.Z" \
+     --notes-file .github/releases/vX.Y.Z.md
+   ```
+
+   Verify the resulting GitHub release body matches the reviewed file. Do not
+   replace curated notes with `--generate-notes`; generated notes may be used
+   only to check that no user-visible merged PR was omitted.
 4. Record the tag commit SHA (`git rev-parse vX.Y.Z`) and the required CI job
    names (the workspace gate jobs that must pass before publication, e.g.
    `workspace-faer`, `workspace-blas`, `extensions`, `docs`, `coverage`,

--- a/crates/tenferro-ad/Cargo.toml
+++ b/crates/tenferro-ad/Cargo.toml
@@ -44,11 +44,11 @@ webgpu = ["dep:tenferro-gpu", "tenferro-gpu/webgpu"]
 rocm = ["dep:tenferro-gpu", "tenferro-gpu/rocm"]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false, features = ["autodiff"] }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.3.0", default-features = false, optional = true }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false, features = ["autodiff"] }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
 computegraph.workspace = true
 lru.workspace = true
 num-complex.workspace = true

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -45,10 +45,10 @@ blas-mkl = [
 ]
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.3.0" }
-tenferro-internal-cpu-kernels = { path = "../tenferro-internal-cpu-kernels", version = "0.3.0" }
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0" }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
+tenferro-internal-cpu-kernels = { path = "../tenferro-internal-cpu-kernels", version = "0.4.0" }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0" }
 num-complex.workspace = true
 num-traits.workspace = true
 rayon.workspace = true

--- a/crates/tenferro-einsum/Cargo.toml
+++ b/crates/tenferro-einsum/Cargo.toml
@@ -65,13 +65,13 @@ rocm = [
 ]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
-tenferro-ad = { path = "../tenferro-ad", version = "0.3.0", default-features = false, optional = true }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.3.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.3.0", default-features = false, optional = true }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-ad = { path = "../tenferro-ad", version = "0.4.0", default-features = false, optional = true }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
 computegraph.workspace = true
 lru.workspace = true
 omeco.workspace = true
@@ -79,7 +79,7 @@ smallvec.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
 criterion.workspace = true
 num-complex.workspace = true
 

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -44,13 +44,13 @@ webgpu = [
 ]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
-tenferro-ad = { path = "../tenferro-ad", version = "0.3.0", default-features = false, optional = true }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.3.0", default-features = false, optional = true }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.3.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-ad = { path = "../tenferro-ad", version = "0.4.0", default-features = false, optional = true }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
 libloading = { workspace = true, optional = true }
 computegraph.workspace = true
 num-complex.workspace = true

--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -55,10 +55,10 @@ webgpu = [
 rocm = []
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.3.0" }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false }
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
 cubecl = { workspace = true, optional = true }
 cubecl-cuda = { workspace = true, optional = true }
 cubecl-common = { workspace = true, optional = true }

--- a/crates/tenferro-internal-cpu-kernels/Cargo.toml
+++ b/crates/tenferro-internal-cpu-kernels/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 name = "tenferro_internal_cpu_kernels"
 
 [dependencies]
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0" }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0" }
 num-complex.workspace = true
 num-traits.workspace = true
 strided-kernel.workspace = true

--- a/crates/tenferro-internal-ops/Cargo.toml
+++ b/crates/tenferro-internal-ops/Cargo.toml
@@ -29,9 +29,9 @@ webgpu = []
 rocm = []
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.3.0" }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.3.0" }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
 computegraph.workspace = true
 num-complex.workspace = true
 thiserror.workspace = true

--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -74,13 +74,13 @@ rocm = ["tenferro-ad?/rocm", "tenferro-internal-ops/rocm"]
 webgpu = ["dep:tenferro-gpu", "tenferro-gpu/webgpu"]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
-tenferro-ad = { path = "../tenferro-ad", version = "0.3.0", default-features = false, optional = true }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.3.0", default-features = false, optional = true }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.3.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.3.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-ad = { path = "../tenferro-ad", version = "0.4.0", default-features = false, optional = true }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
 cblas-sys = { workspace = true, optional = true }
 cblas-inject = { workspace = true, optional = true }
 computegraph = { workspace = true, optional = true }

--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -31,10 +31,10 @@ blas-accelerate = ["tenferro-cpu/blas-accelerate"]
 blas-mkl = ["tenferro-cpu/blas-mkl"]
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.3.0" }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.3.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
 computegraph.workspace = true
 lru.workspace = true
 num-complex.workspace = true

--- a/crates/tenferro-tensor/Cargo.toml
+++ b/crates/tenferro-tensor/Cargo.toml
@@ -25,12 +25,12 @@ name = "tenferro_tensor"
 default = []
 
 [dependencies]
-tenferro-tensor-core = { path = "../tenferro-tensor-core", version = "0.3.0" }
+tenferro-tensor-core = { path = "../tenferro-tensor-core", version = "0.4.0" }
 num-traits.workspace = true
 num-complex.workspace = true
 smallvec.workspace = true
 strided-kernel.workspace = true
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.3.0" }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/tenferro-xla/Cargo.toml
+++ b/crates/tenferro-xla/Cargo.toml
@@ -27,9 +27,9 @@ default = []
 pjrt = ["dep:libloading"]
 
 [dependencies]
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.3.0", default-features = false }
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.3.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.3.0", default-features = false }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
 computegraph.workspace = true
 libloading = { workspace = true, optional = true }
 sha2.workspace = true

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -38,9 +38,9 @@ extension from crates.io:
 
 ```toml
 [dependencies]
-tenferro-runtime = "0.3"
-tenferro-cpu = "0.3"
-tenferro-linalg = "0.3"
+tenferro-runtime = "0.4"
+tenferro-cpu = "0.4"
+tenferro-linalg = "0.4"
 ```
 
 For development against a local checkout of this repository, use path
@@ -188,9 +188,9 @@ Add `tenferro-ad` when the same tensor stack needs graph-based derivatives:
 
 ```toml
 [dependencies]
-tenferro-runtime = "0.3"
-tenferro-cpu = "0.3"
-tenferro-ad = "0.3"
+tenferro-runtime = "0.4"
+tenferro-cpu = "0.4"
+tenferro-ad = "0.4"
 ```
 
 <!-- snippet-source: docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs -->

--- a/docs/worklogs/2026-08-30-v0.4.0-release-preparation.md
+++ b/docs/worklogs/2026-08-30-v0.4.0-release-preparation.md
@@ -1,0 +1,41 @@
+# tenferro v0.4.0 release preparation
+
+## Session summary
+
+Prepared the workspace for v0.4.0 and added curated GitHub release notes to the canonical release workflow. The release notes describe shipped user-visible outcomes only; implementation and review history remain in worklogs and linked pull requests.
+
+## Context read
+
+- `AGENTS.md`, `REPOSITORY_RULES.md`, and the shared repository, Rust, documentation, numerical, and performance rules
+- `.agents/skills/tenferro-release-publish/SKILL.md`
+- `ai/contribution-workflows/release-publish.md`
+- merged changes and pull requests since v0.3.0
+- current API migration, CPU, CUDA, extension, einsum, linalg, and AD documentation
+
+## Baseline and target
+
+All 14 publishable crates report 0.3.0 as their latest stable crates.io version. Every downloaded 0.3.0 archive records Git commit `9505d5bfd60c890212f0ec44aa9cf07fef185f63`, the v0.3.0 tag target. Merged public features since that tag require v0.4.0 under the repository SemVer policy.
+
+## Decisions
+
+1. Store reviewed release notes at `.github/releases/vX.Y.Z.md` and publish that exact file with `gh release create --notes-file`.
+2. Keep release notes user-facing: include shipped behavior, migration guidance, verified performance results, fixes, documentation, and known limitations; exclude experiments, abandoned approaches, CI/debug history, agent activity, and review chronology.
+3. Update the workspace version, every versioned internal path dependency, and copy-paste dependency snippets together.
+4. Keep publication human-only through the existing guarded handoff script.
+
+## Verification
+
+- crates.io baseline and `.cargo_vcs_info.json` provenance for all publishable crates
+- current git-pinned dependency versions exist on crates.io
+- exact-origin-main CI check inventory is green
+- `cargo metadata --format-version 1`
+- `python3 scripts/check-publish-layout.py`
+- publish-layout, release-helper, release-validation-policy, guide-dependency, formatting, doc-snippet, and full fast-PR checks
+- workspace and standalone-extension CI-parity clippy through `scripts/check-pr-fast.sh`
+
+## Remaining steps and risks
+
+- The version-bump PR must merge before tagging.
+- Required CI must pass on the exact tagged commit.
+- A human maintainer must run the guarded publication handoff; the agent must not publish.
+- Post-publication verification must match crates.io archives to the pushed tag before the release is closed.


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Release preparation for v0.4.0.

## Summary

- bump the workspace and every versioned internal path dependency from 0.3.0 to 0.4.0;
- update copy-paste dependency snippets to the 0.4 release line;
- add reviewed, user-facing GitHub release notes at `.github/releases/v0.4.0.md`;
- update the canonical release workflow and skill mirrors to publish curated notes with `--notes-file` and exclude experiments or implementation history.

SemVer evidence: all 14 publishable crates have a consistent 0.3.0 crates.io baseline from tag commit `9505d5bfd60c890212f0ec44aa9cf07fef185f63`; merged public features since that tag require 0.4.0 under the repository policy.

## Work log

[`docs/worklogs/2026-08-30-v0.4.0-release-preparation.md`](docs/worklogs/2026-08-30-v0.4.0-release-preparation.md)

## Verification

- `cargo metadata --format-version 1`
- `python3 scripts/check-publish-layout.py`
- `python3 scripts/test-check-publish-layout.py`
- `python3 scripts/test-release-publish.py`
- `python3 scripts/test-release-validation-policy.py`
- `python3 scripts/check-guide-dependency-snippets.py`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'python3 scripts/test-release-publish.py'`
- committed-head deterministic repository-rules review: pass
- all current git-pinned dependency package versions verified present on crates.io

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules review (deterministic; the external LLM review is permanently disabled) and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. (Not applicable.)
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`. (Not a bug fix.)
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
