### PR TITLE
feat(linalg): add incremental Householder QR

### DIFF
--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -143,6 +143,11 @@ impl LinalgAdRule {
             LinalgOp::EigVals { input_dtype } => {
                 rules::linearize_eig_values(builder, primal_in, tangent_in, input_dtype, ctx)
             }
+            LinalgOp::HouseholderQrFactor
+            | LinalgOp::HouseholderQrFromFactors
+            | LinalgOp::HouseholderQrAppend
+            | LinalgOp::HouseholderQrR { .. }
+            | LinalgOp::HouseholderQrQColumns { .. } => Ok(vec![None; op.output_count()]),
         }
     }
     fn linear_transpose(
@@ -228,7 +233,12 @@ impl LinalgAdRule {
             | LinalgOp::Eigh { .. }
             | LinalgOp::EighVals { .. }
             | LinalgOp::Eig { .. }
-            | LinalgOp::EigVals { .. } => Ok(vec![None; op.input_count()]),
+            | LinalgOp::EigVals { .. }
+            | LinalgOp::HouseholderQrFactor
+            | LinalgOp::HouseholderQrFromFactors
+            | LinalgOp::HouseholderQrAppend
+            | LinalgOp::HouseholderQrR { .. }
+            | LinalgOp::HouseholderQrQColumns { .. } => Ok(vec![None; op.input_count()]),
         }
     }
 }

--- a/crates/tenferro-linalg/src/ad/semantic.rs
+++ b/crates/tenferro-linalg/src/ad/semantic.rs
@@ -63,6 +63,20 @@ impl SemanticLinearizeRule for LinalgAdRule {
         builder: &mut SemanticProgramBuilder,
     ) -> Result<SemanticLinearizeResult, SemanticAdError> {
         let op = semantic_linalg_op(request.op(), SemanticAdRuleRole::Linearize)?;
+        if matches!(
+            op.op(),
+            LinalgOp::HouseholderQrFactor
+                | LinalgOp::HouseholderQrFromFactors
+                | LinalgOp::HouseholderQrAppend
+                | LinalgOp::HouseholderQrR { .. }
+                | LinalgOp::HouseholderQrQColumns { .. }
+        ) {
+            return Err(SemanticAdError::Unsupported {
+                family_id: LINALG_EXTENSION_FAMILY_ID,
+                role: SemanticAdRuleRole::Linearize,
+                message: format!("semantic linearize is unsupported for {:?}", op.op()),
+            });
+        }
         if matches!(op.op(), LinalgOp::LuFactor | LinalgOp::SvdFull) {
             // These value-only operations can appear inside a differentiable
             // composite (for example, `solve` uses `LuFactor` outputs as
@@ -202,7 +216,13 @@ impl SemanticLinearTransposeRule for LinalgAdRule {
                 builder,
                 SemanticAdRuleRole::LinearTranspose,
             ),
-            LinalgOp::LuFactor | LinalgOp::SvdFull => Err(SemanticAdError::Unsupported {
+            LinalgOp::LuFactor
+            | LinalgOp::SvdFull
+            | LinalgOp::HouseholderQrFactor
+            | LinalgOp::HouseholderQrFromFactors
+            | LinalgOp::HouseholderQrAppend
+            | LinalgOp::HouseholderQrR { .. }
+            | LinalgOp::HouseholderQrQColumns { .. } => Err(SemanticAdError::Unsupported {
                 family_id: LINALG_EXTENSION_FAMILY_ID,
                 role: SemanticAdRuleRole::LinearTranspose,
                 message: format!("semantic linear transpose is unsupported for {:?}", op.op()),

--- a/crates/tenferro-linalg/src/ad/support.rs
+++ b/crates/tenferro-linalg/src/ad/support.rs
@@ -96,10 +96,15 @@ pub enum LinalgAdOpKind {
     EigVals,
     TriangularSolve,
     SvdFull,
+    HouseholderQrFactor,
+    HouseholderQrFromFactors,
+    HouseholderQrAppend,
+    HouseholderQrR,
+    HouseholderQrQColumns,
 }
 
 impl LinalgAdOpKind {
-    pub const COUNT: usize = 17;
+    pub const COUNT: usize = 22;
 
     /// Return the manifest index for this operation kind.
     ///
@@ -129,6 +134,11 @@ impl LinalgAdOpKind {
             Self::EigVals => 14,
             Self::TriangularSolve => 15,
             Self::SvdFull => 16,
+            Self::HouseholderQrFactor => 17,
+            Self::HouseholderQrFromFactors => 18,
+            Self::HouseholderQrAppend => 19,
+            Self::HouseholderQrR => 20,
+            Self::HouseholderQrQColumns => 21,
         }
     }
 
@@ -151,6 +161,11 @@ impl LinalgAdOpKind {
             LinalgOp::SvdFull => Self::SvdFull,
             LinalgOp::SvdVals { .. } => Self::SvdVals,
             LinalgOp::Qr { .. } => Self::Qr,
+            LinalgOp::HouseholderQrFactor => Self::HouseholderQrFactor,
+            LinalgOp::HouseholderQrFromFactors => Self::HouseholderQrFromFactors,
+            LinalgOp::HouseholderQrAppend => Self::HouseholderQrAppend,
+            LinalgOp::HouseholderQrR { .. } => Self::HouseholderQrR,
+            LinalgOp::HouseholderQrQColumns { .. } => Self::HouseholderQrQColumns,
             LinalgOp::Eigh { .. } => Self::Eigh,
             LinalgOp::EighVals { .. } => Self::EighVals,
             LinalgOp::Eig { .. } => Self::Eig,
@@ -331,6 +346,12 @@ static QR_OUTPUTS: [LinalgAdOutputSupport; 2] = [
     output(0, "q", LinalgAdRuleSupport::SupportedViaLinearize),
     output(1, "r", LinalgAdRuleSupport::SupportedViaLinearize),
 ];
+static HOUSEHOLDER_QR_STATE_OUTPUTS: [LinalgAdOutputSupport; 2] = [
+    output(0, "packed", LinalgAdRuleSupport::Unsupported),
+    output(1, "coeff", LinalgAdRuleSupport::Unsupported),
+];
+static HOUSEHOLDER_QR_VALUE_OUTPUTS: [LinalgAdOutputSupport; 1] =
+    [output(0, "value", LinalgAdRuleSupport::Unsupported)];
 static EIGH_OUTPUTS: [LinalgAdOutputSupport; 2] = [
     output(0, "eigenvalues", LinalgAdRuleSupport::SupportedViaLinearize),
     output(
@@ -559,6 +580,51 @@ static LINALG_AD_SUPPORT: [LinalgAdSupport; LinalgAdOpKind::COUNT] = [
         LinalgAdRuleSupport::Unsupported,
         &SVD_FULL_OUTPUTS,
         &[],
+    ),
+    support_entry(
+        LinalgAdOpKind::HouseholderQrFactor,
+        LinalgAdRuleSupport::Unsupported,
+        LinalgAdRuleSupport::Unsupported,
+        mode(LinalgAdRuleSupport::Unsupported, LinalgAdRoute::Unsupported),
+        LinalgAdRuleSupport::Unsupported,
+        &HOUSEHOLDER_QR_STATE_OUTPUTS,
+        &["AD support requires the incremental QR oracle family."],
+    ),
+    support_entry(
+        LinalgAdOpKind::HouseholderQrFromFactors,
+        LinalgAdRuleSupport::Unsupported,
+        LinalgAdRuleSupport::Unsupported,
+        mode(LinalgAdRuleSupport::Unsupported, LinalgAdRoute::Unsupported),
+        LinalgAdRuleSupport::Unsupported,
+        &HOUSEHOLDER_QR_STATE_OUTPUTS,
+        &["AD support requires the incremental QR oracle family."],
+    ),
+    support_entry(
+        LinalgAdOpKind::HouseholderQrAppend,
+        LinalgAdRuleSupport::Unsupported,
+        LinalgAdRuleSupport::Unsupported,
+        mode(LinalgAdRuleSupport::Unsupported, LinalgAdRoute::Unsupported),
+        LinalgAdRuleSupport::Unsupported,
+        &HOUSEHOLDER_QR_STATE_OUTPUTS,
+        &["AD support requires the incremental QR oracle family."],
+    ),
+    support_entry(
+        LinalgAdOpKind::HouseholderQrR,
+        LinalgAdRuleSupport::Unsupported,
+        LinalgAdRuleSupport::Unsupported,
+        mode(LinalgAdRuleSupport::Unsupported, LinalgAdRoute::Unsupported),
+        LinalgAdRuleSupport::Unsupported,
+        &HOUSEHOLDER_QR_VALUE_OUTPUTS,
+        &["AD support requires the incremental QR oracle family."],
+    ),
+    support_entry(
+        LinalgAdOpKind::HouseholderQrQColumns,
+        LinalgAdRuleSupport::Unsupported,
+        LinalgAdRuleSupport::Unsupported,
+        mode(LinalgAdRuleSupport::Unsupported, LinalgAdRoute::Unsupported),
+        LinalgAdRuleSupport::Unsupported,
+        &HOUSEHOLDER_QR_VALUE_OUTPUTS,
+        &["AD support requires the incremental QR oracle family."],
     ),
 ];
 

--- a/crates/tenferro-linalg/src/ad/support/tests.rs
+++ b/crates/tenferro-linalg/src/ad/support/tests.rs
@@ -45,6 +45,32 @@ fn manifest_internal_mapping_covers_linalg_op_variants() {
             LinalgAdOpKind::Qr,
         ),
         (
+            LinalgOp::HouseholderQrFactor,
+            LinalgAdOpKind::HouseholderQrFactor,
+        ),
+        (
+            LinalgOp::HouseholderQrFromFactors,
+            LinalgAdOpKind::HouseholderQrFromFactors,
+        ),
+        (
+            LinalgOp::HouseholderQrAppend,
+            LinalgAdOpKind::HouseholderQrAppend,
+        ),
+        (
+            LinalgOp::HouseholderQrR {
+                gauge: QrGauge::Raw,
+            },
+            LinalgAdOpKind::HouseholderQrR,
+        ),
+        (
+            LinalgOp::HouseholderQrQColumns {
+                start: 0,
+                end: 1,
+                gauge: QrGauge::Raw,
+            },
+            LinalgAdOpKind::HouseholderQrQColumns,
+        ),
+        (
             LinalgOp::Eigh {
                 derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
                 gauge: EighGauge::Raw,

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -1,4 +1,14 @@
+use std::ops::Range;
+
 use tenferro_tensor::{BackendSession, Tensor, TensorRead, TensorWrite};
+
+/// Compact provider-neutral Householder QR payload used by backend hooks.
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct CompactQrResult {
+    pub(crate) packed: Tensor,
+    pub(crate) coeff: Tensor,
+}
 
 pub(crate) use crate::error::unsupported_dtype;
 use crate::extension::{
@@ -404,6 +414,66 @@ pub trait LinalgBackend: BackendSession {
         Err(tenferro_tensor::Error::unsupported(
             "qr",
             "backend does not accept tensor reads at this execution boundary",
+        ))
+    }
+
+    #[doc(hidden)]
+    fn householder_qr(&mut self, _input: &Tensor) -> tenferro_tensor::Result<CompactQrResult> {
+        Err(tenferro_tensor::Error::unsupported(
+            "householder_qr",
+            "backend does not implement compact Householder QR",
+        ))
+    }
+
+    #[doc(hidden)]
+    fn householder_qr_from_factors(
+        &mut self,
+        _q: &Tensor,
+        _r: &Tensor,
+    ) -> tenferro_tensor::Result<CompactQrResult> {
+        Err(tenferro_tensor::Error::unsupported(
+            "householder_qr_from_factors",
+            "backend does not implement compact Householder QR factor import",
+        ))
+    }
+
+    #[doc(hidden)]
+    fn householder_qr_append(
+        &mut self,
+        _packed: &Tensor,
+        _coeff: &Tensor,
+        _block: &Tensor,
+    ) -> tenferro_tensor::Result<CompactQrResult> {
+        Err(tenferro_tensor::Error::unsupported(
+            "householder_qr_append",
+            "backend does not implement compact Householder QR append",
+        ))
+    }
+
+    #[doc(hidden)]
+    fn householder_qr_r(
+        &mut self,
+        _packed: &Tensor,
+        _coeff: &Tensor,
+        _options: QrOptions,
+    ) -> tenferro_tensor::Result<Tensor> {
+        Err(tenferro_tensor::Error::unsupported(
+            "householder_qr_r",
+            "backend does not implement compact Householder QR extraction",
+        ))
+    }
+
+    #[doc(hidden)]
+    fn householder_qr_q_columns(
+        &mut self,
+        _packed: &Tensor,
+        _coeff: &Tensor,
+        _columns: Range<usize>,
+        _options: QrOptions,
+    ) -> tenferro_tensor::Result<Tensor> {
+        Err(tenferro_tensor::Error::unsupported(
+            "householder_qr_q_columns",
+            "backend does not implement compact Householder Q-column materialization",
         ))
     }
 

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -1,4 +1,4 @@
-use crate::backend::{unsupported_dtype, LinalgBackend};
+use crate::backend::{unsupported_dtype, CompactQrResult, LinalgBackend};
 
 use super::linalg;
 
@@ -39,6 +39,13 @@ impl FreshLinalgOutput for Vec<Tensor> {
         for output in self {
             output.tag_fresh(domain);
         }
+    }
+}
+
+impl FreshLinalgOutput for CompactQrResult {
+    fn tag_fresh(&mut self, domain: tenferro_tensor::CpuDomainId) {
+        self.packed.tag_fresh(domain);
+        self.coeff.tag_fresh(domain);
     }
 }
 
@@ -410,6 +417,73 @@ impl LinalgBackend for CpuExecSession<'_> {
             context.with_materialized_tensor_read(buffers, "qr", input, |input, buffers| {
                 qr_entered(provider, context, buffers, input)
             })
+        })
+    }
+
+    fn householder_qr(&mut self, input: &Tensor) -> tenferro_tensor::Result<CompactQrResult> {
+        ensure_host_tensor("householder_qr", input)?;
+        let provider = linalg_provider_kind(self.kind(), "householder_qr")?;
+        self.with_linalg_pool_fresh(|context, buffers| {
+            householder_qr_entered(provider, context, buffers, input)
+        })
+    }
+
+    fn householder_qr_from_factors(
+        &mut self,
+        q: &Tensor,
+        r: &Tensor,
+    ) -> tenferro_tensor::Result<CompactQrResult> {
+        ensure_host_tensor("householder_qr_from_factors", q)?;
+        ensure_host_tensor("householder_qr_from_factors", r)?;
+        let provider = linalg_provider_kind(self.kind(), "householder_qr_from_factors")?;
+        self.with_linalg_pool_fresh(|context, buffers| {
+            householder_qr_from_factors_entered(provider, context, buffers, q, r)
+        })
+    }
+
+    fn householder_qr_append(
+        &mut self,
+        packed: &Tensor,
+        coeff: &Tensor,
+        block: &Tensor,
+    ) -> tenferro_tensor::Result<CompactQrResult> {
+        ensure_host_tensor("householder_qr_append", packed)?;
+        ensure_host_tensor("householder_qr_append", coeff)?;
+        ensure_host_tensor("householder_qr_append", block)?;
+        let provider = linalg_provider_kind(self.kind(), "householder_qr_append")?;
+        self.with_linalg_pool_fresh(|context, buffers| {
+            householder_qr_append_entered(provider, context, buffers, packed, coeff, block)
+        })
+    }
+
+    fn householder_qr_r(
+        &mut self,
+        packed: &Tensor,
+        coeff: &Tensor,
+        options: crate::QrOptions,
+    ) -> tenferro_tensor::Result<Tensor> {
+        ensure_host_tensor("householder_qr_r", packed)?;
+        ensure_host_tensor("householder_qr_r", coeff)?;
+        let provider = linalg_provider_kind(self.kind(), "householder_qr_r")?;
+        self.with_linalg_pool_fresh(|context, buffers| {
+            householder_qr_r_entered(provider, context, buffers, packed, coeff, options)
+        })
+    }
+
+    fn householder_qr_q_columns(
+        &mut self,
+        packed: &Tensor,
+        coeff: &Tensor,
+        columns: std::ops::Range<usize>,
+        options: crate::QrOptions,
+    ) -> tenferro_tensor::Result<Tensor> {
+        ensure_host_tensor("householder_qr_q_columns", packed)?;
+        ensure_host_tensor("householder_qr_q_columns", coeff)?;
+        let provider = linalg_provider_kind(self.kind(), "householder_qr_q_columns")?;
+        self.with_linalg_pool_fresh(|context, buffers| {
+            householder_qr_q_columns_entered(
+                provider, context, buffers, packed, coeff, columns, options,
+            )
         })
     }
 
@@ -1715,6 +1789,382 @@ fn qr_entered(
                 Err(unsupported_provider("qr", CpuBackendKind::Blas))
             }
         }
+    }
+}
+
+fn householder_qr_entered(
+    provider: CpuLinalgProvider,
+    context: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    input: &Tensor,
+) -> tenferro_tensor::Result<CompactQrResult> {
+    match provider {
+        CpuLinalgProvider::Faer => {
+            #[cfg(feature = "cpu-faer")]
+            {
+                macro_rules! factor {
+                    ($tensor:expr, $variant:ident) => {{
+                        let (packed, coeff) =
+                            linalg::faer::compact_factor_2d(context, buffers, $tensor)?;
+                        Ok(CompactQrResult {
+                            packed: Tensor::$variant(packed),
+                            coeff: Tensor::$variant(coeff),
+                        })
+                    }};
+                }
+                match input {
+                    Tensor::F32(t) => factor!(t, F32),
+                    Tensor::F64(t) => factor!(t, F64),
+                    Tensor::C32(t) => factor!(t, C32),
+                    Tensor::C64(t) => factor!(t, C64),
+                    _ => Err(unsupported_dtype("householder_qr", input.dtype())),
+                }
+            }
+            #[cfg(not(feature = "cpu-faer"))]
+            {
+                let _ = (context, buffers, input);
+                Err(unsupported_provider("householder_qr", CpuBackendKind::Faer))
+            }
+        }
+        CpuLinalgProvider::Blas => {
+            #[cfg(feature = "cpu-blas")]
+            {
+                let _ = context;
+                macro_rules! factor {
+                    ($tensor:expr, $variant:ident) => {{
+                        let (packed, coeff) = linalg::blas::householder_qr(buffers, $tensor)?;
+                        Ok(CompactQrResult {
+                            packed: Tensor::$variant(packed),
+                            coeff: Tensor::$variant(coeff),
+                        })
+                    }};
+                }
+                match input {
+                    Tensor::F32(t) => factor!(t, F32),
+                    Tensor::F64(t) => factor!(t, F64),
+                    Tensor::C32(t) => factor!(t, C32),
+                    Tensor::C64(t) => factor!(t, C64),
+                    _ => Err(unsupported_dtype("householder_qr", input.dtype())),
+                }
+            }
+            #[cfg(not(feature = "cpu-blas"))]
+            {
+                let _ = (context, buffers, input);
+                Err(unsupported_provider("householder_qr", CpuBackendKind::Blas))
+            }
+        }
+    }
+}
+
+fn householder_qr_from_factors_entered(
+    provider: CpuLinalgProvider,
+    context: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    q: &Tensor,
+    r: &Tensor,
+) -> tenferro_tensor::Result<CompactQrResult> {
+    if q.dtype() != r.dtype() {
+        return Err(Error::dtype_mismatch(
+            "householder_qr_from_factors",
+            q.dtype(),
+            r.dtype(),
+        ));
+    }
+    if provider == CpuLinalgProvider::Faer {
+        #[cfg(feature = "cpu-faer")]
+        {
+            macro_rules! import {
+                ($q:expr, $r:expr, $variant:ident) => {{
+                    let (packed, coeff) = linalg::faer::from_factors_2d(context, buffers, $q, $r)?;
+                    return Ok(CompactQrResult {
+                        packed: Tensor::$variant(packed),
+                        coeff: Tensor::$variant(coeff),
+                    });
+                }};
+            }
+            match (q, r) {
+                (Tensor::F32(q), Tensor::F32(r)) => import!(q, r, F32),
+                (Tensor::F64(q), Tensor::F64(r)) => import!(q, r, F64),
+                (Tensor::C32(q), Tensor::C32(r)) => import!(q, r, C32),
+                (Tensor::C64(q), Tensor::C64(r)) => import!(q, r, C64),
+                _ => return Err(unsupported_dtype("householder_qr_from_factors", q.dtype())),
+            }
+        }
+        #[cfg(not(feature = "cpu-faer"))]
+        return Err(unsupported_provider(
+            "householder_qr_from_factors",
+            CpuBackendKind::Faer,
+        ));
+    }
+    #[cfg(feature = "cpu-blas")]
+    {
+        let _ = context;
+        macro_rules! import {
+            ($q:expr, $r:expr, $variant:ident) => {{
+                let (packed, coeff) = linalg::blas::householder_qr_from_factors(buffers, $q, $r)?;
+                Ok(CompactQrResult {
+                    packed: Tensor::$variant(packed),
+                    coeff: Tensor::$variant(coeff),
+                })
+            }};
+        }
+        match (q, r) {
+            (Tensor::F32(q), Tensor::F32(r)) => import!(q, r, F32),
+            (Tensor::F64(q), Tensor::F64(r)) => import!(q, r, F64),
+            (Tensor::C32(q), Tensor::C32(r)) => import!(q, r, C32),
+            (Tensor::C64(q), Tensor::C64(r)) => import!(q, r, C64),
+            _ => Err(unsupported_dtype("householder_qr_from_factors", q.dtype())),
+        }
+    }
+    #[cfg(not(feature = "cpu-blas"))]
+    {
+        let _ = (context, buffers, q, r);
+        Err(unsupported_provider(
+            "householder_qr_from_factors",
+            CpuBackendKind::Blas,
+        ))
+    }
+}
+
+fn householder_qr_append_entered(
+    provider: CpuLinalgProvider,
+    context: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    packed: &Tensor,
+    coeff: &Tensor,
+    block: &Tensor,
+) -> tenferro_tensor::Result<CompactQrResult> {
+    if packed.dtype() != coeff.dtype() || packed.dtype() != block.dtype() {
+        return Err(Error::dtype_mismatch(
+            "householder_qr_append",
+            packed.dtype(),
+            block.dtype(),
+        ));
+    }
+    if provider == CpuLinalgProvider::Faer {
+        #[cfg(feature = "cpu-faer")]
+        {
+            macro_rules! append {
+                ($packed:expr, $coeff:expr, $block:expr, $variant:ident) => {{
+                    let (packed, coeff) =
+                        linalg::faer::append_2d(context, buffers, $packed, $coeff, $block)?;
+                    return Ok(CompactQrResult {
+                        packed: Tensor::$variant(packed),
+                        coeff: Tensor::$variant(coeff),
+                    });
+                }};
+            }
+            match (packed, coeff, block) {
+                (Tensor::F32(p), Tensor::F32(c), Tensor::F32(b)) => append!(p, c, b, F32),
+                (Tensor::F64(p), Tensor::F64(c), Tensor::F64(b)) => append!(p, c, b, F64),
+                (Tensor::C32(p), Tensor::C32(c), Tensor::C32(b)) => append!(p, c, b, C32),
+                (Tensor::C64(p), Tensor::C64(c), Tensor::C64(b)) => append!(p, c, b, C64),
+                _ => return Err(unsupported_dtype("householder_qr_append", packed.dtype())),
+            }
+        }
+        #[cfg(not(feature = "cpu-faer"))]
+        return Err(unsupported_provider(
+            "householder_qr_append",
+            CpuBackendKind::Faer,
+        ));
+    }
+    #[cfg(feature = "cpu-blas")]
+    {
+        let _ = context;
+        macro_rules! append {
+            ($packed:expr, $coeff:expr, $block:expr, $variant:ident) => {{
+                let (packed, coeff) =
+                    linalg::blas::householder_qr_append(buffers, $packed, $coeff, $block)?;
+                Ok(CompactQrResult {
+                    packed: Tensor::$variant(packed),
+                    coeff: Tensor::$variant(coeff),
+                })
+            }};
+        }
+        match (packed, coeff, block) {
+            (Tensor::F32(p), Tensor::F32(c), Tensor::F32(b)) => append!(p, c, b, F32),
+            (Tensor::F64(p), Tensor::F64(c), Tensor::F64(b)) => append!(p, c, b, F64),
+            (Tensor::C32(p), Tensor::C32(c), Tensor::C32(b)) => append!(p, c, b, C32),
+            (Tensor::C64(p), Tensor::C64(c), Tensor::C64(b)) => append!(p, c, b, C64),
+            _ => Err(unsupported_dtype("householder_qr_append", packed.dtype())),
+        }
+    }
+    #[cfg(not(feature = "cpu-blas"))]
+    {
+        let _ = (context, buffers, packed, coeff, block);
+        Err(unsupported_provider(
+            "householder_qr_append",
+            CpuBackendKind::Blas,
+        ))
+    }
+}
+
+fn householder_qr_r_entered(
+    provider: CpuLinalgProvider,
+    _context: &CpuExecutionContext<'_>,
+    _buffers: &mut BufferPool,
+    packed: &Tensor,
+    coeff: &Tensor,
+    options: crate::QrOptions,
+) -> tenferro_tensor::Result<Tensor> {
+    let positive = options.gauge == crate::QrGauge::PositiveDiagonal;
+    if provider == CpuLinalgProvider::Faer {
+        #[cfg(feature = "cpu-faer")]
+        return match (packed, coeff) {
+            (Tensor::F32(p), Tensor::F32(c)) => {
+                linalg::faer::raw_r_2d(p, c, positive).map(Tensor::F32)
+            }
+            (Tensor::F64(p), Tensor::F64(c)) => {
+                linalg::faer::raw_r_2d(p, c, positive).map(Tensor::F64)
+            }
+            (Tensor::C32(p), Tensor::C32(c)) => {
+                linalg::faer::raw_r_2d(p, c, positive).map(Tensor::C32)
+            }
+            (Tensor::C64(p), Tensor::C64(c)) => {
+                linalg::faer::raw_r_2d(p, c, positive).map(Tensor::C64)
+            }
+            _ => Err(Error::dtype_mismatch(
+                "householder_qr_r",
+                packed.dtype(),
+                coeff.dtype(),
+            )),
+        };
+        #[cfg(not(feature = "cpu-faer"))]
+        return Err(unsupported_provider(
+            "householder_qr_r",
+            CpuBackendKind::Faer,
+        ));
+    }
+    #[cfg(feature = "cpu-blas")]
+    {
+        match (packed, coeff) {
+            (Tensor::F32(p), Tensor::F32(c)) => {
+                linalg::blas::householder_qr_r(p, c, positive).map(Tensor::F32)
+            }
+            (Tensor::F64(p), Tensor::F64(c)) => {
+                linalg::blas::householder_qr_r(p, c, positive).map(Tensor::F64)
+            }
+            (Tensor::C32(p), Tensor::C32(c)) => {
+                linalg::blas::householder_qr_r(p, c, positive).map(Tensor::C32)
+            }
+            (Tensor::C64(p), Tensor::C64(c)) => {
+                linalg::blas::householder_qr_r(p, c, positive).map(Tensor::C64)
+            }
+            _ => Err(Error::dtype_mismatch(
+                "householder_qr_r",
+                packed.dtype(),
+                coeff.dtype(),
+            )),
+        }
+    }
+    #[cfg(not(feature = "cpu-blas"))]
+    {
+        let _ = (_context, packed, coeff, options);
+        Err(unsupported_provider(
+            "householder_qr_r",
+            CpuBackendKind::Blas,
+        ))
+    }
+}
+
+fn householder_qr_q_columns_entered(
+    provider: CpuLinalgProvider,
+    _context: &CpuExecutionContext<'_>,
+    _buffers: &mut BufferPool,
+    packed: &Tensor,
+    coeff: &Tensor,
+    columns: std::ops::Range<usize>,
+    options: crate::QrOptions,
+) -> tenferro_tensor::Result<Tensor> {
+    let positive = options.gauge == crate::QrGauge::PositiveDiagonal;
+    if provider == CpuLinalgProvider::Faer {
+        #[cfg(feature = "cpu-faer")]
+        return match (packed, coeff) {
+            (Tensor::F32(p), Tensor::F32(c)) => linalg::faer::q_columns_2d(
+                _context,
+                _buffers,
+                p,
+                c,
+                columns.start,
+                columns.end,
+                positive,
+            )
+            .map(Tensor::F32),
+            (Tensor::F64(p), Tensor::F64(c)) => linalg::faer::q_columns_2d(
+                _context,
+                _buffers,
+                p,
+                c,
+                columns.start,
+                columns.end,
+                positive,
+            )
+            .map(Tensor::F64),
+            (Tensor::C32(p), Tensor::C32(c)) => linalg::faer::q_columns_2d(
+                _context,
+                _buffers,
+                p,
+                c,
+                columns.start,
+                columns.end,
+                positive,
+            )
+            .map(Tensor::C32),
+            (Tensor::C64(p), Tensor::C64(c)) => linalg::faer::q_columns_2d(
+                _context,
+                _buffers,
+                p,
+                c,
+                columns.start,
+                columns.end,
+                positive,
+            )
+            .map(Tensor::C64),
+            _ => Err(Error::dtype_mismatch(
+                "householder_qr_q_columns",
+                packed.dtype(),
+                coeff.dtype(),
+            )),
+        };
+        #[cfg(not(feature = "cpu-faer"))]
+        return Err(unsupported_provider(
+            "householder_qr_q_columns",
+            CpuBackendKind::Faer,
+        ));
+    }
+    #[cfg(feature = "cpu-blas")]
+    {
+        macro_rules! columns {
+            ($packed:expr, $coeff:expr, $variant:ident) => {
+                linalg::blas::householder_qr_q_columns(
+                    $packed,
+                    $coeff,
+                    columns.start,
+                    columns.end,
+                    positive,
+                )
+                .map(Tensor::$variant)
+            };
+        }
+        match (packed, coeff) {
+            (Tensor::F32(p), Tensor::F32(c)) => columns!(p, c, F32),
+            (Tensor::F64(p), Tensor::F64(c)) => columns!(p, c, F64),
+            (Tensor::C32(p), Tensor::C32(c)) => columns!(p, c, C32),
+            (Tensor::C64(p), Tensor::C64(c)) => columns!(p, c, C64),
+            _ => Err(Error::dtype_mismatch(
+                "householder_qr_q_columns",
+                packed.dtype(),
+                coeff.dtype(),
+            )),
+        }
+    }
+    #[cfg(not(feature = "cpu-blas"))]
+    {
+        let _ = (_context, packed, coeff, columns, options);
+        Err(unsupported_provider(
+            "householder_qr_q_columns",
+            CpuBackendKind::Blas,
+        ))
     }
 }
 

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -1,4 +1,5 @@
 use faer::dyn_stack::{MemBuffer, MemStack};
+use faer::prelude::ReborrowMut;
 use faer::{
     diag::{Diag, DiagRef},
     Conj, Mat, MatMut, MatRef,
@@ -10,10 +11,43 @@ use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar};
 use tenferro_cpu::CpuExecutionContext;
 use tenferro_tensor::{Tensor, TensorScalar, TypedTensor, TypedTensorView, TypedTensorViewMut};
 
-pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
+pub(crate) trait FaerLinalg:
+    Copy + Clone + Default + PartialEq + PoolScalar + std::ops::Mul<Output = Self>
+{
     type Real: Copy + Clone + PoolScalar;
 
     fn parity_one() -> Self;
+    fn compact_factor_data(
+        ctx: &CpuExecutionContext<'_>,
+        data: &mut [Self],
+        rows: usize,
+        cols: usize,
+    ) -> tenferro_tensor::Result<Vec<Self>>;
+    // INVARIANT: these buffers and dimensions mirror the provider reflector ABI.
+    #[allow(clippy::too_many_arguments)]
+    fn apply_reflectors_data(
+        ctx: &CpuExecutionContext<'_>,
+        a: &[Self],
+        a_cols: usize,
+        coeff: &[Self],
+        c: &mut [Self],
+        rows: usize,
+        cols: usize,
+        k: usize,
+        transpose: bool,
+    ) -> tenferro_tensor::Result<()>;
+    fn gemm_data(
+        ctx: &CpuExecutionContext<'_>,
+        a: &[Self],
+        a_rows: usize,
+        a_cols: usize,
+        b: &[Self],
+        b_cols: usize,
+        c: &mut [Self],
+    ) -> tenferro_tensor::Result<()>;
+    fn one() -> Self;
+    fn r_phase(diagonal: Self) -> Self;
+    fn q_phase(diagonal: Self) -> Self;
     fn cholesky_2d(
         ctx: &CpuExecutionContext<'_>,
         buffers: &mut BufferPool,
@@ -407,6 +441,288 @@ fn checked_slice_range(
         .checked_add(slice_size)
         .ok_or_else(|| invalid_config(op, "batch slice end overflows usize"))?;
     Ok(start..end)
+}
+
+fn validate_compact_state<T>(
+    packed: &TypedTensor<T>,
+    coeff: &TypedTensor<T>,
+    op: &'static str,
+) -> tenferro_tensor::Result<(usize, usize, usize)> {
+    let (rows, cols) = matrix_dims(packed, op)?;
+    if coeff.shape().len() != 1 {
+        return Err(tenferro_tensor::Error::rank_mismatch(
+            op,
+            1,
+            coeff.shape().len(),
+        ));
+    }
+    let k = rows.min(cols);
+    if coeff.shape()[0] != k {
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            op,
+            vec![k],
+            vec![coeff.shape()[0]],
+        ));
+    }
+    Ok((rows, cols, k))
+}
+
+pub(crate) fn compact_factor_2d<T: FaerLinalg + 'static>(
+    ctx: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)> {
+    let (rows, cols) = matrix_dims(input, "compact_factor_2d")?;
+    let input_data = input.host_data()?;
+    let mut packed = buffers.acquire_with_capacity::<T>(input_data.len());
+    packed.extend_from_slice(input_data);
+    let coeff = T::compact_factor_data(ctx, &mut packed, rows, cols)?;
+    let k = rows.min(cols);
+    if coeff.len() != k {
+        return Err(invalid_config(
+            "compact_factor_2d",
+            "coefficients: provider returned an invalid coefficient count",
+        ));
+    }
+    Ok((
+        tensor_from_vec_with_template(vec![rows, cols], packed, input.placement())?,
+        tensor_from_vec_with_template(vec![k], coeff, input.placement())?,
+    ))
+}
+
+pub(crate) fn append_2d<T: FaerLinalg + 'static>(
+    ctx: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    packed: &TypedTensor<T>,
+    coeff: &TypedTensor<T>,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)> {
+    let (rows, old_cols, old_k) = validate_compact_state(packed, coeff, "append_2d")?;
+    let (input_rows, block_cols) = matrix_dims(input, "append_2d")?;
+    if input_rows != rows {
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "append_2d",
+            vec![rows, block_cols],
+            vec![input_rows, block_cols],
+        ));
+    }
+    if block_cols == 0 {
+        return Ok((
+            tensor_from_vec_with_template(
+                packed.shape().to_vec(),
+                packed.host_data()?.to_vec(),
+                packed.placement(),
+            )?,
+            tensor_from_vec_with_template(
+                coeff.shape().to_vec(),
+                coeff.host_data()?.to_vec(),
+                coeff.placement(),
+            )?,
+        ));
+    }
+    let new_cols = old_cols
+        .checked_add(block_cols)
+        .ok_or_else(|| invalid_config("append_2d", "shape: column count overflows usize"))?;
+    let new_k = rows.min(new_cols);
+    let mut transformed = buffers.acquire_with_capacity::<T>(checked_product(
+        "append_2d",
+        "transformed block",
+        &[rows, block_cols],
+    )?);
+    transformed.extend_from_slice(input.host_data()?);
+    T::apply_reflectors_data(
+        ctx,
+        packed.host_data()?,
+        old_cols,
+        coeff.host_data()?,
+        &mut transformed,
+        rows,
+        block_cols,
+        old_k,
+        true,
+    )?;
+    let trailing_rows = rows - old_k;
+    let trailing_len =
+        checked_product("append_2d", "trailing block", &[trailing_rows, block_cols])?;
+    let mut trailing = buffers.acquire_with_capacity::<T>(trailing_len);
+    for col in 0..block_cols {
+        trailing.extend_from_slice(&transformed[col * rows + old_k..(col + 1) * rows]);
+    }
+    let new_coeff = if trailing_rows == 0 {
+        Vec::new()
+    } else {
+        T::compact_factor_data(ctx, &mut trailing, trailing_rows, block_cols)?
+    };
+    let mut output = buffers.acquire_with_capacity::<T>(checked_product(
+        "append_2d",
+        "packed state",
+        &[rows, new_cols],
+    )?);
+    output.extend_from_slice(packed.host_data()?);
+    for col in 0..block_cols {
+        output.extend_from_slice(&transformed[col * rows..col * rows + old_k]);
+        output.extend_from_slice(&trailing[col * trailing_rows..(col + 1) * trailing_rows]);
+    }
+    let mut output_coeff = buffers.acquire_with_capacity::<T>(new_k);
+    output_coeff.extend_from_slice(coeff.host_data()?);
+    output_coeff.extend_from_slice(&new_coeff);
+    if output_coeff.len() != new_k {
+        return Err(invalid_config(
+            "append_2d",
+            "coefficients: provider returned an invalid coefficient count",
+        ));
+    }
+    Ok((
+        tensor_from_vec_with_template(vec![rows, new_cols], output, packed.placement())?,
+        tensor_from_vec_with_template(vec![new_k], output_coeff, packed.placement())?,
+    ))
+}
+
+pub(crate) fn from_factors_2d<T: FaerLinalg + 'static>(
+    ctx: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    q: &TypedTensor<T>,
+    r: &TypedTensor<T>,
+) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)> {
+    let (rows, q_cols) = matrix_dims(q, "from_factors_2d")?;
+    let (r_rows, cols) = matrix_dims(r, "from_factors_2d")?;
+    if r_rows != q_cols {
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "from_factors_2d",
+            vec![q_cols, cols],
+            vec![r_rows, cols],
+        ));
+    }
+    if q_cols > rows.min(cols) {
+        return Err(invalid_config(
+            "from_factors_2d",
+            "shape: Q column count must not exceed min(Q rows, R columns)",
+        ));
+    }
+    let k = rows.min(cols);
+    let r_data = r.host_data()?;
+    for col in 0..cols.min(q_cols) {
+        for row in col + 1..q_cols {
+            if r_data[row + col * q_cols] != T::default() {
+                return Err(invalid_config(
+                    "from_factors_2d",
+                    "R must be upper trapezoidal",
+                ));
+            }
+        }
+    }
+    let q_data = q.host_data()?;
+    let mut q_packed = buffers.acquire_with_capacity::<T>(q_data.len());
+    q_packed.extend_from_slice(q_data);
+    let q_coeff = T::compact_factor_data(ctx, &mut q_packed, rows, q_cols)?;
+    let folded_len = checked_product("from_factors_2d", "folded R", &[q_cols, cols])?;
+    let mut folded = buffers.acquire_with_capacity::<T>(folded_len);
+    folded.resize(folded_len, T::default());
+    let triangular_len =
+        checked_product("from_factors_2d", "triangular factor", &[q_cols, q_cols])?;
+    let mut t = buffers.acquire_with_capacity::<T>(triangular_len);
+    t.resize(triangular_len, T::default());
+    for col in 0..q_cols {
+        for row in 0..q_cols {
+            if row <= col {
+                t[row + col * q_cols] = q_packed[row + col * rows];
+            }
+        }
+    }
+    T::gemm_data(ctx, &t, q_cols, q_cols, r_data, cols, &mut folded)?;
+    let output_len = checked_product("from_factors_2d", "packed state", &[rows, cols])?;
+    let mut output = buffers.acquire_with_capacity::<T>(output_len);
+    output.resize(output_len, T::default());
+    for col in 0..cols {
+        for row in 0..rows {
+            output[row + col * rows] = if col < q_cols && row > col {
+                q_packed[row + col * rows]
+            } else if row < q_cols {
+                folded[row + col * q_cols]
+            } else {
+                T::default()
+            };
+        }
+    }
+    let mut output_coeff = buffers.acquire_with_capacity::<T>(k);
+    output_coeff.resize(k, T::default());
+    output_coeff[..q_cols].copy_from_slice(&q_coeff);
+    Ok((
+        tensor_from_vec_with_template(vec![rows, cols], output, q.placement())?,
+        tensor_from_vec_with_template(vec![k], output_coeff, q.placement())?,
+    ))
+}
+
+pub(crate) fn raw_r_2d<T: FaerLinalg + 'static>(
+    packed: &TypedTensor<T>,
+    coeff: &TypedTensor<T>,
+    positive_diagonal: bool,
+) -> tenferro_tensor::Result<TypedTensor<T>> {
+    let (rows, cols, k) = validate_compact_state(packed, coeff, "raw_r_2d")?;
+    let mut r = vec![T::default(); checked_product("raw_r_2d", "R", &[k, cols])?];
+    let packed_data = packed.host_data()?;
+    for col in 0..cols {
+        for row in 0..k.min(col + 1) {
+            r[row + col * k] = packed_data[row + col * rows];
+        }
+    }
+    if positive_diagonal {
+        for diag in 0..k {
+            let phase = T::r_phase(r[diag + diag * k]);
+            for col in 0..cols {
+                r[diag + col * k] = r[diag + col * k] * phase;
+            }
+        }
+    }
+    tensor_from_vec_with_template(vec![k, cols], r, packed.placement())
+}
+
+pub(crate) fn q_columns_2d<T: FaerLinalg + 'static>(
+    ctx: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    packed: &TypedTensor<T>,
+    coeff: &TypedTensor<T>,
+    start: usize,
+    end: usize,
+    positive_diagonal: bool,
+) -> tenferro_tensor::Result<TypedTensor<T>> {
+    let (rows, _cols, k) = validate_compact_state(packed, coeff, "q_columns_2d")?;
+    if start > end || end > k {
+        return Err(invalid_config(
+            "q_columns_2d",
+            format!("range: range {start}..{end} is outside 0..{k}"),
+        ));
+    }
+    let columns = end - start;
+    let q_len = checked_product("q_columns_2d", "Q", &[rows, columns])?;
+    let mut q = buffers.acquire_with_capacity::<T>(q_len);
+    q.resize(q_len, T::default());
+    for col in 0..columns {
+        q[start + col + col * rows] = T::one();
+    }
+    if columns != 0 {
+        T::apply_reflectors_data(
+            ctx,
+            packed.host_data()?,
+            packed.shape()[1],
+            coeff.host_data()?,
+            &mut q,
+            rows,
+            columns,
+            k,
+            false,
+        )?;
+        if positive_diagonal {
+            let packed_data = packed.host_data()?;
+            for col in 0..columns {
+                let phase = T::q_phase(packed_data[(start + col) + (start + col) * rows]);
+                for row in 0..rows {
+                    q[row + col * rows] = q[row + col * rows] * phase;
+                }
+            }
+        }
+    }
+    tensor_from_vec_with_template(vec![rows, columns], q, packed.placement())
 }
 
 macro_rules! impl_complex_vec_helpers {
@@ -1197,6 +1513,128 @@ macro_rules! impl_faer_linalg_for_real {
         1.0
     }
 
+    fn compact_factor_data(
+        ctx: &CpuExecutionContext<'_>,
+        data: &mut [Self],
+        rows: usize,
+        cols: usize,
+    ) -> tenferro_tensor::Result<Vec<Self>> {
+        let expected = checked_product("compact_factor_2d", "matrix", &[rows, cols])?;
+        if data.len() != expected {
+            return Err(invalid_config("compact_factor_2d", "matrix: input buffer length does not match dimensions"));
+        }
+        let k = rows.min(cols);
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+        let mut qr = MatMut::from_column_major_slice_mut(data, rows, cols);
+        let mut coeff = Vec::with_capacity(k);
+        for j in 0..k {
+            let mut column = qr.as_mut().col_mut(j).subrows_mut(j, rows - j);
+            let (mut head, tail) = column.rb_mut().split_at_row_mut(1);
+            let info = faer::linalg::householder::make_householder_in_place(&mut head[0], tail);
+            let beta = head[0];
+            head[0] = 1.0 as $scalar;
+            // Faer stores H = I - vv^H/tau; compact state stores 1/tau.
+            coeff.push((1.0 as $scalar) / info.tau);
+            if j + 1 < cols {
+                let mut basis = Mat::<$scalar>::zeros(rows - j, 1);
+                basis[(0, 0)] = 1.0 as $scalar;
+                for row in 1..rows - j {
+                    basis[(row, 0)] = qr[(j + row, j)];
+                }
+                let factor = Mat::from_fn(1, 1, |_, _| info.tau);
+                let mut mem = MemBuffer::new(faer::linalg::householder::apply_block_householder_on_the_left_in_place_scratch::<$scalar>(rows - j, 1, cols - j - 1));
+                let stack = MemStack::new(&mut mem);
+                faer::linalg::householder::apply_block_householder_on_the_left_in_place_with_conj(
+                    basis.as_ref(), factor.as_ref(), Conj::No,
+                    qr.as_mut().submatrix_mut(j, j + 1, rows - j, cols - j - 1),
+                    ctx.faer_parallelism(), stack,
+                );
+            }
+            qr[(j, j)] = beta;
+        }
+        Ok(coeff)
+    }
+
+    // INVARIANT: these buffers and dimensions mirror the provider reflector ABI.
+    #[allow(clippy::too_many_arguments)]
+    fn apply_reflectors_data(
+        ctx: &CpuExecutionContext<'_>,
+        a: &[Self],
+        a_cols: usize,
+        coeff: &[Self],
+        c: &mut [Self],
+        rows: usize,
+        cols: usize,
+        k: usize,
+        transpose: bool,
+    ) -> tenferro_tensor::Result<()> {
+        if k > rows || k > a_cols || coeff.len() != k {
+            return Err(invalid_config("apply_reflectors_2d", "dimensions: reflector count exceeds matrix dimensions"));
+        }
+        if a.len() != checked_product("apply_reflectors_2d", "A", &[rows, a_cols])?
+            || c.len() != checked_product("apply_reflectors_2d", "C", &[rows, cols])?
+        {
+            return Err(invalid_config("apply_reflectors_2d", "matrix: input buffer length does not match dimensions"));
+        }
+        if rows == 0 || cols == 0 || k == 0 {
+            return Ok(());
+        }
+        let basis = MatRef::from_column_major_slice(a, rows, a_cols).subcols(0, k);
+        let factors = Mat::from_fn(1, k, |_, col| {
+            // Rebuild Faer's denominator form transiently from state coeff.
+            (1.0 as $scalar) / coeff[col]
+        });
+        let mut matrix = MatMut::from_column_major_slice_mut(c, rows, cols);
+        let scratch = if transpose {
+            faer::linalg::householder::apply_block_householder_sequence_transpose_on_the_left_in_place_scratch::<$scalar>(rows, 1, cols)
+        } else {
+            faer::linalg::householder::apply_block_householder_sequence_on_the_left_in_place_scratch::<$scalar>(rows, 1, cols)
+        };
+        let mut mem = MemBuffer::new(scratch);
+        let stack = MemStack::new(&mut mem);
+        if transpose {
+            faer::linalg::householder::apply_block_householder_sequence_transpose_on_the_left_in_place_with_conj(
+                basis.as_ref(), factors.as_ref(), Conj::No, matrix.as_mut(), ctx.faer_parallelism(), stack,
+            );
+        } else {
+            faer::linalg::householder::apply_block_householder_sequence_on_the_left_in_place_with_conj(
+                basis.as_ref(), factors.as_ref(), Conj::No, matrix.as_mut(), ctx.faer_parallelism(), stack,
+            );
+        }
+        Ok(())
+    }
+
+    fn gemm_data(
+        ctx: &CpuExecutionContext<'_>,
+        a: &[Self],
+        a_rows: usize,
+        a_cols: usize,
+        b: &[Self],
+        b_cols: usize,
+        c: &mut [Self],
+    ) -> tenferro_tensor::Result<()> {
+        if a.len() != checked_product("from_factors_2d", "T", &[a_rows, a_cols])?
+            || b.len() != checked_product("from_factors_2d", "R", &[a_cols, b_cols])?
+            || c.len() != checked_product("from_factors_2d", "folded R", &[a_rows, b_cols])?
+        {
+            return Err(invalid_config("from_factors_2d", "matrix: input buffer length does not match dimensions"));
+        }
+        if a_rows == 0 || a_cols == 0 || b_cols == 0 {
+            return Ok(());
+        }
+        let lhs = MatRef::from_column_major_slice(a, a_rows, a_cols);
+        let rhs = MatRef::from_column_major_slice(b, a_cols, b_cols);
+        let out = MatMut::from_column_major_slice_mut(c, a_rows, b_cols);
+        faer::linalg::matmul::matmul(out, faer::Accum::Replace, lhs, rhs, 1.0 as $scalar, ctx.faer_parallelism());
+        Ok(())
+    }
+
+    fn one() -> Self { 1.0 }
+    fn r_phase(diagonal: Self) -> Self { if diagonal < 0.0 { -1.0 } else { 1.0 } }
+    fn q_phase(diagonal: Self) -> Self { Self::r_phase(diagonal) }
+
     fn cholesky_2d(
         ctx: &CpuExecutionContext<'_>,
         buffers: &mut BufferPool,
@@ -1973,6 +2411,144 @@ macro_rules! impl_faer_linalg_for_complex {
 
     fn parity_one() -> Self {
         <$complex>::new(1.0, 0.0)
+    }
+
+    fn compact_factor_data(
+        ctx: &CpuExecutionContext<'_>,
+        data: &mut [Self],
+        rows: usize,
+        cols: usize,
+    ) -> tenferro_tensor::Result<Vec<Self>> {
+        let expected = checked_product("compact_factor_2d", "matrix", &[rows, cols])?;
+        if data.len() != expected {
+            return Err(invalid_config("compact_factor_2d", "matrix: input buffer length does not match dimensions"));
+        }
+        let k = rows.min(cols);
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+        let mut qr = MatMut::from_column_major_slice_mut(
+            $to_faer_slice_mut(data),
+            rows,
+            cols,
+        );
+        let mut coeff = Vec::with_capacity(k);
+        for j in 0..k {
+            let mut column = qr.as_mut().col_mut(j).subrows_mut(j, rows - j);
+            let (mut head, tail) = column.rb_mut().split_at_row_mut(1);
+            let info = faer::linalg::householder::make_householder_in_place(&mut head[0], tail);
+            let beta = head[0];
+            head[0] = <$faer_complex>::new(1.0, 0.0);
+            // Faer stores H = I - vv^H/tau; compact state stores 1/tau.
+            coeff.push(<$complex>::new(1.0 / info.tau, 0.0));
+            if j + 1 < cols {
+                let mut basis = Mat::<$faer_complex>::zeros(rows - j, 1);
+                basis[(0, 0)] = <$faer_complex>::new(1.0, 0.0);
+                for row in 1..rows - j {
+                    basis[(row, 0)] = qr[(j + row, j)];
+                }
+                let factor = Mat::from_fn(1, 1, |_, _| <$faer_complex>::new(info.tau, 0.0));
+                let mut mem = MemBuffer::new(faer::linalg::householder::apply_block_householder_on_the_left_in_place_scratch::<$faer_complex>(rows - j, 1, cols - j - 1));
+                let stack = MemStack::new(&mut mem);
+                faer::linalg::householder::apply_block_householder_on_the_left_in_place_with_conj(
+                    basis.as_ref(), factor.as_ref(), Conj::No,
+                    qr.as_mut().submatrix_mut(j, j + 1, rows - j, cols - j - 1),
+                    ctx.faer_parallelism(), stack,
+                );
+            }
+            qr[(j, j)] = beta;
+        }
+        Ok(coeff)
+    }
+
+    // INVARIANT: these buffers and dimensions mirror the provider reflector ABI.
+    #[allow(clippy::too_many_arguments)]
+    fn apply_reflectors_data(
+        ctx: &CpuExecutionContext<'_>,
+        a: &[Self],
+        a_cols: usize,
+        coeff: &[Self],
+        c: &mut [Self],
+        rows: usize,
+        cols: usize,
+        k: usize,
+        transpose: bool,
+    ) -> tenferro_tensor::Result<()> {
+        if k > rows || k > a_cols || coeff.len() != k {
+            return Err(invalid_config("apply_reflectors_2d", "dimensions: reflector count exceeds matrix dimensions"));
+        }
+        if a.len() != checked_product("apply_reflectors_2d", "A", &[rows, a_cols])?
+            || c.len() != checked_product("apply_reflectors_2d", "C", &[rows, cols])?
+        {
+            return Err(invalid_config("apply_reflectors_2d", "matrix: input buffer length does not match dimensions"));
+        }
+        if rows == 0 || cols == 0 || k == 0 {
+            return Ok(());
+        }
+        let basis = MatRef::from_column_major_slice($to_faer_slice(a), rows, a_cols)
+            .subcols(0, k);
+        let coeff = $to_faer_slice(coeff);
+        let factors = Mat::from_fn(1, k, |_, col| {
+            // Rebuild Faer's denominator form transiently from state coeff.
+            <$faer_complex>::new(1.0 / coeff[col].re, 0.0)
+        });
+        let mut matrix = MatMut::from_column_major_slice_mut(
+            $to_faer_slice_mut(c),
+            rows,
+            cols,
+        );
+        let scratch = if transpose {
+            faer::linalg::householder::apply_block_householder_sequence_transpose_on_the_left_in_place_scratch::<$faer_complex>(rows, 1, cols)
+        } else {
+            faer::linalg::householder::apply_block_householder_sequence_on_the_left_in_place_scratch::<$faer_complex>(rows, 1, cols)
+        };
+        let mut mem = MemBuffer::new(scratch);
+        let stack = MemStack::new(&mut mem);
+        if transpose {
+            faer::linalg::householder::apply_block_householder_sequence_transpose_on_the_left_in_place_with_conj(
+                basis.as_ref(), factors.as_ref(), Conj::Yes, matrix.as_mut(), ctx.faer_parallelism(), stack,
+            );
+        } else {
+            faer::linalg::householder::apply_block_householder_sequence_on_the_left_in_place_with_conj(
+                basis.as_ref(), factors.as_ref(), Conj::No, matrix.as_mut(), ctx.faer_parallelism(), stack,
+            );
+        }
+        Ok(())
+    }
+
+    fn gemm_data(
+        ctx: &CpuExecutionContext<'_>,
+        a: &[Self],
+        a_rows: usize,
+        a_cols: usize,
+        b: &[Self],
+        b_cols: usize,
+        c: &mut [Self],
+    ) -> tenferro_tensor::Result<()> {
+        if a.len() != checked_product("from_factors_2d", "T", &[a_rows, a_cols])?
+            || b.len() != checked_product("from_factors_2d", "R", &[a_cols, b_cols])?
+            || c.len() != checked_product("from_factors_2d", "folded R", &[a_rows, b_cols])?
+        {
+            return Err(invalid_config("from_factors_2d", "matrix: input buffer length does not match dimensions"));
+        }
+        if a_rows == 0 || a_cols == 0 || b_cols == 0 {
+            return Ok(());
+        }
+        let lhs = MatRef::from_column_major_slice($to_faer_slice(a), a_rows, a_cols);
+        let rhs = MatRef::from_column_major_slice($to_faer_slice(b), a_cols, b_cols);
+        let out = MatMut::from_column_major_slice_mut($to_faer_slice_mut(c), a_rows, b_cols);
+        faer::linalg::matmul::matmul(out, faer::Accum::Replace, lhs, rhs, <$faer_complex>::new(1.0, 0.0), ctx.faer_parallelism());
+        Ok(())
+    }
+
+    fn one() -> Self { <$complex>::new(1.0, 0.0) }
+    fn r_phase(diagonal: Self) -> Self {
+        let norm = diagonal.norm();
+        if norm == 0.0 { Self::one() } else { diagonal.conj() / norm }
+    }
+    fn q_phase(diagonal: Self) -> Self {
+        let norm = diagonal.norm();
+        if norm == 0.0 { Self::one() } else { diagonal / norm }
     }
 
     fn cholesky_2d(

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg/tests.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg/tests.rs
@@ -1,4 +1,79 @@
 use super::checked_product;
+use crate::{QrOptions, TensorLinalgExt};
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::{BackendSessionHost, Tensor};
+
+fn product(a: &[f64], a_rows: usize, a_cols: usize, b: &[f64], b_cols: usize) -> Vec<f64> {
+    let mut out = vec![0.0; a_rows * b_cols];
+    for col in 0..b_cols {
+        for inner in 0..a_cols {
+            for row in 0..a_rows {
+                out[row + col * a_rows] += a[row + inner * a_rows] * b[inner + col * a_cols];
+            }
+        }
+    }
+    out
+}
+
+fn f64_data(tensor: &Tensor) -> &[f64] {
+    match tensor {
+        Tensor::F64(tensor) => tensor.host_data().unwrap(),
+        _ => panic!("expected f64 tensor"),
+    }
+}
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    let error = actual
+        .iter()
+        .zip(expected)
+        .map(|(actual, expected)| (actual - expected).abs())
+        .fold(0.0, f64::max);
+    assert!(error < 1.0e-10, "max reconstruction error: {error}");
+}
+
+#[test]
+fn compact_factor_and_append_reconstructs_f64() {
+    let a = Tensor::from_vec_col_major(vec![4, 2], vec![1.0, 2.0, 3.0, 4.0, 2.0, 0.0, 1.0, 3.0])
+        .unwrap();
+    let b = Tensor::from_vec_col_major(vec![4, 2], vec![3.0, -1.0, 2.0, 1.0, 0.5, 2.0, -2.0, 4.0])
+        .unwrap();
+    let mut backend = CpuBackend::new();
+    backend
+        .with_backend_session(|session| {
+            let state = a.householder_qr(session)?;
+            let state = state.append_columns(&b, session)?;
+            let q = state.q_columns(0..4, QrOptions::default(), session)?;
+            let r = state.r(QrOptions::default(), session)?;
+            let expected = [
+                1.0, 2.0, 3.0, 4.0, 2.0, 0.0, 1.0, 3.0, 3.0, -1.0, 2.0, 1.0, 0.5, 2.0, -2.0, 4.0,
+            ];
+            assert_close(&product(f64_data(&q), 4, 4, f64_data(&r), 4), &expected);
+            Ok::<(), tenferro_tensor::Error>(())
+        })
+        .unwrap();
+}
+
+#[test]
+fn compact_from_factors_reconstructs_f64() {
+    let q = Tensor::from_vec_col_major(vec![4, 2], vec![1.0, 0.0, 1.0, 0.0, 0.0, 2.0, 0.0, 1.0])
+        .unwrap();
+    let r = Tensor::from_vec_col_major(vec![2, 3], vec![2.0, 0.0, 3.0, 1.0, 4.0, 2.0]).unwrap();
+    let mut backend = CpuBackend::new();
+    backend
+        .with_backend_session(|session| {
+            let state = crate::HouseholderQr::<Tensor>::from_factors(&q, &r, session)?;
+            let q_out = state.q_columns(0..3, QrOptions::default(), session)?;
+            let r_out = state.r(QrOptions::default(), session)?;
+            let expected = product(f64_data(&q), 4, 2, f64_data(&r), 3);
+            assert_close(
+                &product(f64_data(&q_out), 4, 3, f64_data(&r_out), 3),
+                &expected,
+            );
+            Ok::<(), tenferro_tensor::Error>(())
+        })
+        .unwrap();
+}
 
 #[test]
 fn checked_matrix_element_count_reports_typed_overflow() {

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg.rs
@@ -16,7 +16,11 @@ pub(crate) use eig::{eig, eig_values};
 pub(crate) use eigh::{eigh, eigh_values};
 pub(crate) use full_piv_lu::{full_piv_lu, full_piv_lu_solve};
 pub(crate) use lu::{lu, lu_factor};
-pub(crate) use qr::qr;
+pub(crate) use qr::{
+    append_2d as householder_qr_append, compact_factor_2d as householder_qr,
+    from_factors_2d as householder_qr_from_factors, q_columns_2d as householder_qr_q_columns, qr,
+    raw_r_2d as householder_qr_r,
+};
 pub(crate) use solve::{solve, solve_from_views, solve_into};
 pub(crate) use svd::{svd, svd_values};
 pub(crate) use triangular_solve::triangular_solve;

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr.rs
@@ -9,16 +9,506 @@ use super::helpers::{
     split_core_and_batch_result, tensor_from_vec_with_template, work_len,
 };
 
-pub(crate) trait LapackQr: Clone + Copy + Default + PoolScalar {
+type CompactQrResult<T> = (TypedTensor<T>, TypedTensor<T>);
+
+pub(crate) trait LapackQr:
+    Clone + Copy + Default + PartialEq + PoolScalar + std::ops::Mul<Output = Self>
+{
+    fn geqrf_2d(data: &mut [Self], rows: usize, cols: usize) -> tenferro_tensor::Result<Vec<Self>>;
+
+    fn apply_reflectors_2d(
+        a: &[Self],
+        a_cols: usize,
+        tau: &[Self],
+        c: &mut [Self],
+        m: usize,
+        p: usize,
+        k: usize,
+        transpose: bool,
+    ) -> tenferro_tensor::Result<()>;
+
+    fn gemm_2d(
+        a: &[Self],
+        a_rows: usize,
+        a_cols: usize,
+        b: &[Self],
+        b_cols: usize,
+        c: &mut [Self],
+    ) -> tenferro_tensor::Result<()>;
+
+    fn one() -> Self;
+    fn r_phase(diagonal: Self) -> Self;
+    fn q_phase(diagonal: Self) -> Self;
+
     fn qr_2d(
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
 }
 
+fn validate_state<T>(
+    packed: &TypedTensor<T>,
+    tau: &TypedTensor<T>,
+    op: &'static str,
+) -> tenferro_tensor::Result<(usize, usize, usize)> {
+    let (m, n) = matrix_dims(packed, op)?;
+    if tau.shape().len() != 1 {
+        return Err(tenferro_tensor::Error::rank_mismatch(
+            op,
+            1,
+            tau.shape().len(),
+        ));
+    }
+    let k = m.min(n);
+    if tau.shape()[0] != k {
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            op,
+            vec![k],
+            vec![tau.shape()[0]],
+        ));
+    }
+    Ok((m, n, k))
+}
+
+fn validate_buffer_len(
+    op: &'static str,
+    role: &'static str,
+    actual: usize,
+    expected: usize,
+) -> tenferro_tensor::Result<()> {
+    if actual != expected {
+        return Err(tenferro_tensor::Error::invalid_argument(
+            op,
+            role,
+            format!("expected {expected} elements, got {actual}"),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn compact_factor_2d<T: LapackQr>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<CompactQrResult<T>> {
+    let (m, n) = matrix_dims(input, "compact_factor_2d")?;
+    let k = m.min(n);
+    let input_data = input.host_data()?;
+    let mut packed = buffers.acquire_with_capacity::<T>(input_data.len());
+    packed.extend_from_slice(input_data);
+    let tau = if has_zero_dim(input.shape()) {
+        Vec::new()
+    } else {
+        T::geqrf_2d(&mut packed, m, n)?
+    };
+    Ok((
+        tensor_from_vec_with_template(vec![m, n], packed, input)?,
+        tensor_from_vec_with_template(vec![k], tau, input)?,
+    ))
+}
+
+pub(crate) fn append_2d<T: LapackQr>(
+    buffers: &mut BufferPool,
+    packed: &TypedTensor<T>,
+    tau: &TypedTensor<T>,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<CompactQrResult<T>> {
+    let (m, old_n, old_k) = validate_state(packed, tau, "append_2d")?;
+    let (input_m, p) = matrix_dims(input, "append_2d")?;
+    if input_m != m {
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "append_2d",
+            vec![m, p],
+            vec![input_m, p],
+        ));
+    }
+    if p == 0 {
+        return Ok((
+            tensor_from_vec_with_template(
+                packed.shape().to_vec(),
+                packed.host_data()?.to_vec(),
+                packed,
+            )?,
+            tensor_from_vec_with_template(tau.shape().to_vec(), tau.host_data()?.to_vec(), tau)?,
+        ));
+    }
+    let new_n = old_n.checked_add(p).ok_or_else(|| {
+        tenferro_tensor::Error::invalid_argument("append_2d", "shape", "column count overflow")
+    })?;
+    let new_k = m.min(new_n);
+    let input_data = input.host_data()?;
+    let mut transformed = buffers.acquire_with_capacity::<T>(input_data.len());
+    transformed.extend_from_slice(input_data);
+    T::apply_reflectors_2d(
+        packed.host_data()?,
+        old_n,
+        tau.host_data()?,
+        &mut transformed,
+        m,
+        p,
+        old_k,
+        true,
+    )?;
+
+    let trailing_rows = m - old_k;
+    let mut trailing = buffers.acquire_with_capacity::<T>(checked_product(
+        "append_2d",
+        "trailing block",
+        &[trailing_rows, p],
+    )?);
+    for col in 0..p {
+        trailing.extend_from_slice(&transformed[col * m + old_k..(col + 1) * m]);
+    }
+    let new_tau = if trailing_rows == 0 {
+        Vec::new()
+    } else {
+        T::geqrf_2d(&mut trailing, trailing_rows, p)?
+    };
+
+    let packed_len = checked_product("append_2d", "packed state", &[m, new_n])?;
+    let mut output = buffers.acquire_with_capacity::<T>(packed_len);
+    output.extend_from_slice(packed.host_data()?);
+    for col in 0..p {
+        output.extend_from_slice(&transformed[col * m..col * m + old_k]);
+        output.extend_from_slice(&trailing[col * trailing_rows..(col + 1) * trailing_rows]);
+    }
+    let tau_data = tau.host_data()?;
+    let mut output_tau = buffers.acquire_with_capacity::<T>(new_k);
+    output_tau.extend_from_slice(tau_data);
+    output_tau.extend_from_slice(&new_tau);
+    validate_buffer_len("append_2d", "coefficients", output_tau.len(), new_k)?;
+    Ok((
+        tensor_from_vec_with_template(vec![m, new_n], output, packed)?,
+        tensor_from_vec_with_template(vec![new_k], output_tau, packed)?,
+    ))
+}
+
+pub(crate) fn from_factors_2d<T: LapackQr>(
+    buffers: &mut BufferPool,
+    q: &TypedTensor<T>,
+    r: &TypedTensor<T>,
+) -> tenferro_tensor::Result<CompactQrResult<T>> {
+    let (m, s) = matrix_dims(q, "from_factors_2d")?;
+    let (r_s, n) = matrix_dims(r, "from_factors_2d")?;
+    if r_s != s {
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "from_factors_2d",
+            vec![s, n],
+            vec![r_s, n],
+        ));
+    }
+    if s > m.min(n) {
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "from_factors_2d",
+            "shape",
+            "Q column count must not exceed min(Q rows, R columns)",
+        ));
+    }
+    let k = m.min(n);
+    let r_data = r.host_data()?;
+    for col in 0..n.min(s) {
+        for row in col + 1..s {
+            if r_data[row + col * s] != T::default() {
+                return Err(tenferro_tensor::Error::invalid_argument(
+                    "from_factors_2d",
+                    "R",
+                    "must be upper trapezoidal",
+                ));
+            }
+        }
+    }
+    if has_zero_dim(q.shape()) || has_zero_dim(r.shape()) {
+        return Ok((
+            tensor_from_vec_with_template(
+                vec![m, n],
+                buffers.acquire_zeroed::<T>(checked_product(
+                    "from_factors_2d",
+                    "packed state",
+                    &[m, n],
+                )?),
+                q,
+            )?,
+            tensor_from_vec_with_template(vec![k], buffers.acquire_zeroed::<T>(k), q)?,
+        ));
+    }
+
+    let q_data = q.host_data()?;
+    let mut q_packed = buffers.acquire_with_capacity::<T>(q_data.len());
+    q_packed.extend_from_slice(q_data);
+    let q_tau = T::geqrf_2d(&mut q_packed, m, s)?;
+    let t = leading_upper_triangle_from_lapack(&q_packed, m, s, s)?;
+    let mut folded =
+        buffers.acquire_zeroed::<T>(checked_product("from_factors_2d", "folded R", &[s, n])?);
+    T::gemm_2d(&t, s, s, r_data, n, &mut folded)?;
+
+    let mut packed =
+        buffers.acquire_zeroed::<T>(checked_product("from_factors_2d", "packed state", &[m, n])?);
+    for col in 0..n {
+        for row in 0..m {
+            packed[row + col * m] = if col < s && row > col {
+                q_packed[row + col * m]
+            } else if row < s {
+                folded[row + col * s]
+            } else {
+                T::default()
+            };
+        }
+    }
+    let mut tau = buffers.acquire_zeroed::<T>(k);
+    tau[..s].copy_from_slice(&q_tau);
+    Ok((
+        tensor_from_vec_with_template(vec![m, n], packed, q)?,
+        tensor_from_vec_with_template(vec![k], tau, q)?,
+    ))
+}
+
+pub(crate) fn raw_r_2d<T: LapackQr>(
+    packed: &TypedTensor<T>,
+    tau: &TypedTensor<T>,
+    positive_diagonal: bool,
+) -> tenferro_tensor::Result<TypedTensor<T>> {
+    let (m, n, k) = validate_state(packed, tau, "raw_r_2d")?;
+    let mut r = vec![T::default(); checked_product("raw_r_2d", "R", &[k, n])?];
+    let packed_data = packed.host_data()?;
+    for col in 0..n {
+        for row in 0..k.min(col + 1) {
+            r[row + col * k] = packed_data[row + col * m];
+        }
+    }
+    if positive_diagonal {
+        for diag in 0..k {
+            let phase = T::r_phase(r[diag + diag * k]);
+            for col in 0..n {
+                r[diag + col * k] = r[diag + col * k] * phase;
+            }
+        }
+    }
+    tensor_from_vec_with_template(vec![k, n], r, packed)
+}
+
+pub(crate) fn q_columns_2d<T: LapackQr>(
+    packed: &TypedTensor<T>,
+    tau: &TypedTensor<T>,
+    start: usize,
+    end: usize,
+    positive_diagonal: bool,
+) -> tenferro_tensor::Result<TypedTensor<T>> {
+    let (m, n, k) = validate_state(packed, tau, "q_columns_2d")?;
+    if start > end || end > k {
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "q_columns_2d",
+            "range",
+            format!("range {start}..{end} is outside 0..{k}"),
+        ));
+    }
+    let columns = end - start;
+    let mut q = vec![T::default(); checked_product("q_columns_2d", "Q", &[m, columns])?];
+    for col in 0..columns {
+        q[start + col + col * m] = T::one();
+    }
+    if columns != 0 {
+        T::apply_reflectors_2d(
+            packed.host_data()?,
+            n,
+            tau.host_data()?,
+            &mut q,
+            m,
+            columns,
+            k,
+            false,
+        )?;
+        if positive_diagonal {
+            let packed_data = packed.host_data()?;
+            for col in 0..columns {
+                let diag = start + col;
+                let phase = T::q_phase(packed_data[diag + diag * m]);
+                for row in 0..m {
+                    q[row + col * m] = q[row + col * m] * phase;
+                }
+            }
+        }
+    }
+    tensor_from_vec_with_template(vec![m, columns], q, packed)
+}
+
 macro_rules! impl_real_qr {
-    ($scalar:ty, $geqrf:path, $orgqr:path, $geqrf_name:literal, $orgqr_name:literal) => {
+    ($scalar:ty, $geqrf:path, $orgqr:path, $ormqr:path, $gemm:path, $geqrf_name:literal, $orgqr_name:literal, $ormqr_name:literal) => {
         impl LapackQr for $scalar {
+            fn geqrf_2d(
+                data: &mut [Self],
+                rows: usize,
+                cols: usize,
+            ) -> tenferro_tensor::Result<Vec<Self>> {
+                let k = rows.min(cols);
+                validate_buffer_len(
+                    "compact_factor_2d",
+                    "matrix",
+                    data.len(),
+                    checked_product("compact_factor_2d", "matrix", &[rows, cols])?,
+                )?;
+                if k == 0 {
+                    return Ok(Vec::new());
+                }
+                let rows_i32 = dim_i32(rows, "compact_factor_2d")?;
+                let cols_i32 = dim_i32(cols, "compact_factor_2d")?;
+                let mut tau = vec![0.0 as $scalar; k];
+                let mut query = vec![0.0 as $scalar; 1];
+                let mut info = 0;
+                // SAFETY: validated column-major storage covers rows*cols, tau has
+                // min(rows, cols) entries, and lwork=-1 writes only the query slot.
+                unsafe {
+                    $geqrf(
+                        rows_i32, cols_i32, data, rows_i32, &mut tau, &mut query, -1, &mut info,
+                    );
+                }
+                check_lapack_info(
+                    "compact_factor_2d",
+                    concat!($geqrf_name, "(work query)"),
+                    info,
+                )?;
+                let lwork = work_len(query[0] as f64, "compact_factor_2d", $geqrf_name)?;
+                let mut work = vec![0.0 as $scalar; lwork as usize];
+                // SAFETY: dimensions and workspace come from checked input and the
+                // successful LAPACK query; all mutable slices remain live and disjoint.
+                unsafe {
+                    $geqrf(
+                        rows_i32, cols_i32, data, rows_i32, &mut tau, &mut work, lwork, &mut info,
+                    );
+                }
+                check_lapack_info("compact_factor_2d", $geqrf_name, info)?;
+                Ok(tau)
+            }
+
+            fn apply_reflectors_2d(
+                a: &[Self],
+                a_cols: usize,
+                tau: &[Self],
+                c: &mut [Self],
+                m: usize,
+                p: usize,
+                k: usize,
+                transpose: bool,
+            ) -> tenferro_tensor::Result<()> {
+                if k > a_cols || k > m {
+                    return Err(tenferro_tensor::Error::invalid_argument(
+                        "apply_reflectors_2d",
+                        "dimensions",
+                        "reflector count exceeds matrix dimensions",
+                    ));
+                }
+                validate_buffer_len(
+                    "apply_reflectors_2d",
+                    "A",
+                    a.len(),
+                    checked_product("apply_reflectors_2d", "A", &[m, a_cols])?,
+                )?;
+                validate_buffer_len("apply_reflectors_2d", "tau", tau.len(), k)?;
+                validate_buffer_len(
+                    "apply_reflectors_2d",
+                    "C",
+                    c.len(),
+                    checked_product("apply_reflectors_2d", "C", &[m, p])?,
+                )?;
+                if m == 0 || p == 0 || k == 0 {
+                    return Ok(());
+                }
+                let m_i32 = dim_i32(m, "apply_reflectors_2d")?;
+                let p_i32 = dim_i32(p, "apply_reflectors_2d")?;
+                let k_i32 = dim_i32(k, "apply_reflectors_2d")?;
+                let mut query = vec![0.0 as $scalar; 1];
+                let mut info = 0;
+                let trans = if transpose { b'T' } else { b'N' };
+                // SAFETY: validated A, tau, and C slices satisfy LAPACK dimensions;
+                // lwork=-1 writes only the single query element.
+                unsafe {
+                    $ormqr(
+                        b'L', trans, m_i32, p_i32, k_i32, a, m_i32, tau, c, m_i32, &mut query, -1,
+                        &mut info,
+                    );
+                }
+                check_lapack_info(
+                    "apply_reflectors_2d",
+                    concat!($ormqr_name, "(work query)"),
+                    info,
+                )?;
+                let lwork = work_len(query[0] as f64, "apply_reflectors_2d", $ormqr_name)?;
+                let mut work = vec![0.0 as $scalar; lwork as usize];
+                // SAFETY: checked dimensions and queried workspace cover the full
+                // reflector application; A/tau are read-only and C is uniquely mutable.
+                unsafe {
+                    $ormqr(
+                        b'L', trans, m_i32, p_i32, k_i32, a, m_i32, tau, c, m_i32, &mut work,
+                        lwork, &mut info,
+                    );
+                }
+                check_lapack_info("apply_reflectors_2d", $ormqr_name, info)
+            }
+
+            fn gemm_2d(
+                a: &[Self],
+                a_rows: usize,
+                a_cols: usize,
+                b: &[Self],
+                b_cols: usize,
+                c: &mut [Self],
+            ) -> tenferro_tensor::Result<()> {
+                validate_buffer_len(
+                    "from_factors_2d",
+                    "T",
+                    a.len(),
+                    checked_product("from_factors_2d", "T", &[a_rows, a_cols])?,
+                )?;
+                validate_buffer_len(
+                    "from_factors_2d",
+                    "R",
+                    b.len(),
+                    checked_product("from_factors_2d", "R", &[a_cols, b_cols])?,
+                )?;
+                validate_buffer_len(
+                    "from_factors_2d",
+                    "folded R",
+                    c.len(),
+                    checked_product("from_factors_2d", "folded R", &[a_rows, b_cols])?,
+                )?;
+                let m = dim_i32(a_rows, "from_factors_2d")?;
+                let n = dim_i32(b_cols, "from_factors_2d")?;
+                let k = dim_i32(a_cols, "from_factors_2d")?;
+                // SAFETY: the checked slice lengths cover m*k, k*n, and m*n
+                // column-major elements; dimensions and leading dimensions fit LP64 i32.
+                unsafe {
+                    $gemm(
+                        cblas_sys::CBLAS_LAYOUT::CblasColMajor,
+                        cblas_sys::CBLAS_TRANSPOSE::CblasNoTrans,
+                        cblas_sys::CBLAS_TRANSPOSE::CblasNoTrans,
+                        m,
+                        n,
+                        k,
+                        1.0,
+                        a.as_ptr(),
+                        m,
+                        b.as_ptr(),
+                        k,
+                        0.0,
+                        c.as_mut_ptr(),
+                        m,
+                    );
+                }
+                Ok(())
+            }
+
+            fn one() -> Self {
+                1.0
+            }
+            fn r_phase(diagonal: Self) -> Self {
+                if diagonal < 0.0 {
+                    -1.0
+                } else {
+                    1.0
+                }
+            }
+            fn q_phase(diagonal: Self) -> Self {
+                Self::r_phase(diagonal)
+            }
+
             fn qr_2d(
                 _buffers: &mut BufferPool,
                 input: &TypedTensor<Self>,
@@ -90,8 +580,192 @@ macro_rules! impl_real_qr {
 }
 
 macro_rules! impl_complex_qr {
-    ($complex:ty, $geqrf:path, $ungqr:path, $geqrf_name:literal, $ungqr_name:literal) => {
+    ($complex:ty, $geqrf:path, $ungqr:path, $unmqr:path, $gemm:path, $geqrf_name:literal, $ungqr_name:literal, $unmqr_name:literal) => {
         impl LapackQr for $complex {
+            fn geqrf_2d(
+                data: &mut [Self],
+                rows: usize,
+                cols: usize,
+            ) -> tenferro_tensor::Result<Vec<Self>> {
+                let k = rows.min(cols);
+                validate_buffer_len(
+                    "compact_factor_2d",
+                    "matrix",
+                    data.len(),
+                    checked_product("compact_factor_2d", "matrix", &[rows, cols])?,
+                )?;
+                if k == 0 {
+                    return Ok(Vec::new());
+                }
+                let rows_i32 = dim_i32(rows, "compact_factor_2d")?;
+                let cols_i32 = dim_i32(cols, "compact_factor_2d")?;
+                let mut tau = vec![<$complex>::new(0.0, 0.0); k];
+                let mut query = vec![<$complex>::new(0.0, 0.0); 1];
+                let mut info = 0;
+                // SAFETY: validated column-major storage covers rows*cols, tau has
+                // min(rows, cols) entries, and lwork=-1 writes only the query slot.
+                unsafe {
+                    $geqrf(
+                        rows_i32, cols_i32, data, rows_i32, &mut tau, &mut query, -1, &mut info,
+                    );
+                }
+                check_lapack_info(
+                    "compact_factor_2d",
+                    concat!($geqrf_name, "(work query)"),
+                    info,
+                )?;
+                let lwork = work_len(query[0].re as f64, "compact_factor_2d", $geqrf_name)?;
+                let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                // SAFETY: dimensions and workspace come from checked input and the
+                // successful LAPACK query; all mutable slices remain live and disjoint.
+                unsafe {
+                    $geqrf(
+                        rows_i32, cols_i32, data, rows_i32, &mut tau, &mut work, lwork, &mut info,
+                    );
+                }
+                check_lapack_info("compact_factor_2d", $geqrf_name, info)?;
+                Ok(tau)
+            }
+
+            fn apply_reflectors_2d(
+                a: &[Self],
+                a_cols: usize,
+                tau: &[Self],
+                c: &mut [Self],
+                m: usize,
+                p: usize,
+                k: usize,
+                transpose: bool,
+            ) -> tenferro_tensor::Result<()> {
+                if k > a_cols || k > m {
+                    return Err(tenferro_tensor::Error::invalid_argument(
+                        "apply_reflectors_2d",
+                        "dimensions",
+                        "reflector count exceeds matrix dimensions",
+                    ));
+                }
+                validate_buffer_len(
+                    "apply_reflectors_2d",
+                    "A",
+                    a.len(),
+                    checked_product("apply_reflectors_2d", "A", &[m, a_cols])?,
+                )?;
+                validate_buffer_len("apply_reflectors_2d", "tau", tau.len(), k)?;
+                validate_buffer_len(
+                    "apply_reflectors_2d",
+                    "C",
+                    c.len(),
+                    checked_product("apply_reflectors_2d", "C", &[m, p])?,
+                )?;
+                if m == 0 || p == 0 || k == 0 {
+                    return Ok(());
+                }
+                let m_i32 = dim_i32(m, "apply_reflectors_2d")?;
+                let p_i32 = dim_i32(p, "apply_reflectors_2d")?;
+                let k_i32 = dim_i32(k, "apply_reflectors_2d")?;
+                let mut query = vec![<$complex>::new(0.0, 0.0); 1];
+                let mut info = 0;
+                let trans = if transpose { b'C' } else { b'N' };
+                // SAFETY: validated A, tau, and C slices satisfy LAPACK dimensions;
+                // lwork=-1 writes only the single query element.
+                unsafe {
+                    $unmqr(
+                        b'L', trans, m_i32, p_i32, k_i32, a, m_i32, tau, c, m_i32, &mut query, -1,
+                        &mut info,
+                    );
+                }
+                check_lapack_info(
+                    "apply_reflectors_2d",
+                    concat!($unmqr_name, "(work query)"),
+                    info,
+                )?;
+                let lwork = work_len(query[0].re as f64, "apply_reflectors_2d", $unmqr_name)?;
+                let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                // SAFETY: checked dimensions and queried workspace cover the full
+                // reflector application; A/tau are read-only and C is uniquely mutable.
+                unsafe {
+                    $unmqr(
+                        b'L', trans, m_i32, p_i32, k_i32, a, m_i32, tau, c, m_i32, &mut work,
+                        lwork, &mut info,
+                    );
+                }
+                check_lapack_info("apply_reflectors_2d", $unmqr_name, info)
+            }
+
+            fn gemm_2d(
+                a: &[Self],
+                a_rows: usize,
+                a_cols: usize,
+                b: &[Self],
+                b_cols: usize,
+                c: &mut [Self],
+            ) -> tenferro_tensor::Result<()> {
+                validate_buffer_len(
+                    "from_factors_2d",
+                    "T",
+                    a.len(),
+                    checked_product("from_factors_2d", "T", &[a_rows, a_cols])?,
+                )?;
+                validate_buffer_len(
+                    "from_factors_2d",
+                    "R",
+                    b.len(),
+                    checked_product("from_factors_2d", "R", &[a_cols, b_cols])?,
+                )?;
+                validate_buffer_len(
+                    "from_factors_2d",
+                    "folded R",
+                    c.len(),
+                    checked_product("from_factors_2d", "folded R", &[a_rows, b_cols])?,
+                )?;
+                let m = dim_i32(a_rows, "from_factors_2d")?;
+                let n = dim_i32(b_cols, "from_factors_2d")?;
+                let k = dim_i32(a_cols, "from_factors_2d")?;
+                let alpha = <$complex>::new(1.0, 0.0);
+                let beta = <$complex>::new(0.0, 0.0);
+                // SAFETY: the checked slice lengths cover m*k, k*n, and m*n
+                // column-major elements; dimensions and leading dimensions fit LP64 i32.
+                unsafe {
+                    $gemm(
+                        cblas_sys::CBLAS_LAYOUT::CblasColMajor,
+                        cblas_sys::CBLAS_TRANSPOSE::CblasNoTrans,
+                        cblas_sys::CBLAS_TRANSPOSE::CblasNoTrans,
+                        m,
+                        n,
+                        k,
+                        (&alpha as *const $complex).cast(),
+                        a.as_ptr().cast(),
+                        m,
+                        b.as_ptr().cast(),
+                        k,
+                        (&beta as *const $complex).cast(),
+                        c.as_mut_ptr().cast(),
+                        m,
+                    );
+                }
+                Ok(())
+            }
+
+            fn one() -> Self {
+                <$complex>::new(1.0, 0.0)
+            }
+            fn r_phase(diagonal: Self) -> Self {
+                let norm = diagonal.norm();
+                if norm == 0.0 {
+                    Self::one()
+                } else {
+                    diagonal.conj() / norm
+                }
+            }
+            fn q_phase(diagonal: Self) -> Self {
+                let norm = diagonal.norm();
+                if norm == 0.0 {
+                    Self::one()
+                } else {
+                    diagonal / norm
+                }
+            }
+
             fn qr_2d(
                 _buffers: &mut BufferPool,
                 input: &TypedTensor<Self>,
@@ -162,21 +836,45 @@ macro_rules! impl_complex_qr {
     };
 }
 
-impl_real_qr!(f32, lapack::sgeqrf, lapack::sorgqr, "sgeqrf", "sorgqr");
-impl_real_qr!(f64, lapack::dgeqrf, lapack::dorgqr, "dgeqrf", "dorgqr");
+impl_real_qr!(
+    f32,
+    lapack::sgeqrf,
+    lapack::sorgqr,
+    lapack::sormqr,
+    cblas_sys::cblas_sgemm,
+    "sgeqrf",
+    "sorgqr",
+    "sormqr"
+);
+impl_real_qr!(
+    f64,
+    lapack::dgeqrf,
+    lapack::dorgqr,
+    lapack::dormqr,
+    cblas_sys::cblas_dgemm,
+    "dgeqrf",
+    "dorgqr",
+    "dormqr"
+);
 impl_complex_qr!(
     Complex32,
     lapack::cgeqrf,
     lapack::cungqr,
+    lapack::cunmqr,
+    cblas_sys::cblas_cgemm,
     "cgeqrf",
-    "cungqr"
+    "cungqr",
+    "cunmqr"
 );
 impl_complex_qr!(
     Complex64,
     lapack::zgeqrf,
     lapack::zungqr,
+    lapack::zunmqr,
+    cblas_sys::cblas_zgemm,
     "zgeqrf",
-    "zungqr"
+    "zungqr",
+    "zunmqr"
 );
 
 fn qr_2d<T: LapackQr>(
@@ -210,3 +908,7 @@ pub(crate) fn qr<T: LapackQr>(
     }
     batched_multi("qr", buffers, input, qr_2d)
 }
+
+#[cfg(test)]
+#[path = "qr_tests.rs"]
+mod tests;

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr_tests.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr_tests.rs
@@ -1,0 +1,76 @@
+use tenferro_cpu::linalg_interop::BufferPool;
+use tenferro_tensor::TypedTensor;
+
+use super::{append_2d, compact_factor_2d, from_factors_2d, q_columns_2d, raw_r_2d};
+
+fn product(a: &[f64], a_rows: usize, a_cols: usize, b: &[f64], b_cols: usize) -> Vec<f64> {
+    let mut out = vec![0.0; a_rows * b_cols];
+    for col in 0..b_cols {
+        for inner in 0..a_cols {
+            for row in 0..a_rows {
+                out[row + col * a_rows] += a[row + inner * a_rows] * b[inner + col * a_cols];
+            }
+        }
+    }
+    out
+}
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    let error = actual
+        .iter()
+        .zip(expected)
+        .map(|(actual, expected)| (actual - expected).abs())
+        .fold(0.0, f64::max);
+    assert!(error < 1.0e-10, "max reconstruction error: {error}");
+}
+
+#[test]
+fn compact_factor_and_append_reconstruct_without_refactoring_old_columns() {
+    let a =
+        TypedTensor::from_vec_col_major(vec![4, 2], vec![1.0, 2.0, 3.0, 4.0, 2.0, 0.0, 1.0, 3.0])
+            .unwrap();
+    let b =
+        TypedTensor::from_vec_col_major(vec![4, 2], vec![3.0, -1.0, 2.0, 1.0, 0.5, 2.0, -2.0, 4.0])
+            .unwrap();
+    let mut buffers = BufferPool::new();
+
+    let (packed, tau) = compact_factor_2d(&mut buffers, &a).unwrap();
+    let (packed, tau) = append_2d(&mut buffers, &packed, &tau, &b).unwrap();
+    let r = raw_r_2d(&packed, &tau, false).unwrap();
+    let q = q_columns_2d(&packed, &tau, 0, 4, false).unwrap();
+
+    let expected = [
+        1.0, 2.0, 3.0, 4.0, 2.0, 0.0, 1.0, 3.0, 3.0, -1.0, 2.0, 1.0, 0.5, 2.0, -2.0, 4.0,
+    ];
+    assert_close(
+        &product(q.host_data().unwrap(), 4, 4, r.host_data().unwrap(), 4),
+        &expected,
+    );
+}
+
+#[test]
+fn from_factors_reconstructs_product_without_forming_dense_qr_product() {
+    let q =
+        TypedTensor::from_vec_col_major(vec![4, 2], vec![1.0, 0.0, 1.0, 0.0, 0.0, 2.0, 0.0, 1.0])
+            .unwrap();
+    let r =
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![2.0, 0.0, 3.0, 1.0, 4.0, 2.0]).unwrap();
+    let mut buffers = BufferPool::new();
+
+    let (packed, tau) = from_factors_2d(&mut buffers, &q, &r).unwrap();
+    let extracted_r = raw_r_2d(&packed, &tau, false).unwrap();
+    let extracted_q = q_columns_2d(&packed, &tau, 0, 3, false).unwrap();
+
+    let expected = product(q.host_data().unwrap(), 4, 2, r.host_data().unwrap(), 3);
+    assert_close(
+        &product(
+            extracted_q.host_data().unwrap(),
+            4,
+            3,
+            extracted_r.host_data().unwrap(),
+            3,
+        ),
+        &expected,
+    );
+}

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr_tests.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr_tests.rs
@@ -4,7 +4,10 @@ use tenferro_tensor::TypedTensor;
 use super::{append_2d, compact_factor_2d, from_factors_2d, q_columns_2d, raw_r_2d};
 
 fn product(a: &[f64], a_rows: usize, a_cols: usize, b: &[f64], b_cols: usize) -> Vec<f64> {
-    let mut out = vec![0.0; a_rows * b_cols];
+    let output_len = a_rows
+        .checked_mul(b_cols)
+        .expect("test matrix product length fits usize");
+    let mut out = vec![0.0; output_len];
     for col in 0..b_cols {
         for inner in 0..a_cols {
             for row in 0..a_rows {

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -137,6 +137,30 @@ pub trait EagerTensorLinalgExt {
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
     fn qr(&self) -> Result<(EagerTensor, EagerTensor)>;
+
+    /// Initialize opaque compact Householder QR state.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for known invalid metadata,
+    /// `Error::Extension` for unsupported or provider failures, or
+    /// `Error::RuntimeState` when eager execution is unavailable.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::EagerTensorLinalgExt;
+    /// # let runtime = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0])?, runtime)?;
+    /// let qr = a.householder_qr()?;
+    /// assert!(format!("{qr:?}").starts_with("HouseholderQr"));
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    fn householder_qr(&self) -> Result<crate::HouseholderQr<EagerTensor>>;
+
     /// # Errors
     ///
     /// Returns `Error::Validation` for invalid matrix rank or shape,
@@ -626,6 +650,10 @@ impl EagerTensorLinalgExt for EagerTensor {
         qr(self)
     }
 
+    fn householder_qr(&self) -> Result<crate::HouseholderQr<EagerTensor>> {
+        householder_qr(self)
+    }
+
     fn qr_with_options(&self, options: QrOptions) -> Result<(EagerTensor, EagerTensor)> {
         qr_with_options(self, options)
     }
@@ -928,6 +956,25 @@ pub fn svd_full(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor, EagerTenso
 /// `Error::RuntimeState` when the eager runtime or backend is unavailable.
 pub fn qr(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
     qr_with_options(a, QrOptions::default())
+}
+
+/// Initialize compact Householder QR state for an eager matrix.
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for known invalid metadata,
+/// `Error::Extension` for unsupported or provider failures, or
+/// `Error::RuntimeState` when eager execution is unavailable.
+pub fn householder_qr(a: &EagerTensor) -> Result<crate::HouseholderQr<EagerTensor>> {
+    let mut outputs = apply_linalg_eager(LinalgOp::HouseholderQrFactor, &[a])?.into_iter();
+    match (outputs.next(), outputs.next(), outputs.next()) {
+        (Some(packed), Some(coeff), None) => Ok(
+            crate::HouseholderQr::<EagerTensor>::from_eager_outputs(packed, coeff),
+        ),
+        _ => Err(Error::Internal(
+            "householder_qr returned an unexpected output count".into(),
+        )),
+    }
 }
 
 /// QR decomposition for eager tensors with explicit options.

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -305,6 +305,17 @@ pub(crate) enum LinalgOp {
     Qr {
         gauge: QrGauge,
     },
+    HouseholderQrFactor,
+    HouseholderQrFromFactors,
+    HouseholderQrAppend,
+    HouseholderQrR {
+        gauge: QrGauge,
+    },
+    HouseholderQrQColumns {
+        start: usize,
+        end: usize,
+        gauge: QrGauge,
+    },
     Eigh {
         derivative_eps: f64,
         gauge: EighGauge,
@@ -340,7 +351,13 @@ impl LinalgOp {
             | Self::SvdVals { .. }
             | Self::TriangularSolve { .. } => 1,
             Self::Svd { .. } | Self::SvdFull => 3,
-            Self::Qr { .. } | Self::Eigh { .. } | Self::Eig { .. } => 2,
+            Self::Qr { .. }
+            | Self::HouseholderQrFactor
+            | Self::HouseholderQrFromFactors
+            | Self::HouseholderQrAppend
+            | Self::Eigh { .. }
+            | Self::Eig { .. } => 2,
+            Self::HouseholderQrR { .. } | Self::HouseholderQrQColumns { .. } => 1,
             Self::LuFactor => 3,
             Self::Lu => 4,
             Self::FullPivLu => 5,
@@ -349,9 +366,14 @@ impl LinalgOp {
 
     fn input_count(self) -> usize {
         match self {
-            Self::FullPivLuSolve { .. } | Self::Solve | Self::TriangularSolve { .. } => 2,
+            Self::FullPivLuSolve { .. }
+            | Self::Solve
+            | Self::TriangularSolve { .. }
+            | Self::HouseholderQrFromFactors
+            | Self::HouseholderQrR { .. }
+            | Self::HouseholderQrQColumns { .. } => 2,
             Self::LogAbsDetFromLuFactor => 2,
-            Self::SignDetFromLuFactor => 3,
+            Self::SignDetFromLuFactor | Self::HouseholderQrAppend => 3,
             Self::LuSolvePrepared { .. } => 4,
             _ => 1,
         }
@@ -377,6 +399,11 @@ impl LinalgOp {
             Self::LogAbsDetFromLuFactor => 16,
             Self::SignDetFromLuFactor => 17,
             Self::Solve => 18,
+            Self::HouseholderQrFactor => 19,
+            Self::HouseholderQrFromFactors => 20,
+            Self::HouseholderQrAppend => 21,
+            Self::HouseholderQrR { .. } => 22,
+            Self::HouseholderQrQColumns { .. } => 23,
         }
     }
 }
@@ -415,7 +442,12 @@ impl ExtensionOp for LinalgExtensionOp {
             LinalgOp::SvdVals { derivative_eps } | LinalgOp::EighVals { derivative_eps } => {
                 hasher.write_u64(derivative_eps.to_bits());
             }
-            LinalgOp::Qr { gauge } => {
+            LinalgOp::Qr { gauge } | LinalgOp::HouseholderQrR { gauge } => {
+                hash_qr_gauge(hasher, gauge);
+            }
+            LinalgOp::HouseholderQrQColumns { start, end, gauge } => {
+                hasher.write_usize(start);
+                hasher.write_usize(end);
                 hash_qr_gauge(hasher, gauge);
             }
             LinalgOp::Eigh {
@@ -456,7 +488,10 @@ impl ExtensionOp for LinalgExtensionOp {
             | LinalgOp::SignDetFromLuFactor
             | LinalgOp::FullPivLu
             | LinalgOp::SvdFull
-            | LinalgOp::Solve => {}
+            | LinalgOp::Solve
+            | LinalgOp::HouseholderQrFactor
+            | LinalgOp::HouseholderQrFromFactors
+            | LinalgOp::HouseholderQrAppend => {}
         }
     }
 
@@ -568,6 +603,29 @@ impl ExtensionOp for LinalgExtensionOp {
                 vec![svd_values_meta(input_dtypes[0], input_shapes[0])?]
             }
             LinalgOp::Qr { .. } => qr_meta(input_dtypes[0], input_shapes[0])?,
+            LinalgOp::HouseholderQrFactor => {
+                householder_qr_factor_meta(input_dtypes[0], input_shapes[0])?
+            }
+            LinalgOp::HouseholderQrFromFactors => {
+                householder_qr_from_factors_meta(&input_dtypes, &input_shapes)?
+            }
+            LinalgOp::HouseholderQrAppend => {
+                householder_qr_append_meta(&input_dtypes, &input_shapes)?
+            }
+            LinalgOp::HouseholderQrR { .. } => vec![householder_qr_r_meta(
+                input_dtypes[0],
+                input_shapes[0],
+                input_shapes[1],
+            )?],
+            LinalgOp::HouseholderQrQColumns { start, end, .. } => {
+                vec![householder_qr_q_columns_meta(
+                    input_dtypes[0],
+                    input_shapes[0],
+                    input_shapes[1],
+                    start,
+                    end,
+                )?]
+            }
             LinalgOp::Eigh { .. } => eigh_meta(input_dtypes[0], input_shapes[0])?,
             LinalgOp::EighVals { .. } => vec![eigh_values_meta(input_dtypes[0], input_shapes[0])?],
             LinalgOp::Eig { input_dtype } => eig_meta(input_dtype, input_shapes[0])?,
@@ -683,6 +741,11 @@ fn linalg_session_supported<B: BackendSession + 'static>(op: &LinalgExtensionOp)
                 // Complete-pivoting LU and general eig have no CUDA kernels.
                 LinalgOp::FullPivLu | LinalgOp::FullPivLuSolve { .. } => false,
                 LinalgOp::Eig { .. } | LinalgOp::EigVals { .. } => false,
+                LinalgOp::HouseholderQrFactor
+                | LinalgOp::HouseholderQrFromFactors
+                | LinalgOp::HouseholderQrAppend
+                | LinalgOp::HouseholderQrR { .. }
+                | LinalgOp::HouseholderQrQColumns { .. } => false,
                 // Plain partial-pivot solve runs in-session via cuSOLVER
                 // getrf plus prepared pivot/triangular solves
                 // (`gpu/linalg.rs::solve` = lu_factor + lu_solve_prepared, no
@@ -773,6 +836,25 @@ fn execute_linalg<B: LinalgBackend>(
         LinalgOp::SvdFull => backend.svd_full(inputs[0]),
         LinalgOp::SvdVals { .. } => Ok(vec![backend.svd_values(inputs[0])?]),
         LinalgOp::Qr { gauge } => backend.qr_with_options(inputs[0], QrOptions { gauge }),
+        LinalgOp::HouseholderQrFactor => {
+            let state = backend.householder_qr(inputs[0])?;
+            Ok(vec![state.packed, state.coeff])
+        }
+        LinalgOp::HouseholderQrFromFactors => {
+            let state = backend.householder_qr_from_factors(inputs[0], inputs[1])?;
+            Ok(vec![state.packed, state.coeff])
+        }
+        LinalgOp::HouseholderQrAppend => {
+            let state = backend.householder_qr_append(inputs[0], inputs[1], inputs[2])?;
+            Ok(vec![state.packed, state.coeff])
+        }
+        LinalgOp::HouseholderQrR { gauge } => Ok(vec![backend.householder_qr_r(
+            inputs[0],
+            inputs[1],
+            QrOptions { gauge },
+        )?]),
+        LinalgOp::HouseholderQrQColumns { start, end, gauge } => Ok(vec![backend
+            .householder_qr_q_columns(inputs[0], inputs[1], start..end, QrOptions { gauge })?]),
         LinalgOp::Eigh {
             derivative_eps,
             gauge,
@@ -1293,6 +1375,108 @@ fn qr_meta(dtype: DType, shape: &[SymDim]) -> tenferro_tensor::Result<Vec<(DType
         (dtype, matrix_shape(m, k.clone(), batch)),
         (dtype, matrix_shape(k, n, batch)),
     ])
+}
+
+fn require_householder_rank2(op: &'static str, shape: &[SymDim]) -> tenferro_tensor::Result<()> {
+    if shape.len() != 2 {
+        return Err(Error::rank_mismatch(op, 2, shape.len()));
+    }
+    Ok(())
+}
+
+fn householder_qr_factor_meta(
+    dtype: DType,
+    shape: &[SymDim],
+) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+    require_householder_rank2("tenferro-linalg.householder_qr", shape)?;
+    let k = shape[0].clone().min(shape[1].clone());
+    Ok(vec![(dtype, shape.to_vec()), (dtype, vec![k])])
+}
+
+fn householder_qr_from_factors_meta(
+    dtypes: &[DType],
+    shapes: &[&[SymDim]],
+) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+    require_householder_rank2("tenferro-linalg.householder_qr_from_factors", shapes[0])?;
+    require_householder_rank2("tenferro-linalg.householder_qr_from_factors", shapes[1])?;
+    if dtypes[0] != dtypes[1] {
+        return Err(Error::dtype_mismatch(
+            "tenferro-linalg.householder_qr_from_factors",
+            dtypes[0],
+            dtypes[1],
+        ));
+    }
+    let m = shapes[0][0].clone();
+    let n = shapes[1][1].clone();
+    let k = m.clone().min(n.clone());
+    Ok(vec![(dtypes[0], vec![m, n]), (dtypes[0], vec![k])])
+}
+
+fn householder_qr_append_meta(
+    dtypes: &[DType],
+    shapes: &[&[SymDim]],
+) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+    require_householder_rank2("tenferro-linalg.householder_qr_append", shapes[0])?;
+    require_householder_rank2("tenferro-linalg.householder_qr_append", shapes[2])?;
+    if shapes[1].len() != 1 {
+        return Err(Error::rank_mismatch(
+            "tenferro-linalg.householder_qr_append",
+            1,
+            shapes[1].len(),
+        ));
+    }
+    if dtypes[0] != dtypes[1] || dtypes[0] != dtypes[2] {
+        return Err(Error::dtype_mismatch(
+            "tenferro-linalg.householder_qr_append",
+            dtypes[0],
+            dtypes[2],
+        ));
+    }
+    let m = shapes[0][0].clone();
+    let width = shapes[0][1].clone() + shapes[2][1].clone();
+    let k = m.clone().min(width.clone());
+    Ok(vec![(dtypes[0], vec![m, width]), (dtypes[0], vec![k])])
+}
+
+fn householder_qr_r_meta(
+    dtype: DType,
+    packed: &[SymDim],
+    coeff: &[SymDim],
+) -> tenferro_tensor::Result<(DType, Vec<SymDim>)> {
+    require_householder_rank2("tenferro-linalg.householder_qr_r", packed)?;
+    if coeff.len() != 1 {
+        return Err(Error::rank_mismatch(
+            "tenferro-linalg.householder_qr_r",
+            1,
+            coeff.len(),
+        ));
+    }
+    Ok((dtype, vec![coeff[0].clone(), packed[1].clone()]))
+}
+
+fn householder_qr_q_columns_meta(
+    dtype: DType,
+    packed: &[SymDim],
+    coeff: &[SymDim],
+    start: usize,
+    end: usize,
+) -> tenferro_tensor::Result<(DType, Vec<SymDim>)> {
+    require_householder_rank2("tenferro-linalg.householder_qr_q_columns", packed)?;
+    if coeff.len() != 1 || start > end {
+        return Err(Error::invalid_argument(
+            "tenferro-linalg.householder_qr_q_columns",
+            "range",
+            format!("invalid Q-column range {start}..{end}"),
+        ));
+    }
+    if coeff[0].constant_value().is_some_and(|k| end > k) {
+        return Err(Error::invalid_argument(
+            "tenferro-linalg.householder_qr_q_columns",
+            "range",
+            format!("Q-column range {start}..{end} exceeds thin-Q width"),
+        ));
+    }
+    Ok((dtype, vec![packed[0].clone(), SymDim::from(end - start)]))
 }
 
 fn eigh_meta(dtype: DType, shape: &[SymDim]) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {

--- a/crates/tenferro-linalg/src/householder.rs
+++ b/crates/tenferro-linalg/src/householder.rs
@@ -1,0 +1,384 @@
+use std::fmt;
+use std::ops::Range;
+
+use tenferro_tensor::{BackendSession, Tensor};
+
+use crate::backend::CompactQrResult;
+use crate::QrOptions;
+
+/// Opaque compact Householder QR state.
+///
+/// The packed reflector tensors remain private so callers cannot accidentally
+/// treat provider state as ordinary tensor values.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_linalg::{QrOptions, TensorLinalgExt};
+/// use tenferro_tensor::{BackendSessionHost, Tensor};
+///
+/// let a = Tensor::from_vec_col_major(
+///     vec![3, 2],
+///     vec![1.0_f64, 0.0, 1.0, 0.0, 1.0, 1.0],
+/// )?;
+/// let mut host = CpuBackend::new();
+/// let r = host.with_backend_session(|session| {
+///     let qr = a.householder_qr(session)?;
+///     qr.r(QrOptions::default(), session)
+/// })?;
+/// assert_eq!(r.shape(), &[2, 2]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+#[derive(Clone)]
+pub struct HouseholderQr<T> {
+    pub(crate) packed: T,
+    pub(crate) coeff: T,
+}
+
+impl<T> fmt::Debug for HouseholderQr<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HouseholderQr")
+            .finish_non_exhaustive()
+    }
+}
+
+impl HouseholderQr<Tensor> {
+    pub(crate) fn from_backend(state: CompactQrResult) -> Self {
+        Self {
+            packed: state.packed,
+            coeff: state.coeff,
+        }
+    }
+
+    /// Construct compact state for the product of compatible factors `Q * R`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `tenferro_tensor::Error::Validation` for incompatible rank,
+    /// shape, dtype, placement, or a non-trapezoidal R factor;
+    /// `tenferro_tensor::Error::Unsupported` when the provider lacks compact
+    /// QR; or `tenferro_tensor::Error::BackendSource` for provider failures.
+    pub fn from_factors(
+        q: &Tensor,
+        r: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Self> {
+        crate::tensor_ext::with_linalg_backend(session, "householder_qr_from_factors", |backend| {
+            backend
+                .householder_qr_from_factors(q, r)
+                .map(Self::from_backend)
+        })
+    }
+
+    /// Append a column block without refactorizing existing columns.
+    ///
+    /// # Errors
+    ///
+    /// Returns `tenferro_tensor::Error::Validation` for incompatible shape,
+    /// dtype, placement, or malformed state; `tenferro_tensor::Error::Unsupported`
+    /// when append is unavailable; or `tenferro_tensor::Error::BackendSource`
+    /// for reflector or factorization failures.
+    pub fn append_columns(
+        &self,
+        block: &Tensor,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Self> {
+        crate::tensor_ext::with_linalg_backend(session, "householder_qr_append", |backend| {
+            backend
+                .householder_qr_append(&self.packed, &self.coeff, block)
+                .map(Self::from_backend)
+        })
+    }
+
+    /// Extract the thin upper-trapezoidal factor.
+    ///
+    /// # Errors
+    ///
+    /// Returns `tenferro_tensor::Error::Validation` for malformed state,
+    /// `tenferro_tensor::Error::Unsupported` for an unavailable provider path,
+    /// or `tenferro_tensor::Error::BackendSource` for extraction failures.
+    pub fn r(
+        &self,
+        options: QrOptions,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor> {
+        crate::tensor_ext::with_linalg_backend(session, "householder_qr_r", |backend| {
+            backend.householder_qr_r(&self.packed, &self.coeff, options)
+        })
+    }
+
+    /// Materialize a contiguous range of thin-Q columns.
+    ///
+    /// # Errors
+    ///
+    /// Returns `tenferro_tensor::Error::Validation` when the range is outside
+    /// the thin-Q width or state metadata is malformed,
+    /// `tenferro_tensor::Error::Unsupported` for an unavailable provider path,
+    /// or `tenferro_tensor::Error::BackendSource` for execution failures.
+    pub fn q_columns(
+        &self,
+        columns: Range<usize>,
+        options: QrOptions,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<Tensor> {
+        crate::tensor_ext::with_linalg_backend(session, "householder_qr_q_columns", |backend| {
+            backend.householder_qr_q_columns(&self.packed, &self.coeff, columns, options)
+        })
+    }
+}
+
+#[cfg(feature = "autodiff")]
+impl HouseholderQr<tenferro_ad::EagerTensor> {
+    pub(crate) fn from_eager_outputs(
+        packed: tenferro_ad::EagerTensor,
+        coeff: tenferro_ad::EagerTensor,
+    ) -> Self {
+        Self { packed, coeff }
+    }
+
+    /// Construct compact state from compatible eager factors.
+    ///
+    /// # Errors
+    ///
+    /// Returns `tenferro_ad::Error::Validation` for known invalid metadata,
+    /// `tenferro_ad::Error::Extension` for unsupported or provider failures,
+    /// or `tenferro_ad::Error::RuntimeState` when eager execution is unavailable.
+    pub fn from_factors(
+        q: &tenferro_ad::EagerTensor,
+        r: &tenferro_ad::EagerTensor,
+    ) -> tenferro_ad::Result<Self> {
+        eager_state(crate::eager_ext::apply_linalg_eager(
+            crate::extension::LinalgOp::HouseholderQrFromFactors,
+            &[q, r],
+        )?)
+    }
+
+    /// Append an eager column block functionally.
+    ///
+    /// # Errors
+    ///
+    /// Returns `tenferro_ad::Error::Validation` for known invalid metadata,
+    /// `tenferro_ad::Error::Extension` for unsupported or provider failures,
+    /// or `tenferro_ad::Error::RuntimeState` when eager execution is unavailable.
+    pub fn append_columns(&self, block: &tenferro_ad::EagerTensor) -> tenferro_ad::Result<Self> {
+        eager_state(crate::eager_ext::apply_linalg_eager(
+            crate::extension::LinalgOp::HouseholderQrAppend,
+            &[&self.packed, &self.coeff, block],
+        )?)
+    }
+
+    /// Extract eager R.
+    ///
+    /// # Errors
+    ///
+    /// Returns `tenferro_ad::Error::Validation` for known invalid metadata,
+    /// `tenferro_ad::Error::Extension` for unsupported or provider failures,
+    /// or `tenferro_ad::Error::RuntimeState` when eager execution is unavailable.
+    pub fn r(&self, options: QrOptions) -> tenferro_ad::Result<tenferro_ad::EagerTensor> {
+        eager_one(
+            crate::eager_ext::apply_linalg_eager(
+                crate::extension::LinalgOp::HouseholderQrR {
+                    gauge: options.gauge,
+                },
+                &[&self.packed, &self.coeff],
+            )?,
+            "householder_qr_r",
+        )
+    }
+
+    /// Materialize eager thin-Q columns.
+    ///
+    /// # Errors
+    ///
+    /// Returns `tenferro_ad::Error::Validation` for known invalid metadata,
+    /// `tenferro_ad::Error::Extension` for unsupported or provider failures,
+    /// or `tenferro_ad::Error::RuntimeState` when eager execution is unavailable.
+    pub fn q_columns(
+        &self,
+        columns: Range<usize>,
+        options: QrOptions,
+    ) -> tenferro_ad::Result<tenferro_ad::EagerTensor> {
+        eager_one(
+            crate::eager_ext::apply_linalg_eager(
+                crate::extension::LinalgOp::HouseholderQrQColumns {
+                    start: columns.start,
+                    end: columns.end,
+                    gauge: options.gauge,
+                },
+                &[&self.packed, &self.coeff],
+            )?,
+            "householder_qr_q_columns",
+        )
+    }
+}
+
+#[cfg(feature = "autodiff")]
+fn eager_state(
+    outputs: Vec<tenferro_ad::EagerTensor>,
+) -> tenferro_ad::Result<HouseholderQr<tenferro_ad::EagerTensor>> {
+    let mut outputs = outputs.into_iter();
+    match (outputs.next(), outputs.next(), outputs.next()) {
+        (Some(packed), Some(coeff), None) => Ok(HouseholderQr::from_eager_outputs(packed, coeff)),
+        _ => Err(tenferro_ad::Error::Internal(
+            "compact Householder QR returned an unexpected output count".into(),
+        )),
+    }
+}
+
+#[cfg(feature = "autodiff")]
+fn eager_one(
+    outputs: Vec<tenferro_ad::EagerTensor>,
+    op: &'static str,
+) -> tenferro_ad::Result<tenferro_ad::EagerTensor> {
+    let mut outputs = outputs.into_iter();
+    match (outputs.next(), outputs.next()) {
+        (Some(output), None) => Ok(output),
+        _ => Err(tenferro_ad::Error::Internal(format!(
+            "{op} returned an unexpected output count"
+        ))),
+    }
+}
+
+impl HouseholderQr<tenferro_runtime::TracedTensor> {
+    pub(crate) fn from_traced_outputs(
+        packed: tenferro_runtime::TracedTensor,
+        coeff: tenferro_runtime::TracedTensor,
+    ) -> Self {
+        Self { packed, coeff }
+    }
+
+    /// Construct compact state from compatible traced factors.
+    ///
+    /// # Errors
+    ///
+    /// Returns `tenferro_runtime::Error::Validation` for known invalid metadata
+    /// or `tenferro_runtime::Error::Extension` for unsupported operation state.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape constraints and backend provider failures may be reported
+    /// during compile or execution.
+    pub fn from_factors(
+        q: &tenferro_runtime::TracedTensor,
+        r: &tenferro_runtime::TracedTensor,
+    ) -> tenferro_runtime::Result<Self> {
+        crate::validation::ensure_float_or_complex("householder_qr_from_factors", q.dtype())?;
+        crate::validation::ensure_float_or_complex("householder_qr_from_factors", r.dtype())?;
+        traced_state(
+            crate::extension::LinalgOp::HouseholderQrFromFactors,
+            &[q, r],
+        )
+    }
+
+    /// Append a traced column block functionally.
+    ///
+    /// # Errors
+    ///
+    /// Returns `tenferro_runtime::Error::Validation` for known invalid metadata
+    /// or `tenferro_runtime::Error::Extension` for unsupported operation state.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape constraints and backend provider failures may be reported
+    /// during compile or execution.
+    pub fn append_columns(
+        &self,
+        block: &tenferro_runtime::TracedTensor,
+    ) -> tenferro_runtime::Result<Self> {
+        crate::validation::ensure_float_or_complex("householder_qr_append", block.dtype())?;
+        traced_state(
+            crate::extension::LinalgOp::HouseholderQrAppend,
+            &[&self.packed, &self.coeff, block],
+        )
+    }
+
+    /// Extract traced R.
+    ///
+    /// # Errors
+    ///
+    /// Returns `tenferro_runtime::Error::Validation` for known invalid metadata
+    /// or `tenferro_runtime::Error::Extension` for unsupported operation state.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape constraints and backend provider failures may be reported
+    /// during compile or execution.
+    pub fn r(
+        &self,
+        options: QrOptions,
+    ) -> tenferro_runtime::Result<tenferro_runtime::TracedTensor> {
+        traced_one(
+            crate::extension::LinalgOp::HouseholderQrR {
+                gauge: options.gauge,
+            },
+            &[&self.packed, &self.coeff],
+            "householder_qr_r",
+        )
+    }
+
+    /// Materialize traced thin-Q columns.
+    ///
+    /// # Errors
+    ///
+    /// Returns `tenferro_runtime::Error::Validation` for known invalid metadata
+    /// or `tenferro_runtime::Error::Extension` for unsupported operation state.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape constraints and backend provider failures may be reported
+    /// during compile or execution.
+    pub fn q_columns(
+        &self,
+        columns: Range<usize>,
+        options: QrOptions,
+    ) -> tenferro_runtime::Result<tenferro_runtime::TracedTensor> {
+        traced_one(
+            crate::extension::LinalgOp::HouseholderQrQColumns {
+                start: columns.start,
+                end: columns.end,
+                gauge: options.gauge,
+            },
+            &[&self.packed, &self.coeff],
+            "householder_qr_q_columns",
+        )
+    }
+}
+
+fn traced_outputs(
+    op: crate::extension::LinalgOp,
+    inputs: &[&tenferro_runtime::TracedTensor],
+) -> tenferro_runtime::Result<Vec<tenferro_runtime::TracedTensor>> {
+    tenferro_runtime::extension::apply(
+        std::sync::Arc::new(crate::extension::LinalgExtensionOp::new(op)),
+        inputs,
+    )
+}
+
+fn traced_state(
+    op: crate::extension::LinalgOp,
+    inputs: &[&tenferro_runtime::TracedTensor],
+) -> tenferro_runtime::Result<HouseholderQr<tenferro_runtime::TracedTensor>> {
+    let mut outputs = traced_outputs(op, inputs)?.into_iter();
+    match (outputs.next(), outputs.next(), outputs.next()) {
+        (Some(packed), Some(coeff), None) => Ok(HouseholderQr::from_traced_outputs(packed, coeff)),
+        _ => Err(tenferro_runtime::Error::Internal(
+            "compact Householder QR returned an unexpected output count".into(),
+        )),
+    }
+}
+
+fn traced_one(
+    op: crate::extension::LinalgOp,
+    inputs: &[&tenferro_runtime::TracedTensor],
+    name: &'static str,
+) -> tenferro_runtime::Result<tenferro_runtime::TracedTensor> {
+    let mut outputs = traced_outputs(op, inputs)?.into_iter();
+    match (outputs.next(), outputs.next()) {
+        (Some(output), None) => Ok(output),
+        _ => Err(tenferro_runtime::Error::Internal(format!(
+            "{name} returned an unexpected output count"
+        ))),
+    }
+}

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -50,6 +50,7 @@ pub mod error;
 mod extension;
 #[cfg(feature = "cuda")]
 mod gpu;
+mod householder;
 pub mod prelude;
 mod tensor_ext;
 mod traced;
@@ -70,6 +71,7 @@ pub use extension::{
     extension_module, EighGauge, EighOptions, QrGauge, QrOptions, SvdGauge, SvdOptions,
     DEFAULT_DECOMPOSITION_DERIVATIVE_EPS, LINALG_EXTENSION_FAMILY_ID,
 };
+pub use householder::HouseholderQr;
 pub use tensor_ext::{
     LinalgScalar, TensorLinalgExt, TensorReadLinalgExt, TypedEig, TypedFullPivLu, TypedLu,
     TypedSvd, TypedTensorLinalgExt,

--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -202,6 +202,31 @@ pub trait TensorLinalgExt {
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     fn qr(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+
+    /// Initialize opaque compact Householder QR state.
+    ///
+    /// # Errors
+    ///
+    /// Returns validation errors for non-matrix or unsupported-dtype input and
+    /// typed provider errors when compact QR is unavailable.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::TensorLinalgExt;
+    /// use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// let a = Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0])?;
+    /// let mut host = CpuBackend::new();
+    /// let qr = host.with_backend_session(|session| a.householder_qr(session))?;
+    /// assert!(format!("{qr:?}").starts_with("HouseholderQr"));
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn householder_qr(
+        &self,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<crate::HouseholderQr<Tensor>>;
+
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation errors for matrix metadata or options, plus QR backend errors.
@@ -1537,6 +1562,16 @@ impl TensorLinalgExt for Tensor {
     fn qr(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<(Tensor, Tensor)> {
         with_linalg_backend(session, "qr", |backend| two(backend.qr(self)?, "qr"))
     }
+    fn householder_qr(
+        &self,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<crate::HouseholderQr<Tensor>> {
+        with_linalg_backend(session, "householder_qr", |backend| {
+            backend
+                .householder_qr(self)
+                .map(crate::HouseholderQr::from_backend)
+        })
+    }
     fn qr_with_options(
         &self,
         options: QrOptions,
@@ -2143,7 +2178,7 @@ fn typed_eigh<T: LinalgScalar>(
 /// [`LinalgBackend`] implementations remain supported through the SPI trait,
 /// but the concrete op path is built-in-session only. The composite bodies
 /// run on the borrowed `&mut dyn LinalgBackend` exactly as before.
-fn with_linalg_backend<X>(
+pub(crate) fn with_linalg_backend<X>(
     session: &mut dyn BackendSession,
     op: &'static str,
     f: impl FnOnce(&mut dyn LinalgBackend) -> tenferro_tensor::Result<X>,

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -79,6 +79,29 @@ pub trait TracedTensorLinalgExt {
     /// compile or execution time for symbolic inputs.
     fn qr(&self) -> Result<(TracedTensor, TracedTensor)>;
 
+    /// Build opaque compact Householder QR state.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for known invalid graph metadata or
+    /// `Error::Extension` for an unsupported operation.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape and backend provider checks may fail at compile or execution.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::TracedTensorLinalgExt;
+    /// use tenferro_runtime::TracedTensor;
+    /// let a = TracedTensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0])?;
+    /// let qr = a.householder_qr()?;
+    /// assert!(format!("{qr:?}").starts_with("HouseholderQr"));
+    /// # Ok::<(), tenferro_runtime::Error>(())
+    /// ```
+    fn householder_qr(&self) -> Result<crate::HouseholderQr<TracedTensor>>;
+
     /// Build a traced QR operation with explicit gauge options.
     ///
     /// # Errors
@@ -365,6 +388,10 @@ impl TracedTensorLinalgExt for TracedTensor {
         qr(self)
     }
 
+    fn householder_qr(&self) -> Result<crate::HouseholderQr<TracedTensor>> {
+        householder_qr(self)
+    }
+
     fn qr_with_options(&self, options: QrOptions) -> Result<(TracedTensor, TracedTensor)> {
         qr_with_options(self, options)
     }
@@ -605,6 +632,32 @@ pub fn svd_full(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor, TracedT
 /// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn qr(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
     qr_with_options(a, QrOptions::default())
+}
+
+/// Build compact Householder QR state for a traced matrix.
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for known invalid graph metadata or
+/// `Error::Extension` for an unsupported operation.
+///
+/// # Deferred errors
+///
+/// Symbolic shape constraints and backend provider failures may be reported
+/// during compile or execution.
+pub fn householder_qr(a: &TracedTensor) -> Result<crate::HouseholderQr<TracedTensor>> {
+    ensure_float_or_complex("householder_qr", a.dtype)?;
+    let mut outputs = apply(
+        Arc::new(LinalgExtensionOp::new(LinalgOp::HouseholderQrFactor)),
+        &[a],
+    )?
+    .into_iter();
+    match (outputs.next(), outputs.next(), outputs.next()) {
+        (Some(packed), Some(coeff), None) => Ok(
+            crate::HouseholderQr::<TracedTensor>::from_traced_outputs(packed, coeff),
+        ),
+        _ => Err(unexpected_output_count("householder_qr", 2)),
+    }
 }
 
 /// Build a traced QR decomposition op with explicit options.

--- a/crates/tenferro-linalg/tests/integration.rs
+++ b/crates/tenferro-linalg/tests/integration.rs
@@ -21,6 +21,8 @@ mod full_svd_lstsq;
 mod gpu_linalg;
 #[path = "integration/gpu_linalg_source_contract.rs"]
 mod gpu_linalg_source_contract;
+#[path = "integration/householder_qr.rs"]
+mod householder_qr;
 #[path = "integration/inject_dual_abi_tests.rs"]
 mod inject_dual_abi_tests;
 #[path = "integration/inject_tests.rs"]

--- a/crates/tenferro-linalg/tests/integration/ad_support_manifest.rs
+++ b/crates/tenferro-linalg/tests/integration/ad_support_manifest.rs
@@ -33,6 +33,11 @@ fn linalg_ad_support_manifest_covers_all_dispatch_arms_in_order() {
         LinalgAdOpKind::EigVals,
         LinalgAdOpKind::TriangularSolve,
         LinalgAdOpKind::SvdFull,
+        LinalgAdOpKind::HouseholderQrFactor,
+        LinalgAdOpKind::HouseholderQrFromFactors,
+        LinalgAdOpKind::HouseholderQrAppend,
+        LinalgAdOpKind::HouseholderQrR,
+        LinalgAdOpKind::HouseholderQrQColumns,
     ];
 
     let manifest = all_linalg_ad_support();
@@ -46,6 +51,25 @@ fn linalg_ad_support_manifest_covers_all_dispatch_arms_in_order() {
         for (output_index, output) in entry.outputs.iter().enumerate() {
             assert_eq!(output.index, output_index);
         }
+    }
+}
+
+#[test]
+fn incremental_householder_qr_is_explicitly_unsupported_before_oracles() {
+    for kind in [
+        LinalgAdOpKind::HouseholderQrFactor,
+        LinalgAdOpKind::HouseholderQrFromFactors,
+        LinalgAdOpKind::HouseholderQrAppend,
+        LinalgAdOpKind::HouseholderQrR,
+        LinalgAdOpKind::HouseholderQrQColumns,
+    ] {
+        let entry = linalg_ad_support(kind);
+        assert_eq!(entry.jvp.status, LinalgAdRuleSupport::Unsupported);
+        assert_eq!(entry.vjp.status, LinalgAdRuleSupport::Unsupported);
+        assert!(entry
+            .outputs
+            .iter()
+            .all(|output| output.status == LinalgAdRuleSupport::Unsupported));
     }
 }
 

--- a/crates/tenferro-linalg/tests/integration/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/integration/backend_errors.rs
@@ -3,7 +3,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use num_complex::{Complex32, Complex64};
 use tenferro_cpu::CpuBackend;
-use tenferro_linalg::{LinalgBackend, TensorLinalgExt};
+use tenferro_linalg::{LinalgBackend, QrOptions, TensorLinalgExt};
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
     BackendStorageHandle, CompareDir, DType, DotGeneralConfig, Error, ErrorKind, GatherConfig,
@@ -285,6 +285,55 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         eig_values_result: None,
         eig_values_calls: 0,
     };
+    let state_tensor = Tensor::F64(input.duplicate().unwrap());
+    let unsupported = [
+        (
+            LinalgBackend::householder_qr(&mut backend, &state_tensor).unwrap_err(),
+            "householder_qr",
+        ),
+        (
+            LinalgBackend::householder_qr_from_factors(&mut backend, &state_tensor, &state_tensor)
+                .unwrap_err(),
+            "householder_qr_from_factors",
+        ),
+        (
+            LinalgBackend::householder_qr_append(
+                &mut backend,
+                &state_tensor,
+                &state_tensor,
+                &state_tensor,
+            )
+            .unwrap_err(),
+            "householder_qr_append",
+        ),
+        (
+            LinalgBackend::householder_qr_r(
+                &mut backend,
+                &state_tensor,
+                &state_tensor,
+                QrOptions::default(),
+            )
+            .unwrap_err(),
+            "householder_qr_r",
+        ),
+        (
+            LinalgBackend::householder_qr_q_columns(
+                &mut backend,
+                &state_tensor,
+                &state_tensor,
+                0..1,
+                QrOptions::default(),
+            )
+            .unwrap_err(),
+            "householder_qr_q_columns",
+        ),
+    ];
+    for (error, expected_op) in unsupported {
+        assert!(matches!(
+            error,
+            Error::Unsupported { op, .. } if op == expected_op
+        ));
+    }
 
     // The concrete linalg traits dispatch internally to the built-in
     // CPU/CUDA execution sessions; a session without a linalg capability

--- a/crates/tenferro-linalg/tests/integration/householder_qr.rs
+++ b/crates/tenferro-linalg/tests/integration/householder_qr.rs
@@ -1,0 +1,304 @@
+use std::ops::{Add, Mul, Sub};
+
+use num_complex::{Complex32, Complex64};
+use tenferro_cpu::CpuBackend;
+use tenferro_linalg::{HouseholderQr, QrOptions, TensorLinalgExt};
+use tenferro_tensor::{BackendSessionHost, Tensor, TensorScalar};
+
+fn product(a: &[f64], rows: usize, inner: usize, b: &[f64], cols: usize) -> Vec<f64> {
+    let mut output = vec![0.0; rows * cols];
+    for col in 0..cols {
+        for k in 0..inner {
+            for row in 0..rows {
+                output[row + col * rows] += a[row + k * rows] * b[k + col * inner];
+            }
+        }
+    }
+    output
+}
+
+fn assert_close(actual: &[f64], expected: &[f64]) {
+    let error = actual
+        .iter()
+        .zip(expected)
+        .map(|(actual, expected)| (actual - expected).abs())
+        .fold(0.0, f64::max);
+    assert_eq!(actual.len(), expected.len());
+    assert!(error < 1.0e-10, "maximum reconstruction error: {error}");
+}
+
+trait SampleScalar:
+    TensorScalar + Copy + Default + Add<Output = Self> + Sub<Output = Self> + Mul<Output = Self>
+{
+    fn from_parts(real: f64, imaginary: f64) -> Self;
+    fn from_real(value: f64) -> Self {
+        Self::from_parts(value, 0.0)
+    }
+    fn magnitude(self) -> f64;
+}
+
+macro_rules! real_sample {
+    ($scalar:ty) => {
+        impl SampleScalar for $scalar {
+            fn from_parts(real: f64, _imaginary: f64) -> Self {
+                real as Self
+            }
+            fn magnitude(self) -> f64 {
+                self.abs() as f64
+            }
+        }
+    };
+}
+real_sample!(f32);
+real_sample!(f64);
+
+macro_rules! complex_sample {
+    ($scalar:ty, $real:ty) => {
+        impl SampleScalar for $scalar {
+            fn from_parts(real: f64, imaginary: f64) -> Self {
+                Self::new(real as $real, imaginary as $real)
+            }
+            fn magnitude(self) -> f64 {
+                self.norm() as f64
+            }
+        }
+    };
+}
+complex_sample!(Complex32, f32);
+complex_sample!(Complex64, f64);
+
+fn check_factor_dtype<T: SampleScalar>() {
+    let values = [1.0, 2.0, 3.0, 2.0, -1.0, 4.0]
+        .into_iter()
+        .map(T::from_real)
+        .collect::<Vec<_>>();
+    let input = Tensor::from_vec_col_major(vec![3, 2], values.clone()).unwrap();
+    let mut backend = CpuBackend::new();
+    backend.with_backend_session(|session| {
+        let state = input.householder_qr(session).unwrap();
+        let q = state
+            .q_columns(0..2, QrOptions::default(), session)
+            .unwrap();
+        let r = state.r(QrOptions::default(), session).unwrap();
+        let reconstructed = product_generic(
+            q.as_slice::<T>().unwrap(),
+            3,
+            2,
+            r.as_slice::<T>().unwrap(),
+            2,
+        );
+        let error = reconstructed
+            .iter()
+            .zip(values)
+            .map(|(actual, expected)| (*actual - expected).magnitude())
+            .fold(0.0, f64::max);
+        assert!(error < 2.0e-5, "maximum reconstruction error: {error}");
+    });
+}
+
+fn product_generic<T: SampleScalar>(
+    a: &[T],
+    rows: usize,
+    inner: usize,
+    b: &[T],
+    cols: usize,
+) -> Vec<T> {
+    let mut output = vec![T::default(); rows * cols];
+    for col in 0..cols {
+        for k in 0..inner {
+            for row in 0..rows {
+                output[row + col * rows] =
+                    output[row + col * rows] + a[row + k * rows] * b[k + col * inner];
+            }
+        }
+    }
+    output
+}
+
+#[test]
+fn compact_qr_reconstructs_all_supported_dtypes() {
+    check_factor_dtype::<f32>();
+    check_factor_dtype::<f64>();
+    check_factor_dtype::<Complex32>();
+    check_factor_dtype::<Complex64>();
+}
+
+fn check_append_dtype<T: SampleScalar>() {
+    let a_values = [(1.0, 0.5), (2.0, -1.0), (3.0, 0.25)]
+        .into_iter()
+        .map(|(real, imaginary)| T::from_parts(real, imaginary))
+        .collect::<Vec<_>>();
+    let b_values = [(0.5, -0.75), (-1.0, 0.5), (2.0, 1.25)]
+        .into_iter()
+        .map(|(real, imaginary)| T::from_parts(real, imaginary))
+        .collect::<Vec<_>>();
+    let expected = [a_values.as_slice(), b_values.as_slice()].concat();
+    let a = Tensor::from_vec_col_major(vec![3, 1], a_values).unwrap();
+    let b = Tensor::from_vec_col_major(vec![3, 1], b_values).unwrap();
+    let mut backend = CpuBackend::new();
+    backend.with_backend_session(|session| {
+        let state = a
+            .householder_qr(session)
+            .unwrap()
+            .append_columns(&b, session)
+            .unwrap();
+        let q = state
+            .q_columns(0..2, QrOptions::default(), session)
+            .unwrap();
+        let r = state.r(QrOptions::default(), session).unwrap();
+        let reconstructed = product_generic(
+            q.as_slice::<T>().unwrap(),
+            3,
+            2,
+            r.as_slice::<T>().unwrap(),
+            2,
+        );
+        let error = reconstructed
+            .iter()
+            .zip(expected)
+            .map(|(actual, expected)| (*actual - expected).magnitude())
+            .fold(0.0, f64::max);
+        assert!(
+            error < 2.0e-5,
+            "maximum append reconstruction error: {error}"
+        );
+    });
+}
+
+#[test]
+fn compact_qr_append_reconstructs_all_supported_dtypes() {
+    check_append_dtype::<f32>();
+    check_append_dtype::<f64>();
+    check_append_dtype::<Complex32>();
+    check_append_dtype::<Complex64>();
+}
+
+#[test]
+fn concrete_compact_qr_appends_and_reconstructs() {
+    let a =
+        Tensor::from_vec_col_major(vec![4, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 2.0, 0.0, 1.0, 3.0])
+            .unwrap();
+    let b = Tensor::from_vec_col_major(
+        vec![4, 2],
+        vec![3.0_f64, -1.0, 2.0, 1.0, 0.5, 2.0, -2.0, 4.0],
+    )
+    .unwrap();
+    let expected = [a.as_slice::<f64>().unwrap(), b.as_slice::<f64>().unwrap()].concat();
+    let mut backend = CpuBackend::new();
+
+    backend
+        .with_backend_session(|session| {
+            let state = a.householder_qr(session)?.append_columns(&b, session)?;
+            let q = state.q_columns(0..4, QrOptions::default(), session)?;
+            let r = state.r(QrOptions::default(), session)?;
+            assert_close(
+                &product(q.as_slice::<f64>()?, 4, 4, r.as_slice::<f64>()?, 4),
+                &expected,
+            );
+            Ok::<(), tenferro_tensor::Error>(())
+        })
+        .unwrap();
+}
+
+#[test]
+fn rank_deficient_zero_append_and_tall_to_wide_transition_reconstruct() {
+    let a = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 2.0, 4.0, 6.0]).unwrap();
+    let empty = Tensor::from_vec_col_major(vec![3, 0], Vec::<f64>::new()).unwrap();
+    let b =
+        Tensor::from_vec_col_major(vec![3, 2], vec![0.0_f64, 1.0, -1.0, 2.0, 0.5, 3.0]).unwrap();
+    let expected = [a.as_slice::<f64>().unwrap(), b.as_slice::<f64>().unwrap()].concat();
+    let mut backend = CpuBackend::new();
+
+    backend
+        .with_backend_session(|session| {
+            let state = a
+                .householder_qr(session)?
+                .append_columns(&empty, session)?
+                .append_columns(&b, session)?;
+            let q = state.q_columns(0..3, QrOptions::default(), session)?;
+            let r = state.r(QrOptions::default(), session)?;
+            assert_close(
+                &product(q.as_slice::<f64>()?, 3, 3, r.as_slice::<f64>()?, 4),
+                &expected,
+            );
+            Ok::<(), tenferro_tensor::Error>(())
+        })
+        .unwrap();
+}
+
+#[test]
+fn concrete_from_factors_requires_upper_trapezoidal_r() {
+    let q =
+        Tensor::from_vec_col_major(vec![4, 2], vec![1.0_f64, 0.0, 1.0, 0.0, 0.0, 2.0, 0.0, 1.0])
+            .unwrap();
+    let invalid_r = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 1.0, 3.0, 4.0]).unwrap();
+    let mut backend = CpuBackend::new();
+
+    backend.with_backend_session(|session| {
+        let error = HouseholderQr::<Tensor>::from_factors(&q, &invalid_r, session)
+            .expect_err("non-trapezoidal R must be rejected");
+        assert!(matches!(error, tenferro_tensor::Error::Validation { .. }));
+    });
+}
+
+#[test]
+fn traced_compact_qr_preserves_known_shapes() {
+    use tenferro_linalg::TracedTensorLinalgExt;
+    use tenferro_runtime::{GraphCompiler, TracedTensor};
+
+    let a = TracedTensor::from_vec_col_major(
+        vec![4, 2],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 2.0, 0.0, 1.0, 3.0],
+    )
+    .unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![4, 1], vec![3.0_f64, -1.0, 2.0, 1.0]).unwrap();
+    let state = a.householder_qr().unwrap().append_columns(&b).unwrap();
+    let q = state.q_columns(1..3, QrOptions::default()).unwrap();
+    let r = state.r(QrOptions::default()).unwrap();
+    let program = GraphCompiler::new().compile_many(&[&q, &r]).unwrap();
+    let outputs = super::support::run_all(&program, &[]).unwrap();
+    assert_eq!(outputs[0].shape(), &[4, 2]);
+    assert_eq!(outputs[1].shape(), &[3, 3]);
+}
+
+#[cfg(feature = "autodiff")]
+#[test]
+fn householder_qr_ad_rejects_before_oracles() {
+    use tenferro_ad::AdContext;
+    use tenferro_linalg::TracedTensorLinalgExt;
+    use tenferro_runtime::TracedTensor;
+
+    let a = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 0.0, 1.0, 0.0, 1.0, 1.0])
+        .unwrap();
+    let r = a.householder_qr().unwrap().r(QrOptions::default()).unwrap();
+    let loss = r.reduce_sum(None).unwrap();
+    let ad = AdContext::builder()
+        .with_semantic_extension_rules(tenferro_linalg::semantic_ad_rules().unwrap())
+        .unwrap()
+        .build()
+        .unwrap();
+    let error = ad
+        .grad(&loss, &a)
+        .expect_err("incremental QR AD must reject until its oracle-backed rules land");
+    assert!(error.to_string().contains("unsupported"));
+}
+
+#[cfg(feature = "autodiff")]
+#[test]
+fn eager_compact_qr_executes_on_cpu() {
+    use tenferro_ad::{EagerRuntime, EagerTensor};
+    use tenferro_linalg::EagerTensorLinalgExt;
+
+    let runtime = EagerRuntime::with_cpu_backend(CpuBackend::new()).unwrap();
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 0.0, 1.0, 0.0, 1.0, 1.0]).unwrap(),
+        runtime,
+    )
+    .unwrap();
+    let state = a.householder_qr().unwrap();
+    assert_eq!(state.r(QrOptions::default()).unwrap().shape(), &[2, 2]);
+    assert_eq!(
+        state.q_columns(0..2, QrOptions::default()).unwrap().shape(),
+        &[3, 2]
+    );
+}

--- a/docs/design/incremental-householder-qr.md
+++ b/docs/design/incremental-householder-qr.md
@@ -1,0 +1,357 @@
+# Incremental Householder QR
+
+**Issue:** [#1735](https://github.com/tensor4all/tenferro-rs/issues/1735)
+
+**Status:** approved for implementation. `reviewer-flash` Round 3 returned
+**Correct-to-merge** after the Round-2 findings were fixed; see the
+[design work log](../worklogs/2026-09-01-incremental-householder-qr-design.md).
+
+## Purpose
+
+Adaptive algorithms need to append column blocks without refactorizing the
+accumulated matrix or materializing its full orthogonal factor. The existing
+`qr` API returns explicit `(Q, R)` and discards provider reflector state, so it
+cannot provide that operation efficiently.
+
+This design adds an opaque, backend-neutral compact QR state to
+`tenferro-linalg`. The state stays on its input device. CPU and CUDA providers
+execute Householder factorization and reflector application natively; no path
+may download to the host, reconstruct the accumulated matrix, or call one-shot
+QR during append.
+
+## V1 scope
+
+V1 supports:
+
+- rank-2 matrices;
+- `F32`, `F64`, `C32`, and `C64`;
+- initialization from a matrix;
+- initialization from compatible factors `(Q, R)`;
+- functional column-block append;
+- extraction of the thin upper-trapezoidal `R`;
+- materialization of a contiguous range of thin-`Q` columns;
+- concrete `Tensor`, eager `EagerTensor`, and traced `TracedTensor` surfaces;
+- CPU-faer, CPU-BLAS/LAPACK, and CUDA execution;
+- JVP and VJP through every operation on the full-rank differentiable domain.
+
+V1 does not add pivoting, rank revelation, batching, arbitrary Q-column index
+lists, serialization of provider-private handles, or WebGPU/ROCm execution.
+
+## Public state and operations
+
+The public state is:
+
+```rust
+pub struct HouseholderQr<T> { /* private */ }
+```
+
+`T` is `Tensor`, `EagerTensor`, or `TracedTensor`. The payload is private and
+has a bounded summary `Debug` implementation; users cannot treat packed
+reflectors as ordinary tensor values.
+
+The canonical operation vocabulary is:
+
+```text
+A.householder_qr(...)                  -> HouseholderQr
+HouseholderQr::from_factors(Q, R, ...) -> HouseholderQr
+state.append_columns(B, ...)           -> HouseholderQr
+state.r(options, ...)                   -> R
+state.q_columns(start..end, options, ...) -> Q[:, start..end]
+```
+
+Concrete operations take an explicit `LinalgBackend`. Eager and traced
+operations use their owning runtime. `append_columns` consumes and returns the
+state where the Rust surface permits it, allowing provider buffer reuse without
+observable mutation.
+
+`QrOptions` controls output gauge for `r` and `q_columns`. The compact state
+itself always uses raw provider-neutral Householder gauge. Calling `r` and
+`q_columns` with the same options yields mutually consistent factors. Gauge
+post-processing is part of the selected provider execution; it must not call
+the existing host-only gauge helper for backend-resident tensors.
+
+No additional public raw-factor accessors or provider-specific state types are
+added.
+
+## Mathematical state
+
+For an accumulated matrix `A` of shape `m x n`, let `k = min(m, n)`. The
+private logical state contains:
+
+- `packed`, shape `m x n`: `R` on and above the diagonal and Householder tails
+  below it;
+- `coeff`, shape `k`: one coefficient per implicit-unit reflector.
+
+The provider-neutral convention is
+
+```text
+H_j = I - coeff[j] * v_j * v_j^H
+A   = Q R
+Q   = H_0 H_1 ... H_{k-1}
+```
+
+`v_j` is zero before row `j`, one at row `j`, and stores its remaining tail in
+`packed`. Fixed-position zero reflectors remain present, including for
+rank-deficient inputs, so every provider exposes the same shapes and append
+semantics.
+
+LAPACK and cuSOLVER `tau` values map directly to `coeff`. A provider with a
+blocked or reciprocal coefficient representation converts at this state
+boundary. Provider handles and blocked workspace are execution resources, not
+part of `HouseholderQr`.
+
+## Validation
+
+Initialization from `A` requires rank 2 and a supported dtype.
+
+`from_factors(Q, R)` requires:
+
+- rank-2 inputs with the same supported dtype and placement;
+- `Q.shape = [m, s]` and `R.shape = [s, n]`;
+- `s <= min(m, n)`;
+- `R` is exactly upper trapezoidal, as produced by QR factorization;
+- the same eager runtime or concrete backend provider.
+
+It does not assume that `Q` is already orthonormal. The provider factorizes
+`Q = Q_h T` and folds the small triangular factor into `R_h = T R`, producing
+a compact state for the mathematical product `Q R`. Requiring upper-trapezoidal
+`R` keeps `R_h` upper trapezoidal and makes this bridge possible without
+refactorizing the full `m x n` product. Rank-deficient factors remain valid
+primal inputs.
+
+For append, `B` must have shape `m x p` and match the state's dtype, placement,
+runtime, and provider. A zero-column block returns the state unchanged.
+
+`q_columns(start..end)` requires `start <= end <= k` and returns shape
+`m x (end - start)`. `r()` returns shape `k x n`. Zero-sized matrix dimensions
+and empty Q ranges preserve these shape rules without issuing invalid provider
+calls.
+
+Known invalid metadata is rejected at API or graph-build time. Symbolic
+constraints are retained and reported through the existing compile/execution
+error phases. Provider, numerical, and validation failures use existing typed
+linalg/tensor error categories and preserve their source chain.
+
+## Append algorithm
+
+For old width `n`, `k = min(m, n)`, and a block `B` of width `p`:
+
+1. Apply the existing reflector sequence to compute `Y = Q^H B` without
+   materializing `Q`.
+2. Copy `Y[0..k, :]` into the upper-right block of the enlarged `R`.
+3. Householder-factor `Y[k..m, :]` in place.
+4. Store the new reflector tails and coefficients after the old sequence.
+5. Return state shapes `packed: m x (n + p)` and
+   `coeff: min(m, n + p)`.
+
+When `k == m`, append only applies `Q^H` and extends `R`; it creates no new
+reflectors. Existing columns are never refactorized.
+
+`r()` extracts the upper trapezoid. `q_columns(start..end)` initializes only the
+requested identity columns and applies the reflector sequence, so full `Q` is
+materialized only when the caller requests the full range.
+
+## Gauge and rank deficiency
+
+Raw state follows provider QR gauge. `QrGauge::PositiveDiagonal` applies the
+same phase/sign convention as existing `qr_with_options` at output time. The
+phase is computed from the matching diagonal of `R` and applied consistently
+to requested Q columns and R rows.
+
+Primal factorization and append are defined for rank-deficient inputs and do
+not choose a numerical-rank tolerance. Small or zero diagonal entries are
+returned as produced by the provider. AD is defined only on the ordinary
+full-rank differentiable domain; a singular triangular solve in a derivative
+reports the existing typed numerical failure.
+
+## Eager, traced, and runtime representation
+
+The linalg extension vocabulary gains pure operations and matching AD-manifest
+entries for:
+
+- factorization from one matrix;
+- factorization from `(Q, R)`;
+- append from `(packed, coeff, B)`;
+- R extraction from `(packed, coeff)`;
+- Q-column materialization from `(packed, coeff)`.
+
+The phase-2 manifest marks each entry `Unsupported`; phase 3 changes an entry
+only after its oracle and numerical tests land.
+
+State-producing operations return ordered `(packed, coeff)` tensor outputs;
+`HouseholderQr<T>` is the only public wrapper that can construct or consume
+that pair. Payloads record all shape-affecting attributes, including the Q
+column range and gauge, so extension fingerprints and transform-cache keys stay
+structural and deterministic.
+
+The runtime prepares these operations through the existing linalg extension
+module. Missing provider support is explicit; extension execution never falls
+back to eager execution, CPU, full QR, or host reconstruction.
+
+## Backend contract
+
+Hidden `LinalgBackend` hooks operate on the internal compact-state result type.
+Their defaults return `Unsupported`. The hooks are factor, `from_factors`,
+append, R extraction, and Q-column application; they do not expose raw LAPACK
+routines publicly.
+
+### CPU-BLAS/LAPACK
+
+Use `*geqrf`, `*ormqr`/`*unmqr`, and trailing-block `*geqrf`. Dimension and
+workspace sizes are checked before integer conversion and FFI. Scratch comes
+from the existing session-owned linalg pool and threading remains provider
+controlled.
+
+### CPU-faer
+
+Use faer's public `make_householder_in_place` elementary-reflector primitive
+inside the configured `CpuExecutionContext`, storing its scalar `tau` in
+`coeff`. Apply reflectors with faer matrix primitives in the required order.
+The existing convenience QR path uses a blocked `block_size x k` coefficient
+matrix, so it is not the state constructor and is not converted by merely
+reading one row. A later blocked implementation may derive transient WY factors
+from the scalar state, but those factors remain session scratch. Fixed-position
+zero reflectors must be preserved.
+
+### CUDA
+
+cuSOLVER provides `*geqrf` and `*orgqr`/`*ungqr`, but not LAPACK's
+`*ormqr`/`*unmqr`. V1 therefore uses cuSOLVER `*geqrf` for new reflectors and
+applies the stored sequence on the active stream with cuBLAS:
+
+1. `gemv` with conjugate transpose computes `w = v^H C`;
+2. scale by `tau` (or `conj(tau)` for the adjoint reflector application);
+3. real `ger` or complex unconjugated `geru` performs `C -= v w`.
+
+Reflectors are enqueued one at a time in the mathematically required order:
+`Q^H C` applies `j = 0, ..., k - 1` with `conj(tau[j])`, while `Q C`
+applies `j = k - 1, ..., 0` with `tau[j]`. Each `gemv`/rank-1 update covers the
+matrix block in parallel and no GPU thread loops over an unbounded tensor
+domain. The same routine applies `Q^H` during append and applies `Q` to
+requested identity columns. A later blocked-WY
+optimization may replace this routine only if the performance gate requires it;
+there is no full-Q, one-shot-QR, host, or CPU fallback.
+
+`QrGauge::PositiveDiagonal` is also provider-owned on CUDA: a linalg-owned
+same-device kernel computes diagonal phases and scales requested Q columns and
+R rows consistently. Phase 4 shares that kernel with existing CUDA
+`qr_with_options`, replacing its currently inapplicable host-only default gauge
+path. The kernel launches over the output domains and does not download scalar
+phases.
+
+All CUDA work runs inside the scoped `CudaExecSession::with_raw` or typed
+CubeCL session appropriate to the call. Workspace and stream-retention behavior
+follow `gpu-backend-design.md`; synchronization failure must not release
+allocations that an unfinished vendor call can still access. Missing cuSOLVER
+or cuBLAS symbols are typed provider errors, not fallback triggers.
+
+## AD semantics
+
+AD differentiates the mathematical accumulated matrix, not provider packed
+bytes. The opaque state has an abstract tangent:
+
+- the tangent/cotangent of the `packed` output means `dA` / `A_bar` for the
+  accumulated matrix;
+- `coeff` is auxiliary and has no tangent or cotangent.
+
+Because raw fields are private, this interpretation cannot leak into ordinary
+tensor operations.
+
+Rules are:
+
+```text
+factor(A):
+    dstate = dA
+
+from_factors(Q, R):
+    dstate = dQ R + Q dR
+
+append(state(A), B):
+    dstate_new = concatenate(dA, dB, axis=1)
+
+transpose(append):
+    split A_new_bar by the old width into A_bar and B_bar
+```
+
+The append transpose obtains the old width from the packed-state input through
+a runtime `DimExpr::InputDim` shape source. It must not require an exact static
+extent or reinterpret an upper bound as the slice position.
+
+For `r` and `q_columns`, the rule materializes the required primal thin Q/R in
+the derivative program, reuses the existing QR gauge and derivative formulas,
+and selects the requested output tangent. The raw-state factors supplied to the
+existing QR derivative must use exactly the gauge represented by the public
+output; gauge-consistency reconstruction and finite-difference tests enforce
+this invariant. Reverse mode remains `SupportedViaLinearize`. AD execution may
+materialize full thin factors as residual work; primal execution may not.
+
+The `from_factors` transpose follows the real-inner-product convention:
+
+```text
+Q_bar = A_bar R^H
+R_bar = Q^H A_bar
+```
+
+Complex JVP/VJP follows the repository's JAX-style complex convention. Before
+these rules become supported, the linalg AD manifest records the operations as
+`PendingOracle` or `Unsupported`, and the corresponding `tensor-ad-oracles`
+family must land.
+
+## Tests
+
+Primal tests cover all four dtypes where the provider supports them:
+
+- reconstruction after initialization and each of multiple appends;
+- orthogonality of full and selected Q columns;
+- agreement with one-shot QR under the selected gauge;
+- `from_factors` with orthonormal, non-orthonormal, and rank-deficient factors;
+- rank-deficient matrices, zero-column append, empty Q ranges, empty matrix
+  dimensions, tall/square/wide inputs, and tall-to-wide transitions;
+- invalid rank, shape, dtype, range, placement, runtime, and provider cases;
+- CPU-faer/CPU-BLAS parity and CUDA hardware coverage;
+- source-contract checks against hidden host transfer and full refactorization.
+
+AD tests cover JVP and VJP with respect to the initial matrix, both factors,
+and each of at least two appended blocks. They include Q-only, R-only, and
+combined losses; all four dtypes; tall, square, and wide transitions; gauge
+parity; finite differences; and the accepted oracle family. Rank-deficient AD
+is outside the differentiable test domain.
+
+## Performance gate
+
+The primary comparison is compact Householder append against tensor4all's
+current explicit-Q BCGS2 append, not only against one-shot QR. The paired
+experiment also records one-shot QR as a diagnostic baseline.
+
+Before measurements begin, the phase work log must freeze the exact baseline
+and candidate commits, benchmark source, SRC-derived matrix shapes and block
+widths (including rank increment 3 and maximum rank 32), provider/thread and
+hardware settings, case list, statistic, repetitions, noise gate, and numeric
+pass thresholds. The accepted tensor4all-rs #694 one-thread bonds 32, 64, and
+128 are mandatory CPU cases. CUDA cases use the same logical matrices when
+memory permits.
+
+The gate reports every case as `PASS`, `FAIL`, or `INCONCLUSIVE`. Append must
+show no full-refactorization scaling, hidden transfer, or correctness
+regression. Thresholds may not be changed after candidate results are seen.
+
+## Delivery and review gates
+
+1. Land this durable design after an independent design-review verdict.
+2. Land opaque API/IR, `from_factors`, CPU-BLAS and CPU-faer primal execution;
+   mark AD unsupported in the manifest.
+3. Land the oracle family, then JVP/VJP support.
+4. Land CUDA bindings, execution, and hardware tests.
+5. Run the predeclared performance gate and finish user documentation.
+
+Each phase is independently mergeable and receives design-before-code and
+post-diff review. The umbrella issue remains open until all phases and the
+repository-scale final audit pass.
+
+## References
+
+- Camaño, Epperly, and Tropp, adaptive randomized tensor algorithms,
+  [arXiv:2504.06475](https://arxiv.org/abs/2504.06475), especially Appendix C.3.
+- LAPACK `GEQRF`, `ORMQR`/`UNMQR`, and `ORGQR`/`UNGQR` operation contracts.
+- tenferro [`AD contract`](../spec/ad-contract.md) and
+  [`GPU backend design`](gpu-backend-design.md).

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -31,6 +31,7 @@ migration notes live under [Plans](../plans/), not this active design index.
 | [inplace-indexing.md](./inplace-indexing.md) | Partial in-place updates design |
 | [linalg.md](./linalg.md) | Linalg public/composite layer |
 | [linalg-prims.md](./linalg-prims.md) | Backend-facing factorization and solve contracts |
+| [incremental-householder-qr.md](./incremental-householder-qr.md) | Opaque compact QR state, column append, provider execution, and semantic AD contract (#1735) |
 | [capi.md](./capi.md) | C-API: opaque handles, DLPack, einsum + SVD + AD |
 | [capi-error-handling.md](./capi-error-handling.md) | C-API error handling policy |
 | [testing.md](./testing.md) | Testing and performance verification strategy |

--- a/docs/worklogs/2026-09-01-incremental-householder-qr-design.md
+++ b/docs/worklogs/2026-09-01-incremental-householder-qr-design.md
@@ -1,0 +1,76 @@
+# Incremental Householder QR design (#1735)
+
+## Session summary
+
+Created the durable design for an opaque, backend-neutral incremental
+Householder QR state. The design fixes the public state, append algorithm,
+`from_factors` semantics, output gauge, primal rank-deficiency behavior,
+semantic AD tangent, CPU/CUDA ownership, tests, performance gate, and phased
+delivery.
+
+## Context reviewed
+
+- GitHub issue #1735 and its accepted phase plan
+- `AGENTS.md`, `REPOSITORY_RULES.md`, and relevant shared Rust/numerical rules
+- `docs/design/linalg.md`, `linalg-prims.md`, and `gpu-backend-design.md`
+- `docs/spec/ad-contract.md`
+- existing QR public, backend, CPU-faer, LAPACK, CUDA, gauge, and AD-manifest
+  implementations
+- faer elementary and blocked Householder APIs
+
+## Decisions
+
+- Keep provider-neutral scalar reflector coefficients and private packed state.
+- Support matrix and compatible-factor construction in v1.
+- Treat the opaque state's tangent as the accumulated matrix tangent; the
+  coefficient tensor is auxiliary.
+- Implement CPU-faer state construction with elementary Householders rather
+  than converting faer's blocked coefficient matrix.
+- Use cuSOLVER `geqrf` plus streamed cuBLAS `gemv` and `ger`/`geru` for CUDA
+  reflector application because cuSOLVER has no `ormqr`/`unmqr`.
+- Make positive-diagonal gauge provider-owned on CUDA and share the device-side
+  implementation with existing CUDA QR.
+- Deliver CPU primal, AD after oracle coverage, CUDA, and performance evidence
+  as independently reviewed phases.
+
+## Alternatives rejected or deferred
+
+- Explicit-Q state and full-QR append: violate the compact-state and scaling
+  requirements.
+- Provider handles in public state: not portable across eager/traced execution.
+- Host gauge or CPU fallback for CUDA: violates placement policy.
+- Batched, pivoted, arbitrary-index Q extraction, and WebGPU/ROCm support:
+  deferred from v1.
+
+## Design review gate
+
+Reviewer selection was made by the user: `reviewer-flash` (DeepSeek V4 Flash),
+read-only, high thinking.
+
+- Round 1: incomplete; 300-second timeout, no verdict.
+- Round 2: **Findings-require-fix**. Important findings: cuSOLVER has no
+  `ormqr`/`unmqr`; existing positive-diagonal gauge is host-only. Minor
+  findings covered faer scalar coefficients, AD gauge consistency, and
+  symbolic append split width.
+- Round 3: **Correct-to-merge**. All Important findings and requested Minor
+  clarifications were closed. Two non-blocking phase-4 wording/enforcement notes
+  remain for the CUDA post-diff review.
+
+No Rust implementation started before the Round-3 verdict.
+
+## Verification
+
+```text
+git diff --check
+bash scripts/check-pr-fast.sh
+```
+
+The docs-only fast gate passed, including `scripts/check-doc-snippets.py`.
+
+## Remaining risks
+
+- Phase-2 CPU code must preserve fixed reflector positions and backend session
+  allocation/threading contracts.
+- Phase-3 AD requires new oracle families before support is enabled.
+- Phase-4 CUDA performance may require blocked WY application if the simple
+  streamed reflector sequence misses the predeclared gate.

--- a/docs/worklogs/2026-09-01-incremental-householder-qr-phase2.md
+++ b/docs/worklogs/2026-09-01-incremental-householder-qr-phase2.md
@@ -1,0 +1,64 @@
+# Incremental Householder QR Phase 2 (#1735)
+
+## Summary
+
+Implemented the opaque compact state, concrete/eager/traced operation surfaces,
+linalg extension IR, explicit unsupported AD manifest entries, and CPU-faer and
+CPU-BLAS/LAPACK primal providers.
+
+## Implementation
+
+- Public `HouseholderQr<T>` keeps packed reflectors and coefficients private.
+- Extension operations cover factor, factor import, append, R extraction, and
+  contiguous Q-column materialization.
+- CPU append applies old reflectors to only the new block and factors only the
+  trailing residual.
+- LAPACK uses `geqrf` and `ormqr`/`unmqr` with checked LP64 dimensions and
+  workspace queries.
+- faer uses elementary `make_householder_in_place`, stores reciprocal faer tau
+  in the provider-neutral coefficient convention, and applies packed state
+  through zero-copy faer matrix views.
+- `from_factors` factors Q and folds its triangular factor into R. The accepted
+  contract was clarified to require exactly upper-trapezoidal R; arbitrary R
+  would require refactorizing the full product or a more complex reflector
+  composition and is not a previously computed QR factor.
+- CUDA session admission rejects the new operations until Phase 4.
+- All five new AD manifest entries remain explicitly unsupported pending the
+  Phase-3 oracle family.
+
+## Verification
+
+Passed locally:
+
+- `cargo check -p tenferro-linalg --features autodiff`
+- `cargo check -p tenferro-linalg --tests --features autodiff`
+- `cargo check -p tenferro-linalg --no-default-features --features cpu-blas,autodiff`
+- `cargo check -p tenferro-linalg --features cuda,autodiff`
+- focused CPU-faer reconstruction tests for factor, append, factor import,
+  rank deficiency, zero append, tall-to-wide transition, and all four dtypes
+- concrete, eager, and traced public-surface tests
+- linalg AD manifest and extension tests
+- all 181 tenferro-linalg doctests
+- `scripts/check-public-error-docs.py`
+- repository formatting profile
+- `scripts/check-pr-fast.sh --coverage-reviewed` with the all-dtype append
+  reconstruction test after closure review
+
+CPU-BLAS runtime tests could not link in this local shell because no native
+BLAS/LAPACK symbols were configured. The `cpu-blas` Rust code and tests compile;
+provider-linked CI remains the runtime verification owner.
+
+## Review gate
+
+- Design review: `reviewer-flash` Round 3, **Correct-to-merge**.
+- Post-implementation full-diff review Round 1: **Findings-require-fix**.
+  Fixed faer complex append conjugation, added C32/C64 append reconstruction,
+  and changed Householder AD from silent absent gradients to explicit
+  `Unsupported` with an end-to-end rejection test.
+- Closure review: `reviewer-flash`, **Correct-to-merge**. No remaining
+  Critical, Important, or Minor findings in the corrected regions.
+
+## Remaining scope
+
+Phase 3 owns oracle and AD support. Phase 4 owns CUDA execution and hardware
+tests. Phase 5 owns the predeclared performance gate and final user docs.


### PR DESCRIPTION
## Summary

- add the provider-neutral `HouseholderQr<T>` compact state and column-append API
- implement CPU-faer and CPU-BLAS/LAPACK factorization, factor import, append, R extraction, and selected Q-column materialization
- expose concrete, eager, traced, and extension-operation surfaces
- preserve explicit unsupported behavior for AD and CUDA until later issue phases
- document the accepted cross-phase design and Phase 2 implementation decisions

Part of #1735. This PR completes Phase 2 only; it intentionally does not close the umbrella issue.

## Design and worklogs

- [Incremental Householder QR design](docs/design/incremental-householder-qr.md)
- [Design review record](docs/worklogs/2026-09-01-incremental-householder-qr-design.md)
- [Phase 2 implementation record](docs/worklogs/2026-09-01-incremental-householder-qr-phase2.md)

## Verification

- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-linalg --features autodiff compact_qr_append_reconstructs_all_supported_dtypes'`
- CPU-faer and CPU-BLAS feature checks, including `autodiff`
- default-feature tests and doctests
- CUDA feature compile check with explicit unsupported capability
- focused reconstruction, append, factor-import, validation, rank-deficient, zero-column, eager, traced, manifest, and AD-rejection tests
- committed-head `scripts/repository-rules-review.py`: pass

## Review

- pre-implementation design review: `reviewer-flash`, **Correct-to-merge**
- post-implementation review Round 1 findings fixed: complex faer adjoint, complex append coverage, explicit semantic AD rejection
- closure review: `reviewer-flash`, **Correct-to-merge**

## Known environment limitation

The local CPU-BLAS runtime test binary could not link because this host does not provide BLAS/LAPACK symbols. The CPU-BLAS implementation and tests compile successfully; hosted CI owns the linked provider matrix.
