### PR TITLE
feat(linalg): add CUDA Householder QR

### DIFF
--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -417,6 +417,48 @@ pub trait LinalgBackend: BackendSession {
         ))
     }
 
+    /// Compute public QR outputs `(Q, R)` from a tensor read target with options.
+    ///
+    /// Device backends override this hook to keep gauge processing in the input
+    /// placement. The default is appropriate for host backends.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::{with_cpu_exec_session, CpuBackend};
+    /// use tenferro_linalg::{LinalgBackend, QrGauge, QrOptions};
+    /// use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    ///
+    /// let input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
+    /// let mut host = CpuBackend::new();
+    /// let outputs = host.with_backend_session(|session| {
+    ///     with_cpu_exec_session(session, |backend| {
+    ///         backend.qr_with_options_read(
+    ///             TensorRead::from_tensor(&input),
+    ///             QrOptions::default().gauge(QrGauge::PositiveDiagonal),
+    ///         )
+    ///     })
+    ///     .expect("CpuBackend must expose a CpuExecSession")
+    /// })?;
+    /// assert_eq!(outputs[0].shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns the validation, unsupported-dtype, numerical, placement, or
+    /// typed backend/provider errors from [`LinalgBackend::qr_read`], plus
+    /// gauge metadata and host-access errors from the default host gauge path.
+    fn qr_with_options_read(
+        &mut self,
+        input: TensorRead<'_>,
+        options: QrOptions,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let mut outputs = self.qr_read(input)?;
+        apply_qr_gauge(options.gauge, &mut outputs)?;
+        Ok(outputs)
+    }
+
     #[doc(hidden)]
     fn householder_qr(&mut self, _input: &Tensor) -> tenferro_tensor::Result<CompactQrResult> {
         Err(tenferro_tensor::Error::unsupported(

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -799,12 +799,6 @@ fn linalg_session_supported<B: BackendSession + 'static>(op: &LinalgExtensionOp)
                 // Complete-pivoting LU and general eig have no CUDA kernels.
                 LinalgOp::FullPivLu | LinalgOp::FullPivLuSolve { .. } => false,
                 LinalgOp::Eig { .. } | LinalgOp::EigVals { .. } => false,
-                LinalgOp::HouseholderQrFactor
-                | LinalgOp::HouseholderQrFromFactors
-                | LinalgOp::HouseholderQrAppend
-                | LinalgOp::HouseholderQrR { .. }
-                | LinalgOp::HouseholderQrQColumns { .. }
-                | LinalgOp::HouseholderQrThinQ { .. } => false,
                 // Plain partial-pivot solve runs in-session via cuSOLVER
                 // getrf plus prepared pivot/triangular solves
                 // (`gpu/linalg.rs::solve` = lu_factor + lu_solve_prepared, no

--- a/crates/tenferro-linalg/src/gpu/ffi/cusolver.rs
+++ b/crates/tenferro-linalg/src/gpu/ffi/cusolver.rs
@@ -93,6 +93,13 @@ pub enum CublasOperation {
 
 #[repr(i32)]
 #[derive(Clone, Copy, Debug)]
+pub enum CublasPointerMode {
+    Host = 0,
+    Device = 1,
+}
+
+#[repr(i32)]
+#[derive(Clone, Copy, Debug)]
 pub enum CusolverEigMode {
     NoVector = 0,
     Vector = 1,
@@ -696,6 +703,8 @@ type SyevdC64Fn = unsafe extern "C" fn(
 type CublasCreateFn = unsafe extern "C" fn(*mut CublasHandleRaw) -> CublasStatus;
 type CublasDestroyFn = unsafe extern "C" fn(CublasHandleRaw) -> CublasStatus;
 type CublasSetStreamFn = unsafe extern "C" fn(CublasHandleRaw, CudaStream) -> CublasStatus;
+type CublasSetPointerModeFn =
+    unsafe extern "C" fn(CublasHandleRaw, CublasPointerMode) -> CublasStatus;
 type TrsmF32Fn = unsafe extern "C" fn(
     CublasHandleRaw,
     CublasSideMode,
@@ -945,10 +954,56 @@ impl CusolverVtable {
     }
 }
 
+type GemvFn = unsafe extern "C" fn(
+    CublasHandleRaw,
+    CublasOperation,
+    i32,
+    i32,
+    *const c_void,
+    *const c_void,
+    i32,
+    *const c_void,
+    i32,
+    *const c_void,
+    *mut c_void,
+    i32,
+) -> CublasStatus;
+
+type GerFn = unsafe extern "C" fn(
+    CublasHandleRaw,
+    i32,
+    i32,
+    *const c_void,
+    *const c_void,
+    i32,
+    *const c_void,
+    i32,
+    *mut c_void,
+    i32,
+) -> CublasStatus;
+
+type GemmFn = unsafe extern "C" fn(
+    CublasHandleRaw,
+    CublasOperation,
+    CublasOperation,
+    i32,
+    i32,
+    i32,
+    *const c_void,
+    *const c_void,
+    i32,
+    *const c_void,
+    i32,
+    *const c_void,
+    *mut c_void,
+    i32,
+) -> CublasStatus;
+
 struct CublasVtable {
     create: CublasCreateFn,
     destroy: CublasDestroyFn,
     set_stream: CublasSetStreamFn,
+    set_pointer_mode: CublasSetPointerModeFn,
     strsm: TrsmF32Fn,
     dtrsm: TrsmF64Fn,
     ctrsm: TrsmC32Fn,
@@ -957,6 +1012,18 @@ struct CublasVtable {
     dtrsm_batched: TrsmBatchedF64Fn,
     ctrsm_batched: TrsmBatchedC32Fn,
     ztrsm_batched: TrsmBatchedC64Fn,
+    sgemv: GemvFn,
+    dgemv: GemvFn,
+    cgemv: GemvFn,
+    zgemv: GemvFn,
+    sger: GerFn,
+    dger: GerFn,
+    cgeru: GerFn,
+    zgeru: GerFn,
+    sgemm: GemmFn,
+    dgemm: GemmFn,
+    cgemm: GemmFn,
+    zgemm: GemmFn,
 }
 
 impl CublasVtable {
@@ -965,6 +1032,7 @@ impl CublasVtable {
             create: load_symbol(lib, b"cublasCreate_v2\0", "cuBLAS")?,
             destroy: load_symbol(lib, b"cublasDestroy_v2\0", "cuBLAS")?,
             set_stream: load_symbol(lib, b"cublasSetStream_v2\0", "cuBLAS")?,
+            set_pointer_mode: load_symbol(lib, b"cublasSetPointerMode_v2\0", "cuBLAS")?,
             strsm: load_symbol(lib, b"cublasStrsm_v2\0", "cuBLAS")?,
             dtrsm: load_symbol(lib, b"cublasDtrsm_v2\0", "cuBLAS")?,
             ctrsm: load_symbol(lib, b"cublasCtrsm_v2\0", "cuBLAS")?,
@@ -973,6 +1041,18 @@ impl CublasVtable {
             dtrsm_batched: load_symbol(lib, b"cublasDtrsmBatched\0", "cuBLAS")?,
             ctrsm_batched: load_symbol(lib, b"cublasCtrsmBatched\0", "cuBLAS")?,
             ztrsm_batched: load_symbol(lib, b"cublasZtrsmBatched\0", "cuBLAS")?,
+            sgemv: load_symbol(lib, b"cublasSgemv_v2\0", "cuBLAS")?,
+            dgemv: load_symbol(lib, b"cublasDgemv_v2\0", "cuBLAS")?,
+            cgemv: load_symbol(lib, b"cublasCgemv_v2\0", "cuBLAS")?,
+            zgemv: load_symbol(lib, b"cublasZgemv_v2\0", "cuBLAS")?,
+            sger: load_symbol(lib, b"cublasSger_v2\0", "cuBLAS")?,
+            dger: load_symbol(lib, b"cublasDger_v2\0", "cuBLAS")?,
+            cgeru: load_symbol(lib, b"cublasCgeru_v2\0", "cuBLAS")?,
+            zgeru: load_symbol(lib, b"cublasZgeru_v2\0", "cuBLAS")?,
+            sgemm: load_symbol(lib, b"cublasSgemm_v2\0", "cuBLAS")?,
+            dgemm: load_symbol(lib, b"cublasDgemm_v2\0", "cuBLAS")?,
+            cgemm: load_symbol(lib, b"cublasCgemm_v2\0", "cuBLAS")?,
+            zgemm: load_symbol(lib, b"cublasZgemm_v2\0", "cuBLAS")?,
         })
     }
 }
@@ -2331,6 +2411,140 @@ impl CublasHandle {
     pub fn set_stream(&self, stream: CudaStream, op: &'static str) -> Result<()> {
         let status = unsafe { (self.lib.vtable.set_stream)(self.raw, stream) };
         self.lib.check_status(status, op, "cublasSetStream_v2")
+    }
+
+    /// Select whether scalar pointers refer to host or device memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuBLAS rejects the pointer mode.
+    pub fn set_pointer_mode(&self, mode: CublasPointerMode, op: &'static str) -> Result<()> {
+        let status = unsafe { (self.lib.vtable.set_pointer_mode)(self.raw, mode) };
+        self.lib.check_status(status, op, "cublasSetPointerMode_v2")
+    }
+
+    /// Execute a matrix-vector product through cuBLAS.
+    ///
+    /// # Safety
+    ///
+    /// The caller must provide valid device pointers and dimensions for the
+    /// selected scalar dtype. Scalar pointers must match the handle's current
+    /// host/device pointer mode.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuBLAS rejects the operation,
+    /// pointers, dimensions, or leading dimensions.
+    // INVARIANT: arguments mirror the fixed cuBLAS GEMV ABI.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn gemv(
+        &self,
+        dtype: CudaDataType,
+        trans: CublasOperation,
+        m: i32,
+        n: i32,
+        alpha: *const c_void,
+        a: *const c_void,
+        lda: i32,
+        x: *const c_void,
+        incx: i32,
+        beta: *const c_void,
+        y: *mut c_void,
+        incy: i32,
+        op: &'static str,
+    ) -> Result<()> {
+        let function = match dtype {
+            CudaDataType::F32 => self.lib.vtable.sgemv,
+            CudaDataType::F64 => self.lib.vtable.dgemv,
+            CudaDataType::Complex32 => self.lib.vtable.cgemv,
+            CudaDataType::Complex64 => self.lib.vtable.zgemv,
+        };
+        let status = function(self.raw, trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+        self.lib.check_status(status, op, "cublas*gemv_v2")
+    }
+
+    /// Execute an unconjugated rank-1 update through cuBLAS.
+    ///
+    /// Complex dtypes dispatch to `geru`; real dtypes dispatch to `ger`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must provide valid device matrix/vector pointers and a valid
+    /// scalar pointer for `alpha` matching the handle's current host/device
+    /// pointer mode.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuBLAS rejects the operation,
+    /// pointers, dimensions, increments, or leading dimension.
+    // INVARIANT: arguments mirror the fixed cuBLAS GER/GERU ABI.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn geru(
+        &self,
+        dtype: CudaDataType,
+        m: i32,
+        n: i32,
+        alpha: *const c_void,
+        x: *const c_void,
+        incx: i32,
+        y: *const c_void,
+        incy: i32,
+        a: *mut c_void,
+        lda: i32,
+        op: &'static str,
+    ) -> Result<()> {
+        let function = match dtype {
+            CudaDataType::F32 => self.lib.vtable.sger,
+            CudaDataType::F64 => self.lib.vtable.dger,
+            CudaDataType::Complex32 => self.lib.vtable.cgeru,
+            CudaDataType::Complex64 => self.lib.vtable.zgeru,
+        };
+        let status = function(self.raw, m, n, alpha, x, incx, y, incy, a, lda);
+        self.lib.check_status(status, op, "cublas*ger/geru_v2")
+    }
+
+    /// Execute a matrix-matrix product through cuBLAS.
+    ///
+    /// # Safety
+    ///
+    /// The caller must provide valid device matrix pointers, scalar pointers
+    /// matching the handle's current host/device pointer mode, and dimensions
+    /// accepted by cuBLAS.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuBLAS rejects the operation,
+    /// pointers, dimensions, or leading dimensions.
+    // INVARIANT: arguments mirror the fixed cuBLAS GEMM ABI.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn gemm(
+        &self,
+        dtype: CudaDataType,
+        trans_a: CublasOperation,
+        trans_b: CublasOperation,
+        m: i32,
+        n: i32,
+        k: i32,
+        alpha: *const c_void,
+        a: *const c_void,
+        lda: i32,
+        b: *const c_void,
+        ldb: i32,
+        beta: *const c_void,
+        c: *mut c_void,
+        ldc: i32,
+        op: &'static str,
+    ) -> Result<()> {
+        let function = match dtype {
+            CudaDataType::F32 => self.lib.vtable.sgemm,
+            CudaDataType::F64 => self.lib.vtable.dgemm,
+            CudaDataType::Complex32 => self.lib.vtable.cgemm,
+            CudaDataType::Complex64 => self.lib.vtable.zgemm,
+        };
+        let status = function(
+            self.raw, trans_a, trans_b, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+        );
+        self.lib.check_status(status, op, "cublas*gemm_v2")
     }
 
     /// Execute a triangular solve through cuBLAS.

--- a/crates/tenferro-linalg/src/gpu/ffi/cusolver.rs
+++ b/crates/tenferro-linalg/src/gpu/ffi/cusolver.rs
@@ -2431,11 +2431,11 @@ impl CublasHandle {
     /// selected scalar dtype. Scalar pointers must match the handle's current
     /// host/device pointer mode.
     ///
+    // INVARIANT: arguments mirror the fixed cuBLAS GEMV ABI.
     /// # Errors
     ///
     /// Returns `Error::BackendFailure` when cuBLAS rejects the operation,
     /// pointers, dimensions, or leading dimensions.
-    // INVARIANT: arguments mirror the fixed cuBLAS GEMV ABI.
     #[allow(clippy::too_many_arguments)]
     pub unsafe fn gemv(
         &self,
@@ -2473,11 +2473,11 @@ impl CublasHandle {
     /// scalar pointer for `alpha` matching the handle's current host/device
     /// pointer mode.
     ///
+    // INVARIANT: arguments mirror the fixed cuBLAS GER/GERU ABI.
     /// # Errors
     ///
     /// Returns `Error::BackendFailure` when cuBLAS rejects the operation,
     /// pointers, dimensions, increments, or leading dimension.
-    // INVARIANT: arguments mirror the fixed cuBLAS GER/GERU ABI.
     #[allow(clippy::too_many_arguments)]
     pub unsafe fn geru(
         &self,
@@ -2511,11 +2511,11 @@ impl CublasHandle {
     /// matching the handle's current host/device pointer mode, and dimensions
     /// accepted by cuBLAS.
     ///
+    // INVARIANT: arguments mirror the fixed cuBLAS GEMM ABI.
     /// # Errors
     ///
     /// Returns `Error::BackendFailure` when cuBLAS rejects the operation,
     /// pointers, dimensions, or leading dimensions.
-    // INVARIANT: arguments mirror the fixed cuBLAS GEMM ABI.
     #[allow(clippy::too_many_arguments)]
     pub unsafe fn gemm(
         &self,

--- a/crates/tenferro-linalg/src/gpu/kernels.rs
+++ b/crates/tenferro-linalg/src/gpu/kernels.rs
@@ -112,6 +112,209 @@ pub fn complex64_magnitude(out: &mut Array<f64>, input: &Array<Complex64>) {
 }
 
 #[cube(launch_unchecked)]
+pub fn householder_q_columns_identity<E: CubePrimitive>(out: &mut Tensor<E>, start: usize) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < out.len() {
+        let row = out.coordinate(pos, 0usize);
+        let col = out.coordinate(pos, 1usize);
+        out[pos] = if row == start + col {
+            one_value::<E>()
+        } else {
+            zero_value::<E>()
+        };
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn conjugate_vector<C: ComplexCore>(out: &mut Array<C>, input: &Array<C>) {
+    if ABSOLUTE_POS < out.len() {
+        out[ABSOLUTE_POS] = input[ABSOLUTE_POS].conj();
+    }
+}
+
+#[cube]
+fn positive_phase_real<E: CubePrimitive + core::ops::Neg<Output = E> + PartialOrd>(
+    diagonal: E,
+) -> E {
+    if diagonal < zero_value::<E>() {
+        -one_value::<E>()
+    } else {
+        one_value::<E>()
+    }
+}
+
+#[cube]
+fn positive_phase_c32(diagonal: Complex32) -> Complex32 {
+    let magnitude = diagonal.abs();
+    if magnitude == 0.0f32 {
+        Complex32::cast_from(1.0f32)
+    } else {
+        diagonal / Complex32::cast_from(magnitude)
+    }
+}
+
+#[cube]
+fn positive_phase_c64(diagonal: Complex64) -> Complex64 {
+    let magnitude = diagonal.abs();
+    if magnitude == 0.0f64 {
+        Complex64::cast_from(1.0f64)
+    } else {
+        diagonal / Complex64::cast_from(magnitude)
+    }
+}
+
+#[cube]
+fn qr_diagonal_offset<E: CubePrimitive>(
+    phase: &Tensor<E>,
+    r: &Tensor<E>,
+    pos: usize,
+    index: usize,
+    #[comptime] rank: usize,
+) -> usize {
+    let mut offset = index * r.stride(0usize) + index * r.stride(1usize);
+    #[unroll]
+    for axis in 2usize..rank {
+        offset += phase.coordinate(pos, axis - 1usize) * r.stride(axis);
+    }
+    offset
+}
+
+#[cube]
+fn qr_phase_offset<E: CubePrimitive>(
+    out: &Tensor<E>,
+    phase: &Tensor<E>,
+    pos: usize,
+    index: usize,
+    #[comptime] rank: usize,
+) -> usize {
+    let mut offset = index * phase.stride(0usize);
+    #[unroll]
+    for axis in 2usize..rank {
+        offset += out.coordinate(pos, axis) * phase.stride(axis - 1usize);
+    }
+    offset
+}
+
+#[cube(launch_unchecked)]
+pub fn qr_phase_real<E: CubePrimitive + core::ops::Neg<Output = E> + PartialOrd>(
+    phase: &mut Tensor<E>,
+    r: &Tensor<E>,
+    #[comptime] rank: usize,
+) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < phase.len() {
+        let index = phase.coordinate(pos, 0usize);
+        let diagonal = r[qr_diagonal_offset(phase, r, pos, index, rank)];
+        phase[pos] = positive_phase_real::<E>(diagonal);
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn qr_phase_c32(phase: &mut Tensor<Complex32>, r: &Tensor<Complex32>, #[comptime] rank: usize) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < phase.len() {
+        let index = phase.coordinate(pos, 0usize);
+        let diagonal = r[qr_diagonal_offset(phase, r, pos, index, rank)];
+        phase[pos] = positive_phase_c32(diagonal);
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn qr_phase_c64(phase: &mut Tensor<Complex64>, r: &Tensor<Complex64>, #[comptime] rank: usize) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < phase.len() {
+        let index = phase.coordinate(pos, 0usize);
+        let diagonal = r[qr_diagonal_offset(phase, r, pos, index, rank)];
+        phase[pos] = positive_phase_c64(diagonal);
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn qr_apply_phase_real<E: CubePrimitive + core::ops::Mul<Output = E>>(
+    q: &mut Tensor<E>,
+    r: &mut Tensor<E>,
+    phase: &Tensor<E>,
+    q_start: usize,
+    #[comptime] rank: usize,
+) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < q.len() {
+        let index = q_start + q.coordinate(pos, 1usize);
+        q[pos] = q[pos] * phase[qr_phase_offset(q, phase, pos, index, rank)];
+    }
+    if pos < r.len() {
+        let index = r.coordinate(pos, 0usize);
+        r[pos] = r[pos] * phase[qr_phase_offset(r, phase, pos, index, rank)];
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn qr_apply_phase_complex<C: ComplexCore>(
+    q: &mut Tensor<C>,
+    r: &mut Tensor<C>,
+    phase: &Tensor<C>,
+    q_start: usize,
+    #[comptime] rank: usize,
+) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < q.len() {
+        let index = q_start + q.coordinate(pos, 1usize);
+        q[pos] = q[pos] * phase[qr_phase_offset(q, phase, pos, index, rank)];
+    }
+    if pos < r.len() {
+        let index = r.coordinate(pos, 0usize);
+        r[pos] = r[pos] * phase[qr_phase_offset(r, phase, pos, index, rank)].conj();
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn upper_trapezoidal_violation<E: CubePrimitive + PartialEq>(
+    violation: &mut Tensor<i32>,
+    input: &Tensor<E>,
+) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < violation.len() {
+        let row = input.coordinate(pos, 0usize);
+        let col = input.coordinate(pos, 1usize);
+        violation[pos] = if row > col && input[pos] != zero_value::<E>() {
+            1i32
+        } else {
+            0i32
+        };
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn householder_from_factors_assemble<E: CubePrimitive>(
+    packed_out: &mut Tensor<E>,
+    coeff_out: &mut Tensor<E>,
+    packed_q: &Tensor<E>,
+    coeff_q: &Tensor<E>,
+    folded_r: &Tensor<E>,
+    factor_width: usize,
+) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < packed_out.len() {
+        let row = packed_out.coordinate(pos, 0usize);
+        let col = packed_out.coordinate(pos, 1usize);
+        packed_out[pos] = if row < factor_width && row <= col {
+            folded_r[row * folded_r.stride(0usize) + col * folded_r.stride(1usize)]
+        } else if col < factor_width && row > col {
+            packed_q[row * packed_q.stride(0usize) + col * packed_q.stride(1usize)]
+        } else {
+            zero_value::<E>()
+        };
+    }
+    if pos < coeff_out.len() {
+        coeff_out[pos] = if pos < factor_width {
+            coeff_q[pos]
+        } else {
+            zero_value::<E>()
+        };
+    }
+}
+
+#[cube(launch_unchecked)]
 pub fn lu_extract_outputs<E: CubePrimitive + core::ops::Neg<Output = E>>(
     p_out: &mut Tensor<E>,
     l_out: &mut Tensor<E>,

--- a/crates/tenferro-linalg/src/gpu/linalg.rs
+++ b/crates/tenferro-linalg/src/gpu/linalg.rs
@@ -8,10 +8,12 @@ use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 
 use super::ffi::cusolver::{
-    CublasDiagType, CublasFillMode, CublasOperation, CublasSideMode, CudaDataType,
-    CudaLinalgHandles, CudaStream, CusolverEigMode,
+    CublasDiagType, CublasFillMode, CublasOperation, CublasPointerMode, CublasSideMode,
+    CudaDataType, CudaLinalgHandles, CudaStream, CusolverEigMode,
 };
 use super::kernels as cubecl_linalg;
+use crate::backend::CompactQrResult;
+use crate::extension::{QrGauge, QrOptions};
 // validate_nonsingular_gpu uses backend ops (extract_diagonal, magnitude,
 // reduce_min/reduce_max) then downloads scalar summaries — no bulk host
 // roundtrip.
@@ -40,6 +42,20 @@ trait LinalgScalar:
         vt_shape: &[usize],
         op: &'static str,
     ) -> Result<TypedTensor<Self>>;
+
+    fn conjugate_coeff(
+        backend: &mut CudaExecSession<'_>,
+        coeff: &TypedTensor<Self>,
+        op: &'static str,
+    ) -> Result<TypedTensor<Self>>;
+
+    fn apply_positive_qr_gauge(
+        backend: &mut CudaExecSession<'_>,
+        q: &mut TypedTensor<Self>,
+        r: &mut TypedTensor<Self>,
+        q_start: usize,
+        op: &'static str,
+    ) -> Result<()>;
 }
 
 impl LinalgScalar for f32 {
@@ -55,6 +71,24 @@ impl LinalgScalar for f32 {
         op: &'static str,
     ) -> Result<TypedTensor<Self>> {
         copy_matrix_adjoint_real(backend, v, vt_shape, op)
+    }
+
+    fn conjugate_coeff(
+        backend: &mut CudaExecSession<'_>,
+        coeff: &TypedTensor<Self>,
+        op: &'static str,
+    ) -> Result<TypedTensor<Self>> {
+        clone_device_tensor(backend, coeff, op)
+    }
+
+    fn apply_positive_qr_gauge(
+        backend: &mut CudaExecSession<'_>,
+        q: &mut TypedTensor<Self>,
+        r: &mut TypedTensor<Self>,
+        q_start: usize,
+        op: &'static str,
+    ) -> Result<()> {
+        apply_positive_qr_gauge_real(backend, q, r, q_start, op)
     }
 }
 
@@ -72,6 +106,24 @@ impl LinalgScalar for f64 {
     ) -> Result<TypedTensor<Self>> {
         copy_matrix_adjoint_real(backend, v, vt_shape, op)
     }
+
+    fn conjugate_coeff(
+        backend: &mut CudaExecSession<'_>,
+        coeff: &TypedTensor<Self>,
+        op: &'static str,
+    ) -> Result<TypedTensor<Self>> {
+        clone_device_tensor(backend, coeff, op)
+    }
+
+    fn apply_positive_qr_gauge(
+        backend: &mut CudaExecSession<'_>,
+        q: &mut TypedTensor<Self>,
+        r: &mut TypedTensor<Self>,
+        q_start: usize,
+        op: &'static str,
+    ) -> Result<()> {
+        apply_positive_qr_gauge_real(backend, q, r, q_start, op)
+    }
 }
 
 impl LinalgScalar for Complex32 {
@@ -88,6 +140,24 @@ impl LinalgScalar for Complex32 {
     ) -> Result<TypedTensor<Self>> {
         copy_matrix_adjoint_complex(backend, v, vt_shape, op)
     }
+
+    fn conjugate_coeff(
+        backend: &mut CudaExecSession<'_>,
+        coeff: &TypedTensor<Self>,
+        op: &'static str,
+    ) -> Result<TypedTensor<Self>> {
+        conjugate_coeff_complex(backend, coeff, op)
+    }
+
+    fn apply_positive_qr_gauge(
+        backend: &mut CudaExecSession<'_>,
+        q: &mut TypedTensor<Self>,
+        r: &mut TypedTensor<Self>,
+        q_start: usize,
+        op: &'static str,
+    ) -> Result<()> {
+        apply_positive_qr_gauge_c32(backend, q, r, q_start, op)
+    }
 }
 
 impl LinalgScalar for Complex64 {
@@ -103,6 +173,24 @@ impl LinalgScalar for Complex64 {
         op: &'static str,
     ) -> Result<TypedTensor<Self>> {
         copy_matrix_adjoint_complex(backend, v, vt_shape, op)
+    }
+
+    fn conjugate_coeff(
+        backend: &mut CudaExecSession<'_>,
+        coeff: &TypedTensor<Self>,
+        op: &'static str,
+    ) -> Result<TypedTensor<Self>> {
+        conjugate_coeff_complex(backend, coeff, op)
+    }
+
+    fn apply_positive_qr_gauge(
+        backend: &mut CudaExecSession<'_>,
+        q: &mut TypedTensor<Self>,
+        r: &mut TypedTensor<Self>,
+        q_start: usize,
+        op: &'static str,
+    ) -> Result<()> {
+        apply_positive_qr_gauge_c64(backend, q, r, q_start, op)
     }
 }
 
@@ -357,6 +445,302 @@ pub(super) fn qr(backend: &mut CudaExecSession<'_>, input: &Tensor) -> Result<Ve
         Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
             Err(unsupported_linalg_dtype("qr", input))
         }
+    }
+}
+
+pub(super) fn householder_qr(
+    backend: &mut CudaExecSession<'_>,
+    input: &Tensor,
+) -> Result<CompactQrResult> {
+    let (packed, coeff) = match input {
+        Tensor::F32(input) => {
+            let (packed, coeff) = compact_qr_typed(backend, input, "householder_qr")?;
+            (Tensor::F32(packed), Tensor::F32(coeff))
+        }
+        Tensor::F64(input) => {
+            let (packed, coeff) = compact_qr_typed(backend, input, "householder_qr")?;
+            (Tensor::F64(packed), Tensor::F64(coeff))
+        }
+        Tensor::C32(input) => {
+            let (packed, coeff) = compact_qr_typed(backend, input, "householder_qr")?;
+            (Tensor::C32(packed), Tensor::C32(coeff))
+        }
+        Tensor::C64(input) => {
+            let (packed, coeff) = compact_qr_typed(backend, input, "householder_qr")?;
+            (Tensor::C64(packed), Tensor::C64(coeff))
+        }
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            return Err(unsupported_linalg_dtype("householder_qr", input));
+        }
+    };
+    Ok(CompactQrResult { packed, coeff })
+}
+
+fn upper_trapezoidal_violation_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    input: &TypedTensor<T>,
+    op: &'static str,
+) -> Result<TypedTensor<i32>>
+where
+    T: LinalgScalar + TensorScalar + PartialEq,
+{
+    backend.with_cubecl(op, |cubecl| {
+        let output = cubecl.alloc_output::<i32>(input.shape())?;
+        if output.n_elements() == 0 {
+            return Ok(output);
+        }
+        let output_arg = cubecl.tensor_binding(&output, op)?;
+        let input_arg = cubecl.tensor_binding(input, op)?;
+        let launch_count = cubecl.cube_count_1d(output.n_elements())?;
+        // SAFETY: bindings are live device tensors and each thread writes one
+        // independent validation flag.
+        unsafe {
+            cubecl_linalg::upper_trapezoidal_violation::launch_unchecked::<T, CubeclCudaRuntime>(
+                cubecl.client(),
+                launch_count,
+                cubecl.cube_dim_1d(),
+                output_arg.into_tensor_arg(),
+                input_arg.into_tensor_arg(),
+            );
+        }
+        Ok(output)
+    })
+}
+
+fn validate_upper_trapezoidal_gpu(
+    backend: &mut CudaExecSession<'_>,
+    r: &Tensor,
+    op: &'static str,
+) -> Result<()> {
+    if r.shape().len() != 2 {
+        return Err(Error::rank_mismatch(op, 2, r.shape().len()));
+    }
+    if r.shape().contains(&0) {
+        return Ok(());
+    }
+    let flags = match r {
+        Tensor::F32(r) => upper_trapezoidal_violation_typed(backend, r, op)?,
+        Tensor::F64(r) => upper_trapezoidal_violation_typed(backend, r, op)?,
+        Tensor::C32(r) => upper_trapezoidal_violation_typed(backend, r, op)?,
+        Tensor::C64(r) => upper_trapezoidal_violation_typed(backend, r, op)?,
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            return Err(unsupported_linalg_dtype(op, r));
+        }
+    };
+    let maximum = backend.reduce_max(&Tensor::I32(flags), &[0, 1])?;
+    backend.runtime().synchronize()?;
+    let host = download_tensor(backend.runtime(), &maximum)?;
+    let Tensor::I32(value) = host else {
+        return Err(Error::Internal(format!(
+            "{op}: unexpected upper-trapezoidal validation dtype"
+        )));
+    };
+    if value.host_data()?[0] == 0 {
+        Ok(())
+    } else {
+        Err(Error::invalid_argument(
+            op,
+            "r",
+            "R must be exactly upper trapezoidal",
+        ))
+    }
+}
+
+pub(super) fn householder_qr_from_factors(
+    backend: &mut CudaExecSession<'_>,
+    q: &Tensor,
+    r: &Tensor,
+) -> Result<CompactQrResult> {
+    const OP: &str = "householder_qr_from_factors";
+    ensure_supported_linalg_pair(OP, q, r)?;
+    validate_upper_trapezoidal_gpu(backend, r, OP)?;
+    let (packed, coeff) = match (q, r) {
+        (Tensor::F32(q), Tensor::F32(r)) => {
+            let (packed, coeff) = compact_qr_from_factors_typed(backend, q, r, OP)?;
+            (Tensor::F32(packed), Tensor::F32(coeff))
+        }
+        (Tensor::F64(q), Tensor::F64(r)) => {
+            let (packed, coeff) = compact_qr_from_factors_typed(backend, q, r, OP)?;
+            (Tensor::F64(packed), Tensor::F64(coeff))
+        }
+        (Tensor::C32(q), Tensor::C32(r)) => {
+            let (packed, coeff) = compact_qr_from_factors_typed(backend, q, r, OP)?;
+            (Tensor::C32(packed), Tensor::C32(coeff))
+        }
+        (Tensor::C64(q), Tensor::C64(r)) => {
+            let (packed, coeff) = compact_qr_from_factors_typed(backend, q, r, OP)?;
+            (Tensor::C64(packed), Tensor::C64(coeff))
+        }
+        _ => return Err(Error::dtype_mismatch(OP, q.dtype(), r.dtype())),
+    };
+    Ok(CompactQrResult { packed, coeff })
+}
+
+pub(super) fn householder_qr_append(
+    backend: &mut CudaExecSession<'_>,
+    packed: &Tensor,
+    coeff: &Tensor,
+    block: &Tensor,
+) -> Result<CompactQrResult> {
+    ensure_supported_linalg_pair("householder_qr_append", packed, coeff)?;
+    ensure_supported_linalg_pair("householder_qr_append", packed, block)?;
+    let (packed, coeff) = match (packed, coeff, block) {
+        (Tensor::F32(packed), Tensor::F32(coeff), Tensor::F32(block)) => {
+            let (packed, coeff) =
+                compact_qr_append_typed(backend, packed, coeff, block, "householder_qr_append")?;
+            (Tensor::F32(packed), Tensor::F32(coeff))
+        }
+        (Tensor::F64(packed), Tensor::F64(coeff), Tensor::F64(block)) => {
+            let (packed, coeff) =
+                compact_qr_append_typed(backend, packed, coeff, block, "householder_qr_append")?;
+            (Tensor::F64(packed), Tensor::F64(coeff))
+        }
+        (Tensor::C32(packed), Tensor::C32(coeff), Tensor::C32(block)) => {
+            let (packed, coeff) =
+                compact_qr_append_typed(backend, packed, coeff, block, "householder_qr_append")?;
+            (Tensor::C32(packed), Tensor::C32(coeff))
+        }
+        (Tensor::C64(packed), Tensor::C64(coeff), Tensor::C64(block)) => {
+            let (packed, coeff) =
+                compact_qr_append_typed(backend, packed, coeff, block, "householder_qr_append")?;
+            (Tensor::C64(packed), Tensor::C64(coeff))
+        }
+        _ => {
+            return Err(Error::dtype_mismatch(
+                "householder_qr_append",
+                packed.dtype(),
+                block.dtype(),
+            ));
+        }
+    };
+    Ok(CompactQrResult { packed, coeff })
+}
+
+pub(super) fn householder_qr_q_columns(
+    backend: &mut CudaExecSession<'_>,
+    packed: &Tensor,
+    coeff: &Tensor,
+    start: usize,
+    end: usize,
+    options: QrOptions,
+) -> Result<Tensor> {
+    ensure_supported_linalg_pair("householder_qr_q_columns", packed, coeff)?;
+    match (packed, coeff) {
+        (Tensor::F32(packed), Tensor::F32(coeff)) => compact_qr_q_columns_typed(
+            backend,
+            packed,
+            coeff,
+            start,
+            end,
+            options,
+            "householder_qr_q_columns",
+        )
+        .map(Tensor::F32),
+        (Tensor::F64(packed), Tensor::F64(coeff)) => compact_qr_q_columns_typed(
+            backend,
+            packed,
+            coeff,
+            start,
+            end,
+            options,
+            "householder_qr_q_columns",
+        )
+        .map(Tensor::F64),
+        (Tensor::C32(packed), Tensor::C32(coeff)) => compact_qr_q_columns_typed(
+            backend,
+            packed,
+            coeff,
+            start,
+            end,
+            options,
+            "householder_qr_q_columns",
+        )
+        .map(Tensor::C32),
+        (Tensor::C64(packed), Tensor::C64(coeff)) => compact_qr_q_columns_typed(
+            backend,
+            packed,
+            coeff,
+            start,
+            end,
+            options,
+            "householder_qr_q_columns",
+        )
+        .map(Tensor::C64),
+        _ => Err(Error::dtype_mismatch(
+            "householder_qr_q_columns",
+            packed.dtype(),
+            coeff.dtype(),
+        )),
+    }
+}
+
+pub(super) fn householder_qr_r(
+    backend: &mut CudaExecSession<'_>,
+    packed: &Tensor,
+    coeff: &Tensor,
+    options: QrOptions,
+) -> Result<Tensor> {
+    ensure_supported_linalg_pair("householder_qr_r", packed, coeff)?;
+    match (packed, coeff) {
+        (Tensor::F32(packed), Tensor::F32(coeff)) => {
+            compact_qr_r_typed(backend, packed, coeff, options, "householder_qr_r").map(Tensor::F32)
+        }
+        (Tensor::F64(packed), Tensor::F64(coeff)) => {
+            compact_qr_r_typed(backend, packed, coeff, options, "householder_qr_r").map(Tensor::F64)
+        }
+        (Tensor::C32(packed), Tensor::C32(coeff)) => {
+            compact_qr_r_typed(backend, packed, coeff, options, "householder_qr_r").map(Tensor::C32)
+        }
+        (Tensor::C64(packed), Tensor::C64(coeff)) => {
+            compact_qr_r_typed(backend, packed, coeff, options, "householder_qr_r").map(Tensor::C64)
+        }
+        _ => Err(Error::dtype_mismatch(
+            "householder_qr_r",
+            packed.dtype(),
+            coeff.dtype(),
+        )),
+    }
+}
+
+pub(super) fn qr_with_options(
+    backend: &mut CudaExecSession<'_>,
+    input: &Tensor,
+    options: QrOptions,
+) -> Result<Vec<Tensor>> {
+    let mut outputs = qr(backend, input)?;
+    if options.gauge == QrGauge::PositiveDiagonal {
+        apply_qr_gauge_device(backend, &mut outputs, 0, "qr")?;
+    }
+    Ok(outputs)
+}
+
+fn apply_qr_gauge_device(
+    backend: &mut CudaExecSession<'_>,
+    outputs: &mut [Tensor],
+    q_start: usize,
+    op: &'static str,
+) -> Result<()> {
+    if outputs.len() != 2 {
+        return Err(Error::Internal(format!(
+            "{op}: CUDA QR returned {} outputs",
+            outputs.len()
+        )));
+    }
+    let (q, r) = outputs.split_at_mut(1);
+    match (&mut q[0], &mut r[0]) {
+        (Tensor::F32(q), Tensor::F32(r)) => {
+            f32::apply_positive_qr_gauge(backend, q, r, q_start, op)
+        }
+        (Tensor::F64(q), Tensor::F64(r)) => {
+            f64::apply_positive_qr_gauge(backend, q, r, q_start, op)
+        }
+        (Tensor::C32(q), Tensor::C32(r)) => {
+            Complex32::apply_positive_qr_gauge(backend, q, r, q_start, op)
+        }
+        (Tensor::C64(q), Tensor::C64(r)) => {
+            Complex64::apply_positive_qr_gauge(backend, q, r, q_start, op)
+        }
+        (q, r) => Err(Error::dtype_mismatch(op, q.dtype(), r.dtype())),
     }
 }
 
@@ -1081,6 +1465,219 @@ where
         let vt = cubecl.alloc_output::<T>(vt_shape)?;
         launch_matrix_adjoint_complex(cubecl, v, &vt, op)?;
         Ok(vt)
+    })
+}
+
+fn clone_device_tensor<T>(
+    backend: &mut CudaExecSession<'_>,
+    input: &TypedTensor<T>,
+    op: &'static str,
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    backend.with_raw(op, |raw| {
+        let mut output = raw.alloc_output::<T>(input.shape())?;
+        let input_ref = raw.tensor(input)?;
+        let output_ref = raw.tensor_mut(&mut output)?;
+        // SAFETY: both spans are validated on this runtime, output is freshly
+        // allocated and exclusively borrowed, and the copy is stream ordered.
+        unsafe {
+            raw.copy_bytes(
+                output_ref.raw_ptr(),
+                input_ref.raw_ptr() as *const _,
+                input_ref.byte_len(),
+                op,
+            )?;
+        }
+        Ok(output)
+    })
+}
+
+fn conjugate_coeff_complex<T>(
+    backend: &mut CudaExecSession<'_>,
+    coeff: &TypedTensor<T>,
+    op: &'static str,
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar + TensorScalar + ComplexCore,
+{
+    backend.with_cubecl(op, |cubecl| {
+        let output = cubecl.alloc_output::<T>(coeff.shape())?;
+        if output.n_elements() == 0 {
+            return Ok(output);
+        }
+        let output_arg = cubecl.array_arg(&output, op)?;
+        let input_arg = cubecl.array_arg(coeff, op)?;
+        let launch_count = cubecl.cube_count_1d(output.n_elements())?;
+        // SAFETY: bindings describe live device arrays and the launch covers
+        // every coefficient exactly once.
+        unsafe {
+            cubecl_linalg::conjugate_vector::launch_unchecked::<T, CubeclCudaRuntime>(
+                cubecl.client(),
+                launch_count,
+                cubecl.cube_dim_1d(),
+                output_arg,
+                input_arg,
+            );
+        }
+        Ok(output)
+    })
+}
+
+fn apply_positive_qr_gauge_real<T>(
+    backend: &mut CudaExecSession<'_>,
+    q: &mut TypedTensor<T>,
+    r: &mut TypedTensor<T>,
+    q_start: usize,
+    op: &'static str,
+) -> Result<()>
+where
+    T: LinalgScalar + TensorScalar + PartialOrd + std::ops::Mul<Output = T>,
+{
+    backend.with_cubecl(op, |cubecl| {
+        let mut phase_shape = vec![r.shape()[0]];
+        phase_shape.extend_from_slice(&r.shape()[2..]);
+        let phase = cubecl.alloc_output::<T>(&phase_shape)?;
+        let launch_len = q.n_elements().max(r.n_elements());
+        if launch_len == 0 {
+            return Ok(());
+        }
+        let phase_output_arg = cubecl.tensor_binding(&phase, op)?;
+        let r_input_arg = cubecl.tensor_binding(r, op)?;
+        let phase_count = cubecl.cube_count_1d(phase.n_elements())?;
+        // SAFETY: phase/R bindings are live and phase_count covers each batch diagonal.
+        unsafe {
+            cubecl_linalg::qr_phase_real::launch_unchecked::<T, CubeclCudaRuntime>(
+                cubecl.client(),
+                phase_count,
+                cubecl.cube_dim_1d(),
+                phase_output_arg.into_tensor_arg(),
+                r_input_arg.into_tensor_arg(),
+                r.shape().len(),
+            );
+        }
+        let phase_arg = cubecl.tensor_binding(&phase, op)?;
+        let q_arg = cubecl.tensor_binding(q, op)?;
+        let r_arg = cubecl.tensor_binding(r, op)?;
+        let launch_count = cubecl.cube_count_1d(launch_len)?;
+        // SAFETY: phase computation is stream-ordered before scaling, Q/R are
+        // live mutable outputs, and the launch covers both domains.
+        unsafe {
+            cubecl_linalg::qr_apply_phase_real::launch_unchecked::<T, CubeclCudaRuntime>(
+                cubecl.client(),
+                launch_count,
+                cubecl.cube_dim_1d(),
+                q_arg.into_tensor_arg(),
+                r_arg.into_tensor_arg(),
+                phase_arg.into_tensor_arg(),
+                q_start,
+                r.shape().len(),
+            );
+        }
+        Ok(())
+    })
+}
+
+fn apply_positive_qr_gauge_c32(
+    backend: &mut CudaExecSession<'_>,
+    q: &mut TypedTensor<Complex32>,
+    r: &mut TypedTensor<Complex32>,
+    q_start: usize,
+    op: &'static str,
+) -> Result<()> {
+    backend.with_cubecl(op, |cubecl| {
+        let mut phase_shape = vec![r.shape()[0]];
+        phase_shape.extend_from_slice(&r.shape()[2..]);
+        let phase = cubecl.alloc_output::<Complex32>(&phase_shape)?;
+        let launch_len = q.n_elements().max(r.n_elements());
+        if launch_len == 0 {
+            return Ok(());
+        }
+        let phase_output_arg = cubecl.tensor_binding(&phase, op)?;
+        let r_input_arg = cubecl.tensor_binding(r, op)?;
+        let phase_count = cubecl.cube_count_1d(phase.n_elements())?;
+        // SAFETY: phase/R bindings are live and phase_count covers each batch diagonal.
+        unsafe {
+            cubecl_linalg::qr_phase_c32::launch_unchecked::<CubeclCudaRuntime>(
+                cubecl.client(),
+                phase_count,
+                cubecl.cube_dim_1d(),
+                phase_output_arg.into_tensor_arg(),
+                r_input_arg.into_tensor_arg(),
+                r.shape().len(),
+            );
+        }
+        let phase_arg = cubecl.tensor_binding(&phase, op)?;
+        let q_arg = cubecl.tensor_binding(q, op)?;
+        let r_arg = cubecl.tensor_binding(r, op)?;
+        let launch_count = cubecl.cube_count_1d(launch_len)?;
+        // SAFETY: phase computation is stream-ordered before scaling and the
+        // second launch covers Q/R exactly.
+        unsafe {
+            cubecl_linalg::qr_apply_phase_complex::launch_unchecked::<Complex32, CubeclCudaRuntime>(
+                cubecl.client(),
+                launch_count,
+                cubecl.cube_dim_1d(),
+                q_arg.into_tensor_arg(),
+                r_arg.into_tensor_arg(),
+                phase_arg.into_tensor_arg(),
+                q_start,
+                r.shape().len(),
+            );
+        }
+        Ok(())
+    })
+}
+
+fn apply_positive_qr_gauge_c64(
+    backend: &mut CudaExecSession<'_>,
+    q: &mut TypedTensor<Complex64>,
+    r: &mut TypedTensor<Complex64>,
+    q_start: usize,
+    op: &'static str,
+) -> Result<()> {
+    backend.with_cubecl(op, |cubecl| {
+        let mut phase_shape = vec![r.shape()[0]];
+        phase_shape.extend_from_slice(&r.shape()[2..]);
+        let phase = cubecl.alloc_output::<Complex64>(&phase_shape)?;
+        let launch_len = q.n_elements().max(r.n_elements());
+        if launch_len == 0 {
+            return Ok(());
+        }
+        let phase_output_arg = cubecl.tensor_binding(&phase, op)?;
+        let r_input_arg = cubecl.tensor_binding(r, op)?;
+        let phase_count = cubecl.cube_count_1d(phase.n_elements())?;
+        // SAFETY: phase/R bindings are live and phase_count covers each batch diagonal.
+        unsafe {
+            cubecl_linalg::qr_phase_c64::launch_unchecked::<CubeclCudaRuntime>(
+                cubecl.client(),
+                phase_count,
+                cubecl.cube_dim_1d(),
+                phase_output_arg.into_tensor_arg(),
+                r_input_arg.into_tensor_arg(),
+                r.shape().len(),
+            );
+        }
+        let phase_arg = cubecl.tensor_binding(&phase, op)?;
+        let q_arg = cubecl.tensor_binding(q, op)?;
+        let r_arg = cubecl.tensor_binding(r, op)?;
+        let launch_count = cubecl.cube_count_1d(launch_len)?;
+        // SAFETY: phase computation is stream-ordered before scaling and the
+        // second launch covers Q/R exactly.
+        unsafe {
+            cubecl_linalg::qr_apply_phase_complex::launch_unchecked::<Complex64, CubeclCudaRuntime>(
+                cubecl.client(),
+                launch_count,
+                cubecl.cube_dim_1d(),
+                q_arg.into_tensor_arg(),
+                r_arg.into_tensor_arg(),
+                phase_arg.into_tensor_arg(),
+                q_start,
+                r.shape().len(),
+            );
+        }
+        Ok(())
     })
 }
 
@@ -1864,6 +2461,9 @@ where
         }
     }
 }
+
+mod householder_qr;
+use householder_qr::*;
 
 fn qr_typed<T>(
     backend: &mut CudaExecSession<'_>,

--- a/crates/tenferro-linalg/src/gpu/linalg/householder_qr.rs
+++ b/crates/tenferro-linalg/src/gpu/linalg/householder_qr.rs
@@ -1,0 +1,694 @@
+use super::*;
+
+fn initialize_q_columns_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    rows: usize,
+    start: usize,
+    end: usize,
+    op: &'static str,
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    let width = end
+        .checked_sub(start)
+        .ok_or_else(|| Error::invalid_argument(op, "range", "start exceeds end"))?;
+    backend.with_cubecl(op, |cubecl| {
+        let output = cubecl.alloc_output::<T>(&[rows, width])?;
+        if output.n_elements() == 0 {
+            return Ok(output);
+        }
+        let output_arg = cubecl.tensor_binding(&output, op)?;
+        let launch_count = cubecl.cube_count_1d(output.n_elements())?;
+        // SAFETY: output is a live device tensor and each launched thread
+        // writes one selected identity-column element.
+        unsafe {
+            cubecl_linalg::householder_q_columns_identity::launch_unchecked::<T, CubeclCudaRuntime>(
+                cubecl.client(),
+                launch_count,
+                cubecl.cube_dim_1d(),
+                output_arg.into_tensor_arg(),
+                start,
+            );
+        }
+        Ok(output)
+    })
+}
+
+fn linalg_scalar_bytes<T: LinalgScalar>(value: &T) -> &[u8] {
+    // SAFETY: LinalgScalar is sealed in this module to f32/f64/Complex32/
+    // Complex64, all of which have initialized byte representations without
+    // padding; the returned slice cannot outlive `value`.
+    unsafe {
+        std::slice::from_raw_parts(
+            std::ptr::from_ref(value).cast::<u8>(),
+            std::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn apply_householder_reflectors_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    packed: &TypedTensor<T>,
+    coeff: &TypedTensor<T>,
+    target: &mut TypedTensor<T>,
+    adjoint: bool,
+    op: &'static str,
+) -> Result<()>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    let (m, _, k) = compact_qr_state_dims(packed, coeff, op)?;
+    ensure_cubecl_resident_typed(op, target)?;
+    if target.shape().len() != 2 || target.shape()[0] != m {
+        return Err(Error::shape_mismatch(
+            op,
+            vec![m, target.shape().get(1).copied().unwrap_or(0)],
+            target.shape().to_vec(),
+        ));
+    }
+    let columns = target.shape()[1];
+    if k == 0 || columns == 0 {
+        return Ok(());
+    }
+    let coeff_adjoint = adjoint
+        .then(|| T::conjugate_coeff(backend, coeff, op))
+        .transpose()?;
+    let apply_coeff = coeff_adjoint.as_ref().unwrap_or(coeff);
+    let m_i32 = as_i32(m, op, "m")?;
+    let columns_i32 = as_i32(columns, op, "columns")?;
+    let one = T::one();
+    let zero = T::zero();
+    let minus_one = -one;
+
+    backend.with_raw(op, |raw| {
+        let handles = raw.resource(CudaLinalgHandles::load)?;
+        // SAFETY: stream handle is valid for this raw-session scope.
+        let stream = unsafe { raw.stream().raw_handle() } as usize as CudaStream;
+        handles.cublas().set_stream(stream, op)?;
+
+        let one_device = raw.upload_bytes(linalg_scalar_bytes(&one), op)?;
+        let zero_device = raw.upload_bytes(linalg_scalar_bytes(&zero), op)?;
+        let minus_one_device = raw.upload_bytes(linalg_scalar_bytes(&minus_one), op)?;
+        let mut one_ptr = std::ptr::null_mut::<c_void>();
+        let mut zero_ptr = std::ptr::null_mut::<c_void>();
+        let mut minus_one_ptr = std::ptr::null_mut::<c_void>();
+        one_device.with_ptr(|ptr| one_ptr = ptr);
+        zero_device.with_ptr(|ptr| zero_ptr = ptr);
+        minus_one_device.with_ptr(|ptr| minus_one_ptr = ptr);
+
+        let mut v = raw.alloc_output::<T>(&[m])?;
+        let mut w = raw.alloc_output::<T>(&[columns])?;
+        let packed_ref = raw.tensor(packed)?;
+        let coeff_ref = raw.tensor(apply_coeff)?;
+        let target_ref = raw.tensor_mut(target)?;
+        let v_ref = raw.tensor_mut(&mut v)?;
+        let w_ref = raw.tensor_mut(&mut w)?;
+        // SAFETY: every handle is a validated live device span in this raw
+        // session; pointers are retained only for stream-ordered calls below.
+        let (packed_ptr, coeff_ptr, target_ptr, v_ptr, w_ptr) = unsafe {
+            (
+                packed_ref.raw_ptr().cast_const(),
+                coeff_ref.raw_ptr().cast_const(),
+                target_ref.raw_ptr(),
+                v_ref.raw_ptr(),
+                w_ref.raw_ptr(),
+            )
+        };
+        let indices: Box<dyn Iterator<Item = usize>> = if adjoint {
+            Box::new(0..k)
+        } else {
+            Box::new((0..k).rev())
+        };
+        handles
+            .cublas()
+            .set_pointer_mode(CublasPointerMode::Device, op)?;
+        let computation = (|| -> Result<()> {
+            for reflector in indices {
+                let len = m - reflector;
+                let len_i32 = as_i32(len, op, "reflector length")?;
+                let packed_column =
+                    checked_mul_usize(op, "reflector packed column offset", reflector, m)?;
+                let packed_tail_offset =
+                    packed_column.checked_add(reflector + 1).ok_or_else(|| {
+                        Error::invalid_argument(op, "reflector offset", "offset overflowed")
+                    })?;
+                let tail_bytes = checked_mul_usize(
+                    op,
+                    "reflector tail bytes",
+                    len - 1,
+                    std::mem::size_of::<T>(),
+                )?;
+                // SAFETY: checked reflector offsets remain within the packed,
+                // coefficient, target, and scratch allocations.
+                let (packed_tail, tau, target_sub) = unsafe {
+                    (
+                        batch_const_ptr::<T>(packed_ptr, packed_tail_offset),
+                        batch_const_ptr::<T>(coeff_ptr, reflector),
+                        batch_ptr::<T>(target_ptr, reflector),
+                    )
+                };
+                // SAFETY: scalar and tail copies target disjoint live scratch
+                // spans and are ordered on the session stream.
+                unsafe {
+                    raw.copy_bytes(v_ptr, one_ptr.cast_const(), std::mem::size_of::<T>(), op)?;
+                    if len > 1 {
+                        raw.copy_bytes(batch_ptr::<T>(v_ptr, 1), packed_tail, tail_bytes, op)?;
+                    }
+                    match T::DATA_TYPE {
+                        CudaDataType::F32 | CudaDataType::F64 => {
+                            handles.cublas().gemv(
+                                T::DATA_TYPE,
+                                CublasOperation::T,
+                                len_i32,
+                                columns_i32,
+                                tau,
+                                target_sub.cast_const(),
+                                m_i32,
+                                v_ptr.cast_const(),
+                                1,
+                                zero_ptr.cast_const(),
+                                w_ptr,
+                                1,
+                                op,
+                            )?;
+                        }
+                        CudaDataType::Complex32 | CudaDataType::Complex64 => {
+                            handles.cublas().gemm(
+                                T::DATA_TYPE,
+                                CublasOperation::C,
+                                CublasOperation::N,
+                                1,
+                                columns_i32,
+                                len_i32,
+                                tau,
+                                v_ptr.cast_const(),
+                                len_i32,
+                                target_sub.cast_const(),
+                                m_i32,
+                                zero_ptr.cast_const(),
+                                w_ptr,
+                                1,
+                                op,
+                            )?;
+                        }
+                    }
+                    handles.cublas().geru(
+                        T::DATA_TYPE,
+                        len_i32,
+                        columns_i32,
+                        minus_one_ptr.cast_const(),
+                        v_ptr.cast_const(),
+                        1,
+                        w_ptr.cast_const(),
+                        1,
+                        target_sub,
+                        m_i32,
+                        op,
+                    )?;
+                }
+            }
+            Ok(())
+        })();
+        let reset = handles
+            .cublas()
+            .set_pointer_mode(CublasPointerMode::Host, op);
+        computation?;
+        reset
+    })
+}
+
+fn geqrf_trailing_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    matrix: &mut TypedTensor<T>,
+    row_offset: usize,
+    op: &'static str,
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    ensure_cubecl_resident_typed(op, matrix)?;
+    if matrix.shape().len() != 2 || row_offset > matrix.shape()[0] {
+        return Err(Error::invalid_argument(
+            op,
+            "trailing block",
+            "invalid rank or row offset",
+        ));
+    }
+    let rows = matrix.shape()[0] - row_offset;
+    let cols = matrix.shape()[1];
+    let k = rows.min(cols);
+    if rows == 0 || cols == 0 {
+        return backend.with_raw(op, |raw| raw.alloc_output::<T>(&[k]));
+    }
+    let rows_i32 = as_i32(rows, op, "trailing rows")?;
+    let cols_i32 = as_i32(cols, op, "trailing columns")?;
+    let lda = as_i32(matrix.shape()[0], op, "lda")?;
+    backend.with_raw(op, |raw| {
+        let handles = raw.resource(CudaLinalgHandles::load)?;
+        // SAFETY: stream handle is valid for this raw-session scope.
+        let stream = unsafe { raw.stream().raw_handle() } as usize as CudaStream;
+        handles.cusolver().set_stream(stream, op)?;
+        let matrix_ref = raw.tensor_mut(matrix)?;
+        // SAFETY: row_offset is validated inside the first matrix column.
+        let matrix_ptr = unsafe { batch_ptr::<T>(matrix_ref.raw_ptr(), row_offset) };
+        let lwork = handles.cusolver().geqrf_buffer_size(
+            T::DATA_TYPE,
+            rows_i32,
+            cols_i32,
+            matrix_ptr,
+            lda,
+            op,
+        )?;
+        let workspace_bytes = usize::try_from(lwork)
+            .map_err(|_| Error::invalid_argument(op, "workspace", "negative length"))?
+            .checked_mul(std::mem::size_of::<T>())
+            .ok_or_else(|| Error::invalid_argument(op, "workspace", "byte size overflowed"))?;
+        let workspace = raw.alloc_bytes(workspace_bytes, op)?;
+        let mut workspace_ptr = std::ptr::null_mut::<c_void>();
+        workspace.with_ptr(|ptr| workspace_ptr = ptr);
+        let mut coeff = raw.alloc_output::<T>(&[k])?;
+        let mut info = raw.alloc_output::<i32>(&[1])?;
+        let coeff_ref = raw.tensor_mut(&mut coeff)?;
+        let info_ref = raw.tensor_mut(&mut info)?;
+        // SAFETY: matrix/tau/workspace/info pointers are live device spans and
+        // dimensions describe the validated trailing submatrix with lda=m.
+        unsafe {
+            handles.cusolver().geqrf(
+                T::DATA_TYPE,
+                rows_i32,
+                cols_i32,
+                matrix_ptr,
+                lda,
+                coeff_ref.raw_ptr(),
+                workspace_ptr,
+                lwork,
+                info_ref.raw_ptr().cast::<i32>(),
+                op,
+            )?;
+        }
+        let host_info = raw.download_tensor::<i32>(&info, op)?;
+        check_solver_info(op, "cusolverDn*geqrf", host_info.host_data()?[0])?;
+        Ok(coeff)
+    })
+}
+
+fn concatenate_compact_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    packed: &TypedTensor<T>,
+    block: &TypedTensor<T>,
+    coeff: &TypedTensor<T>,
+    trailing_coeff: &TypedTensor<T>,
+    op: &'static str,
+) -> Result<(TypedTensor<T>, TypedTensor<T>)>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    let rows = packed.shape()[0];
+    let width = packed.shape()[1]
+        .checked_add(block.shape()[1])
+        .ok_or_else(|| Error::invalid_argument(op, "shape", "column count overflowed"))?;
+    let coeff_len = coeff.shape()[0]
+        .checked_add(trailing_coeff.shape()[0])
+        .ok_or_else(|| Error::invalid_argument(op, "shape", "coefficient count overflowed"))?;
+    backend.with_raw(op, |raw| {
+        let mut output = raw.alloc_output::<T>(&[rows, width])?;
+        let mut output_coeff = raw.alloc_output::<T>(&[coeff_len])?;
+        let packed_ref = raw.tensor(packed)?;
+        let block_ref = raw.tensor(block)?;
+        let coeff_ref = raw.tensor(coeff)?;
+        let trailing_ref = raw.tensor(trailing_coeff)?;
+        let output_ref = raw.tensor_mut(&mut output)?;
+        let output_coeff_ref = raw.tensor_mut(&mut output_coeff)?;
+        // SAFETY: output layouts concatenate two validated compact column-major
+        // matrices/vectors, all offsets and byte lengths stay in live spans.
+        unsafe {
+            raw.copy_bytes(
+                output_ref.raw_ptr(),
+                packed_ref.raw_ptr() as *const _,
+                packed_ref.byte_len(),
+                op,
+            )?;
+            raw.copy_bytes(
+                output_ref
+                    .raw_ptr()
+                    .cast::<u8>()
+                    .add(packed_ref.byte_len())
+                    .cast(),
+                block_ref.raw_ptr() as *const _,
+                block_ref.byte_len(),
+                op,
+            )?;
+            raw.copy_bytes(
+                output_coeff_ref.raw_ptr(),
+                coeff_ref.raw_ptr() as *const _,
+                coeff_ref.byte_len(),
+                op,
+            )?;
+            raw.copy_bytes(
+                output_coeff_ref
+                    .raw_ptr()
+                    .cast::<u8>()
+                    .add(coeff_ref.byte_len())
+                    .cast(),
+                trailing_ref.raw_ptr() as *const _,
+                trailing_ref.byte_len(),
+                op,
+            )?;
+        }
+        Ok((output, output_coeff))
+    })
+}
+
+fn gemm_nn_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+    op: &'static str,
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    ensure_cubecl_resident_typed(op, lhs)?;
+    ensure_cubecl_resident_typed(op, rhs)?;
+    if lhs.shape().len() != 2 || rhs.shape().len() != 2 || lhs.shape()[1] != rhs.shape()[0] {
+        return Err(Error::invalid_argument(
+            op,
+            "shape",
+            "invalid GEMM operands",
+        ));
+    }
+    let m = lhs.shape()[0];
+    let n = rhs.shape()[1];
+    let k = lhs.shape()[1];
+    if m == 0 || n == 0 || k == 0 {
+        return backend.with_raw(op, |raw| raw.alloc_output::<T>(&[m, n]));
+    }
+    let m_i32 = as_i32(m, op, "gemm m")?;
+    let n_i32 = as_i32(n, op, "gemm n")?;
+    let k_i32 = as_i32(k, op, "gemm k")?;
+    let alpha = T::one();
+    let beta = T::zero();
+    backend.with_raw(op, |raw| {
+        let handles = raw.resource(CudaLinalgHandles::load)?;
+        // SAFETY: stream handle is valid for this raw-session scope.
+        let stream = unsafe { raw.stream().raw_handle() } as usize as CudaStream;
+        handles.cublas().set_stream(stream, op)?;
+        handles
+            .cublas()
+            .set_pointer_mode(CublasPointerMode::Host, op)?;
+        let lhs_ref = raw.tensor(lhs)?;
+        let rhs_ref = raw.tensor(rhs)?;
+        let mut output = raw.alloc_output::<T>(&[m, n])?;
+        let output_ref = raw.tensor_mut(&mut output)?;
+        // SAFETY: all tensors are validated compact column-major device
+        // matrices and dimensions/leading dimensions match their shapes.
+        unsafe {
+            handles.cublas().gemm(
+                T::DATA_TYPE,
+                CublasOperation::N,
+                CublasOperation::N,
+                m_i32,
+                n_i32,
+                k_i32,
+                std::ptr::from_ref(&alpha).cast(),
+                lhs_ref.raw_ptr() as *const _,
+                m_i32,
+                rhs_ref.raw_ptr() as *const _,
+                k_i32,
+                std::ptr::from_ref(&beta).cast(),
+                output_ref.raw_ptr(),
+                m_i32,
+                op,
+            )?;
+        }
+        Ok(output)
+    })
+}
+
+fn assemble_from_factors_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    packed_q: &TypedTensor<T>,
+    coeff_q: &TypedTensor<T>,
+    folded_r: &TypedTensor<T>,
+    output_cols: usize,
+    op: &'static str,
+) -> Result<(TypedTensor<T>, TypedTensor<T>)>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    let rows = packed_q.shape()[0];
+    let factor_width = packed_q.shape()[1];
+    let output_k = rows.min(output_cols);
+    backend.with_cubecl(op, |cubecl| {
+        let packed = cubecl.alloc_output::<T>(&[rows, output_cols])?;
+        let coeff = cubecl.alloc_output::<T>(&[output_k])?;
+        let launch_len = packed.n_elements().max(coeff.n_elements());
+        if launch_len == 0 {
+            return Ok((packed, coeff));
+        }
+        let packed_arg = cubecl.tensor_binding(&packed, op)?;
+        let coeff_arg = cubecl.tensor_binding(&coeff, op)?;
+        let packed_q_arg = cubecl.tensor_binding(packed_q, op)?;
+        let coeff_q_arg = cubecl.tensor_binding(coeff_q, op)?;
+        let folded_arg = cubecl.tensor_binding(folded_r, op)?;
+        let launch_count = cubecl.cube_count_1d(launch_len)?;
+        // SAFETY: bindings describe live device tensors and the launch covers
+        // both packed and coefficient outputs.
+        unsafe {
+            cubecl_linalg::householder_from_factors_assemble::launch_unchecked::<
+                T,
+                CubeclCudaRuntime,
+            >(
+                cubecl.client(),
+                launch_count,
+                cubecl.cube_dim_1d(),
+                packed_arg.into_tensor_arg(),
+                coeff_arg.into_tensor_arg(),
+                packed_q_arg.into_tensor_arg(),
+                coeff_q_arg.into_tensor_arg(),
+                folded_arg.into_tensor_arg(),
+                factor_width,
+            );
+        }
+        Ok((packed, coeff))
+    })
+}
+
+pub(super) fn compact_qr_from_factors_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    q: &TypedTensor<T>,
+    r: &TypedTensor<T>,
+    op: &'static str,
+) -> Result<(TypedTensor<T>, TypedTensor<T>)>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    ensure_cubecl_resident_typed(op, q)?;
+    ensure_cubecl_resident_typed(op, r)?;
+    if q.shape().len() != 2
+        || r.shape().len() != 2
+        || q.shape()[1] != r.shape()[0]
+        || q.shape()[1] > q.shape()[0].min(r.shape()[1])
+    {
+        return Err(Error::invalid_argument(
+            op,
+            "shape",
+            "incompatible Q/R factors",
+        ));
+    }
+    let (packed_q, coeff_q) = compact_qr_typed(backend, q, op)?;
+    let triangular = compact_qr_r_typed(backend, &packed_q, &coeff_q, QrOptions::default(), op)?;
+    let folded = gemm_nn_typed(backend, &triangular, r, op)?;
+    assemble_from_factors_typed(backend, &packed_q, &coeff_q, &folded, r.shape()[1], op)
+}
+
+pub(super) fn compact_qr_append_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    packed: &TypedTensor<T>,
+    coeff: &TypedTensor<T>,
+    block: &TypedTensor<T>,
+    op: &'static str,
+) -> Result<(TypedTensor<T>, TypedTensor<T>)>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    let (m, _, k) = compact_qr_state_dims(packed, coeff, op)?;
+    ensure_cubecl_resident_typed(op, block)?;
+    if block.shape().len() != 2 || block.shape()[0] != m {
+        return Err(Error::shape_mismatch(
+            op,
+            vec![m, block.shape().get(1).copied().unwrap_or(0)],
+            block.shape().to_vec(),
+        ));
+    }
+    let mut transformed = clone_device_tensor(backend, block, op)?;
+    apply_householder_reflectors_typed(backend, packed, coeff, &mut transformed, true, op)?;
+    let trailing_coeff = geqrf_trailing_typed(backend, &mut transformed, k, op)?;
+    concatenate_compact_typed(backend, packed, &transformed, coeff, &trailing_coeff, op)
+}
+
+fn compact_qr_state_dims<T>(
+    packed: &TypedTensor<T>,
+    coeff: &TypedTensor<T>,
+    op: &'static str,
+) -> Result<(usize, usize, usize)>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    ensure_cubecl_resident_typed(op, packed)?;
+    ensure_cubecl_resident_typed(op, coeff)?;
+    if packed.shape().len() != 2 {
+        return Err(Error::rank_mismatch(op, 2, packed.shape().len()));
+    }
+    if coeff.shape().len() != 1 {
+        return Err(Error::rank_mismatch(op, 1, coeff.shape().len()));
+    }
+    let m = packed.shape()[0];
+    let n = packed.shape()[1];
+    let k = m.min(n);
+    if coeff.shape()[0] != k {
+        return Err(Error::shape_mismatch(op, vec![k], coeff.shape().to_vec()));
+    }
+    Ok((m, n, k))
+}
+
+pub(super) fn compact_qr_q_columns_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    packed: &TypedTensor<T>,
+    coeff: &TypedTensor<T>,
+    start: usize,
+    end: usize,
+    options: QrOptions,
+    op: &'static str,
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    let (m, _, k) = compact_qr_state_dims(packed, coeff, op)?;
+    if start > end || end > k {
+        return Err(Error::invalid_argument(
+            op,
+            "range",
+            format!("Q column range {start}..{end} exceeds 0..{k}"),
+        ));
+    }
+    let mut q = initialize_q_columns_typed::<T>(backend, m, start, end, op)?;
+    apply_householder_reflectors_typed(backend, packed, coeff, &mut q, false, op)?;
+    if options.gauge == QrGauge::PositiveDiagonal {
+        let mut r = compact_qr_r_typed(backend, packed, coeff, QrOptions::default(), op)?;
+        T::apply_positive_qr_gauge(backend, &mut q, &mut r, start, op)?;
+    }
+    Ok(q)
+}
+
+pub(super) fn compact_qr_r_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    packed: &TypedTensor<T>,
+    coeff: &TypedTensor<T>,
+    options: QrOptions,
+    op: &'static str,
+) -> Result<TypedTensor<T>>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    let (m, n, k) = compact_qr_state_dims(packed, coeff, op)?;
+    let input = backend.slice_typed(packed, &matrix_slice_config(packed.shape(), k, n))?;
+    let mut r = backend.triu_typed(&input, 0)?;
+    if options.gauge == QrGauge::PositiveDiagonal {
+        let mut q = backend.with_cubecl(op, |cubecl| cubecl.alloc_output::<T>(&[m, 0]))?;
+        T::apply_positive_qr_gauge(backend, &mut q, &mut r, 0, op)?;
+    }
+    Ok(r)
+}
+
+pub(super) fn compact_qr_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    input: &TypedTensor<T>,
+    op: &'static str,
+) -> Result<(TypedTensor<T>, TypedTensor<T>)>
+where
+    T: LinalgScalar + TensorScalar,
+{
+    ensure_cubecl_resident_typed(op, input)?;
+    if input.shape().len() != 2 {
+        return Err(Error::rank_mismatch(op, 2, input.shape().len()));
+    }
+    let m = input.shape()[0];
+    let n = input.shape()[1];
+    let k = m.min(n);
+    if has_zero_dim(input.shape()) {
+        return backend.with_raw(op, |raw| {
+            raw.tensor(input)?;
+            Ok((
+                raw.alloc_output::<T>(input.shape())?,
+                raw.alloc_output::<T>(&[k])?,
+            ))
+        });
+    }
+
+    let m_i32 = as_i32(m, op, "m")?;
+    let n_i32 = as_i32(n, op, "n")?;
+    let lda = as_i32(m, op, "lda")?;
+    backend.with_raw(op, |raw| {
+        let handles = raw.resource(CudaLinalgHandles::load)?;
+        // SAFETY: the stream handle is valid for this raw-session scope and
+        // is bound immediately to the session-owned cuSOLVER handle.
+        let stream = unsafe { raw.stream().raw_handle() } as usize as CudaStream;
+        handles.cusolver().set_stream(stream, op)?;
+
+        let mut packed = raw.alloc_output::<T>(input.shape())?;
+        {
+            let src = raw.tensor(input)?;
+            let dst = raw.tensor_mut(&mut packed)?;
+            // SAFETY: source/destination spans are validated on this runtime,
+            // destination is exclusive, and the copy is stream ordered.
+            unsafe {
+                raw.copy_bytes(dst.raw_ptr(), src.raw_ptr() as *const _, src.byte_len(), op)?;
+            }
+        }
+        let mut coeff = raw.alloc_output::<T>(&[k])?;
+        let lwork = {
+            let packed_ref = raw.tensor(&packed)?;
+            handles.cusolver().geqrf_buffer_size(
+                T::DATA_TYPE,
+                m_i32,
+                n_i32,
+                // SAFETY: packed_ref is a validated live device matrix.
+                unsafe { packed_ref.raw_ptr() },
+                lda,
+                op,
+            )?
+        };
+        let workspace_bytes = usize::try_from(lwork)
+            .map_err(|_| Error::invalid_argument(op, "workspace", "negative length"))?
+            .checked_mul(std::mem::size_of::<T>())
+            .ok_or_else(|| Error::invalid_argument(op, "workspace", "byte size overflowed"))?;
+        let workspace = raw.alloc_bytes(workspace_bytes, op)?;
+        let mut workspace_ptr = std::ptr::null_mut::<c_void>();
+        workspace.with_ptr(|ptr| workspace_ptr = ptr);
+        let mut info = raw.alloc_output::<i32>(&[1])?;
+        let packed_ref = raw.tensor_mut(&mut packed)?;
+        let coeff_ref = raw.tensor_mut(&mut coeff)?;
+        let info_ref = raw.tensor_mut(&mut info)?;
+        // SAFETY: all pointers reference validated live device allocations;
+        // dimensions and workspace match the checked rank-2 matrix.
+        unsafe {
+            handles.cusolver().geqrf(
+                T::DATA_TYPE,
+                m_i32,
+                n_i32,
+                packed_ref.raw_ptr(),
+                lda,
+                coeff_ref.raw_ptr(),
+                workspace_ptr,
+                lwork,
+                info_ref.raw_ptr().cast::<i32>(),
+                op,
+            )?;
+        }
+        let host_info = raw.download_tensor::<i32>(&info, op)?;
+        check_solver_info(op, "cusolverDn*geqrf", host_info.host_data()?[0])?;
+        Ok((packed, coeff))
+    })
+}

--- a/crates/tenferro-linalg/src/gpu/mod.rs
+++ b/crates/tenferro-linalg/src/gpu/mod.rs
@@ -6,6 +6,7 @@ use tenferro_gpu::cuda::CudaExecSession;
 use tenferro_tensor::{Tensor, TensorRead, TensorView};
 
 use crate::backend::{unsupported_dtype, LinalgBackend};
+use crate::QrOptions;
 
 impl LinalgBackend for CudaExecSession<'_> {
     fn cholesky(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
@@ -107,6 +108,14 @@ impl LinalgBackend for CudaExecSession<'_> {
         linalg::qr(self, input)
     }
 
+    fn qr_with_options(
+        &mut self,
+        input: &Tensor,
+        options: QrOptions,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        linalg::qr_with_options(self, input, options)
+    }
+
     fn qr_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         let input = input.tensor_view();
         match input {
@@ -132,6 +141,78 @@ impl LinalgBackend for CudaExecSession<'_> {
             }
             TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
                 Err(unsupported_dtype("qr", input.dtype()))
+            }
+        }
+    }
+
+    fn householder_qr(
+        &mut self,
+        input: &Tensor,
+    ) -> tenferro_tensor::Result<crate::backend::CompactQrResult> {
+        linalg::householder_qr(self, input)
+    }
+
+    fn householder_qr_from_factors(
+        &mut self,
+        q: &Tensor,
+        r: &Tensor,
+    ) -> tenferro_tensor::Result<crate::backend::CompactQrResult> {
+        linalg::householder_qr_from_factors(self, q, r)
+    }
+
+    fn householder_qr_append(
+        &mut self,
+        packed: &Tensor,
+        coeff: &Tensor,
+        block: &Tensor,
+    ) -> tenferro_tensor::Result<crate::backend::CompactQrResult> {
+        linalg::householder_qr_append(self, packed, coeff, block)
+    }
+
+    fn householder_qr_q_columns(
+        &mut self,
+        packed: &Tensor,
+        coeff: &Tensor,
+        range: std::ops::Range<usize>,
+        options: QrOptions,
+    ) -> tenferro_tensor::Result<Tensor> {
+        linalg::householder_qr_q_columns(self, packed, coeff, range.start, range.end, options)
+    }
+
+    fn householder_qr_r(
+        &mut self,
+        packed: &Tensor,
+        coeff: &Tensor,
+        options: QrOptions,
+    ) -> tenferro_tensor::Result<Tensor> {
+        linalg::householder_qr_r(self, packed, coeff, options)
+    }
+
+    fn qr_with_options_read(
+        &mut self,
+        input: TensorRead<'_>,
+        options: QrOptions,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                linalg::qr_with_options(self, &Tensor::F32(compact), options)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                linalg::qr_with_options(self, &Tensor::F64(compact), options)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                linalg::qr_with_options(self, &Tensor::C32(compact), options)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                linalg::qr_with_options(self, &Tensor::C64(compact), options)
+            }
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("qr_with_options_read", input.dtype()))
             }
         }
     }

--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -18,8 +18,7 @@ use tenferro_tensor::{
 };
 
 use crate::extension::{
-    apply_eigh_gauge, apply_qr_gauge, apply_svd_gauge, validate_derivative_eps, EighOptions,
-    QrOptions, SvdOptions,
+    apply_eigh_gauge, apply_svd_gauge, validate_derivative_eps, EighOptions, QrOptions, SvdOptions,
 };
 use crate::LinalgBackend;
 
@@ -1733,9 +1732,10 @@ impl TensorReadLinalgExt for TensorRead<'_> {
         session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
         with_linalg_backend(session, "qr_with_options_read", |backend| {
-            let mut out = backend.qr_read(self)?;
-            apply_qr_gauge(options.gauge, &mut out)?;
-            two(out, "qr_with_options_read")
+            two(
+                backend.qr_with_options_read(self, options)?,
+                "qr_with_options_read",
+            )
         })
     }
     fn lu_read(

--- a/crates/tenferro-linalg/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-linalg/tests/integration/eager_tensor.rs
@@ -1164,7 +1164,7 @@ fn cuda_eager_solve_uses_registered_linalg_runtime() {
 
     let download_backend =
         CudaBackend::new(tenferro_gpu::cuda::CudaDeviceId::from_ordinal(0)).unwrap();
-    let x_host = download_tensor(download_backend.runtime(), x.to_tensor().unwrap()).unwrap();
+    let x_host = download_tensor(download_backend.runtime(), &x.to_tensor().unwrap()).unwrap();
     assert_eq!(x_host.shape(), &[2, 1]);
     assert_close_slice(f64_data(&x_host), &[1.8, -0.4], 1.0e-9);
 }

--- a/crates/tenferro-linalg/tests/integration/gpu_linalg.rs
+++ b/crates/tenferro-linalg/tests/integration/gpu_linalg.rs
@@ -7,8 +7,8 @@ use tenferro_gpu::{
     cuda::download_tensor, cuda::gpu_available, cuda::upload_tensor, cuda::with_cuda_exec_session,
     cuda::CudaBackend, cuda::CudaDeviceId, cuda::CudaExecSession,
 };
-use tenferro_linalg::LinalgBackend;
-use tenferro_tensor::{BackendSessionHost, Error, Tensor, TypedTensor};
+use tenferro_linalg::{HouseholderQr, LinalgBackend, QrGauge, QrOptions, TensorLinalgExt};
+use tenferro_tensor::{BackendSessionHost, Error, Tensor, TensorRead, TypedTensor};
 
 fn cpu_backend() -> CpuBackend {
     CpuBackend::new()
@@ -700,6 +700,470 @@ fn test_cubecl_svd_gesvd_tall_f64_retains_direct_route() {
     let expected_values =
         with_cpu_linalg_session(&mut cpu, |session| session.svd_values(&input)).unwrap();
     assert_tensor_close(&s, &expected_values, 1e-9);
+}
+
+#[test]
+#[ignore]
+fn test_cuda_compact_householder_qr_f64_reconstructs_input() {
+    if !gpu_available() {
+        return;
+    }
+    let input = tensor_f64(vec![4, 2], vec![1.0, 2.0, 3.0, 4.0, 2.0, -1.0, 0.5, 3.0]);
+    let mut gpu = gpu_backend();
+    let device_input = upload(&gpu, &input);
+    let options = QrOptions::default().gauge(QrGauge::PositiveDiagonal);
+    let (q, r) = with_cuda_linalg_session(&mut gpu, |session| {
+        let state = device_input.householder_qr(session).unwrap();
+        (
+            state.q_columns(0..2, options, session).unwrap(),
+            state.r(options, session).unwrap(),
+        )
+    });
+    let q = download(&gpu, &q);
+    let r = download(&gpu, &r);
+    let reconstructed = matmul_f64(
+        q.as_slice::<f64>().unwrap(),
+        r.as_slice::<f64>().unwrap(),
+        4,
+        2,
+        2,
+    );
+    assert_tensor_close(&tensor_f64(vec![4, 2], reconstructed), &input, 1.0e-10);
+}
+
+#[test]
+#[ignore]
+fn test_cuda_compact_householder_qr_append_and_from_factors_f64() {
+    if !gpu_available() {
+        return;
+    }
+    let a = tensor_f64(vec![4, 2], vec![1.0, 2.0, 3.0, 4.0, 2.0, -1.0, 0.5, 3.0]);
+    let b = tensor_f64(vec![4, 2], vec![0.5, 1.0, -2.0, 1.5, 2.0, 0.0, 1.0, -1.0]);
+    let c = tensor_f64(vec![4, 1], vec![1.0, -0.5, 2.0, 0.25]);
+    let q_factor = tensor_f64(vec![4, 2], vec![1.0, 0.0, 1.0, 2.0, 0.5, 1.0, -1.0, 0.0]);
+    let r_factor = tensor_f64(vec![2, 3], vec![2.0, 0.0, -1.0, 3.0, 0.5, 2.0]);
+    let invalid_r = tensor_f64(vec![2, 2], vec![2.0, 1.0, 0.5, 3.0]);
+    let mut gpu = gpu_backend();
+    let a_gpu = upload(&gpu, &a);
+    let b_gpu = upload(&gpu, &b);
+    let c_gpu = upload(&gpu, &c);
+    let q_gpu = upload(&gpu, &q_factor);
+    let r_gpu = upload(&gpu, &r_factor);
+    let invalid_r_gpu = upload(&gpu, &invalid_r);
+    let options = QrOptions::default().gauge(QrGauge::PositiveDiagonal);
+    let (append_q, append_r, factor_q, factor_r) = with_cuda_linalg_session(&mut gpu, |session| {
+        let appended = a_gpu
+            .householder_qr(session)
+            .unwrap()
+            .append_columns(&b_gpu, session)
+            .unwrap()
+            .append_columns(&c_gpu, session)
+            .unwrap();
+        let invalid =
+            HouseholderQr::<Tensor>::from_factors(&q_gpu, &invalid_r_gpu, session).unwrap_err();
+        assert!(matches!(invalid, Error::Validation { .. }));
+        let imported = HouseholderQr::<Tensor>::from_factors(&q_gpu, &r_gpu, session).unwrap();
+        (
+            appended.q_columns(0..4, options, session).unwrap(),
+            appended.r(options, session).unwrap(),
+            imported.q_columns(0..3, options, session).unwrap(),
+            imported.r(options, session).unwrap(),
+        )
+    });
+    let append_q = download(&gpu, &append_q);
+    let append_r = download(&gpu, &append_r);
+    let factor_q = download(&gpu, &factor_q);
+    let factor_r = download(&gpu, &factor_r);
+    let append_actual = matmul_f64(
+        append_q.as_slice::<f64>().unwrap(),
+        append_r.as_slice::<f64>().unwrap(),
+        4,
+        4,
+        5,
+    );
+    let mut combined = a.as_slice::<f64>().unwrap().to_vec();
+    combined.extend_from_slice(b.as_slice::<f64>().unwrap());
+    combined.extend_from_slice(c.as_slice::<f64>().unwrap());
+    assert_tensor_close(
+        &tensor_f64(vec![4, 5], append_actual),
+        &tensor_f64(vec![4, 5], combined),
+        1.0e-9,
+    );
+    let factor_actual = matmul_f64(
+        factor_q.as_slice::<f64>().unwrap(),
+        factor_r.as_slice::<f64>().unwrap(),
+        4,
+        3,
+        3,
+    );
+    let factor_expected = matmul_f64(
+        q_factor.as_slice::<f64>().unwrap(),
+        r_factor.as_slice::<f64>().unwrap(),
+        4,
+        2,
+        3,
+    );
+    assert_tensor_close(
+        &tensor_f64(vec![4, 3], factor_actual),
+        &tensor_f64(vec![4, 3], factor_expected),
+        1.0e-9,
+    );
+}
+
+#[test]
+#[ignore]
+fn test_cuda_compact_householder_qr_complex64_append_reconstructs() {
+    if !gpu_available() {
+        return;
+    }
+    let c = |re, im| Complex64::new(re, im);
+    let a = tensor_c64(
+        vec![3, 2],
+        vec![
+            c(1.0, 0.2),
+            c(2.0, -0.1),
+            c(0.5, 0.3),
+            c(-1.0, 0.4),
+            c(0.2, 0.1),
+            c(2.0, -0.5),
+        ],
+    );
+    let b = tensor_c64(vec![3, 1], vec![c(0.5, -0.2), c(1.5, 0.4), c(-0.7, 0.3)]);
+    let mut gpu = gpu_backend();
+    let a_gpu = upload(&gpu, &a);
+    let b_gpu = upload(&gpu, &b);
+    let options = QrOptions::default().gauge(QrGauge::PositiveDiagonal);
+    let (q, selected, r) = with_cuda_linalg_session(&mut gpu, |session| {
+        let state = a_gpu
+            .householder_qr(session)
+            .unwrap()
+            .append_columns(&b_gpu, session)
+            .unwrap();
+        (
+            state.q_columns(0..3, options, session).unwrap(),
+            state.q_columns(1..2, options, session).unwrap(),
+            state.r(options, session).unwrap(),
+        )
+    });
+    let q = download(&gpu, &q);
+    let selected = download(&gpu, &selected);
+    let r = download(&gpu, &r);
+    assert_tensor_close(
+        &tensor_c64(
+            vec![3, 1],
+            q.as_slice::<Complex64>().unwrap()[3..6].to_vec(),
+        ),
+        &selected,
+        1.0e-12,
+    );
+    let actual = matmul_c64(
+        q.as_slice::<Complex64>().unwrap(),
+        r.as_slice::<Complex64>().unwrap(),
+        3,
+        3,
+        3,
+    );
+    let mut expected = a.as_slice::<Complex64>().unwrap().to_vec();
+    expected.extend_from_slice(b.as_slice::<Complex64>().unwrap());
+    assert_tensor_close(
+        &tensor_c64(vec![3, 3], actual),
+        &tensor_c64(vec![3, 3], expected),
+        1.0e-9,
+    );
+}
+
+#[test]
+#[ignore]
+fn test_cuda_compact_householder_qr_f32_and_c32_reconstruct() {
+    if !gpu_available() {
+        return;
+    }
+    let a = tensor_f32(vec![3, 2], vec![1.0, 2.0, 0.5, -1.0, 0.2, 2.0]);
+    let b = tensor_f32(vec![3, 2], vec![0.5, 1.0, -2.0, 2.0, 0.0, 1.0]);
+    let c = |re, im| Complex32::new(re, im);
+    let complex = tensor_c32(
+        vec![3, 2],
+        vec![
+            c(1.0, 0.2),
+            c(2.0, -0.1),
+            c(0.5, 0.3),
+            c(-1.0, 0.4),
+            c(0.2, 0.1),
+            c(2.0, -0.5),
+        ],
+    );
+    let complex_r = tensor_c32(
+        vec![2, 2],
+        vec![c(1.5, 0.2), c(0.0, 0.0), c(-0.5, 0.3), c(2.0, -0.1)],
+    );
+    let mut gpu = gpu_backend();
+    let a_gpu = upload(&gpu, &a);
+    let b_gpu = upload(&gpu, &b);
+    let complex_gpu = upload(&gpu, &complex);
+    let complex_r_gpu = upload(&gpu, &complex_r);
+    let options = QrOptions::default().gauge(QrGauge::PositiveDiagonal);
+    let (q, r, cq, cr, imported_q, imported_r) = with_cuda_linalg_session(&mut gpu, |session| {
+        let state = a_gpu
+            .householder_qr(session)
+            .unwrap()
+            .append_columns(&b_gpu, session)
+            .unwrap();
+        let complex_state = complex_gpu.householder_qr(session).unwrap();
+        let imported =
+            HouseholderQr::<Tensor>::from_factors(&complex_gpu, &complex_r_gpu, session).unwrap();
+        (
+            state.q_columns(0..3, options, session).unwrap(),
+            state.r(options, session).unwrap(),
+            complex_state.q_columns(0..2, options, session).unwrap(),
+            complex_state.r(options, session).unwrap(),
+            imported.q_columns(0..2, options, session).unwrap(),
+            imported.r(options, session).unwrap(),
+        )
+    });
+    let q = download(&gpu, &q);
+    let r = download(&gpu, &r);
+    let cq = download(&gpu, &cq);
+    let cr = download(&gpu, &cr);
+    let imported_q = download(&gpu, &imported_q);
+    let imported_r = download(&gpu, &imported_r);
+    let actual = matmul_f32(
+        q.as_slice::<f32>().unwrap(),
+        r.as_slice::<f32>().unwrap(),
+        3,
+        3,
+        4,
+    );
+    let mut expected = a.as_slice::<f32>().unwrap().to_vec();
+    expected.extend_from_slice(b.as_slice::<f32>().unwrap());
+    assert_tensor_close(
+        &tensor_f32(vec![3, 4], actual),
+        &tensor_f32(vec![3, 4], expected),
+        2.0e-5,
+    );
+    let complex_actual = matmul_c32(
+        cq.as_slice::<Complex32>().unwrap(),
+        cr.as_slice::<Complex32>().unwrap(),
+        3,
+        2,
+        2,
+    );
+    assert_tensor_close(&tensor_c32(vec![3, 2], complex_actual), &complex, 2.0e-5);
+    let imported_actual = matmul_c32(
+        imported_q.as_slice::<Complex32>().unwrap(),
+        imported_r.as_slice::<Complex32>().unwrap(),
+        3,
+        2,
+        2,
+    );
+    let imported_expected = matmul_c32(
+        complex.as_slice::<Complex32>().unwrap(),
+        complex_r.as_slice::<Complex32>().unwrap(),
+        3,
+        2,
+        2,
+    );
+    assert_tensor_close(
+        &tensor_c32(vec![3, 2], imported_actual),
+        &tensor_c32(vec![3, 2], imported_expected),
+        3.0e-5,
+    );
+}
+
+#[test]
+#[ignore]
+fn test_cuda_compact_householder_qr_rank_deficient_zero_append_and_placement() {
+    if !gpu_available() {
+        return;
+    }
+    let input = tensor_f64(vec![3, 2], vec![1.0, 2.0, 3.0, 2.0, 4.0, 6.0]);
+    let empty = tensor_f64(vec![3, 0], vec![]);
+    let mut gpu = gpu_backend();
+    let input_gpu = upload(&gpu, &input);
+    let empty_gpu = upload(&gpu, &empty);
+    let options = QrOptions::default().gauge(QrGauge::PositiveDiagonal);
+    let (q, selected, r) = with_cuda_linalg_session(&mut gpu, |session| {
+        let placement_error = input.householder_qr(session).unwrap_err();
+        assert!(matches!(placement_error, Error::RuntimeState { .. }));
+        let state = input_gpu
+            .householder_qr(session)
+            .unwrap()
+            .append_columns(&empty_gpu, session)
+            .unwrap();
+        (
+            state.q_columns(0..2, options, session).unwrap(),
+            state.q_columns(1..2, options, session).unwrap(),
+            state.r(options, session).unwrap(),
+        )
+    });
+    let q = download(&gpu, &q);
+    let selected = download(&gpu, &selected);
+    let r = download(&gpu, &r);
+    assert_eq!(selected.shape(), &[3, 1]);
+    assert_tensor_close(
+        &tensor_f64(vec![3, 1], q.as_slice::<f64>().unwrap()[3..6].to_vec()),
+        &selected,
+        1.0e-12,
+    );
+    let actual = matmul_f64(
+        q.as_slice::<f64>().unwrap(),
+        r.as_slice::<f64>().unwrap(),
+        3,
+        2,
+        2,
+    );
+    assert_tensor_close(&tensor_f64(vec![3, 2], actual), &input, 1.0e-9);
+}
+
+#[test]
+#[ignore]
+fn test_cuda_qr_positive_diagonal_owned_and_read_paths_stay_on_device() {
+    if !gpu_available() {
+        return;
+    }
+    let c = |re, im| Complex64::new(re, im);
+    let input = tensor_c64(
+        vec![2, 2],
+        vec![c(-1.0, 0.5), c(2.0, 0.1), c(0.3, -0.7), c(-2.0, 0.4)],
+    );
+    let mut gpu = gpu_backend();
+    let input_gpu = upload(&gpu, &input);
+    let options = QrOptions::default().gauge(QrGauge::PositiveDiagonal);
+    let (owned, read) = with_cuda_linalg_session(&mut gpu, |session| {
+        (
+            session.qr_with_options(&input_gpu, options).unwrap(),
+            session
+                .qr_with_options_read(TensorRead::from_tensor(&input_gpu), options)
+                .unwrap(),
+        )
+    });
+    for outputs in [owned, read] {
+        let r = download(&gpu, &outputs[1]);
+        let values = r.as_slice::<Complex64>().unwrap();
+        for index in 0..2 {
+            let diagonal = values[index + index * 2];
+            assert!(diagonal.re >= 0.0, "negative QR diagonal: {diagonal}");
+            assert!(
+                diagonal.im.abs() < 1.0e-12,
+                "complex QR diagonal: {diagonal}"
+            );
+        }
+    }
+
+    let batched = tensor_c64(
+        vec![2, 2, 2],
+        vec![
+            c(-1.0, 0.5),
+            c(2.0, 0.1),
+            c(0.3, -0.7),
+            c(-2.0, 0.4),
+            c(0.2, -1.5),
+            c(-0.4, 0.8),
+            c(2.0, 0.3),
+            c(-0.5, -2.0),
+        ],
+    );
+    let batched = upload(&gpu, &batched);
+    let outputs = with_cuda_linalg_session(&mut gpu, |session| {
+        session.qr_with_options(&batched, options).unwrap()
+    });
+    let r = download(&gpu, &outputs[1]);
+    let values = r.as_slice::<Complex64>().unwrap();
+    for batch in 0..2 {
+        for index in 0..2 {
+            let diagonal = values[batch * 4 + index + index * 2];
+            assert!(
+                diagonal.re >= 0.0,
+                "negative batched QR diagonal: {diagonal}"
+            );
+            assert!(
+                diagonal.im.abs() < 1.0e-12,
+                "complex batched QR diagonal: {diagonal}"
+            );
+        }
+    }
+
+    let real_batched = tensor_f64(
+        vec![2, 2, 2, 2],
+        vec![
+            -1.0, 0.0, 0.0, 2.0, 1.0, 0.0, 0.0, -3.0, -2.0, 1.0, 0.0, 1.0, 0.5, 0.0, 0.0, -0.25,
+        ],
+    );
+    let real_batched = upload(&gpu, &real_batched);
+    let outputs = with_cuda_linalg_session(&mut gpu, |session| {
+        session.qr_with_options(&real_batched, options).unwrap()
+    });
+    let r = download(&gpu, &outputs[1]);
+    let values = r.as_slice::<f64>().unwrap();
+    for batch in 0..4 {
+        for index in 0..2 {
+            assert!(values[batch * 4 + index + index * 2] >= 0.0);
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn test_cuda_compact_householder_qr_wide_empty_range_and_rank_deficient_import() {
+    if !gpu_available() {
+        return;
+    }
+    let wide = tensor_f64(vec![2, 4], vec![1.0, 2.0, -1.0, 0.5, 2.0, -0.5, 0.25, 1.5]);
+    let rank_q = tensor_f64(vec![3, 2], vec![1.0, 2.0, 3.0, 2.0, 4.0, 6.0]);
+    let rank_r = tensor_f64(vec![2, 2], vec![1.0, 0.0, -0.5, 2.0]);
+    let mut gpu = gpu_backend();
+    let wide_gpu = upload(&gpu, &wide);
+    let rank_q_gpu = upload(&gpu, &rank_q);
+    let rank_r_gpu = upload(&gpu, &rank_r);
+    let options = QrOptions::default().gauge(QrGauge::PositiveDiagonal);
+    let (q, empty_q, r, imported_q, imported_r) = with_cuda_linalg_session(&mut gpu, |session| {
+        let state = wide_gpu.householder_qr(session).unwrap();
+        let imported =
+            HouseholderQr::<Tensor>::from_factors(&rank_q_gpu, &rank_r_gpu, session).unwrap();
+        (
+            state.q_columns(0..2, options, session).unwrap(),
+            state.q_columns(0..0, options, session).unwrap(),
+            state.r(options, session).unwrap(),
+            imported.q_columns(0..2, options, session).unwrap(),
+            imported.r(options, session).unwrap(),
+        )
+    });
+    let q = download(&gpu, &q);
+    let empty_q = download(&gpu, &empty_q);
+    let r = download(&gpu, &r);
+    let imported_q = download(&gpu, &imported_q);
+    let imported_r = download(&gpu, &imported_r);
+    assert_eq!(empty_q.shape(), &[2, 0]);
+    let q_data = q.as_slice::<f64>().unwrap();
+    for lhs in 0..2 {
+        for rhs in 0..2 {
+            let dot = (0..2)
+                .map(|row| q_data[row + lhs * 2] * q_data[row + rhs * 2])
+                .sum::<f64>();
+            let expected = if lhs == rhs { 1.0 } else { 0.0 };
+            assert!((dot - expected).abs() < 1.0e-10);
+        }
+    }
+    let actual = matmul_f64(q_data, r.as_slice::<f64>().unwrap(), 2, 2, 4);
+    assert_tensor_close(&tensor_f64(vec![2, 4], actual), &wide, 1.0e-9);
+    let imported_actual = matmul_f64(
+        imported_q.as_slice::<f64>().unwrap(),
+        imported_r.as_slice::<f64>().unwrap(),
+        3,
+        2,
+        2,
+    );
+    let imported_expected = matmul_f64(
+        rank_q.as_slice::<f64>().unwrap(),
+        rank_r.as_slice::<f64>().unwrap(),
+        3,
+        2,
+        2,
+    );
+    assert_tensor_close(
+        &tensor_f64(vec![3, 2], imported_actual),
+        &tensor_f64(vec![3, 2], imported_expected),
+        1.0e-9,
+    );
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/integration/gpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/integration/gpu_linalg_source_contract.rs
@@ -1,13 +1,35 @@
 use std::{fs, path::Path};
 
 fn linalg_source() -> String {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/gpu/linalg");
+    let mut source = fs::read_to_string(root.with_extension("rs"))
+        .unwrap_or_else(|err| panic!("GPU linalg source should be readable: {err}"));
+    source.push_str(
+        &fs::read_to_string(root.join("householder_qr.rs"))
+            .unwrap_or_else(|err| panic!("GPU Householder QR source should be readable: {err}")),
+    );
+    source
+}
+
+fn gpu_ffi_source() -> String {
     fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("src")
             .join("gpu")
-            .join("linalg.rs"),
+            .join("ffi")
+            .join("cusolver.rs"),
     )
-    .unwrap_or_else(|err| panic!("GPU linalg source should be readable: {err}"))
+    .unwrap_or_else(|err| panic!("GPU linalg FFI source should be readable: {err}"))
+}
+
+fn extension_source() -> String {
+    fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("src/extension.rs"))
+        .unwrap_or_else(|err| panic!("linalg extension source should be readable: {err}"))
+}
+
+fn tensor_ext_source() -> String {
+    fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("src/tensor_ext.rs"))
+        .unwrap_or_else(|err| panic!("tensor extension source should be readable: {err}"))
 }
 
 fn gpu_mod_source() -> String {
@@ -81,6 +103,68 @@ fn assert_unsafe_blocks_have_safety_comments(path: &str, source: &str) {
 #[test]
 fn gpu_linalg_unsafe_blocks_document_safety_invariants() {
     assert_unsafe_blocks_have_safety_comments("src/gpu/linalg.rs", &linalg_source());
+}
+
+#[test]
+fn compact_householder_cuda_uses_incremental_device_native_paths() {
+    let source = linalg_source();
+    let append = source_section(
+        &source,
+        "fn compact_qr_append_typed",
+        "fn compact_qr_state_dims",
+    );
+    assert!(append.contains("apply_householder_reflectors_typed"));
+    assert!(append.contains("geqrf_trailing_typed"));
+    assert!(!append.contains("\n    qr_typed("));
+    assert!(!append.contains("download_tensor"));
+
+    let from_factors = source_section(
+        &source,
+        "fn compact_qr_from_factors_typed",
+        "fn compact_qr_append_typed",
+    );
+    assert!(from_factors.contains("gemm_nn_typed"));
+    assert!(from_factors.contains("assemble_from_factors_typed"));
+    assert!(!from_factors.contains("\n    qr_typed("));
+    assert!(!from_factors.contains("download_tensor"));
+
+    let ffi = gpu_ffi_source();
+    for symbol in [
+        "cublasSgemv_v2",
+        "cublasDgemv_v2",
+        "cublasCgemv_v2",
+        "cublasZgemv_v2",
+        "cublasSger_v2",
+        "cublasDger_v2",
+        "cublasCgeru_v2",
+        "cublasZgeru_v2",
+        "cublasSgemm_v2",
+        "cublasDgemm_v2",
+        "cublasCgemm_v2",
+        "cublasZgemm_v2",
+        "cublasSetPointerMode_v2",
+    ] {
+        assert!(ffi.contains(symbol), "missing CUDA FFI symbol {symbol}");
+    }
+}
+
+#[test]
+fn qr_options_routes_owned_read_and_typed_surfaces_through_backend_hooks() {
+    let backend = read_workspace_source("tenferro-linalg/src/backend.rs");
+    assert!(backend.contains("fn qr_with_options_read("));
+    let tensor_ext = tensor_ext_source();
+    assert!(tensor_ext.contains("backend.qr_with_options_read("));
+    assert!(!tensor_ext.contains("apply_qr_gauge"));
+    let gpu = gpu_mod_source();
+    assert!(gpu.contains("fn qr_with_options("));
+    assert!(gpu.contains("fn qr_with_options_read("));
+    let extension = extension_source();
+    let cuda_admission = source_section(
+        &extension,
+        "if type_id == std::any::TypeId::of::<tenferro_gpu::cuda::CudaBackend>()",
+        "false\n}",
+    );
+    assert!(!cuda_admission.contains("HouseholderQrFactor"));
 }
 
 #[test]

--- a/docs/design/incremental-householder-qr.md
+++ b/docs/design/incremental-householder-qr.md
@@ -239,11 +239,41 @@ R rows consistently. Phase 4 shares that kernel with existing CUDA
 path. The kernel launches over the output domains and does not download scalar
 phases.
 
+Phase 4 extends the cuBLAS vtable and typed wrappers with `S/D/C/Zgemv`,
+`S/Dger`, `C/Zgeru`, and `S/D/C/Zgemm`. Reflector updates fold `-tau` into the
+GER/GERU alpha, so no separate SCAL binding is needed. Dynamic symbol loads and
+wrapper calls return typed load/provider/status errors and use the session-owned
+handle and stream.
+
+CUDA `from_factors(Q, R)` factors Q with `geqrf`, extracts its upper factor T,
+computes `T * R` with typed cuBLAS GEMM, and assembles the provider-neutral
+`m x n` packed state on device. It stores the folded upper factor in the packed
+upper region, Q reflectors below the diagonal where defined, zeroes padding,
+and emits `min(m,n)` coefficients with semantic zeros for padded reflector
+positions. It never forms `Q * R` for a full QR.
+
+The backend contract includes a narrow `qr_with_options_read` hook. Its default
+preserves the CPU `qr_read` plus host-gauge path; CUDA overrides both owned and
+read hooks with the shared device gauge kernel. Concrete owned, `TensorRead`,
+and typed QR-with-options surfaces dispatch through these hooks and never apply
+the host gauge to backend-resident outputs.
+
 All CUDA work runs inside the scoped `CudaExecSession::with_raw` or typed
 CubeCL session appropriate to the call. Workspace and stream-retention behavior
 follow `gpu-backend-design.md`; synchronization failure must not release
 allocations that an unfinished vendor call can still access. Missing cuSOLVER
-or cuBLAS symbols are typed provider errors, not fallback triggers.
+or cuBLAS symbols are typed provider errors, not fallback triggers. Only `i32` cuSOLVER and input-validation status tensors may
+be synchronized and downloaded for error reporting; matrix, reflector,
+coefficient, gauge, and factor payloads stay device-local.
+
+Required implementation seams are `backend.rs`/`tensor_ext.rs` for owned/read/
+typed QR routing, `gpu/ffi/cusolver.rs` for cuBLAS wrappers, `gpu/linalg.rs` and
+`gpu/mod.rs` for the five compact hooks and existing QR overrides, and
+`gpu/kernels.rs` for device gauge/assembly kernels. Portable CI compiles CUDA;
+hardware tests cover all four dtypes, reconstruction, factor import, multiple
+append, rank deficiency, zero columns, tall/square/wide and tall-to-wide,
+selected Q, gauge parity, placement errors, stream retention, no host payload
+transfer, and no full refactorization.
 
 ## AD semantics
 

--- a/docs/worklogs/2026-09-01-incremental-householder-qr-design.md
+++ b/docs/worklogs/2026-09-01-incremental-householder-qr-design.md
@@ -71,6 +71,16 @@ The oracle-first prerequisite merged separately as
 `replay` and `regenerate` required checks; the oracle family covers all five
 operations and all four scalar dtypes.
 
+### Phase 4 amendment review
+
+Before CUDA implementation, `reviewer-flash` identified missing concrete
+cuBLAS GEMV/GER/GERU/GEMM bindings, an unspecified device-native
+`from_factors` fold, and owned/read/typed QR gauge routing as Important design
+gaps. The amendment names each FFI and backend seam, the packed assembly,
+metadata-only solver-info downloads, the shared device gauge, and the
+`qr_with_options_read` hook. Closure review returned **Correct-to-merge** with
+no remaining Critical or Important findings.
+
 ## Verification
 
 ```text

--- a/docs/worklogs/2026-09-01-incremental-householder-qr-phase4.md
+++ b/docs/worklogs/2026-09-01-incremental-householder-qr-phase4.md
@@ -1,0 +1,107 @@
+# Incremental Householder QR Phase 4: CUDA (#1735)
+
+## Session summary
+
+Implemented device-native compact Householder QR for CUDA across factorization,
+factor import, column append, R extraction, selected Q columns, and positive-
+diagonal gauge. The implementation uses cuSOLVER GEQRF, cuBLAS
+GEMV/GEMM/GER/GERU, and linalg-owned CubeCL kernels without host tensor payload
+transfer or full-QR append fallback.
+
+## Context reviewed
+
+- `REPOSITORY_RULES.md` GPU, transfer, FFI, materialization, and validation rules
+- `docs/design/incremental-householder-qr.md` and `gpu-backend-design.md`
+- CUDA raw/CubeCL session ownership and stream-retention contracts
+- existing CUDA QR, cuSOLVER/cuBLAS vtables, solver-info handling, and linalg
+  hardware/source-contract tests
+- Phase-2 compact CPU implementations and Phase-3 abstract-state AD
+
+## Design review gate
+
+The user-selected `reviewer-flash` review found three Important gaps in the
+initial CUDA prose: missing cuBLAS GEMV/GER/GERU/GEMM bindings, unspecified
+CUDA factor-import folding, and owned/read/typed QR gauge routing. The amended
+design names the FFI/backend seams, device packed assembly, metadata-only
+status downloads, shared gauge kernels, and `qr_with_options_read` hook.
+Closure review returned **Correct-to-merge** before CUDA implementation.
+
+## Decisions
+
+- Factorization stores cuSOLVER GEQRF packed output and device tau directly.
+- Reflector application builds one implicit-v vector per reflector, computes
+  real contractions with GEMV and complex contractions with GEMM, folds tau
+  into that contraction, and applies GER/GERU with device pointer mode.
+- Append applies old Q-adjoint to the new block, factors only the trailing
+  residual, and concatenates packed columns and coefficients on device.
+- Factor import factors Q, folds its triangular factor into R with cuBLAS GEMM,
+  and assembles packed state with a CubeCL kernel; it never QR-factorizes Q*R.
+- Positive-diagonal phases are materialized into a device phase vector before
+  separate Q/R scaling, preventing cross-thread diagonal read/write races.
+- The only host downloads are `i32` solver/validation status values. Input
+  factors and tensor outputs remain device-local.
+- GPU Householder code lives in `gpu/linalg/householder_qr.rs`; backend routing,
+  vendor FFI, and kernels stay in their existing ownership seams.
+
+## Verification completed so far
+
+- CUDA+autodiff feature compilation
+- local NVIDIA A100 hardware reconstruction for F32/F64/C32/C64
+- multiple append and square-to-wide transition
+- real and complex factor import
+- rank-deficient factorization, zero-column append, selected Q range, and
+  wrong-placement rejection
+- existing CUDA QR positive-diagonal owned/read path parity
+- source contracts for no full refactorization, no host payload download,
+  required cuBLAS symbols, public QR routing, and unsafe-block comments
+
+## Post-diff review
+
+The user-selected `reviewer-flash` review was split into bounded lanes after a
+broad attempt timed out:
+
+- Householder CUDA math/FFI-use lane found one Important pointer-mode leak on
+  setup errors. Device pointer mode is now entered only after every fallible
+  setup step and always reset before propagating computation errors. Closure
+  review returned **Correct-to-merge**.
+- FFI/kernel/routing lane found one Important batched-gauge bug: phases were
+  initially shared from batch zero. Phase tensors now have shape
+  `[k, batch...]`, and kernels map batch axes explicitly for arbitrary rank.
+  A rank-3 complex and rank-4 real hardware test pass. Closure review returned
+  **Correct-to-merge** with no remaining Critical or Important findings.
+
+Minor review notes were also closed: pointer-mode docs describe host/device
+scalar pointers, source contracts pin every new cuBLAS symbol, and tests add
+empty Q ranges, wide starts, explicit orthogonality, rank-deficient factor
+import, complex nonzero Q ranges, and multi-axis real batches.
+
+## Candidate verification
+
+- CUDA+autodiff feature compilation passed.
+- Local NVIDIA A100 hardware batch: six compact Householder tests passed for
+  F32/F64/C32/C64, multiple append and wide transitions, factor import,
+  rank-deficient inputs, zero-column append, empty/nonzero selected-Q ranges,
+  orthogonality, gauge, and placement errors.
+- Existing CUDA QR positive-diagonal owned/read tests passed for unbatched C64,
+  rank-3 batched C64, and rank-4 batched F64.
+- All 168 CPU-faer linalg library tests and 228 integration tests passed.
+- Source contracts for no full refactorization/host payload transfer, every
+  required cuBLAS symbol, public QR routing, CUDA admission, and unsafe comments
+  passed.
+
+## Candidate gates
+
+- `python3 scripts/ci/run_profile.py fmt` and documentation snippet checks
+  passed.
+- Focused default-feature clippy and all 27 GPU source-contract tests passed.
+- CPU-BLAS-only, CPU-faer+BLAS, and CUDA+autodiff feature checks passed.
+- `scripts/check-pr-fast.sh --coverage-reviewed` passed with the compact CUDA
+  source contract as its focused test, including workspace/standalone clippy,
+  formatting, and docs checks.
+- Worktree deterministic repository-rules review passed; the external LLM lane
+  was skipped with reason `local deterministic review`.
+
+## Remaining gates
+
+Committed-head repository-rules review, exact-commit checks, and hosted CI
+remain pending. Phase-5 performance gates remain separate.


### PR DESCRIPTION
## Summary

- implement compact Householder QR factorization, factor import, incremental append, R extraction, and selected-Q materialization on CUDA for F32/F64/C32/C64
- add cuBLAS GEMV/GER/GERU/GEMM bindings and device-pointer-mode handling for reflector application
- add race-free device positive-diagonal gauge shared by compact QR and existing owned/read/typed CUDA QR surfaces, including batched QR
- keep tensor payloads device-local; only `i32` solver/validation statuses are downloaded

Part of #1735. Phase 2 CPU/API foundation merged as #1742; Phase 3 oracle-backed AD merged as #1743. Performance gates remain Phase 5.

## Design and review gate

Design: [`docs/design/incremental-householder-qr.md`](docs/design/incremental-householder-qr.md)

Worklog: [`docs/worklogs/2026-09-01-incremental-householder-qr-phase4.md`](docs/worklogs/2026-09-01-incremental-householder-qr-phase4.md)

User-selected `reviewer-flash` verdicts:

- amended CUDA design: **Correct-to-merge**
- Householder CUDA math/FFI-use lane after pointer-mode fix: **Correct-to-merge**
- FFI/kernel/routing lane after batched-gauge fix: **Correct-to-merge**

No Critical, Important, or unresolved Minor findings remain.

## Implementation notes

- append applies the old reflector sequence to only the new block, GEQRF-factorizes only the trailing residual, then concatenates packed columns and tau on device
- factor import computes `T * R` with cuBLAS GEMM and assembles provider-neutral packed state with a CubeCL kernel; it never QR-factorizes `Q * R`
- positive-diagonal phases are first materialized as `[k, batch...]`, then consumed by separate Q/R scaling kernels, avoiding diagonal read/write races
- CPU QR-with-options remains unchanged through the backend read-hook default; CUDA overrides owned and read hooks

## Verification

Exact candidate `10809a4a`:

- local NVIDIA A100 hardware:
  - six compact Householder CUDA tests across F32/F64/C32/C64
  - multiple append, square-to-wide, wide-start, factor import, rank-deficient input/import, zero-column append, empty/nonzero Q ranges, orthogonality, gauge, and placement errors
  - owned/read CUDA QR positive-diagonal parity for unbatched C64, rank-3 batched C64, and rank-4 batched F64
- `cargo check` for CPU-BLAS, combined CPU providers, and CUDA+autodiff feature configurations
- 168 CPU-faer linalg library tests and 228 integration tests passed
- all 27 GPU source-contract tests passed
- focused default-feature clippy passed
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test '<compact CUDA source contract>'` passed
- committed-head deterministic repository-rules review passed (external LLM skipped: local deterministic review)
- formatting, docs snippets, and `git diff --check` passed
