### PR TITLE
docs(cuda): add NVIDIA library compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,9 @@ Selected deep dives:
   — static-rank views, mutable disjointness, and explicit `duplicate()`.
 - [Devices and GPU](https://tensor4all.org/tenferro-rs/guides/devices-and-gpu.html)
   — explicit CPU, CUDA, and experimental WebGPU control; tensors never move
-  between devices silently.
+  between devices silently. Its [CUDA compatibility matrix](https://tensor4all.org/tenferro-rs/guides/devices-and-gpu.html#cuda-and-nvidia-library-compatibility)
+  lists the supported and CI-tested driver, runtime, cuTENSOR, cuBLAS,
+  cuSOLVER, and cuFFT combinations.
 - [Dynamic and symbolic shapes](https://tensor4all.org/tenferro-rs/design/dynamic-symbolic-shapes.html)
   — how runtime-dependent dimensions work in traced programs.
 - [XLA and PJRT](https://tensor4all.org/tenferro-rs/guides/xla.html)

--- a/docs/guides/choosing-a-backend.md
+++ b/docs/guides/choosing-a-backend.md
@@ -20,8 +20,9 @@ CUDA does not use a native CubeCL kernel as a silent fallback when a required
 NVIDIA library is unavailable. The operation returns a typed library/provider
 error instead. XLA likewise rejects an unavailable plugin or unsupported
 lowering instead of changing execution backends behind the caller's back. See
-[Devices and GPU](devices-and-gpu.md) and [XLA and PJRT](xla.md) for setup and
-operation coverage.
+the [CUDA and NVIDIA library compatibility matrix](devices-and-gpu.md#cuda-and-nvidia-library-compatibility)
+for supported and CI-tested CUDA stacks, [Devices and GPU](devices-and-gpu.md)
+for operation coverage, and [XLA and PJRT](xla.md) for PJRT setup.
 
 The hardware-gated two-CUDA-device identity and execution evidence can be run
 with:

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -142,11 +142,32 @@ the backend-owned cuTENSOR permutation plan cache. The source and destination
 must be distinct allocations. CUDA does not silently fall back when the
 required NVIDIA library stack is unavailable; the operation returns a typed
 library/provider error instead.
-CUDA 12.4 is the minimum supported driver/NVRTC runtime. CUDA 12.8 or newer
-enables all CubeCL features supported by the GPU, including the 12.8 tensor-map
-extensions. tenferro compiles against CUDA 12.8 cudarc bindings, but resolves
-driver functions dynamically and gates newer functions using the versions of
-the driver and NVRTC loaded at runtime.
+
+## CUDA and NVIDIA library compatibility
+
+“Supported” below is tenferro's runtime contract. “Loader ABI” only means the
+loader probes that soname and required symbols; it does not make every library
+with that soname, or a complete CUDA 11 stack, supported. “CI-tested” records
+the package family or exact archive used by the current GPU workflows.
+
+| Component | Supported runtime contract | Loader ABI | CI-tested setup | Override |
+| --- | --- | --- | --- | --- |
+| NVIDIA driver API | CUDA 12.4 minimum; CUDA 12.8 or newer enables the complete CubeCL feature set, including 12.8 tensor-map extensions | Loaded dynamically through `cudarc`; the selected NVRTC must not be newer than the driver API | RunPod accepts 12.4-or-newer drivers and selects a matching 12.4 or 12.8 runtime tier | System driver; no tenferro override |
+| CUDA runtime and NVRTC | 12.4 baseline; 12.8 full-capability tier | CUDA 12.x runtime/NVRTC libraries | `cuda-cudart-12-4`/`cuda-nvrtc-12-4` and `cuda-cudart-12-8`/`cuda-nvrtc-12-8` runtime trees | `CUDA_PATH`, `LD_LIBRARY_PATH` |
+| cuTENSOR | CUDA 12 build using the v2 API; on compute capability 7.0, use 2.1.x because tenferro rejects 2.2 and newer on that GPU | `libcutensor.so.2`, then `libcutensor.so` | cuTENSOR `2.6.0.4` CUDA 12 archive | `TENFERRO_CUTENSOR_PATH` |
+| cuBLAS | CUDA 12 library matching the selected runtime tier | `libcublas.so.12`, then `libcublas.so` | `libcublas-12-4` and `libcublas-12-8` package families; patch version follows NVIDIA's package repository | `TENFERRO_CUBLAS_PATH` |
+| cuSOLVER | CUDA 12 library matching the selected runtime tier | `libcusolver.so.12`, then `.so.11` and unversioned candidates; the `.so.11` probe alone does not make CUDA 11 a supported stack | `libcusolver-12-4` and `libcusolver-12-8` package families; patch version follows NVIDIA's package repository | `TENFERRO_CUSOLVER_PATH` |
+| cuFFT | CUDA 12 uses the cuFFT 11 ABI | `libcufft.so.11`, then `.so.10` and unversioned candidates; the `.so.10` probe alone does not make CUDA 11 a supported stack | Not separately version-pinned by GPU CI; loader tests verify the search order | `TENFERRO_CUFFT_PATH` |
+
+The current CI values are defined in
+[`ci-cache-publish.yml`](https://github.com/tensor4all/tenferro-rs/blob/main/.github/workflows/ci-cache-publish.yml)
+and [`runpod-gpu-test.yml`](https://github.com/tensor4all/tenferro-rs/blob/main/.github/workflows/runpod-gpu-test.yml).
+Use NVIDIA's [CUDA compatibility documentation](https://docs.nvidia.com/deploy/cuda-compatibility/)
+to map a driver release to the CUDA API levels it supports; tenferro's 12.4
+minimum can be narrower than NVIDIA's general minor-version compatibility.
+tenferro compiles against CUDA 12.8 `cudarc` bindings, resolves driver
+functions dynamically, and gates newer functions using the loaded driver and
+NVRTC versions.
 
 Use the installed CUDA root on your machine. If several roots exist, inspect
 them first:
@@ -164,6 +185,7 @@ export LD_LIBRARY_PATH=$CUDA_PATH/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12
 export TENFERRO_CUTENSOR_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12/libcutensor.so.2
 export TENFERRO_CUSOLVER_PATH=$CUDA_PATH/lib64/libcusolver.so.12
 export TENFERRO_CUBLAS_PATH=$CUDA_PATH/lib64/libcublas.so.12
+export TENFERRO_CUFFT_PATH=$CUDA_PATH/lib64/libcufft.so.11
 export CUBECL_DEBUG_LOG=0
 ```
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -10,8 +10,10 @@ CUDA_PATH=/usr/local/cuda-12.4
 LD_LIBRARY_PATH=/usr/local/cuda-12.4/lib64:$LD_LIBRARY_PATH
 ```
 
-CUDA 12.4 is the minimum runtime. Use a CUDA 12.8-or-newer driver and NVRTC to
-enable the complete CubeCL capability set.
+Choose a matched driver, runtime, NVRTC, and vendor-library stack from the
+[CUDA and NVIDIA library compatibility matrix](devices-and-gpu.md#cuda-and-nvidia-library-compatibility).
+The matrix distinguishes tenferro's minimum, loader ABI candidates, and the
+versions exercised by CI.
 
 For non-standard installs, set the exact library paths:
 
@@ -19,6 +21,7 @@ For non-standard installs, set the exact library paths:
 TENFERRO_CUTENSOR_PATH=/opt/cuda/lib64/libcutensor.so.2
 TENFERRO_CUSOLVER_PATH=/opt/cuda/lib64/libcusolver.so.12
 TENFERRO_CUBLAS_PATH=/opt/cuda/lib64/libcublas.so.12
+TENFERRO_CUFFT_PATH=/opt/cuda/lib64/libcufft.so.11
 ```
 
 ## Unsupported PTX Version

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ compilation, CUDA, or experimental WebGPU only when the workflow needs them.
 | Choosing between `TypedTensor`, `Tensor`, `EagerTensor`, and `TracedTensor` | [Choosing a Tensor API](guides/choosing-an-api.md) |
 | Understanding direct, eager, and traced execution | [Execution Models](guides/execution-models.md) |
 | Column-major storage and row-major import/export | [Memory Order](guides/memory-order.md) |
-| CPU, CUDA, and experimental WebGPU backend behavior | [Devices and GPU](guides/devices-and-gpu.md) |
+| CPU, CUDA, and experimental WebGPU behavior; NVIDIA library compatibility | [Devices and GPU](guides/devices-and-gpu.md#cuda-and-nvidia-library-compatibility) |
 | CPU affinity, NUMA placement, faer, and external BLAS behavior | [CPU Execution and NUMA Placement](guides/cpu-execution.md) |
 | Static-shaped StableHLO and PJRT plugin loading | [XLA and PJRT](guides/xla.md) |
 | Runtime-dependent dimensions in traced graphs | [Dynamic and symbolic shapes](design/dynamic-symbolic-shapes.md) |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -34,7 +34,7 @@
 - [Autodiff](https://tensor4all.org/tenferro-rs/guides/autodiff.html): Describes eager `backward()` and functional or traced `grad`, `vjp`, and `jvp` workflows.
 - [Parallelism and Caching](https://tensor4all.org/tenferro-rs/guides/parallelism-and-caching.html): WARNING — backend/runtime instances own thread pools and caches; per-call construction throws them away.
 - [Memory Order](https://tensor4all.org/tenferro-rs/guides/memory-order.html): WARNING — buffers are column-major; row-major data passed to `from_vec_col_major` is silently reinterpreted as column-major (wrong values), never rejected.
-- [Devices and GPU](https://tensor4all.org/tenferro-rs/guides/devices-and-gpu.html): Documents explicit CPU/GPU placement and transfer boundaries plus CUDA and WebGPU capability coverage.
+- [Devices and GPU](https://tensor4all.org/tenferro-rs/guides/devices-and-gpu.html): Documents explicit CPU/GPU placement, transfer boundaries, CUDA/WebGPU capability coverage, and the supported versus CI-tested CUDA, cuTENSOR, cuBLAS, cuSOLVER, and cuFFT compatibility matrix.
 - [Custom CUDA kernels](https://tensor4all.org/tenferro-rs/guides/custom-cuda-kernels.html): Downstream PTX, CUBIN, NVRTC, raw tensor borrowing, stream ordering, and launch safety through the public CUDA extension API.
 - [Troubleshooting](https://tensor4all.org/tenferro-rs/guides/troubleshooting.html): Covers feature selection, BLAS providers, CUDA setup, workspace traps, and common runtime failures.
 

--- a/docs/worklogs/2026-08-31-cuda-library-compatibility.md
+++ b/docs/worklogs/2026-08-31-cuda-library-compatibility.md
@@ -1,0 +1,44 @@
+# CUDA library compatibility documentation
+
+## Summary
+
+Implemented issue #1738 by adding one user-facing compatibility matrix for the
+CUDA driver/runtime, NVRTC, cuTENSOR, cuBLAS, cuSOLVER, and cuFFT. README,
+`llms.txt`, the documentation landing page, backend selection, and
+troubleshooting now route readers to that matrix.
+
+## Sources reviewed
+
+- CUDA library loaders in `tenferro-gpu`, `tenferro-linalg`, and `tenferro-fft`
+- `.github/workflows/ci-cache-publish.yml`
+- `.github/workflows/runpod-gpu-test.yml`
+- `scripts/ci/install_cuda_runtime_tree.sh`
+- Existing GPU, backend-selection, and troubleshooting guides
+- NVIDIA CUDA compatibility documentation
+
+## Decisions
+
+- Separate tenferro's supported runtime contract from loader soname probing and
+  CI-tested package versions. A loadable soname is not presented as a support
+  guarantee.
+- Keep CUDA 12.4 as the baseline and CUDA 12.8 as the full-capability tier.
+- Record exact CI evidence only where it is pinned: cuTENSOR `2.6.0.4`. For
+  cuBLAS and cuSOLVER, name the NVIDIA package families because CI does not pin
+  their patch versions. State explicitly that cuFFT is not separately pinned.
+- Keep the matrix in the existing Devices and GPU guide instead of creating a
+  new page, so current README, docs sidebar, and `llms.txt` routes remain the
+  shortest path.
+
+## Verification
+
+- `bash scripts/check-pr-fast.sh`
+- `bash scripts/build_docs_site.sh`
+- `python3 scripts/check-docs-site.py --root-dir .`
+- Source-blind review of the rendered Devices and GPU page; its one finding, a
+  missing blank line that prevented the compatibility heading from rendering,
+  was fixed and the heading/TOC anchor was rechecked.
+
+## Remaining limits
+
+The matrix reports the tested package families rather than promising every
+vendor patch release. Future CUDA CI version changes must update the table.


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] Documentation
- [ ] Refactor / cleanup
- [x] Implementation of accepted issue

## Related issue

Fixes #1738

## Summary

- add one CUDA/NVIDIA compatibility matrix that separates supported runtime policy, loader ABI candidates, and CI-tested versions
- cover CUDA/NVRTC, cuTENSOR, cuBLAS, cuSOLVER, and cuFFT, including path overrides and the SM 7.0 cuTENSOR restriction
- route readers from README, the docs landing page, backend selection, troubleshooting, and `llms.txt`

## Work log

[`docs/worklogs/2026-08-31-cuda-library-compatibility.md`](docs/worklogs/2026-08-31-cuda-library-compatibility.md)

## Verification

- `bash scripts/check-pr-fast.sh`
- `bash scripts/build_docs_site.sh`
- `python3 scripts/check-docs-site.py --root-dir .`
- rendered-page source-blind audit; finding fixed and heading/TOC anchor rechecked
- deterministic repository-rules review: pass

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules review (deterministic; the external LLM review is permanently disabled) and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md` (not applicable; documentation only).
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
