### PR TITLE
ci: run Linux and macOS workspace tests in parallel

### DIFF
--- a/.github/workflows/ci-pr-workspace-tests.yml
+++ b/.github/workflows/ci-pr-workspace-tests.yml
@@ -184,30 +184,30 @@ jobs:
 
   macos:
     name: macOS workspace tests
-    needs: [changes, ci-gate]
+    needs: changes
     if: always()
-    runs-on: ${{ needs.ci-gate.result == 'success' && needs.changes.outputs.run_macos == 'true' && 'macos-15' || 'ubuntu-latest' }}
+    runs-on: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_macos == 'true' && 'macos-15' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v5
-        if: needs.ci-gate.result == 'success' && needs.changes.outputs.run_macos == 'true'
+        if: needs.changes.result == 'success' && needs.changes.outputs.run_macos == 'true'
       - uses: dtolnay/rust-toolchain@stable
-        if: needs.ci-gate.result == 'success' && needs.changes.outputs.run_macos == 'true'
+        if: needs.changes.result == 'success' && needs.changes.outputs.run_macos == 'true'
       - uses: Swatinem/rust-cache@v2
-        if: needs.ci-gate.result == 'success' && needs.changes.outputs.run_macos == 'true'
+        if: needs.changes.result == 'success' && needs.changes.outputs.run_macos == 'true'
       - uses: taiki-e/install-action@nextest
-        if: needs.ci-gate.result == 'success' && needs.changes.outputs.run_macos == 'true'
+        if: needs.changes.result == 'success' && needs.changes.outputs.run_macos == 'true'
       - name: Run macOS workspace profile
-        if: needs.ci-gate.result == 'success' && needs.changes.outputs.run_macos == 'true'
+        if: needs.changes.result == 'success' && needs.changes.outputs.run_macos == 'true'
         run: python3 scripts/ci/run_profile.py workspace-faer
       - name: Report macOS disposition
         if: always()
         env:
-          LINUX_GATE_RESULT: ${{ needs.ci-gate.result }}
+          CHANGE_RESULT: ${{ needs.changes.result }}
           RUN_MACOS: ${{ needs.changes.outputs.run_macos }}
           REASON: ${{ needs.changes.outputs.reason }}
         run: |
-          if [ "${LINUX_GATE_RESULT}" != success ]; then
-            echo "Linux workspace gate failed: ${LINUX_GATE_RESULT}"
+          if [ "${CHANGE_RESULT}" != success ]; then
+            echo "Change classification failed: ${CHANGE_RESULT}"
             exit 1
           fi
           if [ "${RUN_MACOS}" != true ]; then echo "macOS tests not required - ${REASON}"; fi

--- a/docs/design/change-aware-ci.md
+++ b/docs/design/change-aware-ci.md
@@ -43,18 +43,21 @@ execute once. Hosted Rust compile/test commands use workspace `[profile.ci]`
 `macOS workspace tests` is a required Apple Silicon execution gate for code
 changes and `main` pushes. It runs the shared `workspace-faer` profile on
 `macos-15`, covering workspace tests and doctests including macOS-only
-Apple/Metal paths. The job starts only after `CI gate (PR workspace tests)` has
-accepted the selected Linux workspace and extension lanes. This keeps macOS
-runner use off failed Linux revisions. The RunPod GPU workflow remains further
-downstream, so a failed macOS run also prevents paid GPU allocation.
+Apple/Metal paths. After change classification, the job starts in parallel with
+the selected Linux workspace and extension lanes. Linux and macOS remain
+independent required checks, reducing pull-request wall-clock time while still
+failing closed on either platform. The RunPod GPU workflow remains further
+downstream of the completed workspace workflow, so a failed Linux or macOS run
+still prevents paid GPU allocation.
 
 The change policy also runs this gate when its workflow, shared profile, or
 classifier changes, so CI-only edits can validate the native lane. Other
 CI-only and docs-only changes run an explicit successful no-op on
 `ubuntu-latest` instead of allocating a macOS runner. A Linux gate failure also
-stays on Ubuntu and fails closed. The older Linux-hosted Apple cross-target
-type-check is removed because the real macOS workspace run compiles and
-executes the same target-gated code.
+does not cancel an already-running macOS lane; both results remain visible and
+merge-blocking. The older Linux-hosted Apple cross-target type-check is removed
+because the real macOS workspace run compiles and executes the same
+target-gated code.
 
 ## RunPod trust boundary
 

--- a/docs/worklogs/2026-09-01-parallel-linux-macos-ci.md
+++ b/docs/worklogs/2026-09-01-parallel-linux-macos-ci.md
@@ -1,0 +1,61 @@
+# Parallel Linux and macOS workspace CI
+
+Date: 2026-09-01
+Issue: #1748
+
+## Summary
+
+Start the required macOS workspace lane after change classification, in
+parallel with the Linux workspace and extension lanes. Previously macOS waited
+for the Linux aggregate gate, extending pull-request wall-clock time.
+
+## Context read
+
+- `.github/workflows/ci-pr-workspace-tests.yml`
+- `scripts/ci/change_policy.py`
+- `scripts/ci/run_profile.py`
+- `scripts/ci/tests/test_workflow_contracts.py`
+- `docs/design/change-aware-ci.md`
+- `docs/worklogs/2026-08-24-macos-ci-restoration.md`
+- GitHub's current Actions billing and hosted-runner documentation
+
+## Decisions
+
+- Depend on `changes`, not `ci-gate`, so native macOS work begins as soon as
+  classification succeeds.
+- Keep the stable `macOS workspace tests` required-check name and preserve the
+  explicit Ubuntu no-op for changes that do not require native validation.
+- Fail closed when classification fails without allocating a macOS runner.
+- Keep the shared `workspace-faer` command profile unchanged; command and
+  feature coverage are outside this ordering-only change.
+- Keep Linux and macOS failures independent and visible. The downstream RunPod
+  workflow still waits for the workspace workflow to complete, preserving the
+  paid GPU allocation boundary.
+
+## Alternatives
+
+- Retain Linux-first ordering to avoid unnecessary macOS work. This was
+  rejected because the repository is public, `macos-15` is a standard hosted
+  runner, and faster cross-platform feedback is more useful than suppressing
+  work on revisions that may fail on Linux.
+- Remove macOS doctests while changing the ordering. This was deferred because
+  command coverage is separate from the dependency-graph change requested by
+  #1748.
+
+## Verification
+
+- `python3.11 -m unittest scripts.ci.tests.test_workflow_contracts scripts.ci.tests.test_change_policy`: pass (50 tests)
+- `python3.11 -m unittest discover -s scripts/ci/tests -v`: pass (198 tests)
+- `actionlint .github/workflows/ci-pr-workspace-tests.yml .github/workflows/runpod-gpu-test.yml`: pass
+- `bash scripts/check-pr-fast.sh --test '<focused CI contract tests>'`: pass
+- `python3 scripts/ci/run_profile.py ci-config`: attempted, but the unrelated
+  release-publish handoff tests fail under this macOS checkout's local command
+  environment; the directly affected CI test suite and `actionlint` pass
+  independently as listed above.
+- Deterministic repository-rules review on the committed head
+
+## Residual risks
+
+Linux failures no longer prevent an already-selected macOS job from consuming
+runner capacity. Both jobs are cancellation-aware at the workflow level, and
+the reduced PR latency is the intentional tradeoff.

--- a/docs/worklogs/2026-09-01-parallel-linux-macos-ci.md
+++ b/docs/worklogs/2026-09-01-parallel-linux-macos-ci.md
@@ -52,7 +52,9 @@ for the Linux aggregate gate, extending pull-request wall-clock time.
   release-publish handoff tests fail under this macOS checkout's local command
   environment; the directly affected CI test suite and `actionlint` pass
   independently as listed above.
-- Deterministic repository-rules review on the committed head
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD
+  --dry-run --llm-skipped-reason "local deterministic review"`: pass; external
+  LLM review intentionally skipped
 
 ## Residual risks
 

--- a/docs/worklogs/2026-09-01-parallel-linux-macos-ci.md
+++ b/docs/worklogs/2026-09-01-parallel-linux-macos-ci.md
@@ -49,9 +49,9 @@ for the Linux aggregate gate, extending pull-request wall-clock time.
 - `actionlint .github/workflows/ci-pr-workspace-tests.yml .github/workflows/runpod-gpu-test.yml`: pass
 - `bash scripts/check-pr-fast.sh --test '<focused CI contract tests>'`: pass
 - `python3 scripts/ci/run_profile.py ci-config`: attempted, but the unrelated
-  release-publish handoff tests fail under this macOS checkout's local command
-  environment; the directly affected CI test suite and `actionlint` pass
-  independently as listed above.
+  release-publish and storage-ownership helper fixtures fail under this macOS
+  checkout's local command environment; the directly affected CI test suite
+  and `actionlint` pass independently as listed above.
 - `python3 scripts/repository-rules-review.py --base origin/main --head HEAD
   --dry-run --llm-skipped-reason "local deterministic review"`: pass; external
   LLM review intentionally skipped

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -26,16 +26,20 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("python3 scripts/ci/run_profile.py docs", text)
         self.assertIn("name: CI configuration checks", text)
 
-    def test_macos_workspace_tests_run_after_linux_gate(self) -> None:
+    def test_macos_workspace_tests_run_in_parallel_with_linux(self) -> None:
         text = read(".github/workflows/ci-pr-workspace-tests.yml")
         start = text.index("  macos:")
         block = text[start:]
         self.assertIn("name: macOS workspace tests", block)
-        self.assertIn("needs: [changes, ci-gate]", block)
+        self.assertIn("needs: changes", block)
+        self.assertNotIn("needs: [changes, ci-gate]", block)
         self.assertIn("run_macos: ${{ steps.policy.outputs.run_macos }}", text)
         self.assertIn("'macos-15' || 'ubuntu-latest'", block)
         self.assertIn("python3 scripts/ci/run_profile.py workspace-faer", block)
-        self.assertIn("Linux workspace gate failed", block)
+        self.assertIn("needs.changes.result == 'success'", block)
+        self.assertIn("Change classification failed", block)
+        self.assertNotIn("needs.ci-gate", block)
+        self.assertNotIn("Linux workspace gate failed", block)
 
         fast = read(".github/workflows/ci.yml")
         self.assertNotIn("macOS-gated GPU type-check", fast)


### PR DESCRIPTION
## Summary

- start the required macOS workspace lane after change classification, in parallel with Linux workspace and extension lanes
- preserve fail-closed classification, the stable required check name, and explicit Ubuntu no-op behavior
- keep RunPod downstream of successful completion of the full workspace workflow
- update the workflow contract test and durable CI design documentation

Closes #1748

## Verification

- `python3.11 -m unittest scripts.ci.tests.test_workflow_contracts scripts.ci.tests.test_change_policy` (50 tests)
- `python3.11 -m unittest discover -s scripts/ci/tests -v` (198 tests)
- `actionlint .github/workflows/ci-pr-workspace-tests.yml .github/workflows/runpod-gpu-test.yml`
- `bash scripts/check-pr-fast.sh --test '<focused CI contract tests>'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --dry-run --llm-skipped-reason "local deterministic review"` (pass)

The full `ci-config` profile was also attempted locally. Unrelated release-publish and storage-ownership helper fixtures fail in this macOS checkout's local command environment; the directly affected complete `scripts/ci/tests` suite and `actionlint` pass independently above.

## Design record

- [Parallel Linux and macOS workspace CI](docs/worklogs/2026-09-01-parallel-linux-macos-ci.md)
