### PR TITLE
fix(cuda): preserve small resources under cache pressure

### DIFF
--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -646,6 +646,12 @@ impl CudaExtensionCache {
         if let Some(entry) = inner.entries.get_mut(&type_id) {
             entry.retained_bytes = retained_bytes;
             inner.refresh_retained_bytes();
+            if inner.retained_bytes > inner.max_retained_bytes.get() {
+                inner.entries.remove(&type_id);
+                inner.order.retain(|candidate| *candidate != type_id);
+                inner.stats.evictions = inner.stats.evictions.saturating_add(1);
+                inner.refresh_retained_bytes();
+            }
             inner.evict_to_limit();
         }
         Ok(())

--- a/crates/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
@@ -210,6 +210,30 @@ fn cuda_extension_cache_allows_dynamic_retained_byte_updates() {
 }
 
 #[test]
+fn cuda_extension_cache_byte_pressure_evicts_largest_entry() {
+    let cache = CudaExtensionCache::with_max_entries(NonZeroUsize::new(8).unwrap());
+    cache
+        .set_max_retained_bytes(NonZeroUsize::new(64).unwrap())
+        .unwrap();
+    drop(cache.get_or_try_init::<usize>(|| Ok(17)).unwrap());
+    drop(
+        cache
+            .get_or_try_init::<String>(|| Ok("gpu".to_string()))
+            .unwrap(),
+    );
+
+    cache.update_retained_bytes::<String>(128).unwrap();
+
+    let value = cache.get_or_try_init::<usize>(|| Ok(23)).unwrap();
+    assert_eq!(*value, 17);
+    drop(value);
+    let stats = cache.stats().unwrap();
+    assert_eq!(stats.entries, 1);
+    assert!(stats.retained_bytes <= 64);
+    assert_eq!(stats.evictions, 1);
+}
+
+#[test]
 fn cuda_backend_exposes_extension_cache_retained_byte_controls() {
     let _getter: fn(&CudaBackend) -> crate::Result<NonZeroUsize> =
         CudaBackend::cuda_extension_cache_max_retained_bytes;


### PR DESCRIPTION
## Type

- [x] Bug fix

## Related issue

Refs #1733 (this commit was pushed to `perf/cuda-dot-dispatch` after that PR merged, so it never reached `main`)

## Summary

Cherry-picks `858ca67b` from `perf/cuda-dot-dispatch`. It was authored as part
of the #1733 work stream but landed on the branch after the squash merge, so
its content is missing from `main`.

The fix makes `CudaExtensionCache::update_retained_bytes` evict the just-updated
entry immediately when the update itself pushes retained bytes past the limit,
instead of only running the general `evict_to_limit` pass. Without it, a small
resource can be dropped by general eviction while an oversized entry survives.

- Adds byte-pressure eviction of the updated entry in
  `crates/tenferro-gpu/src/cubecl/mod.rs`
- Adds regression test
  `cuda_extension_cache_byte_pressure_evicts_largest_entry`

Bug-fix scope gate applied: fixes existing cache-contract behavior, no new
APIs, dependencies, or features.

## Work log

Not needed: single-commit cherry-pick of existing reviewed work.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules review (deterministic; the external LLM
      review is permanently disabled) and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by
      maintainers. (n/a — bug fix)
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from
      `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and
      linked it above. (n/a)

**Verification**

- `cargo test -p tenferro-gpu --features cuda --lib cuda_extension_cache` — 7 passed
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test '...'` — passed
- `scripts/repository-rules-review.py` — pass (local deterministic review)