### PR TITLE
perf(linalg): benchmark small Householder QR appends

### DIFF
--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -120,6 +120,11 @@ required-features = ["autodiff"]
 name = "incremental_householder_qr"
 harness = false
 
+[[bench]]
+name = "householder_qr_small_appends"
+harness = false
+required-features = ["autodiff"]
+
 [[test]]
 name = "integration"
 path = "tests/integration.rs"

--- a/crates/tenferro-linalg/benches/householder_qr_small_appends.rs
+++ b/crates/tenferro-linalg/benches/householder_qr_small_appends.rs
@@ -1,0 +1,617 @@
+use std::env;
+use std::fs;
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::Instant;
+
+use num_complex::Complex64;
+use serde::Serialize;
+use tenferro_ad::{EagerRuntime, EagerTensor};
+use tenferro_cpu::{with_cpu_exec_session, CpuBackend, CpuBackendKind, CpuExecSession};
+use tenferro_linalg::{EagerTensorLinalgExt, HouseholderQr, QrGauge, QrOptions, TensorLinalgExt};
+use tenferro_tensor::{BackendSessionHost, Tensor};
+
+const INITIAL_RANK: usize = 5;
+const BLOCK_WIDTH: usize = 3;
+const APPENDS: usize = 9;
+const FINAL_RANK: usize = INITIAL_RANK + BLOCK_WIDTH * APPENDS;
+const SAMPLE_BATCH: usize = 64;
+const CPU_CLOCK_WARMUP_MS: u64 = 50;
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum Lane {
+    Append,
+    R,
+    QColumns,
+    Complete,
+    FreshSessionComplete,
+    EagerComplete,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum BenchDType {
+    F64,
+    C64,
+}
+
+impl BenchDType {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::F64 => "f64",
+            Self::C64 => "c64",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Config {
+    backend: CpuBackendKind,
+    lane: Lane,
+    dtype: BenchDType,
+    rows: usize,
+    warmups: usize,
+    repetitions: usize,
+    git_commit: String,
+}
+
+#[derive(Serialize)]
+struct ThreadEnvironment {
+    rayon_num_threads: Option<String>,
+    openblas_num_threads: Option<String>,
+    omp_num_threads: Option<String>,
+    mkl_num_threads: Option<String>,
+}
+
+#[derive(Serialize)]
+struct Record {
+    schema: &'static str,
+    git_commit: String,
+    backend: &'static str,
+    lane: Lane,
+    dtype: &'static str,
+    gauge: &'static str,
+    rows: usize,
+    initial_rank: usize,
+    block_width: usize,
+    appends: usize,
+    final_rank: usize,
+    sample_batch: usize,
+    warmups: usize,
+    repetitions: usize,
+    cpu_affinity: Option<String>,
+    cpu_frequency_mhz: Option<f64>,
+    thread_environment: ThreadEnvironment,
+    timings_ms: Vec<f64>,
+    reconstruction_relative_error: f64,
+    orthogonality_relative_error: f64,
+}
+
+fn main() {
+    let config = parse_args().unwrap_or_else(|error| panic!("{error}"));
+    let (initial, blocks, accumulated) = generate_inputs(config.rows, config.dtype).unwrap();
+    let (timings_ms, q, r) = match config.lane {
+        Lane::FreshSessionComplete => run_fresh_session(&config, &initial, &blocks),
+        Lane::EagerComplete => run_eager(&config, initial, blocks),
+        lane => run_concrete(&config, lane, &initial, &blocks),
+    }
+    .unwrap_or_else(|error| panic!("benchmark failed: {error}"));
+    let (reconstruction_relative_error, orthogonality_relative_error) =
+        errors(&q, &r, &accumulated, config.dtype).unwrap();
+    let backend = match config.backend {
+        CpuBackendKind::Faer => "faer",
+        CpuBackendKind::Blas => "blas",
+    };
+    let record = Record {
+        schema: "tenferro.householder-qr-small-appends.v1",
+        git_commit: config.git_commit.clone(),
+        backend,
+        lane: config.lane,
+        dtype: config.dtype.name(),
+        gauge: "raw",
+        rows: config.rows,
+        initial_rank: INITIAL_RANK,
+        block_width: BLOCK_WIDTH,
+        appends: APPENDS,
+        final_rank: FINAL_RANK,
+        sample_batch: SAMPLE_BATCH,
+        warmups: config.warmups,
+        repetitions: config.repetitions,
+        cpu_affinity: process_affinity(),
+        cpu_frequency_mhz: pinned_cpu_frequency_mhz(),
+        thread_environment: ThreadEnvironment {
+            rayon_num_threads: env::var("RAYON_NUM_THREADS").ok(),
+            openblas_num_threads: env::var("OPENBLAS_NUM_THREADS").ok(),
+            omp_num_threads: env::var("OMP_NUM_THREADS").ok(),
+            mkl_num_threads: env::var("MKL_NUM_THREADS").ok(),
+        },
+        timings_ms,
+        reconstruction_relative_error,
+        orthogonality_relative_error,
+    };
+    println!("{}", serde_json::to_string(&record).unwrap());
+}
+
+fn parse_args() -> Result<Config, String> {
+    let mut backend = None;
+    let mut lane = None;
+    let mut rows = None;
+    let mut dtype = BenchDType::F64;
+    let mut warmups = 3;
+    let mut repetitions = 10;
+    let args = env::args()
+        .skip(1)
+        .filter(|argument| argument != "--bench")
+        .collect::<Vec<_>>();
+    let mut index = 0;
+    while index < args.len() {
+        let value = args
+            .get(index + 1)
+            .ok_or_else(|| format!("missing value after {}", args[index]))?;
+        match args[index].as_str() {
+            "--backend" => {
+                backend = Some(match value.as_str() {
+                    "faer" => CpuBackendKind::Faer,
+                    "blas" => CpuBackendKind::Blas,
+                    _ => return Err(format!("unknown backend {value:?}")),
+                })
+            }
+            "--lane" => {
+                lane = Some(match value.as_str() {
+                    "append" => Lane::Append,
+                    "r" => Lane::R,
+                    "q-columns" => Lane::QColumns,
+                    "complete" => Lane::Complete,
+                    "fresh-session-complete" => Lane::FreshSessionComplete,
+                    "eager-complete" => Lane::EagerComplete,
+                    _ => return Err(format!("unknown lane {value:?}")),
+                })
+            }
+            "--rows" => rows = Some(parse(value, "rows")?),
+            "--dtype" => {
+                dtype = match value.as_str() {
+                    "f64" => BenchDType::F64,
+                    "c64" => BenchDType::C64,
+                    _ => return Err(format!("unknown dtype {value:?}")),
+                }
+            }
+            "--warmups" => warmups = parse(value, "warmups")?,
+            "--repetitions" => repetitions = parse(value, "repetitions")?,
+            other => return Err(format!("unknown option {other:?}")),
+        }
+        index += 2;
+    }
+    let rows = rows.ok_or_else(|| "--rows is required".to_string())?;
+    if ![64, 128, 256].contains(&rows) {
+        return Err("rows must be one of 64, 128, or 256".into());
+    }
+    if repetitions == 0 {
+        return Err("repetitions must be positive".into());
+    }
+    Ok(Config {
+        backend: backend.ok_or_else(|| "--backend is required".to_string())?,
+        lane: lane.ok_or_else(|| "--lane is required".to_string())?,
+        dtype,
+        rows,
+        warmups,
+        repetitions,
+        git_commit: env::var("TENFERRO_BENCH_GIT_COMMIT")
+            .map_err(|_| "TENFERRO_BENCH_GIT_COMMIT is required".to_string())?,
+    })
+}
+
+fn parse<T: std::str::FromStr>(value: &str, field: &str) -> Result<T, String> {
+    value
+        .parse()
+        .map_err(|_| format!("invalid {field}: {value:?}"))
+}
+
+fn generate_inputs(
+    rows: usize,
+    dtype: BenchDType,
+) -> Result<(Tensor, Vec<Tensor>, Tensor), String> {
+    match dtype {
+        BenchDType::F64 => {
+            generate_inputs_typed(rows, |real, _, diagonal| real + f64::from(diagonal))
+        }
+        BenchDType::C64 => generate_inputs_typed(rows, |real, imag, diagonal| {
+            Complex64::new(real + f64::from(diagonal), imag)
+        }),
+    }
+}
+
+fn generate_inputs_typed<T>(
+    rows: usize,
+    value: impl Fn(f64, f64, bool) -> T,
+) -> Result<(Tensor, Vec<Tensor>, Tensor), String>
+where
+    Tensor: From<tenferro_tensor::TypedTensor<T>>,
+    T: tenferro_tensor::TensorScalar,
+{
+    let mut state = 7_u64;
+    let mut values = Vec::with_capacity(rows * FINAL_RANK);
+    let scale = (rows as f64).sqrt().recip();
+    for column in 0..FINAL_RANK {
+        for row in 0..rows {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            let real = (((state >> 11) as f64) / ((1_u64 << 53) as f64) * 2.0 - 1.0) * scale;
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            let imag = (((state >> 11) as f64) / ((1_u64 << 53) as f64) * 2.0 - 1.0) * scale;
+            values.push(value(real, imag, row == column));
+        }
+    }
+    let initial_len = rows * INITIAL_RANK;
+    let initial = Tensor::from(
+        tenferro_tensor::TypedTensor::from_vec_col_major(
+            vec![rows, INITIAL_RANK],
+            values[..initial_len].to_vec(),
+        )
+        .map_err(to_string)?,
+    );
+    let blocks = (0..APPENDS)
+        .map(|block| {
+            let start = initial_len + block * rows * BLOCK_WIDTH;
+            tenferro_tensor::TypedTensor::from_vec_col_major(
+                vec![rows, BLOCK_WIDTH],
+                values[start..start + rows * BLOCK_WIDTH].to_vec(),
+            )
+            .map(Tensor::from)
+            .map_err(to_string)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let accumulated = Tensor::from(
+        tenferro_tensor::TypedTensor::from_vec_col_major(vec![rows, FINAL_RANK], values)
+            .map_err(to_string)?,
+    );
+    Ok((initial, blocks, accumulated))
+}
+
+fn run_concrete(
+    config: &Config,
+    lane: Lane,
+    initial: &Tensor,
+    blocks: &[Tensor],
+) -> Result<(Vec<f64>, Tensor, Tensor), String> {
+    let mut backend =
+        CpuBackend::with_threads_and_kind(1, config.backend).map_err(|error| error.to_string())?;
+    backend.with_backend_session(|session| {
+        with_cpu_exec_session(session, |session| {
+            let total = config.warmups + config.repetitions;
+            let mut timings = Vec::with_capacity(config.repetitions);
+            for iteration in 0..total {
+                let states = (0..SAMPLE_BATCH)
+                    .map(|_| initial.householder_qr(session).map_err(to_string))
+                    .collect::<Result<Vec<_>, _>>()?;
+                warm_cpu_clock();
+                let elapsed = if matches!(lane, Lane::Complete) {
+                    let start = Instant::now();
+                    for state in states {
+                        black_box(complete_concrete(state, blocks, session)?);
+                    }
+                    start.elapsed()
+                } else {
+                    let mut elapsed = std::time::Duration::ZERO;
+                    for state in states {
+                        elapsed += attributed_concrete(state, blocks, session, lane)?;
+                    }
+                    elapsed
+                }
+                .as_secs_f64()
+                    * 1.0e3;
+                if iteration >= config.warmups {
+                    timings.push(elapsed);
+                }
+            }
+            let state = initial.householder_qr(session).map_err(to_string)?;
+            let final_state = append_sequence(state, blocks, session)?;
+            let q = final_state
+                .q_columns(0..FINAL_RANK, raw_options(), session)
+                .map_err(to_string)?;
+            let r = final_state.r(raw_options(), session).map_err(to_string)?;
+            Ok((timings, q, r))
+        })
+        .ok_or_else(|| "CPU execution session unavailable".to_string())?
+    })
+}
+
+fn append_sequence(
+    mut state: HouseholderQr<Tensor>,
+    blocks: &[Tensor],
+    session: &mut CpuExecSession<'_>,
+) -> Result<HouseholderQr<Tensor>, String> {
+    for block in blocks {
+        state = state.append_columns(block, session).map_err(to_string)?;
+    }
+    Ok(state)
+}
+
+fn attributed_concrete(
+    mut state: HouseholderQr<Tensor>,
+    blocks: &[Tensor],
+    session: &mut CpuExecSession<'_>,
+    lane: Lane,
+) -> Result<std::time::Duration, String> {
+    let mut elapsed = std::time::Duration::ZERO;
+    for (append, block) in blocks.iter().enumerate() {
+        let start = Instant::now();
+        state = state.append_columns(block, session).map_err(to_string)?;
+        if matches!(lane, Lane::Append) {
+            elapsed += start.elapsed();
+        }
+
+        let start = Instant::now();
+        black_box(state.r(raw_options(), session).map_err(to_string)?);
+        if matches!(lane, Lane::R) {
+            elapsed += start.elapsed();
+        }
+
+        let column = INITIAL_RANK + append * BLOCK_WIDTH;
+        let start = Instant::now();
+        black_box(
+            state
+                .q_columns(column..column + BLOCK_WIDTH, raw_options(), session)
+                .map_err(to_string)?,
+        );
+        if matches!(lane, Lane::QColumns) {
+            elapsed += start.elapsed();
+        }
+    }
+    black_box(state);
+    Ok(elapsed)
+}
+
+fn complete_concrete(
+    mut state: HouseholderQr<Tensor>,
+    blocks: &[Tensor],
+    session: &mut CpuExecSession<'_>,
+) -> Result<HouseholderQr<Tensor>, String> {
+    for (append, block) in blocks.iter().enumerate() {
+        state = state.append_columns(block, session).map_err(to_string)?;
+        black_box(state.r(raw_options(), session).map_err(to_string)?);
+        let start = INITIAL_RANK + append * BLOCK_WIDTH;
+        black_box(
+            state
+                .q_columns(start..start + BLOCK_WIDTH, raw_options(), session)
+                .map_err(to_string)?,
+        );
+    }
+    Ok(state)
+}
+
+fn run_fresh_session(
+    config: &Config,
+    initial: &Tensor,
+    blocks: &[Tensor],
+) -> Result<(Vec<f64>, Tensor, Tensor), String> {
+    let mut backend = CpuBackend::with_threads_and_kind(1, config.backend).map_err(to_string)?;
+    let total = config.warmups + config.repetitions;
+    let mut timings = Vec::with_capacity(config.repetitions);
+    for iteration in 0..total {
+        let states = (0..SAMPLE_BATCH)
+            .map(|_| backend.with_backend_session(|session| initial.householder_qr(session)))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(to_string)?;
+        warm_cpu_clock();
+        let start = Instant::now();
+        for mut state in states {
+            for (append, block) in blocks.iter().enumerate() {
+                state = backend
+                    .with_backend_session(|session| state.append_columns(block, session))
+                    .map_err(to_string)?;
+                black_box(
+                    backend
+                        .with_backend_session(|session| state.r(raw_options(), session))
+                        .map_err(to_string)?,
+                );
+                let start = INITIAL_RANK + append * BLOCK_WIDTH;
+                black_box(
+                    backend
+                        .with_backend_session(|session| {
+                            state.q_columns(start..start + BLOCK_WIDTH, raw_options(), session)
+                        })
+                        .map_err(to_string)?,
+                );
+            }
+        }
+        let elapsed = start.elapsed().as_secs_f64() * 1.0e3;
+        if iteration >= config.warmups {
+            timings.push(elapsed);
+        }
+    }
+    let mut state = backend
+        .with_backend_session(|session| initial.householder_qr(session))
+        .map_err(to_string)?;
+    for block in blocks {
+        state = backend
+            .with_backend_session(|session| state.append_columns(block, session))
+            .map_err(to_string)?;
+    }
+    let q = backend
+        .with_backend_session(|session| state.q_columns(0..FINAL_RANK, raw_options(), session))
+        .map_err(to_string)?;
+    let r = backend
+        .with_backend_session(|session| state.r(raw_options(), session))
+        .map_err(to_string)?;
+    Ok((timings, q, r))
+}
+
+fn run_eager(
+    config: &Config,
+    initial: Tensor,
+    blocks: Vec<Tensor>,
+) -> Result<(Vec<f64>, Tensor, Tensor), String> {
+    let runtime = EagerRuntime::with_cpu_backend(
+        CpuBackend::with_threads_and_kind(1, config.backend).map_err(to_string)?,
+    )
+    .map_err(to_string)?;
+    let initial = EagerTensor::from_tensor_in(initial, Arc::clone(&runtime)).map_err(to_string)?;
+    let blocks = blocks
+        .into_iter()
+        .map(|block| EagerTensor::from_tensor_in(block, Arc::clone(&runtime)).map_err(to_string))
+        .collect::<Result<Vec<_>, _>>()?;
+    let initial_state = initial.householder_qr().map_err(to_string)?;
+    let total = config.warmups + config.repetitions;
+    let mut timings = Vec::with_capacity(config.repetitions);
+    for iteration in 0..total {
+        let states = (0..SAMPLE_BATCH)
+            .map(|_| initial_state.clone())
+            .collect::<Vec<_>>();
+        warm_cpu_clock();
+        let start = Instant::now();
+        for state in states {
+            black_box(complete_eager(state, &blocks)?);
+        }
+        let elapsed = start.elapsed().as_secs_f64() * 1.0e3;
+        if iteration >= config.warmups {
+            timings.push(elapsed);
+        }
+    }
+    let state = complete_eager(initial_state, &blocks)?;
+    let q = state
+        .q_columns(0..FINAL_RANK, raw_options())
+        .map_err(to_string)?
+        .to_tensor()
+        .map_err(to_string)?;
+    let r = state
+        .r(raw_options())
+        .map_err(to_string)?
+        .to_tensor()
+        .map_err(to_string)?;
+    Ok((timings, q, r))
+}
+
+fn complete_eager(
+    mut state: HouseholderQr<EagerTensor>,
+    blocks: &[EagerTensor],
+) -> Result<HouseholderQr<EagerTensor>, String> {
+    for (append, block) in blocks.iter().enumerate() {
+        state = state.append_columns(block).map_err(to_string)?;
+        black_box(state.r(raw_options()).map_err(to_string)?);
+        let start = INITIAL_RANK + append * BLOCK_WIDTH;
+        black_box(
+            state
+                .q_columns(start..start + BLOCK_WIDTH, raw_options())
+                .map_err(to_string)?,
+        );
+    }
+    Ok(state)
+}
+
+fn warm_cpu_clock() {
+    let start = Instant::now();
+    let duration = std::time::Duration::from_millis(CPU_CLOCK_WARMUP_MS);
+    let mut state = 1_u64;
+    while start.elapsed() < duration {
+        state = black_box(
+            state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1),
+        );
+    }
+    black_box(state);
+}
+
+fn process_affinity() -> Option<String> {
+    fs::read_to_string("/proc/self/status")
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("Cpus_allowed_list:\t"))
+        .map(str::to_owned)
+}
+
+fn pinned_cpu_frequency_mhz() -> Option<f64> {
+    let cpu = process_affinity()?.parse::<usize>().ok()?;
+    fs::read_to_string(format!(
+        "/sys/devices/system/cpu/cpu{cpu}/cpufreq/scaling_cur_freq"
+    ))
+    .ok()?
+    .trim()
+    .parse::<f64>()
+    .ok()
+    .map(|khz| khz / 1_000.0)
+}
+
+fn raw_options() -> QrOptions {
+    QrOptions::default().gauge(QrGauge::Raw)
+}
+
+fn to_string(error: impl std::fmt::Display) -> String {
+    error.to_string()
+}
+
+fn errors(q: &Tensor, r: &Tensor, a: &Tensor, dtype: BenchDType) -> Result<(f64, f64), String> {
+    match dtype {
+        BenchDType::F64 => errors_f64(q, r, a),
+        BenchDType::C64 => errors_c64(q, r, a),
+    }
+}
+
+fn errors_f64(q: &Tensor, r: &Tensor, a: &Tensor) -> Result<(f64, f64), String> {
+    let q = q.as_slice::<f64>().map_err(to_string)?;
+    let r = r.as_slice::<f64>().map_err(to_string)?;
+    let a = a.as_slice::<f64>().map_err(to_string)?;
+    let rows = a.len() / FINAL_RANK;
+    let mut residual_sq = 0.0;
+    let mut norm_sq = 0.0;
+    for col in 0..FINAL_RANK {
+        for row in 0..rows {
+            let actual = (0..FINAL_RANK)
+                .map(|inner| q[row + inner * rows] * r[inner + col * FINAL_RANK])
+                .sum::<f64>();
+            let expected = a[row + col * rows];
+            residual_sq += (actual - expected).powi(2);
+            norm_sq += expected.powi(2);
+        }
+    }
+    let mut orthogonality_sq = 0.0;
+    for left in 0..FINAL_RANK {
+        for right in 0..FINAL_RANK {
+            let actual = (0..rows)
+                .map(|row| q[row + left * rows] * q[row + right * rows])
+                .sum::<f64>();
+            let expected = f64::from(left == right);
+            orthogonality_sq += (actual - expected).powi(2);
+        }
+    }
+    Ok((
+        residual_sq.sqrt() / norm_sq.sqrt().max(f64::MIN_POSITIVE),
+        orthogonality_sq.sqrt() / (FINAL_RANK as f64).sqrt(),
+    ))
+}
+
+fn errors_c64(q: &Tensor, r: &Tensor, a: &Tensor) -> Result<(f64, f64), String> {
+    let q = q.as_slice::<Complex64>().map_err(to_string)?;
+    let r = r.as_slice::<Complex64>().map_err(to_string)?;
+    let a = a.as_slice::<Complex64>().map_err(to_string)?;
+    let rows = a.len() / FINAL_RANK;
+    let mut residual_sq = 0.0;
+    let mut norm_sq = 0.0;
+    for col in 0..FINAL_RANK {
+        for row in 0..rows {
+            let actual = (0..FINAL_RANK)
+                .map(|inner| q[row + inner * rows] * r[inner + col * FINAL_RANK])
+                .sum::<Complex64>();
+            let expected = a[row + col * rows];
+            residual_sq += (actual - expected).norm_sqr();
+            norm_sq += expected.norm_sqr();
+        }
+    }
+    let mut orthogonality_sq = 0.0;
+    for left in 0..FINAL_RANK {
+        for right in 0..FINAL_RANK {
+            let actual = (0..rows)
+                .map(|row| q[row + left * rows].conj() * q[row + right * rows])
+                .sum::<Complex64>();
+            let expected = Complex64::new(f64::from(left == right), 0.0);
+            orthogonality_sq += (actual - expected).norm_sqr();
+        }
+    }
+    Ok((
+        residual_sq.sqrt() / norm_sq.sqrt().max(f64::MIN_POSITIVE),
+        orthogonality_sq.sqrt() / (FINAL_RANK as f64).sqrt(),
+    ))
+}

--- a/crates/tenferro-linalg/tests/integration.rs
+++ b/crates/tenferro-linalg/tests/integration.rs
@@ -34,6 +34,8 @@ mod linalg_internal_path_contract;
 #[cfg(feature = "autodiff")]
 #[path = "integration/oracle_replay.rs"]
 mod oracle_replay;
+#[path = "integration/small_append_performance_contract.rs"]
+mod small_append_performance_contract;
 #[path = "integration/support.rs"]
 mod support;
 #[path = "integration/traced_ad_explicit.rs"]

--- a/crates/tenferro-linalg/tests/integration/small_append_performance_contract.rs
+++ b/crates/tenferro-linalg/tests/integration/small_append_performance_contract.rs
@@ -1,0 +1,58 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .unwrap()
+        .to_path_buf()
+}
+
+#[test]
+fn small_append_benchmark_pins_issue_1750_workflow() {
+    let root = workspace_root();
+    let benchmark = fs::read_to_string(
+        root.join("crates/tenferro-linalg/benches/householder_qr_small_appends.rs"),
+    )
+    .unwrap();
+    let manifest = fs::read_to_string(root.join("crates/tenferro-linalg/Cargo.toml")).unwrap();
+    let design = fs::read_to_string(
+        root.join("docs/design/incremental-householder-qr-small-append-performance.md"),
+    )
+    .unwrap();
+
+    for required in [
+        "const INITIAL_RANK: usize = 5",
+        "const BLOCK_WIDTH: usize = 3",
+        "const APPENDS: usize = 9",
+        "const SAMPLE_BATCH: usize = 64",
+        "const CPU_CLOCK_WARMUP_MS: u64 = 50",
+        "[64, 128, 256]",
+        "BenchDType::F64",
+        "BenchDType::C64",
+        "errors_c64",
+        ".conj()",
+        "tenferro.householder-qr-small-appends.v1",
+        "Lane::Append",
+        "Lane::R",
+        "Lane::QColumns",
+        "Lane::Complete",
+        "Lane::FreshSessionComplete",
+        "Lane::EagerComplete",
+        "QrGauge::Raw",
+        "reconstruction_relative_error",
+        "orthogonality_relative_error",
+        "cpu_affinity",
+        "cpu_frequency_mhz",
+        "thread_environment",
+        "TENFERRO_BENCH_GIT_COMMIT is required",
+        "warm_cpu_clock();",
+        "attributed_concrete",
+        "elapsed += start.elapsed();",
+    ] {
+        assert!(benchmark.contains(required), "benchmark drift: {required}");
+    }
+    assert!(manifest.contains("name = \"householder_qr_small_appends\""));
+    assert!(design.contains("complete ~= append + R + selected-Q"));
+}

--- a/docs/design/incremental-householder-qr-small-append-performance.md
+++ b/docs/design/incremental-householder-qr-small-append-performance.md
@@ -1,0 +1,85 @@
+# Incremental Householder QR small-append performance
+
+**Issue:** [#1750](https://github.com/tensor4all/tenferro-rs/issues/1750)
+
+## Goal
+
+Explain and remove tenferro-owned overhead in the initial-rank-5 plus nine
+width-3 appends (final rank 32) at 64, 128, and 256 rows. Do not add an
+SRC-specific API.
+
+## Measurement before optimization
+
+Keep the frozen #1735 benchmark unchanged. Add a separate benchmark with the
+exact downstream schedule and report these timed components independently:
+
+1. time only compact `append_columns` within the complete workflow;
+2. time only `r()` within the same workflow;
+3. time only the newly appended `q_columns` within the same workflow;
+4. time the complete append + R + selected-Q workflow.
+
+The component lanes execute the identical interleaved operation sequence and
+sum only their selected `Instant` intervals. This keeps state/cache conditions
+matched, so `complete ~= append + R + selected-Q` is the reconciliation equation.
+
+Run the four components through one reused concrete backend session. Add a
+concrete complete-workflow lane that opens a backend session for every operation,
+matching the rejected adapter before its Matrix conversions. Add an eager
+complete-workflow lane using one reused `EagerRuntime`; these lanes isolate
+session-entry and eager-dispatch cost. Pin `QrGauge::Raw` in every
+output lane, matching the rejected downstream adapter; remeasure an accepted
+adapter if it requires another gauge. F64 and C64 are performance dtypes so
+the real matrix path and complex SRC sketch path are both represented; the
+existing #1735 tests retain correctness coverage for F32/F64/C32/C64.
+Input generation, initial factorization, and final correctness checks remain
+outside timing. The initial reproducer benchmark is CPU-only, one-thread, and
+release-mode because #1750's measured regression is the CPU tensor4all adapter.
+The existing #1735 gate retains CUDA correctness and scaling coverage; add a
+matching CUDA small-workflow lane only after a measured CUDA regression or a
+shared API candidate makes it relevant.
+
+All lanes live in one binary and commit. Each timing sample follows an untimed
+50 ms pinned-core clock warmup and is a fixed batch of independently reset
+nine-append sequences. Choose one batch size before measurement and use it for
+every lane;
+a process median below 1 ms is `INCONCLUSIVE`. Record at least seven process
+medians, alternate lane order, and classify process-median CoV above 10% or a
+CPU-frequency validity failure as `INCONCLUSIVE`; the sequential runner owns
+this cross-process classification from the benchmark records. Record every raw
+sample, provider, dtype, row count, schedule, batch size, thread settings, and
+the exact tenferro commit; the benchmark refuses to run without the commit. Correctness checks use reconstruction and
+orthogonality residuals after the final append.
+
+## Decision rule
+
+Classify costs before changing APIs or kernels. Compare row scaling and verify
+that complete-workflow time agrees with the separately measured component sum:
+
+- If all concrete components have a similar size-insensitive floor, optimize
+  shared dispatch, validation, allocation, or session plumbing before kernels.
+- If append grows with matrix work and dominates after subtracting that floor,
+  optimize the compact append backend.
+- If R extraction dominates, optimize or narrow the triangular-factor access.
+- If selected-Q dominates, optimize reflector application for the requested
+  range.
+- If the fresh-session-to-reused-session delta dominates, keep one session or
+  add a generic batching/fusion seam rather than changing reflector kernels.
+- If the eager-to-fresh-session delta dominates, optimize eager dispatch rather
+  than the backend session or reflector kernels.
+- If downstream inverse-adjoint maintenance dominates, design a generic
+  triangular solve/update operation only after a matching benchmark exists.
+
+Promote a candidate only if its paired complete-workflow median improves by at
+least 10%, no component median regresses by more than 5%, and correctness,
+dtype support, AD semantics, and placement remain unchanged. Re-run the
+tensor4all SRC comparison before recommending replacement of BCGS2.
+
+## Known design mismatch to verify
+
+The #1735 design said append would consume and return state where Rust permits
+buffer reuse, but the shipped concrete API takes `&self` and the CPU providers
+copy the old packed state and coefficient vector into new outputs. The #1735
+performance gate timed append only on much taller SRC-derived matrices and
+explicitly omitted inverse-adjoint maintenance. It therefore established the
+reflector algorithm's scaling, not competitiveness of the intended small public
+workflow.

--- a/docs/worklogs/2026-09-02-householder-qr-small-appends.md
+++ b/docs/worklogs/2026-09-02-householder-qr-small-appends.md
@@ -1,0 +1,199 @@
+# Householder QR small-append performance investigation (#1750)
+
+## Summary
+
+Added a separate factor-5 plus nine append-3 benchmark for 64, 128, and 256
+rows. It measures raw append, R extraction, newly appended Q columns, the
+complete workflow in one reused CPU session, the same workflow with one fresh
+session per operation, and the eager workflow.
+
+The compact reflector kernel is not the reported regression. On the measured
+faer path, raw compact append was 4.6--7.0x faster than the explicit-Q BCGS2
+diagnostic. Across F64/C64, opening a session for each append/R/Q operation made
+the complete compact workflow 1.9--3.4x slower than reusing one session; eager
+dispatch made it 4.0--7.2x slower. This localizes the first tenferro-visible cost to operation
+submission/session boundaries, before Matrix conversion or inverse-adjoint
+maintenance is added.
+
+## Context and protocol
+
+- Base commit: `c27977aee2db33b33f18b2d6c91e5a8d36daa236`.
+- Design: `docs/design/incremental-householder-qr-small-append-performance.md`.
+- Pre-implementation review: `reviewer-flash`, high thinking, read-only.
+  Initial verdict required fixed-cost attribution and a batched/noise protocol;
+  closure verdict was **Correct-to-merge**.
+- CPU: AMD EPYC 7713P, logical CPU 17, release profile, faer, F64 and C64.
+- Threads: `RAYON_NUM_THREADS=OPENBLAS_NUM_THREADS=OMP_NUM_THREADS=MKL_NUM_THREADS=1`.
+- Each sample batches 64 independently reset workflows after an untimed 50 ms
+  pinned-core clock warmup. Seven fresh processes per case used alternating
+  lane order; each process used three warmups and ten measurements. Every
+  process-median CoV was below 7.4%. Every record reported affinity `17` and
+  CPU frequency 3097--3100 MHz; the runner treats missing observations as
+  `INCONCLUSIVE`.
+- `TENFERRO_BENCH_GIT_COMMIT` is mandatory; benchmark records also retain
+  affinity, CPU frequency, and the four thread-control variables.
+- Accepted raw artifacts are local under `/tmp`: F64
+  `tenferro-1750-small-appends-f64-final.jsonl` (SHA-256
+  `00d8edb3b15810d049899e0413988427f521ae2ea79be779652ba7e4d391e875`) and
+  C64 `tenferro-1750-small-appends-c64-final.jsonl` (SHA-256
+  `fcd16a635a9f45f83b70a3787ef1840359a468595577226cbc1d8924c4998a42`), for
+  benchmark source SHA-256
+  `3a0662f81e4171f57c228f867563c2393747949b0d92b0b23527c31a1ce0f703`.
+  The external sequential runner injected the source hash, cycle, and order
+  fields into each raw record.
+
+Two complete predecessor runs were `INCONCLUSIVE`: precomputing and retaining
+all nine post-append states made the R/Q component lanes cache/lifetime-mismatched
+with the complete workflow and produced CoV above 10%. No favorable cases were
+selected from those runs. The benchmark was corrected to execute the identical
+interleaved workflow in every component lane and accumulate only the selected
+operation intervals; the full suite was then rerun from scratch. The final
+report is `PASS` under the predeclared 10% CoV and >=1 ms gates.
+
+## Results
+
+Times below are median microseconds per complete nine-append sequence (the raw
+records contain batched milliseconds).
+
+### F64
+
+| rows | append | R outputs | selected Q | reused-session complete | fresh-session complete | eager complete |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 64 | 56.9 | 19.3 | 37.7 | 113.7 | 391.9 | 814.9 |
+| 128 | 74.6 | 19.2 | 47.5 | 141.2 | 422.0 | 856.3 |
+| 256 | 111.3 | 19.5 | 66.3 | 197.3 | 467.7 | 1019.0 |
+
+### C64
+
+| rows | append | R outputs | selected Q | reused-session complete | fresh-session complete | eager complete |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 64 | 76.2 | 19.6 | 52.0 | 147.3 | 430.1 | 874.0 |
+| 128 | 113.6 | 19.9 | 80.1 | 212.8 | 498.5 | 1034.0 |
+| 256 | 180.1 | 19.9 | 133.5 | 334.2 | 621.2 | 1342.6 |
+
+The reused complete lane was 99.6--100.2% of the separately attributed
+component sum. Per-operation session entry made F64 2.4--3.4x and C64
+1.9--2.9x slower than session reuse. Eager made F64 5.2--7.2x and C64 4.0--5.9x
+slower. The fixed boundary cost remains clear, but its fraction shrinks as
+complex arithmetic grows.
+
+A diagnostic run of the existing #1735 benchmark on the same exact schedule
+measured compact append versus explicit-Q BCGS2 at approximately 57/401,
+77/496, and 131/601 microseconds for 64/128/256 rows. These sub-millisecond
+single-process aggregates are diagnostic rather than acceptance evidence. The
+256-row append estimate differs by about 17% from the new batched lane, which
+reinforces that limitation; even the slower estimate leaves a 4.6x margin over
+BCGS2 and cannot explain the downstream 41--52% regression as a slow reflector
+kernel.
+
+All benchmark lanes reconstructed the accumulated matrix with relative error
+at or below `3.6e-16`; final Q orthogonality error was at or below `5.3e-16`.
+
+## Why the previous delivery was not replacement-optimal
+
+1. The #1735 gate measured append only inside one reused backend session, on
+   2,048--32,768 rows. It did not measure the 64--256-row public workflow.
+2. Its correspondence ledger explicitly omitted inverse-adjoint/error-estimate
+   maintenance. That made the BCGS2 comparison conservative for raw append but
+   could not establish downstream replacement competitiveness.
+3. The rejected tensor4all adapter opened a default session independently for
+   append, R, and selected-Q, then converted every output between `Matrix` and
+   tenferro tensors. The concrete tenferro API already permits all three calls
+   in one `with_backend_session` closure, as its executable guide demonstrates.
+4. The design said append would consume state where Rust permits reuse, but the
+   shipped API takes `&self`; CPU append copies the old packed matrix and
+   coefficients into new buffers. This is a real design/implementation mismatch,
+   though the current measurements show session boundaries dominate it.
+5. Python keeps inverse-R information in its compact state and updates the new
+   triangular block. Tenferro intentionally stores raw provider-neutral R and
+   exposes only full R materialization, so the adapter must extract and
+   reinvert R. A generic triangular solve/update seam still needs a benchmark
+   including estimator maintenance before it is justified.
+
+## Downstream adapter and SRC rerun
+
+The rejected tensor4all adapter was reconstructed in a disposable worktree at
+its recorded tenferro pin `548fd5a1`. The same 64-sequence, seven-process,
+alternating-order protocol included Matrix conversion, Q/R retention, selected-Q
+copy, and error estimation after every append.
+
+Contrary to the historical 41--52% slowdown, compact Householder was faster
+than explicit-Q BCGS2 in fresh reruns:
+
+| dtype | rows 64 | rows 128 | rows 256 |
+| --- | ---: | ---: | ---: |
+| F64 compact / BCGS2 | 0.496 | 0.437 | 0.505 |
+| C64 compact / BCGS2 | 0.579 | 0.551 | 0.613 |
+
+The C64 adapter-complete variant that copied newly selected Q columns and ran
+the estimator after every append remained 39--45% faster than BCGS2. Thus the
+reported adapter regression is not reproducible on the current recorded source
+and pinned environment.
+
+Two measured candidates were rejected:
+
+- Combining append/R/Q under one downstream default-session closure changed
+  medians by -2.1%, -1.6%, and +1.1% at 64/128/256 rows: neutral. Maximum
+  process-median CoV was 2.0%.
+- Reusing the existing BCGS2 block inverse-adjoint updater in the compact path
+  was 27--44% slower. Maximum process-median CoV was 2.9%. At rank <=32, its
+  small solve, multiple Matrix matmuls, and allocations cost more than the
+  existing full triangular solve.
+
+Finally, seven paired end-to-end adaptive SRC processes (10 sites,
+`rank_increment=3`, `max_rank=32`, C64 sketch path) measured compact/BCGS2
+ratios of 0.982, 0.955, and 0.986 at input bonds 32, 64, and 128. Compact was
+neutral to 4.5% faster, with process CoV below 6.3%; no correctness tolerance
+was changed. This is insufficient evidence for a broad replacement speedup
+claim, but it rules out the historical slowdown on the tested source.
+
+## API and rule findings
+
+- **Concrete API:** sufficient for session reuse. Although per-operation entry
+  is visible in isolation, downstream session fusion was neutral, so no new
+  public API is justified for this part.
+- **Eager API:** every extension operation reaches
+  `with_extension_execution_context`, locks runtime/cache state, and opens a
+  backend session. It has no public sequence scope that lets append/R/Q share
+  one session. This is the measured tenferro API gap.
+- **Ownership contract:** `append_columns(&self, ...) -> Self` contradicts the
+  accepted design's consume-and-reuse statement. Any future ownership-based
+  optimization needs an owned backend hook and a source/performance contract;
+  changing only the public receiver would not remove provider copies.
+- **Triangular estimator contract:** adding raw packed access would leak provider
+  state and is rejected. The existing block inverse updater was slower at the
+  measured ranks, so a new solve/update API is not justified by current data.
+- **Rule gap:** the shared performance protocol requires an end-to-end need gate
+  for optimization candidates, but it did not require a proposed replacement
+  API to benchmark the exact downstream public operation sequence, mandatory
+  outputs, conversions, smallest representative shapes, and session policy.
+- **Rule gap:** benchmark guidance separates setup from operation timing but does
+  not require paired internal-session and intended-public-surface lanes when
+  fixed per-call dispatch may dominate.
+- **Rule enforcement gap:** the reviewed design's consume/reuse promise was not
+  tied to a source-contract test, allowing the shipped `&self` API and full
+  state copy to pass review.
+
+The minimal rule correction is to tighten the existing performance-gated
+experiment protocol, not add another standalone policy: replacement claims must
+include the exact intended public workflow and its mandatory output/state
+maintenance, plus an internal boundary breakdown. Performance claims based on
+ownership reuse must identify and test the owned execution seam.
+
+## Verification
+
+- `cargo check -p tenferro-linalg --features autodiff --bench householder_qr_small_appends`
+- `cargo test -p tenferro-linalg --test integration small_append_benchmark_pins_issue_1750_workflow`
+- release smoke and seven-process faer measurements for every benchmark lane
+- reconstruction and orthogonality checks embedded in every benchmark record
+
+## Next steps
+
+1. Land the benchmark and retain both F64 and C64 rows.
+2. Do not land the neutral session-fusion candidate or the slower block-inverse
+   candidate.
+3. Treat #1750's optimization request as not currently reproducible; reopen the
+   API/kernel decision only if the long-term suite shows a regression.
+4. Track the operation sequence in
+   [tenferro-benchmark#94](https://github.com/tensor4all/tenferro-benchmark/issues/94)
+   so future reports retain both reused-session and public/eager boundary costs.


### PR DESCRIPTION
## Summary

- add a dedicated F64/C64 benchmark for issue #1750's initial-5 plus 3-column x9 compact Householder QR workload at 64/128/256 rows
- separate append, R materialization, selected-Q materialization, reused-session complete, fresh-session complete, and eager complete lanes
- pin the workload and benchmark contract with a source-contract integration test
- document the measurement protocol, results, downstream adapter A/B rerun, rejected optimization candidates, and API/rule findings

## Result

The historical downstream 41--52% slowdown did not reproduce on the recorded source and tenferro pin:

| dtype | compact / BCGS2 at rows 64 / 128 / 256 |
| --- | --- |
| F64 | 0.496 / 0.437 / 0.505 |
| C64 | 0.579 / 0.551 / 0.613 |

End-to-end adaptive SRC measured 0.982 / 0.955 / 0.986 at bonds 32/64/128. Two candidate changes failed the need gate and are intentionally not included:

- downstream session fusion: -2.1%, -1.6%, +1.1%
- existing block inverse-adjoint updater: 27--44% slower

The useful change is therefore the regression benchmark, not an unproven API or kernel optimization. A long-term suite follow-up is tracked in tensor4all/tenferro-benchmark#94.

## Verification

- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-linalg --test integration small_append_benchmark_pins_issue_1750_workflow'`
- F64 and C64 release smoke runs with reconstruction and orthogonality evidence
- seven-process, alternating-order benchmark runs for every lane and row count; maximum process-median CoV < 7.4%
- downstream adapter and adaptive SRC paired A/B reruns
- repository-rules review: pass

## Review gate

- design: `docs/design/incremental-householder-qr-small-append-performance.md`, reviewed before implementation; final verdict `Correct-to-merge`
- full diff: read-only cross-model `reviewer-flash` closure review; final verdict `Correct-to-merge`
- non-blocking review hardening applied: C64 conjugation and schema are pinned by the source-contract test; downstream A/B CoV is recorded

Closes #1750
