### PR TITLE
fix(runtime): prevent prepared cache lost wakeups

### DIFF
--- a/crates/tenferro-runtime/src/runtime/cache.rs
+++ b/crates/tenferro-runtime/src/runtime/cache.rs
@@ -411,6 +411,29 @@ impl<K: PreparedCacheKey, V: PreparedValue> PreparedPlanCache<K, V> {
         signature_bytes: usize,
         producer: impl FnOnce() -> CacheProduced<K, V>,
     ) -> Result<CacheLookup<K, V>, Arc<PrepareError>> {
+        self.get_or_prepare_inner(key, behavior, signature_bytes, producer, || {})
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_or_prepare_with_entry_wait_hook_for_test(
+        &self,
+        key: K,
+        behavior: CacheInFlightBehavior,
+        signature_bytes: usize,
+        producer: impl FnOnce() -> CacheProduced<K, V>,
+        before_entry_wait: impl FnMut(),
+    ) -> Result<CacheLookup<K, V>, Arc<PrepareError>> {
+        self.get_or_prepare_inner(key, behavior, signature_bytes, producer, before_entry_wait)
+    }
+
+    fn get_or_prepare_inner(
+        &self,
+        key: K,
+        behavior: CacheInFlightBehavior,
+        signature_bytes: usize,
+        producer: impl FnOnce() -> CacheProduced<K, V>,
+        mut before_entry_wait: impl FnMut(),
+    ) -> Result<CacheLookup<K, V>, Arc<PrepareError>> {
         let summary = key.summary();
         check_preparation_stack::<K>(summary)?;
         let digest = key.compact_digest();
@@ -419,10 +442,13 @@ impl<K: PreparedCacheKey, V: PreparedValue> PreparedPlanCache<K, V> {
             match self.probe(&key, digest)? {
                 ProbeResult::Entry(entry_id) => match self.handle_entry(entry_id)? {
                     EntryAction::Return(lookup) => return Ok(lookup),
-                    EntryAction::Wait(waiter) => match waiter.wait_once()? {
-                        WaitOutcome::RetryProbe => continue,
-                        WaitOutcome::Return(lookup) => return Ok(lookup),
-                    },
+                    EntryAction::Wait(waiter) => {
+                        before_entry_wait();
+                        match waiter.wait_once()? {
+                            WaitOutcome::RetryProbe => continue,
+                            WaitOutcome::Return(lookup) => return Ok(lookup),
+                        }
+                    }
                     EntryAction::ReturnRetry => continue,
                 },
                 ProbeResult::Queue(queue_id) => {
@@ -867,6 +893,11 @@ impl<K: PreparedCacheKey, V: PreparedValue> PreparedPlanCache<K, V> {
             panic!("poison prepared cache state for test");
         }));
     }
+
+    #[cfg(test)]
+    pub(crate) fn notify_entry_waiters_for_test(&self) {
+        self.changed.notify_all();
+    }
 }
 
 #[derive(Debug)]
@@ -1056,22 +1087,34 @@ struct EntryWaitGuard<'a, K: PreparedCacheKey, V: PreparedValue> {
 
 impl<K: PreparedCacheKey, V: PreparedValue> EntryWaitGuard<'_, K, V> {
     fn wait_once(mut self) -> Result<WaitOutcome<K, V>, Arc<PrepareError>> {
-        let state = self.cache.lock_state()?;
-        let mut state = match self.cache.changed.wait(state) {
-            Ok(state) => state,
-            Err(error) => {
-                drop(error.into_inner());
-                return Err(Arc::new(PrepareError::CacheState {
-                    source: poisoned_state_error(),
-                }));
-            }
-        };
+        let mut state = self.cache.lock_state()?;
+        while self.same_attempt_is_preparing(&state) {
+            state = match self.cache.changed.wait(state) {
+                Ok(state) => state,
+                Err(error) => {
+                    drop(error.into_inner());
+                    return Err(Arc::new(PrepareError::CacheState {
+                        source: poisoned_state_error(),
+                    }));
+                }
+            };
+        }
         let outcome = self.complete_with_locked_state(&mut state);
         drop(state);
         if matches!(outcome, WaitOutcome::RetryProbe) {
             self.cache.changed.notify_all();
         }
         Ok(outcome)
+    }
+
+    fn same_attempt_is_preparing(&self, state: &CacheState<K, V>) -> bool {
+        matches!(
+            state.entries.get(&self.entry_id),
+            Some(EntryRecord {
+                state: PreparedEntryState::Preparing { attempt_id, .. },
+                ..
+            }) if *attempt_id == self.attempt_id
+        )
     }
 
     fn complete_with_locked_state(&mut self, state: &mut CacheState<K, V>) -> WaitOutcome<K, V> {

--- a/crates/tenferro-runtime/src/runtime/cache.rs
+++ b/crates/tenferro-runtime/src/runtime/cache.rs
@@ -411,19 +411,27 @@ impl<K: PreparedCacheKey, V: PreparedValue> PreparedPlanCache<K, V> {
         signature_bytes: usize,
         producer: impl FnOnce() -> CacheProduced<K, V>,
     ) -> Result<CacheLookup<K, V>, Arc<PrepareError>> {
-        self.get_or_prepare_inner(key, behavior, signature_bytes, producer, || {})
+        self.get_or_prepare_inner(key, behavior, signature_bytes, producer, || {}, || {})
     }
 
     #[cfg(test)]
-    pub(crate) fn get_or_prepare_with_entry_wait_hook_for_test(
+    pub(crate) fn get_or_prepare_with_entry_wait_hooks_for_test(
         &self,
         key: K,
         behavior: CacheInFlightBehavior,
         signature_bytes: usize,
         producer: impl FnOnce() -> CacheProduced<K, V>,
         before_entry_wait: impl FnMut(),
+        before_condvar_wait: impl FnMut(),
     ) -> Result<CacheLookup<K, V>, Arc<PrepareError>> {
-        self.get_or_prepare_inner(key, behavior, signature_bytes, producer, before_entry_wait)
+        self.get_or_prepare_inner(
+            key,
+            behavior,
+            signature_bytes,
+            producer,
+            before_entry_wait,
+            before_condvar_wait,
+        )
     }
 
     fn get_or_prepare_inner(
@@ -433,6 +441,7 @@ impl<K: PreparedCacheKey, V: PreparedValue> PreparedPlanCache<K, V> {
         signature_bytes: usize,
         producer: impl FnOnce() -> CacheProduced<K, V>,
         mut before_entry_wait: impl FnMut(),
+        mut before_condvar_wait: impl FnMut(),
     ) -> Result<CacheLookup<K, V>, Arc<PrepareError>> {
         let summary = key.summary();
         check_preparation_stack::<K>(summary)?;
@@ -444,7 +453,7 @@ impl<K: PreparedCacheKey, V: PreparedValue> PreparedPlanCache<K, V> {
                     EntryAction::Return(lookup) => return Ok(lookup),
                     EntryAction::Wait(waiter) => {
                         before_entry_wait();
-                        match waiter.wait_once()? {
+                        match waiter.wait_once(&mut before_condvar_wait)? {
                             WaitOutcome::RetryProbe => continue,
                             WaitOutcome::Return(lookup) => return Ok(lookup),
                         }
@@ -893,11 +902,6 @@ impl<K: PreparedCacheKey, V: PreparedValue> PreparedPlanCache<K, V> {
             panic!("poison prepared cache state for test");
         }));
     }
-
-    #[cfg(test)]
-    pub(crate) fn notify_entry_waiters_for_test(&self) {
-        self.changed.notify_all();
-    }
 }
 
 #[derive(Debug)]
@@ -1086,9 +1090,13 @@ struct EntryWaitGuard<'a, K: PreparedCacheKey, V: PreparedValue> {
 }
 
 impl<K: PreparedCacheKey, V: PreparedValue> EntryWaitGuard<'_, K, V> {
-    fn wait_once(mut self) -> Result<WaitOutcome<K, V>, Arc<PrepareError>> {
+    fn wait_once(
+        mut self,
+        before_condvar_wait: &mut impl FnMut(),
+    ) -> Result<WaitOutcome<K, V>, Arc<PrepareError>> {
         let mut state = self.cache.lock_state()?;
         while self.same_attempt_is_preparing(&state) {
+            before_condvar_wait();
             state = match self.cache.changed.wait(state) {
                 Ok(state) => state,
                 Err(error) => {

--- a/crates/tenferro-runtime/src/runtime/tests/cache.rs
+++ b/crates/tenferro-runtime/src/runtime/tests/cache.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroUsize;
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Barrier, Mutex, Weak};
+use std::sync::{mpsc, Arc, Barrier, Mutex, Weak};
 use std::thread;
 use std::time::Duration;
 
@@ -350,6 +350,89 @@ fn same_key_has_one_producer_and_shared_result() {
         for value in &results[1..] {
             assert!(Arc::ptr_eq(&results[0], value));
         }
+    });
+}
+
+#[test]
+fn same_key_waiter_does_not_miss_publication_before_first_wait() {
+    let cache = Arc::new(PreparedPlanCache::<TestKey, TestValue>::new(limits(
+        8, 4096, 2, 2,
+    )));
+    let producer_entered = Arc::new(Barrier::new(2));
+    let producer_release = Arc::new(Barrier::new(2));
+    let waiter_before_wait = Arc::new(Barrier::new(2));
+    let waiter_release = Arc::new(Barrier::new(2));
+
+    thread::scope(|scope| {
+        let producer = {
+            let cache = Arc::clone(&cache);
+            let producer_entered = Arc::clone(&producer_entered);
+            let producer_release = Arc::clone(&producer_release);
+            scope.spawn(move || {
+                cache
+                    .get_or_prepare(TestKey(8), CacheInFlightBehavior::Wait, 0, || {
+                        producer_entered.wait();
+                        producer_release.wait();
+                        CacheProduced::Ready {
+                            value: TestValue::new(16),
+                            shared: None,
+                        }
+                    })
+                    .unwrap()
+            })
+        };
+        producer_entered.wait();
+
+        let (completed_tx, completed_rx) = mpsc::channel();
+        let waiter = {
+            let cache = Arc::clone(&cache);
+            let waiter_before_wait = Arc::clone(&waiter_before_wait);
+            let waiter_release = Arc::clone(&waiter_release);
+            scope.spawn(move || {
+                let lookup = cache
+                    .get_or_prepare_with_entry_wait_hook_for_test(
+                        TestKey(8),
+                        CacheInFlightBehavior::Wait,
+                        0,
+                        || panic!("same-key waiter must not become the producer"),
+                        move || {
+                            waiter_before_wait.wait();
+                            waiter_release.wait();
+                        },
+                    )
+                    .unwrap();
+                completed_tx.send(()).unwrap();
+                lookup
+            })
+        };
+        waiter_before_wait.wait();
+
+        producer_release.wait();
+        let produced = match producer.join().unwrap() {
+            CacheLookup::Ready(value) => value,
+            other => panic!("expected producer ready lookup, got {other:?}"),
+        };
+        waiter_release.wait();
+
+        let completed_without_rescue = completed_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+        cache.notify_entry_waiters_for_test();
+        if !completed_without_rescue {
+            // Let a broken unconditional wait exit so the scoped thread can be joined and the
+            // regression reports a normal assertion failure instead of hanging the test suite.
+            completed_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("rescued waiter should finish after a replacement notification");
+        }
+
+        let waited = match waiter.join().unwrap() {
+            CacheLookup::Ready(value) => value,
+            other => panic!("expected waiter ready lookup, got {other:?}"),
+        };
+        assert!(
+            completed_without_rescue,
+            "waiter missed publication before its first condition-variable wait"
+        );
+        assert!(Arc::ptr_eq(&produced, &waited));
     });
 }
 

--- a/crates/tenferro-runtime/src/runtime/tests/cache.rs
+++ b/crates/tenferro-runtime/src/runtime/tests/cache.rs
@@ -1,9 +1,9 @@
 use std::num::NonZeroUsize;
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{mpsc, Arc, Barrier, Mutex, Weak};
+use std::sync::{Arc, Barrier, Mutex, Weak};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use tenferro_cpu::CpuBackend;
 
@@ -382,14 +382,13 @@ fn same_key_waiter_does_not_miss_publication_before_first_wait() {
     };
     producer_entered.wait();
 
-    let (completed_tx, completed_rx) = mpsc::channel();
     let waiter = {
         let cache = Arc::clone(&cache);
         let waiter_before_wait = Arc::clone(&waiter_before_wait);
         let waiter_release = Arc::clone(&waiter_release);
         thread::spawn(move || {
             let lookup = cache
-                .get_or_prepare_with_entry_wait_hook_for_test(
+                .get_or_prepare_with_entry_wait_hooks_for_test(
                     TestKey(8),
                     CacheInFlightBehavior::Wait,
                     0,
@@ -398,9 +397,9 @@ fn same_key_waiter_does_not_miss_publication_before_first_wait() {
                         waiter_before_wait.wait();
                         waiter_release.wait();
                     },
+                    || panic!("waiter must not sleep after producer publication"),
                 )
                 .unwrap();
-            completed_tx.send(()).unwrap();
             lookup
         })
     };
@@ -413,38 +412,10 @@ fn same_key_waiter_does_not_miss_publication_before_first_wait() {
     };
     waiter_release.wait();
 
-    let completed_without_rescue = completed_rx.recv_timeout(Duration::from_secs(1)).is_ok();
-    let waiter_completed = if completed_without_rescue {
-        true
-    } else {
-        // Repeated notifications let the old unconditional wait exit regardless of whether the
-        // waiter is descheduled before or after any individual notification.
-        let rescue_deadline = Instant::now() + Duration::from_secs(10);
-        loop {
-            cache.notify_entry_waiters_for_test();
-            let remaining = rescue_deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                break false;
-            }
-            match completed_rx.recv_timeout(remaining.min(Duration::from_millis(10))) {
-                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break true,
-                Err(mpsc::RecvTimeoutError::Timeout) => {}
-            }
-        }
-    };
-    assert!(
-        waiter_completed,
-        "waiter did not finish within the rescue deadline"
-    );
-
     let waited = match waiter.join().unwrap() {
         CacheLookup::Ready(value) => value,
         other => panic!("expected waiter ready lookup, got {other:?}"),
     };
-    assert!(
-        completed_without_rescue,
-        "waiter missed publication before its first condition-variable wait"
-    );
     assert!(Arc::ptr_eq(&produced, &waited));
 }
 

--- a/crates/tenferro-runtime/src/runtime/tests/cache.rs
+++ b/crates/tenferro-runtime/src/runtime/tests/cache.rs
@@ -3,7 +3,7 @@ use std::panic::{self, AssertUnwindSafe};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Barrier, Mutex, Weak};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tenferro_cpu::CpuBackend;
 
@@ -363,77 +363,89 @@ fn same_key_waiter_does_not_miss_publication_before_first_wait() {
     let waiter_before_wait = Arc::new(Barrier::new(2));
     let waiter_release = Arc::new(Barrier::new(2));
 
-    thread::scope(|scope| {
-        let producer = {
-            let cache = Arc::clone(&cache);
-            let producer_entered = Arc::clone(&producer_entered);
-            let producer_release = Arc::clone(&producer_release);
-            scope.spawn(move || {
-                cache
-                    .get_or_prepare(TestKey(8), CacheInFlightBehavior::Wait, 0, || {
-                        producer_entered.wait();
-                        producer_release.wait();
-                        CacheProduced::Ready {
-                            value: TestValue::new(16),
-                            shared: None,
-                        }
-                    })
-                    .unwrap()
-            })
-        };
-        producer_entered.wait();
+    let producer = {
+        let cache = Arc::clone(&cache);
+        let producer_entered = Arc::clone(&producer_entered);
+        let producer_release = Arc::clone(&producer_release);
+        thread::spawn(move || {
+            cache
+                .get_or_prepare(TestKey(8), CacheInFlightBehavior::Wait, 0, || {
+                    producer_entered.wait();
+                    producer_release.wait();
+                    CacheProduced::Ready {
+                        value: TestValue::new(16),
+                        shared: None,
+                    }
+                })
+                .unwrap()
+        })
+    };
+    producer_entered.wait();
 
-        let (completed_tx, completed_rx) = mpsc::channel();
-        let waiter = {
-            let cache = Arc::clone(&cache);
-            let waiter_before_wait = Arc::clone(&waiter_before_wait);
-            let waiter_release = Arc::clone(&waiter_release);
-            scope.spawn(move || {
-                let lookup = cache
-                    .get_or_prepare_with_entry_wait_hook_for_test(
-                        TestKey(8),
-                        CacheInFlightBehavior::Wait,
-                        0,
-                        || panic!("same-key waiter must not become the producer"),
-                        move || {
-                            waiter_before_wait.wait();
-                            waiter_release.wait();
-                        },
-                    )
-                    .unwrap();
-                completed_tx.send(()).unwrap();
-                lookup
-            })
-        };
-        waiter_before_wait.wait();
+    let (completed_tx, completed_rx) = mpsc::channel();
+    let waiter = {
+        let cache = Arc::clone(&cache);
+        let waiter_before_wait = Arc::clone(&waiter_before_wait);
+        let waiter_release = Arc::clone(&waiter_release);
+        thread::spawn(move || {
+            let lookup = cache
+                .get_or_prepare_with_entry_wait_hook_for_test(
+                    TestKey(8),
+                    CacheInFlightBehavior::Wait,
+                    0,
+                    || panic!("same-key waiter must not become the producer"),
+                    move || {
+                        waiter_before_wait.wait();
+                        waiter_release.wait();
+                    },
+                )
+                .unwrap();
+            completed_tx.send(()).unwrap();
+            lookup
+        })
+    };
+    waiter_before_wait.wait();
 
-        producer_release.wait();
-        let produced = match producer.join().unwrap() {
-            CacheLookup::Ready(value) => value,
-            other => panic!("expected producer ready lookup, got {other:?}"),
-        };
-        waiter_release.wait();
+    producer_release.wait();
+    let produced = match producer.join().unwrap() {
+        CacheLookup::Ready(value) => value,
+        other => panic!("expected producer ready lookup, got {other:?}"),
+    };
+    waiter_release.wait();
 
-        let completed_without_rescue = completed_rx.recv_timeout(Duration::from_secs(1)).is_ok();
-        cache.notify_entry_waiters_for_test();
-        if !completed_without_rescue {
-            // Let a broken unconditional wait exit so the scoped thread can be joined and the
-            // regression reports a normal assertion failure instead of hanging the test suite.
-            completed_rx
-                .recv_timeout(Duration::from_secs(1))
-                .expect("rescued waiter should finish after a replacement notification");
+    let completed_without_rescue = completed_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+    let waiter_completed = if completed_without_rescue {
+        true
+    } else {
+        // Repeated notifications let the old unconditional wait exit regardless of whether the
+        // waiter is descheduled before or after any individual notification.
+        let rescue_deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            cache.notify_entry_waiters_for_test();
+            let remaining = rescue_deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break false;
+            }
+            match completed_rx.recv_timeout(remaining.min(Duration::from_millis(10))) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break true,
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+            }
         }
+    };
+    assert!(
+        waiter_completed,
+        "waiter did not finish within the rescue deadline"
+    );
 
-        let waited = match waiter.join().unwrap() {
-            CacheLookup::Ready(value) => value,
-            other => panic!("expected waiter ready lookup, got {other:?}"),
-        };
-        assert!(
-            completed_without_rescue,
-            "waiter missed publication before its first condition-variable wait"
-        );
-        assert!(Arc::ptr_eq(&produced, &waited));
-    });
+    let waited = match waiter.join().unwrap() {
+        CacheLookup::Ready(value) => value,
+        other => panic!("expected waiter ready lookup, got {other:?}"),
+    };
+    assert!(
+        completed_without_rescue,
+        "waiter missed publication before its first condition-variable wait"
+    );
+    assert!(Arc::ptr_eq(&produced, &waited));
 }
 
 #[test]

--- a/docs/worklogs/2026-09-01-issue-1744-cache-lost-wakeup.md
+++ b/docs/worklogs/2026-09-01-issue-1744-cache-lost-wakeup.md
@@ -35,14 +35,12 @@ cached `Arc`, but it did not control the registration-to-wait interval.
   spurious Condvar wakeups.
 - Keep retained and ephemeral completion accounting in the existing
   `complete_with_locked_state` path.
-- Add a test-only callback around the real entry-wait boundary rather than a
-  probabilistic repetition test. The regression pauses the waiter after
-  registration, completes producer publication, and then permits the first
-  wait attempt.
-- After the bounded observation window, repeatedly issue replacement
-  notifications while polling for completion up to a rescue deadline. Use an
-  unscoped waiter so even deadline exhaustion cannot block failure reporting on
-  an implicit scoped-thread join.
+- Add test-only callbacks around the real entry-wait boundary and immediately
+  before `Condvar::wait` rather than a probabilistic repetition or timeout
+  test. The regression pauses the waiter after registration, completes producer
+  publication, and then permits the predicate check. Entering the condition
+  variable after publication panics directly, so a broken implementation fails
+  without sleeping.
 - Do not change cache ownership, limits, statistics, public APIs, dependencies,
   backends, feature flags, or CI workflow policy.
 
@@ -55,8 +53,8 @@ instance was found in those paths.
 ## Verification
 
 - The deterministic regression failed against the old unconditional wait in
-  about one second with `waiter missed publication before its first
-  condition-variable wait` and completed without hanging.
+  0.03 seconds with `waiter must not sleep after producer publication` and
+  completed without hanging.
 - `cargo nextest run -p tenferro-runtime --cargo-profile ci 'same_key_'
   --no-fail-fast`: 2 passed.
 - `cargo nextest run -p tenferro-runtime --cargo-profile ci --no-fail-fast`:
@@ -69,9 +67,7 @@ instance was found in those paths.
 
 ## Residual risk
 
-The regression uses a one-second bounded observation only to distinguish the
-fixed path from an old waiter that needs rescue notifications. The ordering of
-waiter registration, producer publication, and waiter release is controlled by
-barriers, so correctness does not depend on probabilistically hitting the race.
-The ten-second rescue deadline is failure containment for a broken
-implementation, not part of the passing-path correctness criterion.
+The ordering of waiter registration, producer publication, predicate checking,
+and any attempted condition-variable wait is controlled by barriers and a
+test-only hook. The regression has no scheduling deadline, so correctness does
+not depend on how quickly the waiter runs after it is released.

--- a/docs/worklogs/2026-09-01-issue-1744-cache-lost-wakeup.md
+++ b/docs/worklogs/2026-09-01-issue-1744-cache-lost-wakeup.md
@@ -39,9 +39,10 @@ cached `Arc`, but it did not control the registration-to-wait interval.
   probabilistic repetition test. The regression pauses the waiter after
   registration, completes producer publication, and then permits the first
   wait attempt.
-- Give the regression a replacement notification after its bounded observation
-  window so the old implementation reports a normal assertion failure instead
-  of hanging the whole suite.
+- After the bounded observation window, repeatedly issue replacement
+  notifications while polling for completion up to a rescue deadline. Use an
+  unscoped waiter so even deadline exhaustion cannot block failure reporting on
+  an implicit scoped-thread join.
 - Do not change cache ownership, limits, statistics, public APIs, dependencies,
   backends, feature flags, or CI workflow policy.
 
@@ -69,6 +70,8 @@ instance was found in those paths.
 ## Residual risk
 
 The regression uses a one-second bounded observation only to distinguish the
-fixed path from an old waiter that needs a rescue notification. The ordering of
+fixed path from an old waiter that needs rescue notifications. The ordering of
 waiter registration, producer publication, and waiter release is controlled by
 barriers, so correctness does not depend on probabilistically hitting the race.
+The ten-second rescue deadline is failure containment for a broken
+implementation, not part of the passing-path correctness criterion.

--- a/docs/worklogs/2026-09-01-issue-1744-cache-lost-wakeup.md
+++ b/docs/worklogs/2026-09-01-issue-1744-cache-lost-wakeup.md
@@ -1,0 +1,74 @@
+# Issue #1744: Prepared-plan cache lost wakeup
+
+## Scope
+
+Fix the prepared-plan cache waiter race that left the macOS workspace test for
+PR #1741 blocked after producer publication. Preserve the existing single-flight
+cache semantics and public API.
+
+## Context read
+
+- Shared tensor4all common repository/performance and Rust rules.
+- `AGENTS.md`, `CONTRIBUTING.md`, and the cache, test-organization, and
+  contribution sections of `REPOSITORY_RULES.md`.
+- Issue #1744 and the stalled macOS and downstream GPU-gate Actions jobs.
+- `crates/tenferro-runtime/src/runtime/cache.rs` and its module-local cache
+  tests.
+- Neighboring Condvar loops in the runtime queue-ticket and execution paths.
+
+## Root cause
+
+`handle_entry` registered a waiter while holding the cache mutex, then returned
+an `EntryWaitGuard`. `EntryWaitGuard::wait_once` later reacquired the mutex and
+unconditionally entered `Condvar::wait`. A producer could publish and notify in
+the interval between registration and that first wait, leaving the waiter
+asleep with no remaining state transition to wake it.
+
+The existing same-key test exposed the race nondeterministically. Its eight
+callers verify that one producer runs and that every waiter receives the same
+cached `Arc`, but it did not control the registration-to-wait interval.
+
+## Decisions
+
+- Recheck the guarded predicate after acquiring the mutex and wait in a loop
+  only while the same entry and attempt remain `Preparing`. This also handles
+  spurious Condvar wakeups.
+- Keep retained and ephemeral completion accounting in the existing
+  `complete_with_locked_state` path.
+- Add a test-only callback around the real entry-wait boundary rather than a
+  probabilistic repetition test. The regression pauses the waiter after
+  registration, completes producer publication, and then permits the first
+  wait attempt.
+- Give the regression a replacement notification after its bounded observation
+  window so the old implementation reports a normal assertion failure instead
+  of hanging the whole suite.
+- Do not change cache ownership, limits, statistics, public APIs, dependencies,
+  backends, feature flags, or CI workflow policy.
+
+## Same-pattern review
+
+The other Condvar users in `runtime/cache.rs` and `runtime/execution.rs` already
+check their protected predicates in loops before waiting. No related lost-wakeup
+instance was found in those paths.
+
+## Verification
+
+- The deterministic regression failed against the old unconditional wait in
+  about one second with `waiter missed publication before its first
+  condition-variable wait` and completed without hanging.
+- `cargo nextest run -p tenferro-runtime --cargo-profile ci 'same_key_'
+  --no-fail-fast`: 2 passed.
+- `cargo nextest run -p tenferro-runtime --cargo-profile ci --no-fail-fast`:
+  558 passed. The compile-fail fixture was run with network access because it
+  resolves the crates.io index in a temporary project.
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p
+  tenferro-runtime same_key_waiter_does_not_miss_publication_before_first_wait'`:
+  passed repository formatting, documentation snippets, root/extension clippy,
+  and the focused debug-profile regression test.
+
+## Residual risk
+
+The regression uses a one-second bounded observation only to distinguish the
+fixed path from an old waiter that needs a rescue notification. The ordering of
+waiter registration, producer publication, and waiter release is controlled by
+barriers, so correctness does not depend on probabilistically hitting the race.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactoring
- [ ] Performance
- [ ] CI / build
- [ ] New feature accepted in a linked issue

## Related issue

Fixes #1744

## Summary

- Recheck the prepared-cache entry/attempt predicate under the mutex before and after condition-variable waits, eliminating the lost-wakeup window.
- Add a deterministic regression test that publishes between waiter registration and its first wait; the old implementation fails normally rather than hanging.
- Preserve the existing single-flight result sharing, accounting, cache limits, and public API.
- Audit neighboring condition-variable paths; they already use predicate loops and need no related change.

## Work log

- [Issue #1744 prepared-plan cache lost wakeup](docs/worklogs/2026-09-01-issue-1744-cache-lost-wakeup.md)

## Verification

- `cargo nextest run -p tenferro-runtime --cargo-profile ci 'same_key_' --no-fail-fast` (2 passed)
- `cargo nextest run -p tenferro-runtime --cargo-profile ci --no-fail-fast` (558 passed)
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-runtime same_key_waiter_does_not_miss_publication_before_first_wait'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1744.json --dry-run --llm-skipped-reason "local deterministic review"` (pass)
- Temporarily restoring the old unconditional wait makes the new regression fail in about one second with `waiter missed publication before its first condition-variable wait`, without hanging the suite.

## Checklist

- [x] I reviewed the diff against `REPOSITORY_RULES.md`.
- [x] I added regression coverage for the changed behavior.
- [x] I ran the focused local PR gate.
- [x] I documented the implementation tradeoff and residual risk in a work log.
- [x] This change introduces no public API, dependency, backend, feature-flag, or architectural change.
