### PR TITLE
Fix eager extension dispatch for runtime placement

### DIFF
--- a/crates/tenferro-einsum/src/eager_ad.rs
+++ b/crates/tenferro-einsum/src/eager_ad.rs
@@ -4,19 +4,27 @@ use std::collections::hash_map::DefaultHasher;
 use std::error::Error as StdError;
 use std::hash::{Hash, Hasher};
 use std::mem::size_of;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use computegraph::compile::{compile, CompiledProgram, Instruction};
 use computegraph::graph::GraphBuilder;
 use computegraph::materialize::materialize_merge;
 use computegraph::resolve::resolve;
 use computegraph::types::{ValueKey, ValueRef};
-use tenferro_ad::extension::{adopt_untracked_eager_value, apply_eager_with_extension_session};
+use tenferro_ad::extension::{
+    adopt_untracked_eager_value, apply_eager_with_targeted_extension_session,
+    EagerExtensionBackendKind, EagerExtensionTarget,
+};
 use tenferro_ad::{EagerRuntime, EagerTensor};
+use tenferro_cpu::CpuBackend;
+#[cfg(feature = "cuda")]
+use tenferro_gpu::cuda::CudaBackend;
+#[cfg(feature = "webgpu")]
+use tenferro_gpu::webgpu::WebGpuBackend;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_runtime::{ErrorPhase, ExtensionCacheKey};
+use tenferro_runtime::{ErrorPhase, ExtensionCacheKey, ExtensionModule};
 use tenferro_tensor::{ErrorKind, ShapeMismatch, Tensor, ValidationError, ValidationKind};
 
 use crate::binary_dot::{try_build_exact_output_binary_dot_plan, BinaryDotOperandOrder};
@@ -74,30 +82,39 @@ pub trait EagerEinsumExt {
     fn einsum_subscripts(&self, subscripts: &EinsumSubscripts) -> Result<EagerTensor>;
 }
 
-fn eager_cpu_extension_module(
-) -> tenferro_runtime::Result<Arc<dyn tenferro_runtime::ExtensionModule>> {
-    static MODULE: OnceLock<Arc<dyn tenferro_runtime::ExtensionModule>> = OnceLock::new();
-    if let Some(module) = MODULE.get() {
-        return Ok(Arc::clone(module));
+fn eager_extension_module(
+    target: EagerExtensionTarget,
+) -> tenferro_runtime::Result<Arc<dyn ExtensionModule>> {
+    let EagerExtensionTarget {
+        engine_id,
+        backend_kind,
+    } = target;
+    match backend_kind {
+        EagerExtensionBackendKind::Cpu => {
+            crate::extension::extension_module::<CpuBackend>(engine_id)
+                .map_err(eager_runtime_config_error)
+        }
+        #[cfg(feature = "cuda")]
+        EagerExtensionBackendKind::Cuda => {
+            crate::extension::extension_module::<CudaBackend>(engine_id)
+                .map_err(eager_runtime_config_error)
+        }
+        #[cfg(feature = "webgpu")]
+        EagerExtensionBackendKind::WebGpu => {
+            crate::extension::extension_module::<WebGpuBackend>(engine_id)
+                .map_err(eager_runtime_config_error)
+        }
     }
+}
 
-    let engine_id = tenferro_cpu::runtime_engine_id().map_err(|source| {
-        tenferro_runtime::Error::runtime_state_source(
-            "tenferro_einsum::eager_extension_module",
-            ErrorPhase::Execution,
-            source,
-        )
-    })?;
-    let module = crate::extension::extension_module::<tenferro_cpu::CpuBackend>(engine_id)
-        .map_err(|source| {
-            tenferro_runtime::Error::runtime_state_source(
-                "tenferro_einsum::eager_extension_module",
-                ErrorPhase::Execution,
-                source,
-            )
-        })?;
-    let _ = MODULE.set(Arc::clone(&module));
-    Ok(MODULE.get().cloned().unwrap_or(module))
+fn eager_runtime_config_error(
+    source: tenferro_runtime::RuntimeConfigError,
+) -> tenferro_runtime::Error {
+    tenferro_runtime::Error::runtime_state_source(
+        "tenferro_einsum::eager_extension_module",
+        ErrorPhase::Execution,
+        source,
+    )
 }
 
 impl EagerEinsumExt for [&EagerTensor] {
@@ -271,7 +288,7 @@ fn einsum_subscripts_with_broadcast(
         EinsumExtensionOp::with_output_shape_hint(subscripts.clone(), output_shape_hint, plan_spec)
     });
     let mut outputs =
-        apply_eager_with_extension_session(op, inputs, eager_cpu_extension_module()?)?;
+        apply_eager_with_targeted_extension_session(op, inputs, eager_extension_module)?;
     outputs.pop().ok_or_else(|| {
         Error::Runtime(tenferro_runtime::Error::MissingInput(
             "einsum extension produced no eager output".into(),

--- a/crates/tenferro-einsum/tests/integration.rs
+++ b/crates/tenferro-einsum/tests/integration.rs
@@ -1,3 +1,5 @@
+#[path = "integration/cuda_eager_tensor.rs"]
+mod cuda_eager_tensor;
 #[path = "integration/eager_tensor.rs"]
 mod eager_tensor;
 #[path = "integration/error_public.rs"]

--- a/crates/tenferro-einsum/tests/integration/cuda_eager_tensor.rs
+++ b/crates/tenferro-einsum/tests/integration/cuda_eager_tensor.rs
@@ -1,0 +1,39 @@
+#![cfg(all(feature = "autodiff", feature = "cuda"))]
+
+use tenferro_ad::{EagerRuntime, EagerTensor};
+use tenferro_einsum::EagerEinsumExt;
+use tenferro_gpu::cuda::{
+    download_tensor, gpu_available, upload_tensor, CudaBackend, CudaDeviceId,
+};
+use tenferro_runtime::Tensor;
+
+#[test]
+#[ignore]
+fn cuda_eager_three_operand_einsum_stays_resident() {
+    if !gpu_available() {
+        eprintln!("skipping CUDA eager einsum test: no CUDA device");
+        return;
+    }
+
+    let backend = CudaBackend::new(CudaDeviceId::from_ordinal(0)).unwrap();
+    let runtime = EagerRuntime::with_cuda_backend(backend.clone()).unwrap();
+    let make_input = |shape: Vec<usize>, values: Vec<f64>| {
+        let host = Tensor::from_vec_col_major(shape, values).unwrap();
+        let device = upload_tensor(backend.runtime(), &host).unwrap();
+        EagerTensor::from_tensor_in(device, runtime.clone()).unwrap()
+    };
+    let lhs = make_input(vec![2, 2, 2], vec![1.0; 8]);
+    let middle = make_input(vec![2, 2, 2], vec![1.0; 8]);
+    let rhs = make_input(vec![2, 2, 2], vec![1.0; 8]);
+
+    // Three operands force the general extension path rather than the direct
+    // binary-dot path.
+    let output = [&lhs, &middle, &rhs].einsum("bij,bjk,bkl->bil").unwrap();
+
+    assert_eq!(output.runtime().id(), runtime.id());
+    assert_eq!(output.shape(), &[2, 2, 2]);
+    let resident = output.to_tensor().unwrap();
+    assert!(resident.as_slice::<f64>().is_err());
+    let host = download_tensor(backend.runtime(), &resident).unwrap();
+    assert_eq!(host.as_slice::<f64>().unwrap(), &[4.0; 8]);
+}

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -1,8 +1,15 @@
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use tenferro_ad::error::{Error, Result};
-use tenferro_ad::extension::apply_eager_with_extension_session;
+use tenferro_ad::extension::{
+    apply_eager_with_targeted_extension_session, EagerExtensionBackendKind, EagerExtensionTarget,
+};
 use tenferro_ad::EagerTensor;
+use tenferro_cpu::CpuBackend;
+#[cfg(feature = "cuda")]
+use tenferro_gpu::cuda::CudaBackend;
+#[cfg(feature = "webgpu")]
+use tenferro_gpu::webgpu::WebGpuBackend;
 use tenferro_runtime::{ErrorPhase, ExtensionModule};
 
 use crate::eager_composites;
@@ -751,20 +758,27 @@ pub(crate) fn apply_linalg_eager(
     inputs: &[&EagerTensor],
 ) -> Result<Vec<EagerTensor>> {
     let op = Arc::new(LinalgExtensionOp::new(op));
-    apply_eager_with_extension_session(op, inputs, eager_cpu_extension_module()?)
+    apply_eager_with_targeted_extension_session(op, inputs, eager_extension_module)
 }
 
-fn eager_cpu_extension_module() -> Result<Arc<dyn ExtensionModule>> {
-    static MODULE: OnceLock<Arc<dyn ExtensionModule>> = OnceLock::new();
-    if let Some(module) = MODULE.get() {
-        return Ok(Arc::clone(module));
+fn eager_extension_module(target: EagerExtensionTarget) -> Result<Arc<dyn ExtensionModule>> {
+    let EagerExtensionTarget {
+        engine_id,
+        backend_kind,
+    } = target;
+    match backend_kind {
+        EagerExtensionBackendKind::Cpu => {
+            extension_module::<CpuBackend>(engine_id).map_err(eager_runtime_config_error)
+        }
+        #[cfg(feature = "cuda")]
+        EagerExtensionBackendKind::Cuda => {
+            extension_module::<CudaBackend>(engine_id).map_err(eager_runtime_config_error)
+        }
+        #[cfg(feature = "webgpu")]
+        EagerExtensionBackendKind::WebGpu => {
+            extension_module::<WebGpuBackend>(engine_id).map_err(eager_runtime_config_error)
+        }
     }
-
-    let engine_id = tenferro_cpu::runtime_engine_id().map_err(eager_runtime_config_error)?;
-    let module = extension_module::<tenferro_cpu::CpuBackend>(engine_id)
-        .map_err(eager_runtime_config_error)?;
-    let _ = MODULE.set(Arc::clone(&module));
-    Ok(MODULE.get().cloned().unwrap_or(module))
 }
 
 fn eager_runtime_config_error(source: tenferro_runtime::RuntimeConfigError) -> Error {

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -271,6 +271,7 @@ pub(crate) fn validate_derivative_eps(
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[doc(hidden)]
+#[allow(dead_code)]
 pub(crate) enum LinalgOp {
     Cholesky,
     Lu,

--- a/crates/tenferro-linalg/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-linalg/tests/integration/eager_tensor.rs
@@ -1156,15 +1156,131 @@ fn cuda_eager_solve_uses_registered_linalg_runtime() {
         CudaBackend::new(tenferro_gpu::cuda::CudaDeviceId::from_ordinal(0)).unwrap();
     let a_gpu = upload_tensor(upload_backend.runtime(), &a_host).unwrap();
     let b_gpu = upload_tensor(upload_backend.runtime(), &b_host).unwrap();
-    let ctx = EagerRuntime::with_cuda_backend(upload_backend).unwrap();
+    let ctx = EagerRuntime::with_cuda_backend(upload_backend.clone()).unwrap();
     let a = EagerTensor::from_tensor_in(a_gpu, ctx.clone()).unwrap();
     let b = EagerTensor::from_tensor_in(b_gpu, ctx).unwrap();
 
     let x = a.solve(&b).unwrap();
 
-    let download_backend =
-        CudaBackend::new(tenferro_gpu::cuda::CudaDeviceId::from_ordinal(0)).unwrap();
-    let x_host = download_tensor(download_backend.runtime(), &x.to_tensor().unwrap()).unwrap();
+    let x_host = download_tensor(upload_backend.runtime(), &x.to_tensor().unwrap()).unwrap();
     assert_eq!(x_host.shape(), &[2, 1]);
     assert_close_slice(f64_data(&x_host), &[1.8, -0.4], 1.0e-9);
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore]
+fn cuda_eager_qr_and_svd_f64_stay_resident_and_reconstruct() {
+    if !gpu_available() {
+        eprintln!("skipping CUDA eager f64 decomposition test: no CUDA device");
+        return;
+    }
+
+    let expected = [1.0_f64, 3.0, 2.0, 4.0];
+    let host = Tensor::from_vec_col_major(vec![2, 2], expected.to_vec()).unwrap();
+    let backend = CudaBackend::new(tenferro_gpu::cuda::CudaDeviceId::from_ordinal(0)).unwrap();
+    let device = upload_tensor(backend.runtime(), &host).unwrap();
+    let runtime = EagerRuntime::with_cuda_backend(backend.clone()).unwrap();
+    let input = EagerTensor::from_tensor_in(device, runtime.clone()).unwrap();
+
+    let (q, r) = input.qr().unwrap();
+    let (u, s, vt) = input.svd().unwrap();
+    for output in [&q, &r, &u, &s, &vt] {
+        assert_eq!(output.runtime().id(), runtime.id());
+        assert!(output.to_tensor().unwrap().as_slice::<f64>().is_err());
+    }
+
+    let download = |output: &EagerTensor| {
+        download_tensor(backend.runtime(), &output.to_tensor().unwrap()).unwrap()
+    };
+    let q = download(&q);
+    let r = download(&r);
+    let u = download(&u);
+    let s = download(&s);
+    let vt = download(&vt);
+    let qr = matmul_2x2_f64(f64_data(&q), f64_data(&r));
+    let mut us = f64_data(&u).to_vec();
+    for col in 0..2 {
+        for row in 0..2 {
+            us[row + 2 * col] *= f64_data(&s)[col];
+        }
+    }
+    let usvt = matmul_2x2_f64(&us, f64_data(&vt));
+    assert_close_slice(&qr, &expected, 1.0e-9);
+    assert_close_slice(&usvt, &expected, 1.0e-9);
+}
+
+#[cfg(feature = "cuda")]
+fn matmul_2x2_f64(lhs: &[f64], rhs: &[f64]) -> Vec<f64> {
+    (0..4)
+        .map(|linear| {
+            let row = linear % 2;
+            let col = linear / 2;
+            (0..2).map(|k| lhs[row + 2 * k] * rhs[k + 2 * col]).sum()
+        })
+        .collect()
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore]
+fn cuda_eager_qr_and_svd_c64_stay_resident_and_reconstruct() {
+    if !gpu_available() {
+        eprintln!("skipping CUDA eager c64 decomposition test: no CUDA device");
+        return;
+    }
+
+    let expected = [
+        Complex64::new(1.0, 0.5),
+        Complex64::new(3.0, -0.5),
+        Complex64::new(2.0, -1.0),
+        Complex64::new(4.0, 0.25),
+    ];
+    let host = Tensor::from_vec_col_major(vec![2, 2], expected.to_vec()).unwrap();
+    let backend = CudaBackend::new(tenferro_gpu::cuda::CudaDeviceId::from_ordinal(0)).unwrap();
+    let device = upload_tensor(backend.runtime(), &host).unwrap();
+    let runtime = EagerRuntime::with_cuda_backend(backend.clone()).unwrap();
+    let input = EagerTensor::from_tensor_in(device, runtime.clone()).unwrap();
+
+    let (q, r) = input.qr().unwrap();
+    let (u, s, vt) = input.svd().unwrap();
+    for output in [&q, &r, &u, &s, &vt] {
+        assert_eq!(output.runtime().id(), runtime.id());
+        let resident = output.to_tensor().unwrap();
+        assert!(match output.dtype() {
+            tenferro_tensor::DType::C64 => resident.as_slice::<Complex64>().is_err(),
+            tenferro_tensor::DType::F64 => resident.as_slice::<f64>().is_err(),
+            dtype => panic!("unexpected decomposition dtype {dtype:?}"),
+        });
+    }
+
+    let download = |output: &EagerTensor| {
+        download_tensor(backend.runtime(), &output.to_tensor().unwrap()).unwrap()
+    };
+    let q = download(&q);
+    let r = download(&r);
+    let u = download(&u);
+    let s = download(&s);
+    let vt = download(&vt);
+    let qr = matmul_2x2_c64(c64_data(&q), c64_data(&r));
+    let mut us = c64_data(&u).to_vec();
+    for col in 0..2 {
+        for row in 0..2 {
+            us[row + 2 * col] *= f64_data(&s)[col];
+        }
+    }
+    let usvt = matmul_2x2_c64(&us, c64_data(&vt));
+    assert_close_c64_slice(&qr, &expected, 1.0e-8);
+    assert_close_c64_slice(&usvt, &expected, 1.0e-8);
+}
+
+#[cfg(feature = "cuda")]
+fn matmul_2x2_c64(lhs: &[Complex64], rhs: &[Complex64]) -> Vec<Complex64> {
+    (0..4)
+        .map(|linear| {
+            let row = linear % 2;
+            let col = linear / 2;
+            (0..2).map(|k| lhs[row + 2 * k] * rhs[k + 2 * col]).sum()
+        })
+        .collect()
 }

--- a/docs/design/eager-extension-placement-dispatch.md
+++ b/docs/design/eager-extension-placement-dispatch.md
@@ -1,0 +1,136 @@
+# Placement-aware eager extension dispatch
+
+**Status:** Reviewed and approved for tenferro-rs #1752, a dependency of tensor4all-rs #720
+
+## Problem
+
+The eager einsum and linalg convenience APIs validate that all operands belong
+to one `EagerRuntime`, but then install an extension module specialized for
+`tenferro_cpu::CpuBackend` regardless of that runtime's actual backend.
+Consequently:
+
+- a non-direct CUDA eager einsum can enter a CPU extension session with device
+  operands and fail at the CPU placement boundary;
+- CUDA eager QR and SVD fail preparation with no eligible extension engine;
+- enabling CUDA features or proving direct CUDA-session kernels does not make
+  the eager extension surfaces CUDA-capable.
+
+On an NVIDIA A100, direct CUDA-session QR and SVD tests pass while the
+corresponding eager calls fail. This isolates the defect to eager extension
+module selection rather than the CUDA kernels.
+
+`tenferro-fft` already uses the intended seam:
+`apply_eager_with_targeted_extension_session` obtains the owning runtime's
+validated `EagerExtensionTarget`, and a module factory selects the matching
+backend module.
+
+## Scope
+
+Migrate eager extension dispatch in:
+
+- `tenferro-einsum` for the extension-backed N-ary/general einsum path;
+- `tenferro-linalg` for eager decomposition and solve operations.
+
+The change owns no tensor transfer and changes no numerical kernel. Inputs must
+already belong to one runtime and satisfy that runtime's placement contract.
+Outputs remain in the same runtime and placement.
+
+## Dispatch contract
+
+Each eager operation delegates to
+`apply_eager_with_targeted_extension_session`. The module factory matches the
+validated target:
+
+- CPU target -> `extension_module::<CpuBackend>(engine_id)`;
+- CUDA target, under `cuda` -> `extension_module::<CudaBackend>(engine_id)`;
+- WebGPU target, under `webgpu`, only for an operation family with an actual
+  WebGPU session implementation -> `extension_module::<WebGpuBackend>(engine_id)`;
+- a compiled target without an implementation returns a typed unsupported
+  error before execution.
+
+Backend modules may be retained in one process-wide immutable `OnceLock` per
+backend family because they contain extension registration metadata, not a
+backend, device allocation, execution context, stream, or mutable cache. The
+runtime remains the owner of backend state and extension caches. The cached
+module must be keyed strongly enough that adding nonzero-device engine IDs in
+the future cannot reuse incompatible registration metadata; if engine IDs vary
+by device, cache per engine ID or avoid the global cache.
+
+The selected module must match the runtime target. There is no CPU fallback,
+implicit upload/download, host materialization, or fresh backend construction.
+Mixed eager contexts continue to fail in the existing input validation before
+module selection.
+
+## Feature behavior
+
+CPU-only builds keep their current behavior and do not compile GPU types.
+CUDA and WebGPU match arms remain feature-gated. Enabling multiple backend
+features is supported; runtime identity, not Cargo feature priority, selects
+the module.
+
+`tenferro-linalg` must not claim WebGPU operations that its session capability
+contract rejects. Such calls return the existing typed unsupported/runtime
+error. `tenferro-einsum` preserves its supported WebGPU eager path.
+
+## Tests
+
+### Hardware-independent
+
+- Existing CPU eager einsum and linalg suites remain green.
+- CPU-only, CUDA, WebGPU, and combined feature builds compile.
+- A source/behavior regression proves eager module selection is target-based,
+  not CPU-hardcoded.
+- Mixed eager contexts fail before extension installation.
+- Repeated calls reuse the runtime registration/cache rather than replacing a
+  module on every call.
+- Unsupported target/operation combinations preserve typed sources and never
+  execute on CPU.
+
+### CUDA hardware
+
+Using one CUDA `EagerRuntime`:
+
+- a three-operand einsum that cannot take the direct binary-dot path executes
+  and returns a CUDA-resident output;
+- eager QR reconstructs the input and returns CUDA-resident factors;
+- eager SVD reconstructs the input and returns CUDA-resident factors/values;
+- F32, F64, C32, and C64 coverage follows the existing direct CUDA-session
+  capability matrix;
+- host extraction fails before explicit download;
+- downloaded results match the direct-session/CPU reference within existing
+  tolerances;
+- no transfer or CPU backend call occurs inside the eager operation.
+
+## Performance gate
+
+Measure one warm-up followed by repeated small N-ary einsum, QR, and SVD calls
+on CPU and CUDA. The change must not add repeated extension-module replacement
+or backend construction to the steady-state path. Report setup, explicit
+transfer, warm-up/JIT, synchronized steady state, and explicit download
+separately. Numerical and residency assertions remain outside timed loops.
+
+## Non-goals
+
+- Changing the public eager operation vocabulary.
+- Adding CUDA kernels or silently emulating unsupported operations.
+- Changing tensor4all execution contexts or SRC.
+- Multi-GPU context construction, device selection, sharding, or transfer.
+- Making CUDA a default feature.
+- Changing AD rules or decomposition gauge/tolerance semantics.
+
+## Review gate
+
+- Reviewer: `reviewer-flash` (DeepSeek family, read-only)
+- Review round: pre-implementation design review
+- Verdict: **Correct-to-implement**
+- Evidence: the reviewer confirmed the CPU hard-coding in eager einsum/linalg,
+  the existing FFT targeted-dispatch seam, feature-gated backend matching, and
+  found no blocking issue in the dispatch, cache, no-fallback, or test design.
+
+## Downstream handoff
+
+After this change is merged, tensor4all-rs can update all tenferro pins together
+and implement its caller-owned, context-scoped intermediate construction seam.
+Tensor4all SRC must still explicitly construct probes/caps in the supplied
+context and validate all input/result residency; this tenferro change alone
+does not make SRC placement-aware.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -19,6 +19,7 @@ migration notes live under [Plans](../plans/), not this active design index.
 | [output-modes.md](./output-modes.md) | Output-update vocabulary for `_read`, `_into`, `_add_to`, and dot `_into_accum` surfaces |
 | [algebra.md](./algebra.md) | Algebra boundary, external numeric extensions, tropical paths |
 | [einsum.md](./einsum.md) | Einsum public API, N-ary contraction tree, algebra dispatch |
+| [eager-extension-placement-dispatch.md](./eager-extension-placement-dispatch.md) | Runtime-targeted eager einsum/linalg extension registration with no backend fallback or transfer |
 | [fft-backend-execution.md](./fft-backend-execution.md) | FFT backend capability, validated plan descriptors, no-fallback placement semantics, and backend-neutral cache ownership |
 | [contraction-pipeline.md](./contraction-pipeline.md) | Binary contraction pipeline, copy elision |
 | [dot-general-overhead.md](./dot-general-overhead.md) | Fixed-cost analysis for many small `dot_general` contractions |


### PR DESCRIPTION
Closes #1752

Fixes the eager einsum and linalg paths that unconditionally installed CPU extension modules for CUDA EagerRuntime values. Both now use EagerExtensionTarget and select CPU/CUDA/WebGPU modules by the owning runtime target, with no transfer or fallback.

Validation:
- cargo check -j 8 -p tenferro-einsum -p tenferro-linalg --all-targets
- cargo test -j 8 -p tenferro-einsum --test integration (25 passed)
- cargo test -j 8 -p tenferro-linalg --test integration (149 passed)
- CUDA A100: eager 3-operand einsum, QR/SVD F64+C64, solve, and existing CUDA linalg tests pass
- CUDA/WebGPU feature checks pass
- repository-rules review passes

Design: docs/design/eager-extension-placement-dispatch.md
Downstream: tensor4all-rs #720