### PR TITLE
Add CPU rank-revealing QR across tensor surfaces

### DIFF
--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -126,6 +126,10 @@ impl LinalgAdRule {
             LinalgOp::Qr { .. } => {
                 rules::linearize_qr(builder, primal_in, primal_out, tangent_in, ctx)
             }
+            LinalgOp::RankRevealingQr { .. } => Err(ADRuleError::unsupported(
+                "tenferro-linalg.rank_revealing_qr",
+                ADRuleKind::Jvp,
+            )),
             LinalgOp::Eigh { derivative_eps, .. } => rules::linearize_eigh(
                 builder,
                 primal_in,
@@ -265,6 +269,10 @@ impl LinalgAdRule {
             }
             LinalgOp::HouseholderQrThinQ { .. } => Err(ADRuleError::unsupported(
                 "tenferro-linalg.householder_qr_thin_q",
+                ADRuleKind::Transpose,
+            )),
+            LinalgOp::RankRevealingQr { .. } => Err(ADRuleError::unsupported(
+                "tenferro-linalg.rank_revealing_qr",
                 ADRuleKind::Transpose,
             )),
             LinalgOp::Cholesky

--- a/crates/tenferro-linalg/src/ad/support.rs
+++ b/crates/tenferro-linalg/src/ad/support.rs
@@ -104,10 +104,11 @@ pub enum LinalgAdOpKind {
     HouseholderQrThinQ,
     HouseholderQrAppendTangent,
     HouseholderQrSplitTangent,
+    RankRevealingQr,
 }
 
 impl LinalgAdOpKind {
-    pub const COUNT: usize = 25;
+    pub const COUNT: usize = 26;
 
     /// Return the manifest index for this operation kind.
     ///
@@ -145,6 +146,7 @@ impl LinalgAdOpKind {
             Self::HouseholderQrThinQ => 22,
             Self::HouseholderQrAppendTangent => 23,
             Self::HouseholderQrSplitTangent => 24,
+            Self::RankRevealingQr => 25,
         }
     }
 
@@ -167,6 +169,7 @@ impl LinalgAdOpKind {
             LinalgOp::SvdFull => Self::SvdFull,
             LinalgOp::SvdVals { .. } => Self::SvdVals,
             LinalgOp::Qr { .. } => Self::Qr,
+            LinalgOp::RankRevealingQr { .. } => Self::RankRevealingQr,
             LinalgOp::HouseholderQrFactor => Self::HouseholderQrFactor,
             LinalgOp::HouseholderQrFromFactors => Self::HouseholderQrFromFactors,
             LinalgOp::HouseholderQrAppend => Self::HouseholderQrAppend,
@@ -354,6 +357,12 @@ static SVD_FULL_OUTPUTS: [LinalgAdOutputSupport; 3] = [
 static QR_OUTPUTS: [LinalgAdOutputSupport; 2] = [
     output(0, "q", LinalgAdRuleSupport::SupportedViaLinearize),
     output(1, "r", LinalgAdRuleSupport::SupportedViaLinearize),
+];
+static RANK_REVEALING_QR_OUTPUTS: [LinalgAdOutputSupport; 4] = [
+    output(0, "q", LinalgAdRuleSupport::Unsupported),
+    output(1, "r", LinalgAdRuleSupport::Unsupported),
+    output(2, "column_permutation", LinalgAdRuleSupport::Unsupported),
+    output(3, "rank", LinalgAdRuleSupport::Unsupported),
 ];
 static HOUSEHOLDER_QR_STATE_OUTPUTS: [LinalgAdOutputSupport; 2] = [
     output(0, "packed", LinalgAdRuleSupport::SupportedViaLinearize),
@@ -686,6 +695,15 @@ static LINALG_AD_SUPPORT: [LinalgAdSupport; LinalgAdOpKind::COUNT] = [
         LinalgAdRuleSupport::Unsupported,
         &HOUSEHOLDER_QR_RESIDUAL_OUTPUTS,
         &["Internal transpose residual; no public differentiable surface."],
+    ),
+    support_entry(
+        LinalgAdOpKind::RankRevealingQr,
+        LinalgAdRuleSupport::Unsupported,
+        LinalgAdRuleSupport::Unsupported,
+        mode(LinalgAdRuleSupport::Unsupported, LinalgAdRoute::Unsupported),
+        LinalgAdRuleSupport::Unsupported,
+        &RANK_REVEALING_QR_OUTPUTS,
+        &["Pivot selection and numerical rank are discontinuous; all outputs are initially unsupported for AD."],
     ),
 ];
 

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -15,6 +15,7 @@ use crate::extension::{
     apply_eigh_gauge, apply_qr_gauge, apply_svd_gauge, validate_derivative_eps, EighOptions,
     QrOptions, SvdOptions,
 };
+use crate::RankRevealingQrOptions;
 
 /// Backend surface required by the linalg extension runtime.
 ///
@@ -457,6 +458,30 @@ pub trait LinalgBackend: BackendSession {
         let mut outputs = self.qr_read(input)?;
         apply_qr_gauge(options.gauge, &mut outputs)?;
         Ok(outputs)
+    }
+
+    #[doc(hidden)]
+    fn rank_revealing_qr(
+        &mut self,
+        _input: &Tensor,
+        _options: RankRevealingQrOptions,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Err(tenferro_tensor::Error::unsupported(
+            "rank_revealing_qr",
+            "backend does not implement rank-revealing QR",
+        ))
+    }
+
+    #[doc(hidden)]
+    fn rank_revealing_qr_read(
+        &mut self,
+        _input: TensorRead<'_>,
+        _options: RankRevealingQrOptions,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Err(tenferro_tensor::Error::unsupported(
+            "rank_revealing_qr",
+            "backend does not implement borrowed rank-revealing QR",
+        ))
     }
 
     #[doc(hidden)]

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -1,4 +1,6 @@
 use crate::backend::{unsupported_dtype, CompactQrResult, LinalgBackend};
+use crate::extension::apply_qr_gauge;
+use crate::rank_revealing_qr::validate_rank_revealing_qr_options;
 
 use super::linalg;
 
@@ -417,6 +419,41 @@ impl LinalgBackend for CpuExecSession<'_> {
             context.with_materialized_tensor_read(buffers, "qr", input, |input, buffers| {
                 qr_entered(provider, context, buffers, input)
             })
+        })
+    }
+
+    fn rank_revealing_qr(
+        &mut self,
+        input: &Tensor,
+        options: crate::RankRevealingQrOptions,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        validate_rank_revealing_qr_options("rank_revealing_qr", options)?;
+        ensure_host_tensor("rank_revealing_qr", input)?;
+        ensure_supported_linalg_dtype("rank_revealing_qr", input.dtype())?;
+        let provider = linalg_provider_kind(self.kind(), "rank_revealing_qr")?;
+        self.with_linalg_pool_fresh(|context, buffers| {
+            rank_revealing_qr_entered(provider, context, buffers, input, options)
+        })
+    }
+
+    fn rank_revealing_qr_read(
+        &mut self,
+        input: TensorRead<'_>,
+        options: crate::RankRevealingQrOptions,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        validate_rank_revealing_qr_options("rank_revealing_qr", options)?;
+        ensure_host_tensor_read("rank_revealing_qr", &input)?;
+        ensure_supported_linalg_dtype("rank_revealing_qr", input.dtype())?;
+        let provider = linalg_provider_kind(self.kind(), "rank_revealing_qr")?;
+        self.with_linalg_pool_fresh(move |context, buffers| {
+            context.with_materialized_tensor_read(
+                buffers,
+                "rank_revealing_qr",
+                input,
+                |input, buffers| {
+                    rank_revealing_qr_entered(provider, context, buffers, input, options)
+                },
+            )
         })
     }
 
@@ -1790,6 +1827,92 @@ fn qr_entered(
             }
         }
     }
+}
+
+fn rank_revealing_qr_entered(
+    provider: CpuLinalgProvider,
+    context: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    input: &Tensor,
+    options: crate::RankRevealingQrOptions,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    macro_rules! map_result {
+        ($result:expr, $variant:ident) => {{
+            $result.map(|result| {
+                vec![
+                    Tensor::$variant(result.q),
+                    Tensor::$variant(result.r),
+                    Tensor::I64(result.column_permutation),
+                    Tensor::I64(result.rank),
+                ]
+            })
+        }};
+    }
+    let mut outputs = match provider {
+        CpuLinalgProvider::Faer => {
+            #[cfg(feature = "cpu-faer")]
+            {
+                match input {
+                    Tensor::F32(t) => map_result!(
+                        linalg::faer::rank_revealing_qr(context, buffers, t, options),
+                        F32
+                    ),
+                    Tensor::F64(t) => map_result!(
+                        linalg::faer::rank_revealing_qr(context, buffers, t, options),
+                        F64
+                    ),
+                    Tensor::C32(t) => map_result!(
+                        linalg::faer::rank_revealing_qr(context, buffers, t, options),
+                        C32
+                    ),
+                    Tensor::C64(t) => map_result!(
+                        linalg::faer::rank_revealing_qr(context, buffers, t, options),
+                        C64
+                    ),
+                    _ => Err(unsupported_dtype("rank_revealing_qr", input.dtype())),
+                }
+            }
+            #[cfg(not(feature = "cpu-faer"))]
+            {
+                let _ = (context, buffers, input, options);
+                Err(unsupported_provider(
+                    "rank_revealing_qr",
+                    CpuBackendKind::Faer,
+                ))
+            }
+        }
+        CpuLinalgProvider::Blas => {
+            #[cfg(feature = "cpu-blas")]
+            {
+                let _ = context;
+                match input {
+                    Tensor::F32(t) => {
+                        map_result!(linalg::blas::rank_revealing_qr(buffers, t, options), F32)
+                    }
+                    Tensor::F64(t) => {
+                        map_result!(linalg::blas::rank_revealing_qr(buffers, t, options), F64)
+                    }
+                    Tensor::C32(t) => {
+                        map_result!(linalg::blas::rank_revealing_qr(buffers, t, options), C32)
+                    }
+                    Tensor::C64(t) => {
+                        map_result!(linalg::blas::rank_revealing_qr(buffers, t, options), C64)
+                    }
+                    _ => Err(unsupported_dtype("rank_revealing_qr", input.dtype())),
+                }
+            }
+            #[cfg(not(feature = "cpu-blas"))]
+            {
+                let _ = (context, buffers, input, options);
+                Err(unsupported_provider(
+                    "rank_revealing_qr",
+                    CpuBackendKind::Blas,
+                ))
+            }
+        }
+    }?;
+    apply_qr_gauge(options.gauge, &mut outputs[..2])?;
+    Ok(outputs)
 }
 
 fn householder_qr_entered(

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -17,6 +17,8 @@ pub(crate) trait FaerLinalg:
     type Real: Copy + Clone + PoolScalar;
 
     fn parity_one() -> Self;
+    fn is_finite(self) -> bool;
+    fn magnitude(self) -> f64;
     fn compact_factor_data(
         ctx: &CpuExecutionContext<'_>,
         data: &mut [Self],
@@ -143,6 +145,12 @@ pub(crate) trait FaerLinalg:
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
+    fn rank_revealing_qr_2d(
+        ctx: &CpuExecutionContext<'_>,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+        options: crate::RankRevealingQrOptions,
+    ) -> tenferro_tensor::Result<super::rank_revealing_qr::TypedRrqr<Self>>;
     fn eigh_2d(
         ctx: &CpuExecutionContext<'_>,
         buffers: &mut BufferPool,
@@ -1513,6 +1521,14 @@ macro_rules! impl_faer_linalg_for_real {
         1.0
     }
 
+    fn is_finite(self) -> bool {
+        self.is_finite()
+    }
+
+    fn magnitude(self) -> f64 {
+        self.abs() as f64
+    }
+
     fn compact_factor_data(
         ctx: &CpuExecutionContext<'_>,
         data: &mut [Self],
@@ -2163,6 +2179,92 @@ macro_rules! impl_faer_linalg_for_real {
         Self::qr_core(ctx, buffers, mat, m, n, input.placement())
     }
 
+    fn rank_revealing_qr_2d(
+        ctx: &CpuExecutionContext<'_>,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+        options: crate::RankRevealingQrOptions,
+    ) -> tenferro_tensor::Result<super::rank_revealing_qr::TypedRrqr<Self>> {
+        let (m, n) = matrix_dims(input, "rank_revealing_qr")?;
+        let k = m.min(n);
+        let block_size =
+            faer::linalg::qr::no_pivoting::factor::recommended_block_size::<Self>(m, n);
+        let mut qr = Mat::zeros(m, n);
+        qr.copy_from(Self::faer_mat_ref_compact(input.host_data()?, m, n));
+        let mut coeff = Mat::zeros(block_size, k);
+        let mut permutation = vec![0usize; n];
+        let mut inverse_permutation = vec![0usize; n];
+        // Following faer 0.24's public column-pivoted QR factor API; the
+        // provider's forward permutation is the public gather convention.
+        let mut mem = MemBuffer::new(
+            faer::linalg::qr::col_pivoting::factor::qr_in_place_scratch::<usize, Self>(
+                m,
+                n,
+                block_size,
+                ctx.faer_parallelism(),
+                Default::default(),
+            ),
+        );
+        faer::linalg::qr::col_pivoting::factor::qr_in_place(
+            qr.as_mut(),
+            coeff.as_mut(),
+            &mut permutation,
+            &mut inverse_permutation,
+            ctx.faer_parallelism(),
+            MemStack::new(&mut mem),
+            Default::default(),
+        );
+        let mut q = Mat::identity(m, k);
+        let mut mem = MemBuffer::new(
+            faer::linalg::householder::apply_block_householder_sequence_on_the_left_in_place_scratch::<Self>(
+                m,
+                block_size,
+                k,
+            ),
+        );
+        faer::linalg::householder::apply_block_householder_sequence_on_the_left_in_place_with_conj(
+            qr.as_ref().subcols(0, k),
+            coeff.as_ref(),
+            Conj::No,
+            q.as_mut(),
+            ctx.faer_parallelism(),
+            MemStack::new(&mut mem),
+        );
+        let rank = super::rank_revealing_qr::prefix_rank(
+            (0..k).map(|index| qr[(index, index)].abs() as f64),
+            options,
+        )?;
+        let permutation = permutation
+            .into_iter()
+            .map(|column| {
+                i64::try_from(column).map_err(|_| {
+                    invalid_config(
+                        "rank_revealing_qr",
+                        "column permutation exceeds i64 range",
+                    )
+                })
+            })
+            .collect::<tenferro_tensor::Result<Vec<_>>>()?;
+        Ok(crate::RankRevealingQrResult {
+            q: tensor_from_vec_with_template(
+                vec![m, k],
+                col_major_vec_from_mat(buffers, q.as_ref())?,
+                input.placement(),
+            )?,
+            r: tensor_from_vec_with_template(
+                vec![k, n],
+                upper_triangle_vec_from_mat(qr.as_ref().get(..k, ..))?,
+                input.placement(),
+            )?,
+            column_permutation: tensor_from_vec_with_template(
+                vec![n],
+                permutation,
+                input.placement(),
+            )?,
+            rank: tensor_from_vec_with_template(vec![], vec![rank], input.placement())?,
+        })
+    }
+
     fn eigh_2d(
         ctx: &CpuExecutionContext<'_>,
         buffers: &mut BufferPool,
@@ -2411,6 +2513,14 @@ macro_rules! impl_faer_linalg_for_complex {
 
     fn parity_one() -> Self {
         <$complex>::new(1.0, 0.0)
+    }
+
+    fn is_finite(self) -> bool {
+        self.re.is_finite() && self.im.is_finite()
+    }
+
+    fn magnitude(self) -> f64 {
+        self.norm() as f64
     }
 
     fn compact_factor_data(
@@ -3159,6 +3269,107 @@ macro_rules! impl_faer_linalg_for_complex {
         Self::qr_core(ctx, buffers, mat, m, n, input.placement())
     }
 
+    fn rank_revealing_qr_2d(
+        ctx: &CpuExecutionContext<'_>,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+        options: crate::RankRevealingQrOptions,
+    ) -> tenferro_tensor::Result<super::rank_revealing_qr::TypedRrqr<Self>> {
+        let (m, n) = matrix_dims(input, "rank_revealing_qr")?;
+        let k = m.min(n);
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, m, n);
+        // SAFETY: the compile-time layout checks in impl_complex_faer_casts
+        // prove Self and faer's complex scalar have identical representation.
+        let mat: MatRef<'_, $faer_complex> = unsafe {
+            MatRef::from_raw_parts(
+                mat.as_ptr().cast::<$faer_complex>(),
+                m,
+                n,
+                mat.row_stride(),
+                mat.col_stride(),
+            )
+        };
+        let block_size =
+            faer::linalg::qr::no_pivoting::factor::recommended_block_size::<$faer_complex>(m, n);
+        let mut qr = Mat::zeros(m, n);
+        qr.copy_from(mat);
+        let mut coeff = Mat::zeros(block_size, k);
+        let mut permutation = vec![0usize; n];
+        let mut inverse_permutation = vec![0usize; n];
+        // Following faer 0.24's public column-pivoted QR factor API; the
+        // provider's forward permutation is the public gather convention.
+        let mut mem = MemBuffer::new(
+            faer::linalg::qr::col_pivoting::factor::qr_in_place_scratch::<usize, $faer_complex>(
+                m,
+                n,
+                block_size,
+                ctx.faer_parallelism(),
+                Default::default(),
+            ),
+        );
+        faer::linalg::qr::col_pivoting::factor::qr_in_place(
+            qr.as_mut(),
+            coeff.as_mut(),
+            &mut permutation,
+            &mut inverse_permutation,
+            ctx.faer_parallelism(),
+            MemStack::new(&mut mem),
+            Default::default(),
+        );
+        let mut q = Mat::identity(m, k);
+        let mut mem = MemBuffer::new(
+            faer::linalg::householder::apply_block_householder_sequence_on_the_left_in_place_scratch::<$faer_complex>(
+                m,
+                block_size,
+                k,
+            ),
+        );
+        faer::linalg::householder::apply_block_householder_sequence_on_the_left_in_place_with_conj(
+            qr.as_ref().subcols(0, k),
+            coeff.as_ref(),
+            Conj::No,
+            q.as_mut(),
+            ctx.faer_parallelism(),
+            MemStack::new(&mut mem),
+        );
+        let rank = super::rank_revealing_qr::prefix_rank(
+            (0..k).map(|index| {
+                let value = qr[(index, index)];
+                (value.re as f64).hypot(value.im as f64)
+            }),
+            options,
+        )?;
+        let permutation = permutation
+            .into_iter()
+            .map(|column| {
+                i64::try_from(column).map_err(|_| {
+                    invalid_config(
+                        "rank_revealing_qr",
+                        "column permutation exceeds i64 range",
+                    )
+                })
+            })
+            .collect::<tenferro_tensor::Result<Vec<_>>>()?;
+        Ok(crate::RankRevealingQrResult {
+            q: tensor_from_vec_with_template(
+                vec![m, k],
+                $vec_from_mat(buffers, q.as_ref())?,
+                input.placement(),
+            )?,
+            r: tensor_from_vec_with_template(
+                vec![k, n],
+                $matrix_from_predicate(qr.as_ref(), k, n, |row, col| row <= col)?,
+                input.placement(),
+            )?,
+            column_permutation: tensor_from_vec_with_template(
+                vec![n],
+                permutation,
+                input.placement(),
+            )?,
+            rank: tensor_from_vec_with_template(vec![], vec![rank], input.placement())?,
+        })
+    }
+
     fn eigh_2d(
         ctx: &CpuExecutionContext<'_>,
         buffers: &mut BufferPool,
@@ -3892,6 +4103,31 @@ pub(crate) fn qr<T: FaerLinalg>(
     }
     batched_multi_result("qr", buffers, input, 2, |buffers, batch| {
         T::qr_2d(ctx, buffers, batch)
+    })
+}
+
+pub(crate) fn rank_revealing_qr<T: FaerLinalg>(
+    ctx: &CpuExecutionContext<'_>,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+    options: crate::RankRevealingQrOptions,
+) -> tenferro_tensor::Result<super::rank_revealing_qr::TypedRrqr<T>> {
+    crate::rank_revealing_qr::validate_rank_revealing_qr_options("rank_revealing_qr", options)?;
+    super::rank_revealing_qr::batched(buffers, input, |buffers, batch| {
+        let data = batch.host_data()?;
+        if data.iter().any(|&value| !value.is_finite()) {
+            return Err(crate::error::into_tensor_error(
+                "rank_revealing_qr",
+                crate::Error::NonFinite {
+                    op: "rank_revealing_qr",
+                    role: "input",
+                },
+            ));
+        }
+        if data.iter().all(|&value| value.magnitude() == 0.0) {
+            return super::rank_revealing_qr::zero_matrix_result(batch, T::one());
+        }
+        T::rank_revealing_qr_2d(ctx, buffers, batch, options)
     })
 }
 

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg.rs
@@ -19,7 +19,7 @@ pub(crate) use lu::{lu, lu_factor};
 pub(crate) use qr::{
     append_2d as householder_qr_append, compact_factor_2d as householder_qr,
     from_factors_2d as householder_qr_from_factors, q_columns_2d as householder_qr_q_columns, qr,
-    raw_r_2d as householder_qr_r,
+    rank_revealing_qr, raw_r_2d as householder_qr_r,
 };
 pub(crate) use solve::{solve, solve_from_views, solve_into};
 pub(crate) use svd::{svd, svd_values};

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr.rs
@@ -877,6 +877,302 @@ impl_complex_qr!(
     "zunmqr"
 );
 
+pub(crate) trait LapackRankRevealingQr: LapackQr {
+    fn is_finite(self) -> bool;
+    fn magnitude(self) -> f64;
+    fn geqp3(
+        buffers: &mut BufferPool,
+        data: &mut [Self],
+        rows: usize,
+        cols: usize,
+        permutation: &mut [i32],
+        tau: &mut [Self],
+    ) -> tenferro_tensor::Result<()>;
+    fn generate_q(
+        buffers: &mut BufferPool,
+        q: &mut [Self],
+        rows: usize,
+        cols: usize,
+        tau: &[Self],
+    ) -> tenferro_tensor::Result<()>;
+}
+
+macro_rules! impl_real_rank_revealing_qr {
+    ($scalar:ty, $geqp3:path, $orgqr:path, $geqp3_name:literal, $orgqr_name:literal) => {
+        impl LapackRankRevealingQr for $scalar {
+            fn is_finite(self) -> bool {
+                self.is_finite()
+            }
+
+            fn magnitude(self) -> f64 {
+                self.abs() as f64
+            }
+
+            fn geqp3(
+                buffers: &mut BufferPool,
+                data: &mut [Self],
+                rows: usize,
+                cols: usize,
+                permutation: &mut [i32],
+                tau: &mut [Self],
+            ) -> tenferro_tensor::Result<()> {
+                let m = dim_i32(rows, "rank_revealing_qr")?;
+                let n = dim_i32(cols, "rank_revealing_qr")?;
+                let mut query = [0.0 as $scalar];
+                let mut info = 0;
+                // SAFETY: all matrix, pivot, tau, and query lengths follow the
+                // checked LAPACK dimensions; lwork=-1 writes only query[0].
+                unsafe {
+                    $geqp3(m, n, data, m, permutation, tau, &mut query, -1, &mut info);
+                }
+                check_lapack_info(
+                    "rank_revealing_qr",
+                    concat!($geqp3_name, "(work query)"),
+                    info,
+                )?;
+                let lwork = work_len(query[0] as f64, "rank_revealing_qr", $geqp3_name)?;
+                let mut work = buffers.acquire_zeroed::<$scalar>(lwork as usize);
+                // SAFETY: dimensions and workspace were validated by the
+                // successful query; all mutable buffers are live and disjoint.
+                unsafe {
+                    $geqp3(m, n, data, m, permutation, tau, &mut work, lwork, &mut info);
+                }
+                <$scalar as PoolScalar>::pool_release(buffers, work);
+                check_lapack_info("rank_revealing_qr", $geqp3_name, info)
+            }
+
+            fn generate_q(
+                buffers: &mut BufferPool,
+                q: &mut [Self],
+                rows: usize,
+                cols: usize,
+                tau: &[Self],
+            ) -> tenferro_tensor::Result<()> {
+                let m = dim_i32(rows, "rank_revealing_qr")?;
+                let k = dim_i32(cols, "rank_revealing_qr")?;
+                let mut query = [0.0 as $scalar];
+                let mut info = 0;
+                // SAFETY: q is checked m-by-k column-major storage, tau has k
+                // entries, and lwork=-1 writes only query[0].
+                unsafe { $orgqr(m, k, k, q, m, tau, &mut query, -1, &mut info) };
+                check_lapack_info(
+                    "rank_revealing_qr",
+                    concat!($orgqr_name, "(work query)"),
+                    info,
+                )?;
+                let lwork = work_len(query[0] as f64, "rank_revealing_qr", $orgqr_name)?;
+                let mut work = buffers.acquire_zeroed::<$scalar>(lwork as usize);
+                // SAFETY: the successful query validated the dimensions and
+                // workspace; q, tau, work, and info remain live and disjoint.
+                unsafe { $orgqr(m, k, k, q, m, tau, &mut work, lwork, &mut info) };
+                <$scalar as PoolScalar>::pool_release(buffers, work);
+                check_lapack_info("rank_revealing_qr", $orgqr_name, info)
+            }
+        }
+    };
+}
+
+macro_rules! impl_complex_rank_revealing_qr {
+    ($complex:ty, $real:ty, $geqp3:path, $ungqr:path, $geqp3_name:literal, $ungqr_name:literal) => {
+        impl LapackRankRevealingQr for $complex {
+            fn is_finite(self) -> bool {
+                self.re.is_finite() && self.im.is_finite()
+            }
+
+            fn magnitude(self) -> f64 {
+                self.norm() as f64
+            }
+
+            fn geqp3(
+                buffers: &mut BufferPool,
+                data: &mut [Self],
+                rows: usize,
+                cols: usize,
+                permutation: &mut [i32],
+                tau: &mut [Self],
+            ) -> tenferro_tensor::Result<()> {
+                let m = dim_i32(rows, "rank_revealing_qr")?;
+                let n = dim_i32(cols, "rank_revealing_qr")?;
+                let rwork_len =
+                    checked_product("rank_revealing_qr", "GEQP3 real workspace", &[2, cols])?;
+                let mut rwork = buffers.acquire_zeroed::<$real>(rwork_len);
+                let mut query = [<$complex>::new(0.0, 0.0)];
+                let mut info = 0;
+                // SAFETY: all matrix, pivot, tau, real-work, and query lengths
+                // follow checked LAPACK dimensions; lwork=-1 writes query[0].
+                unsafe {
+                    $geqp3(
+                        m,
+                        n,
+                        data,
+                        m,
+                        permutation,
+                        tau,
+                        &mut query,
+                        -1,
+                        &mut rwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info(
+                    "rank_revealing_qr",
+                    concat!($geqp3_name, "(work query)"),
+                    info,
+                )?;
+                let lwork = work_len(query[0].re as f64, "rank_revealing_qr", $geqp3_name)?;
+                let mut work = buffers.acquire_zeroed::<$complex>(lwork as usize);
+                // SAFETY: dimensions and workspace were validated by the
+                // successful query; all mutable buffers are live and disjoint.
+                unsafe {
+                    $geqp3(
+                        m,
+                        n,
+                        data,
+                        m,
+                        permutation,
+                        tau,
+                        &mut work,
+                        lwork,
+                        &mut rwork,
+                        &mut info,
+                    );
+                }
+                <$complex as PoolScalar>::pool_release(buffers, work);
+                <$real as PoolScalar>::pool_release(buffers, rwork);
+                check_lapack_info("rank_revealing_qr", $geqp3_name, info)
+            }
+
+            fn generate_q(
+                buffers: &mut BufferPool,
+                q: &mut [Self],
+                rows: usize,
+                cols: usize,
+                tau: &[Self],
+            ) -> tenferro_tensor::Result<()> {
+                let m = dim_i32(rows, "rank_revealing_qr")?;
+                let k = dim_i32(cols, "rank_revealing_qr")?;
+                let mut query = [<$complex>::new(0.0, 0.0)];
+                let mut info = 0;
+                // SAFETY: q is checked m-by-k column-major storage, tau has k
+                // entries, and lwork=-1 writes only query[0].
+                unsafe { $ungqr(m, k, k, q, m, tau, &mut query, -1, &mut info) };
+                check_lapack_info(
+                    "rank_revealing_qr",
+                    concat!($ungqr_name, "(work query)"),
+                    info,
+                )?;
+                let lwork = work_len(query[0].re as f64, "rank_revealing_qr", $ungqr_name)?;
+                let mut work = buffers.acquire_zeroed::<$complex>(lwork as usize);
+                // SAFETY: the successful query validated the dimensions and
+                // workspace; q, tau, work, and info remain live and disjoint.
+                unsafe { $ungqr(m, k, k, q, m, tau, &mut work, lwork, &mut info) };
+                <$complex as PoolScalar>::pool_release(buffers, work);
+                check_lapack_info("rank_revealing_qr", $ungqr_name, info)
+            }
+        }
+    };
+}
+
+impl_real_rank_revealing_qr!(f32, lapack::sgeqp3, lapack::sorgqr, "sgeqp3", "sorgqr");
+impl_real_rank_revealing_qr!(f64, lapack::dgeqp3, lapack::dorgqr, "dgeqp3", "dorgqr");
+impl_complex_rank_revealing_qr!(
+    Complex32,
+    f32,
+    lapack::cgeqp3,
+    lapack::cungqr,
+    "cgeqp3",
+    "cungqr"
+);
+impl_complex_rank_revealing_qr!(
+    Complex64,
+    f64,
+    lapack::zgeqp3,
+    lapack::zungqr,
+    "zgeqp3",
+    "zungqr"
+);
+
+fn normalize_lapack_permutation(permutation: &[i32]) -> tenferro_tensor::Result<Vec<i64>> {
+    let n = permutation.len();
+    let mut seen = vec![false; n];
+    let mut normalized = Vec::with_capacity(n);
+    for &column in permutation {
+        let zero_based = column
+            .checked_sub(1)
+            .and_then(|value| usize::try_from(value).ok());
+        let Some(zero_based) = zero_based.filter(|&value| value < n && !seen[value]) else {
+            return Err(tenferro_tensor::Error::invalid_argument(
+                "rank_revealing_qr",
+                "column_permutation",
+                "LAPACK GEQP3 returned an invalid pivot permutation",
+            ));
+        };
+        seen[zero_based] = true;
+        normalized.push(i64::try_from(zero_based).map_err(|_| {
+            tenferro_tensor::Error::invalid_argument(
+                "rank_revealing_qr",
+                "column_permutation",
+                "column index exceeds i64 range",
+            )
+        })?);
+    }
+    Ok(normalized)
+}
+
+fn rank_revealing_qr_2d<T: LapackRankRevealingQr>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+    options: crate::RankRevealingQrOptions,
+) -> tenferro_tensor::Result<crate::cpu::linalg::rank_revealing_qr::TypedRrqr<T>> {
+    let (m, n) = matrix_dims(input, "rank_revealing_qr")?;
+    let k = m.min(n);
+    let input_data = input.host_data()?;
+    if input_data.iter().any(|&value| !value.is_finite()) {
+        return Err(crate::error::into_tensor_error(
+            "rank_revealing_qr",
+            crate::Error::NonFinite {
+                op: "rank_revealing_qr",
+                role: "input",
+            },
+        ));
+    }
+    if input_data.iter().all(|&value| value.magnitude() == 0.0) {
+        return crate::cpu::linalg::rank_revealing_qr::zero_matrix_result(input, T::one());
+    }
+
+    let mut qr = input_data.to_vec();
+    let mut permutation = vec![0_i32; n];
+    let mut tau = vec![T::default(); k];
+    T::geqp3(buffers, &mut qr, m, n, &mut permutation, &mut tau)?;
+    let r = leading_upper_triangle_from_lapack(&qr, m, k, n)?;
+    let rank = crate::cpu::linalg::rank_revealing_qr::prefix_rank(
+        (0..k).map(|index| r[index + index * k].magnitude()),
+        options,
+    )?;
+    let mut q = Vec::with_capacity(checked_product("rank_revealing_qr", "Q matrix", &[m, k])?);
+    for column in 0..k {
+        let start = column.checked_mul(m).ok_or_else(|| {
+            tenferro_tensor::Error::validation(
+                "rank_revealing_qr",
+                tenferro_tensor::ValidationError::IntegerOverflow,
+            )
+        })?;
+        q.extend_from_slice(&qr[start..start + m]);
+    }
+    T::generate_q(buffers, &mut q, m, k, &tau)?;
+
+    Ok(crate::RankRevealingQrResult {
+        q: tensor_from_vec_with_template(vec![m, k], q, input)?,
+        r: tensor_from_vec_with_template(vec![k, n], r, input)?,
+        column_permutation: tensor_from_vec_with_template(
+            vec![n],
+            normalize_lapack_permutation(&permutation)?,
+            input,
+        )?,
+        rank: tensor_from_vec_with_template(vec![], vec![rank], input)?,
+    })
+}
+
 fn qr_2d<T: LapackQr>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
@@ -907,6 +1203,17 @@ pub(crate) fn qr<T: LapackQr>(
         ]);
     }
     batched_multi("qr", buffers, input, qr_2d)
+}
+
+pub(crate) fn rank_revealing_qr<T: LapackRankRevealingQr>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+    options: crate::RankRevealingQrOptions,
+) -> tenferro_tensor::Result<crate::cpu::linalg::rank_revealing_qr::TypedRrqr<T>> {
+    crate::rank_revealing_qr::validate_rank_revealing_qr_options("rank_revealing_qr", options)?;
+    crate::cpu::linalg::rank_revealing_qr::batched(buffers, input, |buffers, batch| {
+        rank_revealing_qr_2d(buffers, batch, options)
+    })
 }
 
 #[cfg(test)]

--- a/crates/tenferro-linalg/src/cpu/linalg/mod.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/mod.rs
@@ -5,6 +5,8 @@ pub mod faer_linalg;
 #[cfg_attr(feature = "cpu-faer", allow(dead_code, unused_imports))]
 pub mod lapack_linalg;
 
+mod rank_revealing_qr;
+
 use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar, PooledUninitOutput};
 use tenferro_tensor::{TypedTensor, TypedTensorView};
 

--- a/crates/tenferro-linalg/src/cpu/linalg/rank_revealing_qr.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/rank_revealing_qr.rs
@@ -1,0 +1,240 @@
+use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar};
+use tenferro_tensor::{TensorScalar, TypedTensor};
+
+use crate::{RankRevealingQrOptions, RankRevealingQrResult};
+
+pub(crate) type TypedRrqr<T> = RankRevealingQrResult<TypedTensor<T>, TypedTensor<i64>>;
+
+pub(crate) fn prefix_rank(
+    diagonal_magnitudes: impl IntoIterator<Item = f64>,
+    options: RankRevealingQrOptions,
+) -> tenferro_tensor::Result<i64> {
+    let diagonal = diagonal_magnitudes.into_iter().collect::<Vec<_>>();
+    if diagonal.iter().any(|value| !value.is_finite()) {
+        return Err(crate::error::into_tensor_error(
+            "rank_revealing_qr",
+            crate::Error::NonFinite {
+                op: "rank_revealing_qr",
+                role: "R diagonal",
+            },
+        ));
+    }
+    let Some(&leading) = diagonal.first() else {
+        return Ok(0);
+    };
+    // A finite rtol times a finite leading magnitude can overflow to infinity;
+    // that means no diagonal clears the requested threshold, hence rank zero.
+    let threshold = options.atol.max(options.rtol * leading);
+    let rank = diagonal
+        .iter()
+        .take_while(|&&value| value > threshold)
+        .count();
+    i64::try_from(rank).map_err(|_| {
+        tenferro_tensor::Error::invalid_argument(
+            "rank_revealing_qr",
+            "rank",
+            "rank exceeds i64 range",
+        )
+    })
+}
+
+pub(crate) fn identity_permutation(n: usize) -> tenferro_tensor::Result<Vec<i64>> {
+    (0..n)
+        .map(|column| {
+            i64::try_from(column).map_err(|_| {
+                tenferro_tensor::Error::invalid_argument(
+                    "rank_revealing_qr",
+                    "column_permutation",
+                    "column index exceeds i64 range",
+                )
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn zero_matrix_result<T>(
+    input: &TypedTensor<T>,
+    one: T,
+) -> tenferro_tensor::Result<TypedRrqr<T>>
+where
+    T: Copy + Default + TensorScalar,
+{
+    let [m, n] = input.shape() else {
+        return Err(tenferro_tensor::Error::rank_mismatch(
+            "rank_revealing_qr",
+            2,
+            input.shape().len(),
+        ));
+    };
+    let k = (*m).min(*n);
+    let q_len = checked_product(&[*m, k], "Q")?;
+    let r_len = checked_product(&[k, *n], "R")?;
+    let mut q = vec![T::default(); q_len];
+    for diagonal in 0..k {
+        q[diagonal + diagonal * *m] = one;
+    }
+    Ok(RankRevealingQrResult {
+        q: tensor_with_template(vec![*m, k], q, input)?,
+        r: tensor_with_template(vec![k, *n], vec![T::default(); r_len], input)?,
+        column_permutation: tensor_with_template(vec![*n], identity_permutation(*n)?, input)?,
+        rank: tensor_with_template(vec![], vec![0_i64], input)?,
+    })
+}
+
+pub(crate) fn batched<T, F>(
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+    factor: F,
+) -> tenferro_tensor::Result<TypedRrqr<T>>
+where
+    T: Copy + Default + PoolScalar,
+    F: Fn(&mut BufferPool, &TypedTensor<T>) -> tenferro_tensor::Result<TypedRrqr<T>>,
+{
+    if input.shape().len() < 2 {
+        return Err(tenferro_tensor::Error::rank_mismatch(
+            "rank_revealing_qr",
+            2,
+            input.shape().len(),
+        ));
+    }
+    let m = input.shape()[0];
+    let n = input.shape()[1];
+    let k = m.min(n);
+    let batch_shape = &input.shape()[2..];
+    let batch_count = checked_product(batch_shape, "batch")?;
+    let matrix_len = checked_product(&[m, n], "input matrix")?;
+
+    if batch_shape.is_empty() {
+        return factor(buffers, input);
+    }
+    if batch_count == 0 {
+        return empty_batched_result(input, m, n, k, batch_shape);
+    }
+
+    let q_batch_len = checked_product(&[m, k], "Q batch")?;
+    let r_batch_len = checked_product(&[k, n], "R batch")?;
+    let mut q_data = Vec::with_capacity(checked_repeated(q_batch_len, batch_count, "Q")?);
+    let mut r_data = Vec::with_capacity(checked_repeated(r_batch_len, batch_count, "R")?);
+    let mut permutation_data = Vec::with_capacity(checked_repeated(n, batch_count, "permutation")?);
+    let mut rank_data = Vec::with_capacity(batch_count);
+
+    let input_data = input.host_data()?;
+    let mut batch_input =
+        tensor_with_template(vec![m, n], input_data[..matrix_len].to_vec(), input)?;
+    for batch_index in 0..batch_count {
+        if batch_index != 0 {
+            let start = batch_index.checked_mul(matrix_len).ok_or_else(overflow)?;
+            let end = start.checked_add(matrix_len).ok_or_else(overflow)?;
+            batch_input
+                .host_data_mut()?
+                .copy_from_slice(&input_data[start..end]);
+        }
+        let result = factor(buffers, &batch_input)?;
+        validate_core_shapes(&result, m, n, k)?;
+        q_data.extend_from_slice(result.q.host_data()?);
+        r_data.extend_from_slice(result.r.host_data()?);
+        permutation_data.extend_from_slice(result.column_permutation.host_data()?);
+        rank_data.extend_from_slice(result.rank.host_data()?);
+    }
+
+    Ok(RankRevealingQrResult {
+        q: tensor_with_template(matrix_shape(m, k, batch_shape), q_data, input)?,
+        r: tensor_with_template(matrix_shape(k, n, batch_shape), r_data, input)?,
+        column_permutation: tensor_with_template(
+            vector_shape(n, batch_shape),
+            permutation_data,
+            input,
+        )?,
+        rank: tensor_with_template(batch_shape.to_vec(), rank_data, input)?,
+    })
+}
+
+fn empty_batched_result<T: Copy + Default + TensorScalar>(
+    input: &TypedTensor<T>,
+    m: usize,
+    n: usize,
+    k: usize,
+    batch_shape: &[usize],
+) -> tenferro_tensor::Result<TypedRrqr<T>> {
+    Ok(RankRevealingQrResult {
+        q: tensor_with_template(matrix_shape(m, k, batch_shape), Vec::new(), input)?,
+        r: tensor_with_template(matrix_shape(k, n, batch_shape), Vec::new(), input)?,
+        column_permutation: tensor_with_template(vector_shape(n, batch_shape), Vec::new(), input)?,
+        rank: tensor_with_template(batch_shape.to_vec(), Vec::new(), input)?,
+    })
+}
+
+fn validate_core_shapes<T>(
+    result: &TypedRrqr<T>,
+    m: usize,
+    n: usize,
+    k: usize,
+) -> tenferro_tensor::Result<()> {
+    for (role, actual, expected) in [
+        ("Q", result.q.shape(), &[m, k][..]),
+        ("R", result.r.shape(), &[k, n][..]),
+        (
+            "column_permutation",
+            result.column_permutation.shape(),
+            &[n][..],
+        ),
+        ("rank", result.rank.shape(), &[][..]),
+    ] {
+        if actual != expected {
+            return Err(tenferro_tensor::Error::invalid_argument(
+                "rank_revealing_qr",
+                "provider output",
+                format!("{role} shape {actual:?} does not match {expected:?}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn tensor_with_template<T: Clone + TensorScalar, U>(
+    shape: Vec<usize>,
+    data: Vec<T>,
+    template: &TypedTensor<U>,
+) -> tenferro_tensor::Result<TypedTensor<T>> {
+    let mut tensor = TypedTensor::from_vec_col_major(shape, data)?;
+    tensor.set_placement(template.placement().clone());
+    Ok(tensor)
+}
+
+fn matrix_shape(rows: usize, cols: usize, batch: &[usize]) -> Vec<usize> {
+    let mut shape = vec![rows, cols];
+    shape.extend_from_slice(batch);
+    shape
+}
+
+fn vector_shape(len: usize, batch: &[usize]) -> Vec<usize> {
+    let mut shape = vec![len];
+    shape.extend_from_slice(batch);
+    shape
+}
+
+fn checked_product(shape: &[usize], role: &'static str) -> tenferro_tensor::Result<usize> {
+    tenferro_tensor::validate::checked_shape_product("rank_revealing_qr", role, shape)
+}
+
+fn checked_repeated(
+    per_batch: usize,
+    batch_count: usize,
+    role: &'static str,
+) -> tenferro_tensor::Result<usize> {
+    per_batch.checked_mul(batch_count).ok_or_else(|| {
+        tenferro_tensor::Error::invalid_argument(
+            "rank_revealing_qr",
+            role,
+            "batched output length overflows usize",
+        )
+    })
+}
+
+fn overflow() -> tenferro_tensor::Error {
+    tenferro_tensor::Error::invalid_argument(
+        "rank_revealing_qr",
+        "batch offset",
+        "batch offset overflows usize",
+    )
+}

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -17,6 +17,8 @@ use crate::extension::{
     extension_module, validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, QrOptions,
     SvdOptions,
 };
+use crate::rank_revealing_qr::validate_rank_revealing_qr_options;
+use crate::{RankRevealingQrOptions, RankRevealingQrResult};
 
 /// Linear algebra extension methods for [`EagerTensor`].
 pub trait EagerTensorLinalgExt {
@@ -190,6 +192,31 @@ pub trait EagerTensorLinalgExt {
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
     fn qr_with_options(&self, options: QrOptions) -> Result<(EagerTensor, EagerTensor)>;
+    /// Compute column-pivoted rank-revealing QR with four tensor outputs.
+    ///
+    /// # Errors
+    /// Returns validation errors for rank, dtype, or invalid tolerances;
+    /// numerical failure for non-finite values; and explicit unsupported,
+    /// backend, runtime, or output-contract errors.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{EagerTensorLinalgExt, RankRevealingQrOptions};
+    /// # let runtime = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+    /// # let a = EagerTensor::from_tensor_in(
+    /// #     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?, runtime)?;
+    /// let result = a.rank_revealing_qr(RankRevealingQrOptions::default())?;
+    /// assert_eq!(result.column_permutation.shape(), &[2]);
+    /// assert_eq!(result.rank.value()?.as_slice::<i64>()?, &[2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    fn rank_revealing_qr(
+        &self,
+        options: RankRevealingQrOptions,
+    ) -> Result<RankRevealingQrResult<EagerTensor>>;
     /// # Errors
     ///
     /// Returns `Error::Validation` for an invalid matrix rank or shape,
@@ -665,6 +692,13 @@ impl EagerTensorLinalgExt for EagerTensor {
         qr_with_options(self, options)
     }
 
+    fn rank_revealing_qr(
+        &self,
+        options: RankRevealingQrOptions,
+    ) -> Result<RankRevealingQrResult<EagerTensor>> {
+        rank_revealing_qr(self, options)
+    }
+
     fn lu(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor, EagerTensor)> {
         lu(self)
     }
@@ -1027,6 +1061,61 @@ pub fn qr_with_options(a: &EagerTensor, options: QrOptions) -> Result<(EagerTens
         )?,
         "qr",
     )
+}
+
+/// Column-pivoted rank-revealing QR for eager tensors.
+///
+/// # Errors
+/// Returns validation errors for invalid rank, dtype, or tolerances; numerical
+/// failure for non-finite values; and explicit unsupported, backend, runtime,
+/// or output-contract errors.
+///
+/// # Examples
+///
+/// ```rust
+/// # use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+/// # use tenferro_cpu::CpuBackend;
+/// # use tenferro_linalg::{EagerTensorLinalgExt, RankRevealingQrOptions};
+/// # let runtime = EagerRuntime::with_cpu_backend(CpuBackend::new())?;
+/// # let a = EagerTensor::from_tensor_in(
+/// #     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?, runtime)?;
+/// let result = a.rank_revealing_qr(RankRevealingQrOptions::default())?;
+/// assert_eq!(result.rank.shape(), &[]);
+/// # Ok::<(), tenferro_ad::Error>(())
+/// ```
+pub fn rank_revealing_qr(
+    a: &EagerTensor,
+    options: RankRevealingQrOptions,
+) -> Result<RankRevealingQrResult<EagerTensor>> {
+    validate_rank_revealing_qr_options("rank_revealing_qr", options)?;
+    let mut outputs = apply_linalg_eager(
+        LinalgOp::RankRevealingQr {
+            gauge: options.gauge,
+            rtol: options.rtol,
+            atol: options.atol,
+        },
+        &[a],
+    )?
+    .into_iter();
+    match (
+        outputs.next(),
+        outputs.next(),
+        outputs.next(),
+        outputs.next(),
+        outputs.next(),
+    ) {
+        (Some(q), Some(r), Some(column_permutation), Some(rank), None) => {
+            Ok(RankRevealingQrResult {
+                q,
+                r,
+                column_permutation,
+                rank,
+            })
+        }
+        _ => Err(Error::Internal(
+            "rank_revealing_qr eager op returned an unexpected number of outputs".into(),
+        )),
+    }
 }
 
 /// LU factorization for eager tensors.

--- a/crates/tenferro-linalg/src/error.rs
+++ b/crates/tenferro-linalg/src/error.rs
@@ -60,6 +60,14 @@ pub enum Error {
         /// Linalg operation that failed to converge.
         op: &'static str,
     },
+    /// The input or a required computed quantity was non-finite.
+    #[error("{op} encountered non-finite {role}")]
+    NonFinite {
+        /// Linalg operation that encountered the non-finite value.
+        op: &'static str,
+        /// Input or computed quantity that was non-finite.
+        role: &'static str,
+    },
     /// The input matrix or factorization became singular.
     #[error("{op} is singular")]
     Singular {
@@ -93,7 +101,9 @@ impl Error {
     #[must_use]
     pub fn kind(&self) -> ErrorKind {
         match self {
-            Self::NonConvergence { .. } | Self::Singular { .. } => ErrorKind::NumericalFailure,
+            Self::NonConvergence { .. } | Self::NonFinite { .. } | Self::Singular { .. } => {
+                ErrorKind::NumericalFailure
+            }
             Self::UnsupportedDType { .. } => ErrorKind::Unsupported,
         }
     }

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -13,6 +13,7 @@ use tenferro_tensor::{BackendSession, DType, Error, ErrorKind, Tensor, TensorBac
 use tenferro_gpu::cuda::with_cuda_exec_session;
 
 use crate::backend::LinalgBackend;
+use crate::RankRevealingQrOptions;
 
 mod gauge;
 #[cfg(all(test, not(feature = "cuda")))]
@@ -306,6 +307,11 @@ pub(crate) enum LinalgOp {
     Qr {
         gauge: QrGauge,
     },
+    RankRevealingQr {
+        gauge: QrGauge,
+        rtol: f64,
+        atol: f64,
+    },
     HouseholderQrFactor,
     HouseholderQrFromFactors,
     HouseholderQrAppend,
@@ -362,6 +368,7 @@ impl LinalgOp {
             | Self::SvdVals { .. }
             | Self::TriangularSolve { .. } => 1,
             Self::Svd { .. } | Self::SvdFull => 3,
+            Self::RankRevealingQr { .. } | Self::Lu => 4,
             Self::Qr { .. }
             | Self::HouseholderQrFactor
             | Self::HouseholderQrFromFactors
@@ -374,7 +381,6 @@ impl LinalgOp {
             | Self::HouseholderQrAppendTangent
             | Self::HouseholderQrSplitTangent { .. } => 1,
             Self::LuFactor => 3,
-            Self::Lu => 4,
             Self::FullPivLu => 5,
         }
     }
@@ -425,6 +431,7 @@ impl LinalgOp {
             Self::HouseholderQrThinQ { .. } => 24,
             Self::HouseholderQrAppendTangent => 25,
             Self::HouseholderQrSplitTangent { .. } => 26,
+            Self::RankRevealingQr { .. } => 27,
         }
     }
 }
@@ -467,6 +474,11 @@ impl ExtensionOp for LinalgExtensionOp {
             | LinalgOp::HouseholderQrR { gauge }
             | LinalgOp::HouseholderQrThinQ { gauge } => {
                 hash_qr_gauge(hasher, gauge);
+            }
+            LinalgOp::RankRevealingQr { gauge, rtol, atol } => {
+                hash_qr_gauge(hasher, gauge);
+                hasher.write_u64(rtol.to_bits());
+                hasher.write_u64(atol.to_bits());
             }
             LinalgOp::HouseholderQrQColumns { start, end, gauge } => {
                 hasher.write_usize(start);
@@ -628,6 +640,9 @@ impl ExtensionOp for LinalgExtensionOp {
                 vec![svd_values_meta(input_dtypes[0], input_shapes[0])?]
             }
             LinalgOp::Qr { .. } => qr_meta(input_dtypes[0], input_shapes[0])?,
+            LinalgOp::RankRevealingQr { .. } => {
+                rank_revealing_qr_meta(input_dtypes[0], input_shapes[0])?
+            }
             LinalgOp::HouseholderQrFactor => {
                 householder_qr_factor_meta(input_dtypes[0], input_shapes[0])?
             }
@@ -807,7 +822,7 @@ fn linalg_session_supported<B: BackendSession + 'static>(op: &LinalgExtensionOp)
                 LinalgOp::Solve => true,
                 // Full-matrices SVD falls back to the default `svd_full`
                 // impl, which reports `Unsupported`.
-                LinalgOp::SvdFull => false,
+                LinalgOp::SvdFull | LinalgOp::RankRevealingQr { .. } => false,
                 // Conjugate-only prepared LU solve is unsupported on CUDA.
                 LinalgOp::LuSolvePrepared {
                     transpose_a: false,
@@ -890,6 +905,9 @@ fn execute_linalg<B: LinalgBackend>(
         LinalgOp::SvdFull => backend.svd_full(inputs[0]),
         LinalgOp::SvdVals { .. } => Ok(vec![backend.svd_values(inputs[0])?]),
         LinalgOp::Qr { gauge } => backend.qr_with_options(inputs[0], QrOptions { gauge }),
+        LinalgOp::RankRevealingQr { gauge, rtol, atol } => {
+            backend.rank_revealing_qr(inputs[0], RankRevealingQrOptions { gauge, rtol, atol })
+        }
         LinalgOp::HouseholderQrFactor => {
             let state = backend.householder_qr(inputs[0])?;
             Ok(vec![state.packed, state.coeff])
@@ -1451,6 +1469,20 @@ fn qr_meta(dtype: DType, shape: &[SymDim]) -> tenferro_tensor::Result<Vec<(DType
     Ok(vec![
         (dtype, matrix_shape(m, k.clone(), batch)),
         (dtype, matrix_shape(k, n, batch)),
+    ])
+}
+
+fn rank_revealing_qr_meta(
+    dtype: DType,
+    shape: &[SymDim],
+) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+    let (m, n, batch) = matrix_meta_parts("tenferro-linalg.rank_revealing_qr", shape)?;
+    let k = m.clone().min(n.clone());
+    Ok(vec![
+        (dtype, matrix_shape(m, k.clone(), batch)),
+        (dtype, matrix_shape(k, n.clone(), batch)),
+        (DType::I64, vector_shape(n, batch)),
+        (DType::I64, batch.to_vec()),
     ])
 }
 

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -52,6 +52,7 @@ mod extension;
 mod gpu;
 mod householder;
 pub mod prelude;
+mod rank_revealing_qr;
 mod tensor_ext;
 mod traced;
 mod validation;
@@ -72,8 +73,9 @@ pub use extension::{
     DEFAULT_DECOMPOSITION_DERIVATIVE_EPS, LINALG_EXTENSION_FAMILY_ID,
 };
 pub use householder::HouseholderQr;
+pub use rank_revealing_qr::{RankRevealingQrOptions, RankRevealingQrResult};
 pub use tensor_ext::{
     LinalgScalar, TensorLinalgExt, TensorReadLinalgExt, TypedEig, TypedFullPivLu, TypedLu,
-    TypedSvd, TypedTensorLinalgExt,
+    TypedRankRevealingQrResult, TypedSvd, TypedTensorLinalgExt,
 };
 pub use traced::TracedTensorLinalgExt;

--- a/crates/tenferro-linalg/src/prelude.rs
+++ b/crates/tenferro-linalg/src/prelude.rs
@@ -1,9 +1,11 @@
 //! Linear algebra extension traits and their method-resolution types.
 
-pub use crate::{EighOptions, QrOptions, SvdOptions};
+pub use crate::{
+    EighOptions, QrOptions, RankRevealingQrOptions, RankRevealingQrResult, SvdOptions,
+};
 pub use crate::{
     LinalgBackend, LinalgScalar, TensorLinalgExt, TensorReadLinalgExt, TracedTensorLinalgExt,
-    TypedEig, TypedFullPivLu, TypedLu, TypedSvd, TypedTensorLinalgExt,
+    TypedEig, TypedFullPivLu, TypedLu, TypedRankRevealingQrResult, TypedSvd, TypedTensorLinalgExt,
 };
 
 pub use tenferro_runtime::{Tensor, TensorRead, TracedTensor, TypedTensor};

--- a/crates/tenferro-linalg/src/rank_revealing_qr.rs
+++ b/crates/tenferro-linalg/src/rank_revealing_qr.rs
@@ -1,0 +1,138 @@
+use tenferro_tensor::Error;
+
+use crate::QrGauge;
+
+/// Four fixed-shape outputs of a rank-revealing QR factorization.
+///
+/// `Q` and `R` use `T`; the column permutation and numerical rank use `M`.
+/// For dynamic, eager, and traced tensors, `T` and `M` are the same tensor
+/// type. Typed tensors use [`crate::TypedRankRevealingQrResult`], whose metadata
+/// tensors have scalar type `i64`.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::RankRevealingQrResult;
+///
+/// let result = RankRevealingQrResult {
+///     q: "q",
+///     r: "r",
+///     column_permutation: vec![1_i64, 0],
+///     rank: vec![2_i64],
+/// };
+/// assert_eq!(result.column_permutation, [1, 0]);
+/// assert_eq!(result.rank, [2]);
+/// ```
+#[derive(Clone, Debug)]
+pub struct RankRevealingQrResult<T, M = T> {
+    /// Thin orthonormal factor with shape `[m, min(m, n), batch...]`.
+    pub q: T,
+    /// Upper-trapezoidal factor with shape `[min(m, n), n, batch...]`.
+    pub r: T,
+    /// Zero-based original column at each factor column, shaped `[n, batch...]`.
+    pub column_permutation: M,
+    /// Leading-prefix numerical rank, shaped `[batch...]`.
+    pub rank: M,
+}
+
+/// Options for column-pivoted rank-revealing QR.
+///
+/// Rank is the length of the leading diagonal prefix satisfying
+/// `abs(R[i,i]) > max(atol, rtol * abs(R[0,0]))`. Both tolerances must be
+/// finite and non-negative. The default uses zero tolerances so callers choose
+/// an application-specific numerical threshold explicitly.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::{QrGauge, RankRevealingQrOptions};
+///
+/// let options = RankRevealingQrOptions::default()
+///     .gauge(QrGauge::PositiveDiagonal)
+///     .rtol(1.0e-10)
+///     .atol(1.0e-14);
+/// assert_eq!(options.rtol, 1.0e-10);
+/// assert_eq!(options.atol, 1.0e-14);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RankRevealingQrOptions {
+    /// QR sign or phase convention. The default is [`QrGauge::Raw`].
+    pub gauge: QrGauge,
+    /// Relative diagonal threshold. The default is `0.0`.
+    pub rtol: f64,
+    /// Absolute diagonal threshold. The default is `0.0`.
+    pub atol: f64,
+}
+
+impl Default for RankRevealingQrOptions {
+    fn default() -> Self {
+        Self {
+            gauge: QrGauge::Raw,
+            rtol: 0.0,
+            atol: 0.0,
+        }
+    }
+}
+
+impl RankRevealingQrOptions {
+    /// Return options with the requested QR gauge.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::{QrGauge, RankRevealingQrOptions};
+    ///
+    /// let options = RankRevealingQrOptions::default().gauge(QrGauge::PositiveDiagonal);
+    /// assert_eq!(options.gauge, QrGauge::PositiveDiagonal);
+    /// ```
+    pub fn gauge(mut self, gauge: QrGauge) -> Self {
+        self.gauge = gauge;
+        self
+    }
+
+    /// Return options with the requested relative rank tolerance.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::RankRevealingQrOptions;
+    ///
+    /// let options = RankRevealingQrOptions::default().rtol(1.0e-8);
+    /// assert_eq!(options.rtol, 1.0e-8);
+    /// ```
+    pub fn rtol(mut self, rtol: f64) -> Self {
+        self.rtol = rtol;
+        self
+    }
+
+    /// Return options with the requested absolute rank tolerance.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::RankRevealingQrOptions;
+    ///
+    /// let options = RankRevealingQrOptions::default().atol(1.0e-12);
+    /// assert_eq!(options.atol, 1.0e-12);
+    /// ```
+    pub fn atol(mut self, atol: f64) -> Self {
+        self.atol = atol;
+        self
+    }
+}
+
+pub(crate) fn validate_rank_revealing_qr_options(
+    op: &'static str,
+    options: RankRevealingQrOptions,
+) -> tenferro_tensor::Result<()> {
+    for (name, value) in [("rtol", options.rtol), ("atol", options.atol)] {
+        if !value.is_finite() || value < 0.0 {
+            return Err(Error::invalid_argument(
+                op,
+                name,
+                format!("must be finite and non-negative, got {value}"),
+            ));
+        }
+    }
+    Ok(())
+}

--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -20,7 +20,7 @@ use tenferro_tensor::{
 use crate::extension::{
     apply_eigh_gauge, apply_svd_gauge, validate_derivative_eps, EighOptions, QrOptions, SvdOptions,
 };
-use crate::LinalgBackend;
+use crate::{LinalgBackend, RankRevealingQrOptions, RankRevealingQrResult};
 
 /// Scalar types supported by statically typed linear algebra methods.
 ///
@@ -70,6 +70,24 @@ pub type TypedSvd<T> = (
     TypedTensor<<T as TensorScalar>::Real>,
     TypedTensor<T>,
 );
+/// Fixed typed output for rank-revealing QR.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::{RankRevealingQrResult, TypedRankRevealingQrResult};
+/// use tenferro_tensor::TypedTensor;
+///
+/// let result: TypedRankRevealingQrResult<f64> = RankRevealingQrResult {
+///     q: TypedTensor::from_vec_col_major(vec![1, 1], vec![1.0])?,
+///     r: TypedTensor::from_vec_col_major(vec![1, 1], vec![2.0])?,
+///     column_permutation: TypedTensor::from_vec_col_major(vec![1], vec![0_i64])?,
+///     rank: TypedTensor::from_vec_col_major(vec![], vec![1_i64])?,
+/// };
+/// assert_eq!(result.rank.as_slice()?, &[1]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+pub type TypedRankRevealingQrResult<T> = RankRevealingQrResult<TypedTensor<T>, TypedTensor<i64>>;
 /// Fixed typed output tuple for LU decomposition.
 ///
 /// # Examples
@@ -247,6 +265,33 @@ pub trait TensorLinalgExt {
         options: QrOptions,
         session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// Compute column-pivoted rank-revealing QR with fixed-shape tensor metadata.
+    ///
+    /// # Errors
+    /// Returns validation errors for rank, dtype, or invalid tolerances;
+    /// numerical failure for non-finite input or diagonal values; and explicit
+    /// unsupported/backend errors when the selected provider cannot execute RRQR.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{RankRevealingQrOptions, TensorLinalgExt};
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let result = host.with_backend_session(|session| {
+    ///     a.rank_revealing_qr(RankRevealingQrOptions::default().rtol(1e-12), session)
+    /// })?;
+    /// assert_eq!(result.column_permutation.shape(), &[2]);
+    /// assert_eq!(result.rank.shape(), &[]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn rank_revealing_qr(
+        &self,
+        options: RankRevealingQrOptions,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<RankRevealingQrResult<Tensor>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, unsupported-backend, numerical, or output-contract errors.
@@ -697,6 +742,32 @@ pub trait TensorReadLinalgExt {
         options: QrOptions,
         session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// Compute rank-revealing QR from a borrowed tensor read.
+    ///
+    /// # Errors
+    /// Returns validation, same-placement materialization, numerical, backend,
+    /// or explicit unsupported errors.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{RankRevealingQrOptions, TensorReadLinalgExt};
+    /// # use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// # let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let result = host.with_backend_session(|session| {
+    ///     TensorRead::from_tensor(&a).rank_revealing_qr_read(
+    ///         RankRevealingQrOptions::default(), session)
+    /// })?;
+    /// assert_eq!(result.rank.as_slice::<i64>()?, &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn rank_revealing_qr_read(
+        self,
+        options: RankRevealingQrOptions,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<RankRevealingQrResult<Tensor>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, same-placement materialization, backend, numerical, or contract errors.
@@ -1208,6 +1279,31 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
         options: QrOptions,
         session: &mut dyn BackendSession,
     ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)>;
+    /// Compute typed rank-revealing QR with `i64` permutation and rank tensors.
+    ///
+    /// # Errors
+    /// Returns validation, numerical, backend, unsupported, or typed-output
+    /// contract errors.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{RankRevealingQrOptions, TypedTensorLinalgExt};
+    /// # use tenferro_tensor::{BackendSessionHost, TypedTensor};
+    /// # let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0])?;
+    /// # let mut host = CpuBackend::new();
+    /// let result = host.with_backend_session(|session| {
+    ///     a.rank_revealing_qr(RankRevealingQrOptions::default(), session)
+    /// })?;
+    /// assert_eq!(result.rank.as_slice()?, &[2_i64]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn rank_revealing_qr(
+        &self,
+        options: RankRevealingQrOptions,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedRankRevealingQrResult<T>>;
     /// # Errors
     /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
     /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
@@ -1580,6 +1676,15 @@ impl TensorLinalgExt for Tensor {
             two(backend.qr_with_options(self, options)?, "qr_with_options")
         })
     }
+    fn rank_revealing_qr(
+        &self,
+        options: RankRevealingQrOptions,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<RankRevealingQrResult<Tensor>> {
+        with_linalg_backend(session, "rank_revealing_qr", |backend| {
+            rank_revealing_qr_result(backend.rank_revealing_qr(self, options)?)
+        })
+    }
     fn lu(
         &self,
         session: &mut dyn BackendSession,
@@ -1736,6 +1841,15 @@ impl TensorReadLinalgExt for TensorRead<'_> {
                 backend.qr_with_options_read(self, options)?,
                 "qr_with_options_read",
             )
+        })
+    }
+    fn rank_revealing_qr_read(
+        self,
+        options: RankRevealingQrOptions,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<RankRevealingQrResult<Tensor>> {
+        with_linalg_backend(session, "rank_revealing_qr_read", |backend| {
+            rank_revealing_qr_result(backend.rank_revealing_qr_read(self, options)?)
         })
     }
     fn lu_read(
@@ -1961,6 +2075,22 @@ impl<T: LinalgScalar> TypedTensorLinalgExt<T> for TypedTensor<T> {
         })
     }
 
+    fn rank_revealing_qr(
+        &self,
+        options: RankRevealingQrOptions,
+        session: &mut dyn BackendSession,
+    ) -> tenferro_tensor::Result<TypedRankRevealingQrResult<T>> {
+        with_linalg_backend(session, "rank_revealing_qr", |backend| {
+            let result = T::tensor_read(self).rank_revealing_qr_read(options, backend)?;
+            Ok(RankRevealingQrResult {
+                q: typed_output::<T>(result.q)?,
+                r: typed_output::<T>(result.r)?,
+                column_permutation: typed_output::<i64>(result.column_permutation)?,
+                rank: typed_output::<i64>(result.rank)?,
+            })
+        })
+    }
+
     fn lu(&self, session: &mut dyn BackendSession) -> tenferro_tensor::Result<TypedLu<T>> {
         with_linalg_backend(session, "lu", |backend| {
             let (p, l, u, parity) = T::tensor_read(self).lu_read(backend)?;
@@ -2142,6 +2272,18 @@ impl<T: LinalgScalar> TypedTensorLinalgExt<T> for TypedTensor<T> {
             )
         })
     }
+}
+
+fn rank_revealing_qr_result(
+    outputs: Vec<Tensor>,
+) -> tenferro_tensor::Result<RankRevealingQrResult<Tensor>> {
+    let (q, r, column_permutation, rank) = four(outputs, "rank_revealing_qr")?;
+    Ok(RankRevealingQrResult {
+        q,
+        r,
+        column_permutation,
+        rank,
+    })
 }
 
 fn typed_svd<T: LinalgScalar>(

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -9,7 +9,9 @@ use tenferro_runtime::{
 use crate::extension::{
     validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, QrOptions, SvdOptions,
 };
+use crate::rank_revealing_qr::validate_rank_revealing_qr_options;
 use crate::validation::{ensure_float_or_complex, validate_lstsq};
+use crate::{RankRevealingQrOptions, RankRevealingQrResult};
 
 /// Linear algebra extension methods for [`TracedTensor`].
 pub trait TracedTensorLinalgExt {
@@ -114,6 +116,33 @@ pub trait TracedTensorLinalgExt {
     /// Symbolic shape checks and backend QR failures can be deferred to compile
     /// or execution.
     fn qr_with_options(&self, options: QrOptions) -> Result<(TracedTensor, TracedTensor)>;
+
+    /// Build fixed-arity traced column-pivoted rank-revealing QR.
+    ///
+    /// # Errors
+    /// Returns graph-build validation errors for rank, dtype, or invalid
+    /// tolerances, and extension registration failures.
+    ///
+    /// # Deferred errors
+    /// Symbolic shape checks, non-finite numerical failures, and unsupported
+    /// backend execution are reported during compile or execution.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::{RankRevealingQrOptions, TracedTensorLinalgExt};
+    /// use tenferro_runtime::TracedTensor;
+    /// let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 0.0, 0.0, 1.0, 1.0, 1.0])?;
+    /// let result = a.rank_revealing_qr(RankRevealingQrOptions::default())?;
+    /// assert_eq!(result.q.rank, 2);
+    /// assert_eq!(result.column_permutation.rank, 1);
+    /// assert_eq!(result.rank.rank, 0);
+    /// # Ok::<(), tenferro_runtime::Error>(())
+    /// ```
+    fn rank_revealing_qr(
+        &self,
+        options: RankRevealingQrOptions,
+    ) -> Result<RankRevealingQrResult<TracedTensor>>;
 
     /// Build a traced Hermitian eigendecomposition operation.
     ///
@@ -394,6 +423,13 @@ impl TracedTensorLinalgExt for TracedTensor {
 
     fn qr_with_options(&self, options: QrOptions) -> Result<(TracedTensor, TracedTensor)> {
         qr_with_options(self, options)
+    }
+
+    fn rank_revealing_qr(
+        &self,
+        options: RankRevealingQrOptions,
+    ) -> Result<RankRevealingQrResult<TracedTensor>> {
+        rank_revealing_qr(self, options)
     }
 
     fn eigh(&self) -> Result<(TracedTensor, TracedTensor)> {
@@ -700,6 +736,52 @@ pub fn qr_with_options(
         )?,
         "qr",
     )
+}
+
+/// Build a traced column-pivoted rank-revealing QR operation.
+///
+/// # Errors
+/// Returns graph-build validation errors for invalid rank, dtype, or
+/// tolerances, plus extension registration failures.
+///
+/// # Deferred errors
+/// Symbolic shape checks, non-finite numerical failures, and unsupported
+/// backend execution are reported during compile or execution.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::{RankRevealingQrOptions, TracedTensorLinalgExt};
+/// use tenferro_runtime::TracedTensor;
+/// let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
+/// let result = a.rank_revealing_qr(RankRevealingQrOptions::default())?;
+/// assert_eq!(result.column_permutation.rank, 1);
+/// assert_eq!(result.rank.rank, 0);
+/// # Ok::<(), tenferro_runtime::Error>(())
+/// ```
+pub fn rank_revealing_qr(
+    a: &TracedTensor,
+    options: RankRevealingQrOptions,
+) -> Result<RankRevealingQrResult<TracedTensor>> {
+    validate_rank_revealing_qr_options("rank_revealing_qr", options)?;
+    ensure_float_or_complex("rank_revealing_qr", a.dtype)?;
+    let (q, r, column_permutation, rank) = four_outputs(
+        apply(
+            Arc::new(LinalgExtensionOp::new(LinalgOp::RankRevealingQr {
+                gauge: options.gauge,
+                rtol: options.rtol,
+                atol: options.atol,
+            })),
+            &[a],
+        )?,
+        "rank_revealing_qr",
+    )?;
+    Ok(RankRevealingQrResult {
+        q,
+        r,
+        column_permutation,
+        rank,
+    })
 }
 
 /// Build a traced Hermitian eigenvalue decomposition op using default options.

--- a/crates/tenferro-linalg/tests/integration/ad_support_manifest.rs
+++ b/crates/tenferro-linalg/tests/integration/ad_support_manifest.rs
@@ -41,6 +41,7 @@ fn linalg_ad_support_manifest_covers_all_dispatch_arms_in_order() {
         LinalgAdOpKind::HouseholderQrThinQ,
         LinalgAdOpKind::HouseholderQrAppendTangent,
         LinalgAdOpKind::HouseholderQrSplitTangent,
+        LinalgAdOpKind::RankRevealingQr,
     ];
 
     let manifest = all_linalg_ad_support();
@@ -54,6 +55,16 @@ fn linalg_ad_support_manifest_covers_all_dispatch_arms_in_order() {
         for (output_index, output) in entry.outputs.iter().enumerate() {
             assert_eq!(output.index, output_index);
         }
+    }
+}
+
+#[test]
+fn rank_revealing_qr_is_explicitly_unsupported_for_ad() {
+    let entry = linalg_ad_support(LinalgAdOpKind::RankRevealingQr);
+    assert_eq!(entry.jvp.status, LinalgAdRuleSupport::Unsupported);
+    assert_eq!(entry.vjp.status, LinalgAdRuleSupport::Unsupported);
+    for output in entry.outputs {
+        assert_eq!(output.status, LinalgAdRuleSupport::Unsupported);
     }
 }
 

--- a/crates/tenferro-linalg/tests/integration/concrete_surface.rs
+++ b/crates/tenferro-linalg/tests/integration/concrete_surface.rs
@@ -128,6 +128,41 @@ fn rank_revealing_qr_supports_all_float_and_complex_dtypes() {
 }
 
 #[test]
+fn rank_revealing_qr_handles_empty_dimensions_and_empty_batches() {
+    let inputs: [(Vec<usize>, Vec<f64>); 3] = [
+        (vec![0, 3], vec![]),
+        (vec![3, 0], vec![]),
+        (vec![2, 2, 0], vec![]),
+    ];
+    let mut host = CpuBackend::new();
+    host.with_backend_session(|session| {
+        for (shape, data) in inputs {
+            let input = Tensor::from_vec_col_major(shape, data).unwrap();
+            let result = input
+                .rank_revealing_qr(RankRevealingQrOptions::default(), session)
+                .unwrap();
+            let ranks = result.rank.as_slice::<i64>().unwrap();
+            if result.rank.shape().is_empty() {
+                assert_eq!(ranks, &[0]);
+            } else {
+                assert!(ranks.is_empty());
+            }
+        }
+    });
+}
+
+#[test]
+fn rank_revealing_qr_rejects_non_finite_input() {
+    let input = Tensor::from_vec_col_major(vec![2, 1], vec![f64::NAN, 1.0]).unwrap();
+    let mut host = CpuBackend::new();
+    host.with_backend_session(|session| {
+        assert!(input
+            .rank_revealing_qr(RankRevealingQrOptions::default(), session)
+            .is_err());
+    });
+}
+
+#[test]
 fn rank_revealing_qr_rejects_invalid_tolerances() {
     let input = Tensor::from_vec_col_major(vec![1, 1], vec![1.0_f64]).unwrap();
     let mut host = CpuBackend::new();

--- a/crates/tenferro-linalg/tests/integration/concrete_surface.rs
+++ b/crates/tenferro-linalg/tests/integration/concrete_surface.rs
@@ -1,8 +1,8 @@
 use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::{
-    EighOptions, LinalgBackend, QrOptions, SvdOptions, TensorLinalgExt, TensorReadLinalgExt,
-    TypedTensorLinalgExt,
+    EighOptions, LinalgBackend, QrOptions, RankRevealingQrOptions, SvdOptions, TensorLinalgExt,
+    TensorReadLinalgExt, TypedTensorLinalgExt,
 };
 use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead, TensorScalar, TypedTensor};
 
@@ -29,6 +29,132 @@ fn dynamic_and_read_surfaces_return_fixed_tuples() {
         assert_eq!(r.shape(), &[2, 2]);
         assert_eq!(sign.as_slice::<f64>().unwrap(), &[1.0]);
         assert!((logabsdet.as_slice::<f64>().unwrap()[0] - 8.0_f64.ln()).abs() < 1.0e-12);
+    });
+}
+
+#[test]
+fn rank_revealing_qr_handles_interspersed_dependence() {
+    // Columns are a, a, b. A prefix-only non-pivoted rank guard cannot retain
+    // the later independent column, whereas CPQR must report rank two.
+    let input = Tensor::from_vec_col_major(
+        vec![4, 3],
+        vec![
+            1.0_f64, 2.0, 3.0, 4.0, // a
+            1.0, 2.0, 3.0, 4.0, // duplicate a
+            0.0, 1.0, 0.0, 0.0, // independent b
+        ],
+    )
+    .unwrap();
+    let mut host = CpuBackend::new();
+
+    host.with_backend_session(|session| {
+        let result = input
+            .rank_revealing_qr(RankRevealingQrOptions::default().rtol(1.0e-12), session)
+            .unwrap();
+        assert_eq!(result.q.shape(), &[4, 3]);
+        assert_eq!(result.r.shape(), &[3, 3]);
+        assert_eq!(result.column_permutation.shape(), &[3]);
+        assert_eq!(result.rank.shape(), &[] as &[usize]);
+        assert_eq!(result.rank.as_slice::<i64>().unwrap(), &[2]);
+
+        let permutation = result.column_permutation.as_slice::<i64>().unwrap();
+        let mut sorted = permutation.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(sorted, vec![0, 1, 2]);
+
+        let q = result.q.as_slice::<f64>().unwrap();
+        let r = result.r.as_slice::<f64>().unwrap();
+        let source = input.as_slice::<f64>().unwrap();
+        for lhs_col in 0..3 {
+            for rhs_col in 0..3 {
+                let inner = (0..4)
+                    .map(|row| q[row + lhs_col * 4] * q[row + rhs_col * 4])
+                    .sum::<f64>();
+                let expected = if lhs_col == rhs_col { 1.0 } else { 0.0 };
+                assert!((inner - expected).abs() < 1.0e-11);
+            }
+        }
+        for factor_col in 0..3 {
+            let source_col = usize::try_from(permutation[factor_col]).unwrap();
+            for row in 0..4 {
+                let reconstructed = (0..3)
+                    .map(|inner| q[row + inner * 4] * r[inner + factor_col * 3])
+                    .sum::<f64>();
+                assert!((reconstructed - source[row + source_col * 4]).abs() < 1.0e-11);
+            }
+        }
+    });
+}
+
+#[test]
+fn rank_revealing_qr_supports_all_float_and_complex_dtypes() {
+    use num_complex::Complex32;
+
+    let inputs = vec![
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f32, 0.0, 1.0, 0.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 1.0, 0.0]).unwrap(),
+        Tensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex32::new(1.0, 1.0),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(1.0, 1.0),
+                Complex32::new(0.0, 0.0),
+            ],
+        )
+        .unwrap(),
+        Tensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex64::new(1.0, 1.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(1.0, 1.0),
+                Complex64::new(0.0, 0.0),
+            ],
+        )
+        .unwrap(),
+    ];
+    let mut host = CpuBackend::new();
+    host.with_backend_session(|session| {
+        for input in &inputs {
+            let result = input
+                .rank_revealing_qr(RankRevealingQrOptions::default().rtol(1.0e-6), session)
+                .unwrap();
+            assert_eq!(result.q.dtype(), input.dtype());
+            assert_eq!(result.r.dtype(), input.dtype());
+            assert_eq!(result.rank.as_slice::<i64>().unwrap(), &[1]);
+        }
+    });
+}
+
+#[test]
+fn rank_revealing_qr_rejects_invalid_tolerances() {
+    let input = Tensor::from_vec_col_major(vec![1, 1], vec![1.0_f64]).unwrap();
+    let mut host = CpuBackend::new();
+    host.with_backend_session(|session| {
+        for options in [
+            RankRevealingQrOptions::default().rtol(f64::NAN),
+            RankRevealingQrOptions::default().rtol(-1.0),
+            RankRevealingQrOptions::default().atol(f64::INFINITY),
+        ] {
+            assert!(input.rank_revealing_qr(options, session).is_err());
+        }
+    });
+}
+
+#[test]
+fn rank_revealing_qr_zero_and_batched_metadata() {
+    let input = Tensor::from_vec_col_major(vec![2, 2, 2], vec![0.0_f64; 8]).unwrap();
+    let mut host = CpuBackend::new();
+    host.with_backend_session(|session| {
+        let result = input
+            .rank_revealing_qr(RankRevealingQrOptions::default(), session)
+            .unwrap();
+        assert_eq!(result.q.shape(), &[2, 2, 2]);
+        assert_eq!(result.r.shape(), &[2, 2, 2]);
+        assert_eq!(result.column_permutation.shape(), &[2, 2]);
+        assert_eq!(result.rank.shape(), &[2]);
+        assert_eq!(result.rank.as_slice::<i64>().unwrap(), &[0, 0]);
     });
 }
 

--- a/crates/tenferro-linalg/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-linalg/tests/integration/eager_tensor.rs
@@ -9,8 +9,8 @@ use tenferro_gpu::{
     cuda::download_tensor, cuda::gpu_available, cuda::upload_tensor, cuda::CudaBackend,
 };
 use tenferro_linalg::{
-    EagerTensorLinalgExt, EighGauge, EighOptions, LinalgBackend, QrGauge, QrOptions, SvdGauge,
-    SvdOptions,
+    EagerTensorLinalgExt, EighGauge, EighOptions, LinalgBackend, QrGauge, QrOptions,
+    RankRevealingQrOptions, SvdGauge, SvdOptions,
 };
 
 fn test_ctx() -> Arc<EagerRuntime> {
@@ -26,6 +26,27 @@ fn ad_test_ctx() -> Arc<EagerRuntime> {
         .build()
         .unwrap();
     EagerRuntime::with_cpu_backend_and_ad_context(CpuBackend::new(), &ad).unwrap()
+}
+
+#[test]
+fn eager_rank_revealing_qr_keeps_metadata_in_runtime() {
+    let runtime = test_ctx();
+    let input = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 1.0, 2.0, 3.0]).unwrap(),
+        Arc::clone(&runtime),
+    )
+    .unwrap();
+    let result = input
+        .rank_revealing_qr(RankRevealingQrOptions::default().rtol(1.0e-12))
+        .unwrap();
+    assert!(Arc::ptr_eq(result.q.runtime(), &runtime));
+    assert!(Arc::ptr_eq(result.r.runtime(), &runtime));
+    assert!(Arc::ptr_eq(result.column_permutation.runtime(), &runtime));
+    assert!(Arc::ptr_eq(result.rank.runtime(), &runtime));
+    assert_eq!(
+        result.rank.to_tensor().unwrap().as_slice::<i64>().unwrap(),
+        &[1]
+    );
 }
 
 fn f64_data(tensor: &Tensor) -> &[f64] {

--- a/crates/tenferro-linalg/tests/integration/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/integration/traced_extension.rs
@@ -1,8 +1,8 @@
 use num_complex::{Complex32, Complex64};
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::{
-    EighGauge, EighOptions, LinalgBackend, QrGauge, QrOptions, SvdGauge, SvdOptions,
-    TracedTensorLinalgExt,
+    EighGauge, EighOptions, LinalgBackend, QrGauge, QrOptions, RankRevealingQrOptions, SvdGauge,
+    SvdOptions, TracedTensorLinalgExt,
 };
 use tenferro_runtime::{DType, Error, GraphCompiler, Runtime, Tensor, TracedTensor, TypedTensor};
 use tenferro_tensor::Error as TensorError;
@@ -37,6 +37,37 @@ fn traced_with_dtype(dtype: DType, shape: Vec<usize>) -> TracedTensor {
         ),
     };
     TracedTensor::from_tensor_concrete_shape(tensor).unwrap()
+}
+
+#[test]
+fn rank_revealing_qr_traced_fixed_outputs_execute() {
+    let a = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(
+            vec![3, 3],
+            vec![1.0_f64, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let result = a
+        .rank_revealing_qr(RankRevealingQrOptions::default().rtol(1.0e-12))
+        .unwrap();
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_many(&[
+            &result.q,
+            &result.r,
+            &result.column_permutation,
+            &result.rank,
+        ])
+        .unwrap();
+    let outputs = support::run_all(&program, &[]).unwrap();
+    assert_eq!(outputs.len(), 4);
+    assert_eq!(outputs[0].shape(), &[3, 3]);
+    assert_eq!(outputs[1].shape(), &[3, 3]);
+    assert_eq!(outputs[2].shape(), &[3]);
+    assert_eq!(outputs[3].shape(), &[] as &[usize]);
+    assert_eq!(outputs[3].as_slice::<i64>().unwrap(), &[2]);
 }
 
 #[test]

--- a/docs/worklogs/2026-09-05-rank-revealing-qr-cpu.md
+++ b/docs/worklogs/2026-09-05-rank-revealing-qr-cpu.md
@@ -1,0 +1,42 @@
+# Rank-revealing QR CPU phase
+
+## Scope
+
+Implements issue #1754's fixed-four-output RRQR contract for concrete, typed,
+eager, and traced surfaces, with CPU-faer and CPU-BLAS/LAPACK providers. CUDA
+remains an explicit unsupported backend until the native provider phase.
+
+## Context reviewed
+
+- `docs/design/rank-revealing-qr.md`
+- `docs/design/dynamic-symbolic-shapes.md`
+- existing QR, full-pivot LU, Householder QR, extension metadata, and AD support
+  implementations
+- faer 0.24 column-pivoted QR and LAPACK `xGEQP3` contracts
+
+## Decisions
+
+- RRQR is a distinct fixed-arity extension op; ordinary QR stays a two-output
+  hot path.
+- Rank and permutation are I64 tensors, so traced and batched execution never
+  embeds data-dependent host metadata.
+- Q/R keep full thin shapes. No dynamic compact shape or fixed-rank mask is
+  introduced.
+- Provider permutations are normalized to the documented zero-based gather
+  convention.
+- RRQR differentiation is explicitly unsupported in every AD dispatch and
+  manifest entry for this phase.
+
+## Verification
+
+Focused tests cover interspersed dependent columns, zero/batched matrices, all
+four floating/complex dtypes, invalid tolerances, eager runtime ownership,
+traced four-output execution, and unsupported AD manifest entries. Default
+integration tests, doctests, clippy, CPU-BLAS compilation, and repository-rule
+checks are run before PR creation.
+
+## Remaining phase
+
+A native CUDA column-pivoted Householder implementation is required because
+CUDA 12.4 cuSOLVER has no `GEQP3`. It must not download matrix payloads or fall
+back to CPU. tensor4all integration follows the merged CUDA phase.


### PR DESCRIPTION
Implements CPU phase of #1754 and the approved `docs/design/rank-revealing-qr.md`.

- distinct fixed-four-output RRQR extension op
- tensor-valued I64 permutation/rank metadata for direct, typed, eager, and traced surfaces
- CPU-faer and CPU-BLAS/LAPACK CPQR for F32/F64/C32/C64 and trailing batches
- explicit unsupported AD classification and CUDA default (native CUDA follows separately)
- reconstruction, orthogonality, dependence, zero/batch, dtype, tolerance, eager-runtime, traced execution, and manifest tests

Worklog: `docs/worklogs/2026-09-05-rank-revealing-qr-cpu.md`.

Review: reviewer-flash Correct-to-merge, 0 blocking; all minor findings fixed or covered.

Closes no issue; native CUDA and tensor4all integration follow.