### PR TITLE
Execute rank-revealing QR natively on CUDA

### DIFF
--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -822,7 +822,7 @@ fn linalg_session_supported<B: BackendSession + 'static>(op: &LinalgExtensionOp)
                 LinalgOp::Solve => true,
                 // Full-matrices SVD falls back to the default `svd_full`
                 // impl, which reports `Unsupported`.
-                LinalgOp::SvdFull | LinalgOp::RankRevealingQr { .. } => false,
+                LinalgOp::SvdFull => false,
                 // Conjugate-only prepared LU solve is unsupported on CUDA.
                 LinalgOp::LuSolvePrepared {
                     transpose_a: false,

--- a/crates/tenferro-linalg/src/gpu/kernels.rs
+++ b/crates/tenferro-linalg/src/gpu/kernels.rs
@@ -1,3 +1,7 @@
+#[path = "kernels/rank_revealing_qr.rs"]
+mod rank_revealing_qr;
+pub(super) use rank_revealing_qr::*;
+
 use cubecl::prelude::*;
 use num_complex::{Complex32, Complex64};
 

--- a/crates/tenferro-linalg/src/gpu/kernels/rank_revealing_qr.rs
+++ b/crates/tenferro-linalg/src/gpu/kernels/rank_revealing_qr.rs
@@ -1,0 +1,762 @@
+// INVARIANT: CubeCL expands kernel signatures and index expressions into
+// generated Rust that triggers host-side style lints; the device IR still
+// uses the validated launch domains and bounds below.
+#![allow(
+    clippy::too_many_arguments,
+    clippy::eq_op,
+    clippy::unnecessary_cast,
+    clippy::neg_cmp_op_on_partial_ord
+)]
+
+use cubecl::prelude::*;
+use num_complex::{Complex32, Complex64};
+
+#[cube]
+fn rrqr_zero<E: CubePrimitive>() -> E {
+    E::cast_from(0u32)
+}
+
+#[cube]
+fn rrqr_one<E: CubePrimitive>() -> E {
+    E::cast_from(1u32)
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn initialize_permutation(permutation: &mut Tensor<i64>, n: usize) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < permutation.len() {
+        permutation[pos] = (pos % n) as i64;
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn column_norms_real<
+    F: Float + CubeElement + CubePrimitive<WithScalar<bool> = bool, WithScalar<F> = F>,
+>(
+    work: &Tensor<F>,
+    norms: &mut Tensor<F>,
+    step: usize,
+    m: usize,
+    n: usize,
+) {
+    let task = CUBE_POS_X as usize;
+    let trailing = n - step;
+    let batch = task / trailing;
+    let column = step + task % trailing;
+    let matrix_base = batch * m * n;
+    let mut row = step + UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut local_max = F::new(0.0f32);
+    let mut invalid = 0u32.runtime();
+    while row < m {
+        let magnitude = work[matrix_base + row + column * m].abs();
+        let finite_probe = magnitude - magnitude;
+        if finite_probe != finite_probe {
+            invalid = 1u32;
+        } else if magnitude > local_max {
+            local_max = magnitude;
+        }
+        row += plane_width;
+    }
+    let scale = plane_max(local_max);
+    row = step + UNIT_POS as usize;
+    let mut local_sum = F::new(0.0f32);
+    if scale > F::new(0.0f32) {
+        while row < m {
+            let scaled = work[matrix_base + row + column * m].abs() / scale;
+            local_sum += scaled * scaled;
+            row += plane_width;
+        }
+    }
+    let norm = scale * plane_sum(local_sum).sqrt();
+    let norm_probe = norm - norm;
+    let invalid = plane_sum(invalid) > 0u32 || norm_probe != norm_probe;
+    if UNIT_POS == 0 {
+        norms[column + batch * n] = if invalid { -F::new(1.0f32) } else { norm };
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn column_norms_c32(
+    work: &Tensor<Complex32>,
+    norms: &mut Tensor<f32>,
+    step: usize,
+    m: usize,
+    n: usize,
+) {
+    let task = CUBE_POS_X as usize;
+    let trailing = n - step;
+    let batch = task / trailing;
+    let column = step + task % trailing;
+    let matrix_base = batch * m * n;
+    let mut row = step + UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut local_max = 0.0f32;
+    let mut invalid = 0u32.runtime();
+    while row < m {
+        let magnitude = work[matrix_base + row + column * m].abs();
+        let finite_probe = magnitude - magnitude;
+        if finite_probe != finite_probe {
+            invalid = 1u32;
+        } else if magnitude > local_max {
+            local_max = magnitude;
+        }
+        row += plane_width;
+    }
+    let scale = plane_max(local_max);
+    row = step + UNIT_POS as usize;
+    let mut local_sum = 0.0f32;
+    if scale > 0.0f32 {
+        while row < m {
+            let scaled = work[matrix_base + row + column * m].abs() / scale;
+            local_sum += scaled * scaled;
+            row += plane_width;
+        }
+    }
+    let norm = scale * plane_sum(local_sum).sqrt();
+    let norm_probe = norm - norm;
+    let invalid = plane_sum(invalid) > 0u32 || norm_probe != norm_probe;
+    if UNIT_POS == 0 {
+        norms[column + batch * n] = if invalid {
+            0.0f32.runtime() - 1.0f32
+        } else {
+            norm
+        };
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn column_norms_c64(
+    work: &Tensor<Complex64>,
+    norms: &mut Tensor<f64>,
+    step: usize,
+    m: usize,
+    n: usize,
+) {
+    let task = CUBE_POS_X as usize;
+    let trailing = n - step;
+    let batch = task / trailing;
+    let column = step + task % trailing;
+    let matrix_base = batch * m * n;
+    let mut row = step + UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut local_max = 0.0f64;
+    let mut invalid = 0u32.runtime();
+    while row < m {
+        let magnitude = work[matrix_base + row + column * m].abs();
+        let finite_probe = magnitude - magnitude;
+        if finite_probe != finite_probe {
+            invalid = 1u32;
+        } else if magnitude > local_max {
+            local_max = magnitude;
+        }
+        row += plane_width;
+    }
+    let scale = plane_max(local_max);
+    row = step + UNIT_POS as usize;
+    let mut local_sum = 0.0f64;
+    if scale > 0.0f64 {
+        while row < m {
+            let scaled = work[matrix_base + row + column * m].abs() / scale;
+            local_sum += scaled * scaled;
+            row += plane_width;
+        }
+    }
+    let norm = scale * plane_sum(local_sum).sqrt();
+    let norm_probe = norm - norm;
+    let invalid = plane_sum(invalid) > 0u32 || norm_probe != norm_probe;
+    if UNIT_POS == 0 {
+        norms[column + batch * n] = if invalid {
+            0.0f64.runtime() - 1.0f64
+        } else {
+            norm
+        };
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn select_pivot<
+    F: Float + CubeElement + CubePrimitive<WithScalar<bool> = bool, WithScalar<F> = F>,
+>(
+    norms: &Tensor<F>,
+    permutation: &Tensor<i64>,
+    pivots: &mut Tensor<i64>,
+    status: &mut Tensor<i64>,
+    step: usize,
+    n: usize,
+) {
+    let batch = CUBE_POS_X as usize;
+    let mut column = step + UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut local_max = F::new(0.0f32);
+    let mut local_original = u32::MAX.runtime();
+    let mut local_column = u32::MAX.runtime();
+    let mut invalid = 0u32.runtime();
+    while column < n {
+        let offset = column + batch * n;
+        let norm = norms[offset];
+        let original = permutation[offset] as u32;
+        if norm < F::new(0.0f32) {
+            invalid = 1u32;
+        } else if norm > local_max || (norm == local_max && original < local_original) {
+            local_max = norm;
+            local_original = original;
+            local_column = column as u32;
+        }
+        column += plane_width;
+    }
+    let maximum = plane_max(local_max);
+    let original = plane_min(if local_max == maximum {
+        local_original
+    } else {
+        u32::MAX.runtime()
+    });
+    let selected = plane_min(if local_max == maximum && local_original == original {
+        local_column
+    } else {
+        u32::MAX.runtime()
+    });
+    let any_invalid = plane_sum(invalid) > 0u32;
+    if UNIT_POS == 0 {
+        pivots[batch] = if selected == u32::MAX {
+            step as i64
+        } else {
+            selected as i64
+        };
+        if any_invalid {
+            status[batch] = 1i64;
+        }
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn swap_columns<E: CubePrimitive>(
+    work: &mut Tensor<E>,
+    permutation: &mut Tensor<i64>,
+    pivots: &Tensor<i64>,
+    step: usize,
+    m: usize,
+    n: usize,
+) {
+    let pos = ABSOLUTE_POS as usize;
+    let batches = pivots.len();
+    if pos < m * batches {
+        let row = pos % m;
+        let batch = pos / m;
+        let pivot = pivots[batch] as usize;
+        if pivot != step {
+            let matrix_base = batch * m * n;
+            let left = matrix_base + row + step * m;
+            let right = matrix_base + row + pivot * m;
+            let value = work[left];
+            work[left] = work[right];
+            work[right] = value;
+            if row == 0usize {
+                let left = step + batch * n;
+                let right = pivot + batch * n;
+                let original = permutation[left];
+                permutation[left] = permutation[right];
+                permutation[right] = original;
+            }
+        }
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn reflector_real<
+    F: Float + CubeElement + CubePrimitive<WithScalar<bool> = bool, WithScalar<F> = F>,
+>(
+    work: &mut Tensor<F>,
+    coeff: &mut Tensor<F>,
+    step: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+) {
+    let batch = CUBE_POS_X as usize;
+    let matrix_base = batch * m * n;
+    let mut row = step + UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut local_max = F::new(0.0f32);
+    while row < m {
+        let magnitude = work[matrix_base + row + step * m].abs();
+        if magnitude > local_max {
+            local_max = magnitude;
+        }
+        row += plane_width;
+    }
+    let scale = plane_max(local_max);
+    row = step + UNIT_POS as usize;
+    let mut local_sum = F::new(0.0f32);
+    if scale > F::new(0.0f32) {
+        while row < m {
+            let scaled = work[matrix_base + row + step * m].abs() / scale;
+            local_sum += scaled * scaled;
+            row += plane_width;
+        }
+    }
+    let norm = scale * plane_sum(local_sum).sqrt();
+    let x0 = work[matrix_base + step + step * m];
+    if norm == F::new(0.0f32) {
+        if UNIT_POS == 0 {
+            coeff[step + batch * k] = F::new(0.0f32);
+        }
+    } else {
+        let phase = if x0 < F::new(0.0f32) {
+            -F::new(1.0f32)
+        } else {
+            F::new(1.0f32)
+        };
+        let alpha = -phase * norm;
+        let denominator = x0 - alpha;
+        row = step + 1usize + UNIT_POS as usize;
+        while row < m {
+            let offset = matrix_base + row + step * m;
+            work[offset] = work[offset] / denominator;
+            row += plane_width;
+        }
+        if UNIT_POS == 0 {
+            work[matrix_base + step + step * m] = alpha;
+            coeff[step + batch * k] = F::new(1.0f32) + x0.abs() / norm;
+        }
+    }
+}
+
+#[cube]
+fn c32_from_real(value: f32) -> Complex32 {
+    Complex32::cast_from(value)
+}
+
+#[cube]
+fn c64_from_real(value: f64) -> Complex64 {
+    Complex64::cast_from(value)
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn reflector_c32(
+    work: &mut Tensor<Complex32>,
+    coeff: &mut Tensor<Complex32>,
+    step: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+) {
+    let batch = CUBE_POS_X as usize;
+    let matrix_base = batch * m * n;
+    let mut row = step + UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut local_max = 0.0f32;
+    while row < m {
+        let magnitude = work[matrix_base + row + step * m].abs();
+        if magnitude > local_max {
+            local_max = magnitude;
+        }
+        row += plane_width;
+    }
+    let scale = plane_max(local_max);
+    row = step + UNIT_POS as usize;
+    let mut local_sum = 0.0f32;
+    if scale > 0.0f32 {
+        while row < m {
+            let scaled = work[matrix_base + row + step * m].abs() / scale;
+            local_sum += scaled * scaled;
+            row += plane_width;
+        }
+    }
+    let norm = scale * plane_sum(local_sum).sqrt();
+    let x0 = work[matrix_base + step + step * m];
+    if norm == 0.0f32 {
+        if UNIT_POS == 0 {
+            coeff[step + batch * k] = Complex32::cast_from(0.0f32);
+        }
+    } else {
+        let x0_abs = x0.abs();
+        let phase = if x0_abs == 0.0f32 {
+            Complex32::cast_from(1.0f32)
+        } else {
+            x0 / Complex32::cast_from(x0_abs)
+        };
+        let alpha = -phase * Complex32::cast_from(norm);
+        let denominator = x0 - alpha;
+        row = step + 1usize + UNIT_POS as usize;
+        while row < m {
+            let offset = matrix_base + row + step * m;
+            work[offset] = work[offset] / denominator;
+            row += plane_width;
+        }
+        if UNIT_POS == 0 {
+            work[matrix_base + step + step * m] = alpha;
+            coeff[step + batch * k] = Complex32::cast_from(1.0f32 + x0_abs / norm);
+        }
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn reflector_c64(
+    work: &mut Tensor<Complex64>,
+    coeff: &mut Tensor<Complex64>,
+    step: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+) {
+    let batch = CUBE_POS_X as usize;
+    let matrix_base = batch * m * n;
+    let mut row = step + UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut local_max = 0.0f64;
+    while row < m {
+        let magnitude = work[matrix_base + row + step * m].abs();
+        if magnitude > local_max {
+            local_max = magnitude;
+        }
+        row += plane_width;
+    }
+    let scale = plane_max(local_max);
+    row = step + UNIT_POS as usize;
+    let mut local_sum = 0.0f64;
+    if scale > 0.0f64 {
+        while row < m {
+            let scaled = work[matrix_base + row + step * m].abs() / scale;
+            local_sum += scaled * scaled;
+            row += plane_width;
+        }
+    }
+    let norm = scale * plane_sum(local_sum).sqrt();
+    let x0 = work[matrix_base + step + step * m];
+    if norm == 0.0f64 {
+        if UNIT_POS == 0 {
+            coeff[step + batch * k] = Complex64::cast_from(0.0f64);
+        }
+    } else {
+        let x0_abs = x0.abs();
+        let phase = if x0_abs == 0.0f64 {
+            Complex64::cast_from(1.0f64)
+        } else {
+            x0 / Complex64::cast_from(x0_abs)
+        };
+        let alpha = -phase * Complex64::cast_from(norm);
+        let denominator = x0 - alpha;
+        row = step + 1usize + UNIT_POS as usize;
+        while row < m {
+            let offset = matrix_base + row + step * m;
+            work[offset] = work[offset] / denominator;
+            row += plane_width;
+        }
+        if UNIT_POS == 0 {
+            work[matrix_base + step + step * m] = alpha;
+            coeff[step + batch * k] = Complex64::cast_from(1.0f64 + x0_abs / norm);
+        }
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn apply_reflector_real<
+    F: Float + CubeElement + CubePrimitive<WithScalar<bool> = bool, WithScalar<F> = F>,
+>(
+    packed: &Tensor<F>,
+    target: &mut Tensor<F>,
+    step: usize,
+    first_column: usize,
+    column_count: usize,
+    m: usize,
+    packed_columns: usize,
+    target_columns: usize,
+    k: usize,
+    coeff: &Tensor<F>,
+) {
+    let task = CUBE_POS_X as usize;
+    let batch = task / column_count;
+    let column = first_column + task % column_count;
+    let packed_base = batch * m * packed_columns;
+    let target_base = batch * m * target_columns;
+    let mut row = step + UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut dot = F::new(0.0f32);
+    while row < m {
+        let vector = if row == step {
+            F::new(1.0f32)
+        } else {
+            packed[packed_base + row + step * m]
+        };
+        dot = dot + vector * target[target_base + row + column * m];
+        row += plane_width;
+    }
+    dot = plane_sum(dot) * coeff[step + batch * k];
+    row = step + UNIT_POS as usize;
+    while row < m {
+        let vector = if row == step {
+            F::new(1.0f32)
+        } else {
+            packed[packed_base + row + step * m]
+        };
+        let offset = target_base + row + column * m;
+        target[offset] = target[offset] - vector * dot;
+        row += plane_width;
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn apply_reflector_c32(
+    packed: &Tensor<Complex32>,
+    target: &mut Tensor<Complex32>,
+    step: usize,
+    first_column: usize,
+    column_count: usize,
+    m: usize,
+    packed_columns: usize,
+    target_columns: usize,
+    k: usize,
+    coeff: &Tensor<Complex32>,
+    imaginary_unit: &Tensor<Complex32>,
+) {
+    let task = CUBE_POS_X as usize;
+    let batch = task / column_count;
+    let column = first_column + task % column_count;
+    let packed_base = batch * m * packed_columns;
+    let target_base = batch * m * target_columns;
+    let mut row = step + UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut dot = Complex32::cast_from(0.0f32);
+    while row < m {
+        let vector = if row == step {
+            Complex32::cast_from(1.0f32)
+        } else {
+            packed[packed_base + row + step * m]
+        };
+        dot = dot + vector.conj() * target[target_base + row + column * m];
+        row += plane_width;
+    }
+    let dot_real = plane_sum(dot.real_val());
+    let dot_imag = plane_sum(dot.imag_val());
+    dot = (Complex32::cast_from(dot_real) + imaginary_unit[0] * Complex32::cast_from(dot_imag))
+        * coeff[step + batch * k];
+    row = step + UNIT_POS as usize;
+    while row < m {
+        let vector = if row == step {
+            Complex32::cast_from(1.0f32)
+        } else {
+            packed[packed_base + row + step * m]
+        };
+        let offset = target_base + row + column * m;
+        target[offset] = target[offset] - vector * dot;
+        row += plane_width;
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn apply_reflector_c64(
+    packed: &Tensor<Complex64>,
+    target: &mut Tensor<Complex64>,
+    step: usize,
+    first_column: usize,
+    column_count: usize,
+    m: usize,
+    packed_columns: usize,
+    target_columns: usize,
+    k: usize,
+    coeff: &Tensor<Complex64>,
+    imaginary_unit: &Tensor<Complex64>,
+) {
+    let task = CUBE_POS_X as usize;
+    let batch = task / column_count;
+    let column = first_column + task % column_count;
+    let packed_base = batch * m * packed_columns;
+    let target_base = batch * m * target_columns;
+    let mut row = step + UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut dot = Complex64::cast_from(0.0f64);
+    while row < m {
+        let vector = if row == step {
+            Complex64::cast_from(1.0f64)
+        } else {
+            packed[packed_base + row + step * m]
+        };
+        dot = dot + vector.conj() * target[target_base + row + column * m];
+        row += plane_width;
+    }
+    let dot_real = plane_sum(dot.real_val());
+    let dot_imag = plane_sum(dot.imag_val());
+    dot = (Complex64::cast_from(dot_real) + imaginary_unit[0] * Complex64::cast_from(dot_imag))
+        * coeff[step + batch * k];
+    row = step + UNIT_POS as usize;
+    while row < m {
+        let vector = if row == step {
+            Complex64::cast_from(1.0f64)
+        } else {
+            packed[packed_base + row + step * m]
+        };
+        let offset = target_base + row + column * m;
+        target[offset] = target[offset] - vector * dot;
+        row += plane_width;
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn initialize_q<E: CubePrimitive>(q: &mut Tensor<E>, m: usize, k: usize) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < q.len() {
+        let row = pos % m;
+        let column = (pos / m) % k;
+        q[pos] = if row == column {
+            rrqr_one::<E>()
+        } else {
+            rrqr_zero::<E>()
+        };
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn extract_r<E: CubePrimitive>(
+    work: &Tensor<E>,
+    r: &mut Tensor<E>,
+    m: usize,
+    n: usize,
+    k: usize,
+) {
+    let pos = ABSOLUTE_POS as usize;
+    if pos < r.len() {
+        let row = pos % k;
+        let column = (pos / k) % n;
+        let batch = pos / (k * n);
+        r[pos] = if row <= column {
+            work[batch * m * n + row + column * m]
+        } else {
+            rrqr_zero::<E>()
+        };
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn prefix_rank_real<
+    F: Float + CubeElement + CubePrimitive<WithScalar<bool> = bool, WithScalar<F> = F>,
+>(
+    r: &Tensor<F>,
+    rank: &mut Tensor<i64>,
+    status: &mut Tensor<i64>,
+    k: usize,
+    n: usize,
+    rtol: F,
+    atol: F,
+) {
+    let batch = CUBE_POS_X as usize;
+    let base = batch * k * n;
+    let leading = r[base].abs();
+    let relative = rtol * leading;
+    let threshold = if atol > relative { atol } else { relative };
+    let mut diagonal = UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut first_failure = u32::MAX.runtime();
+    let mut invalid = 0u32.runtime();
+    while diagonal < k {
+        let value = r[base + diagonal + diagonal * k].abs();
+        let finite_probe = value - value;
+        if finite_probe != finite_probe {
+            invalid = 1u32;
+        }
+        if !(value > threshold) && (diagonal as u32) < first_failure {
+            first_failure = diagonal as u32;
+        }
+        diagonal += plane_width;
+    }
+    let first_failure = plane_min(first_failure);
+    let any_invalid = plane_sum(invalid) > 0u32;
+    if UNIT_POS == 0 {
+        rank[batch] = if first_failure == u32::MAX {
+            k as i64
+        } else {
+            first_failure as i64
+        };
+        if any_invalid {
+            status[batch] = 1i64;
+        }
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn prefix_rank_c32(
+    r: &Tensor<Complex32>,
+    rank: &mut Tensor<i64>,
+    status: &mut Tensor<i64>,
+    k: usize,
+    n: usize,
+    rtol: f32,
+    atol: f32,
+) {
+    let batch = CUBE_POS_X as usize;
+    let base = batch * k * n;
+    let leading = r[base].abs();
+    let relative = rtol * leading;
+    let threshold = if atol > relative { atol } else { relative };
+    let mut diagonal = UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut first_failure = u32::MAX.runtime();
+    let mut invalid = 0u32.runtime();
+    while diagonal < k {
+        let value = r[base + diagonal + diagonal * k].abs();
+        let finite_probe = value - value;
+        if finite_probe != finite_probe {
+            invalid = 1u32;
+        }
+        if !(value > threshold) && (diagonal as u32) < first_failure {
+            first_failure = diagonal as u32;
+        }
+        diagonal += plane_width;
+    }
+    let first_failure = plane_min(first_failure);
+    let any_invalid = plane_sum(invalid) > 0u32;
+    if UNIT_POS == 0 {
+        rank[batch] = if first_failure == u32::MAX {
+            k as i64
+        } else {
+            first_failure as i64
+        };
+        if any_invalid {
+            status[batch] = 1i64;
+        }
+    }
+}
+
+#[cube(launch_unchecked)]
+pub(crate) fn prefix_rank_c64(
+    r: &Tensor<Complex64>,
+    rank: &mut Tensor<i64>,
+    status: &mut Tensor<i64>,
+    k: usize,
+    n: usize,
+    rtol: f64,
+    atol: f64,
+) {
+    let batch = CUBE_POS_X as usize;
+    let base = batch * k * n;
+    let leading = r[base].abs();
+    let relative = rtol * leading;
+    let threshold = if atol > relative { atol } else { relative };
+    let mut diagonal = UNIT_POS as usize;
+    let plane_width = PLANE_DIM as usize;
+    let mut first_failure = u32::MAX.runtime();
+    let mut invalid = 0u32.runtime();
+    while diagonal < k {
+        let value = r[base + diagonal + diagonal * k].abs();
+        let finite_probe = value - value;
+        if finite_probe != finite_probe {
+            invalid = 1u32;
+        }
+        if !(value > threshold) && (diagonal as u32) < first_failure {
+            first_failure = diagonal as u32;
+        }
+        diagonal += plane_width;
+    }
+    let first_failure = plane_min(first_failure);
+    let any_invalid = plane_sum(invalid) > 0u32;
+    if UNIT_POS == 0 {
+        rank[batch] = if first_failure == u32::MAX {
+            k as i64
+        } else {
+            first_failure as i64
+        };
+        if any_invalid {
+            status[batch] = 1i64;
+        }
+    }
+}

--- a/crates/tenferro-linalg/src/gpu/linalg.rs
+++ b/crates/tenferro-linalg/src/gpu/linalg.rs
@@ -410,6 +410,14 @@ pub(super) fn qr(backend: &mut CudaExecSession<'_>, input: &Tensor) -> Result<Ve
     }
 }
 
+pub(super) fn rank_revealing_qr(
+    backend: &mut CudaExecSession<'_>,
+    input: &Tensor,
+    options: crate::RankRevealingQrOptions,
+) -> Result<Vec<Tensor>> {
+    rank_revealing_qr::rank_revealing_qr(backend, input, options)
+}
+
 pub(super) fn householder_qr(
     backend: &mut CudaExecSession<'_>,
     input: &Tensor,
@@ -2394,6 +2402,7 @@ where
 }
 
 mod householder_qr;
+mod rank_revealing_qr;
 use householder_qr::*;
 
 fn qr_typed<T>(

--- a/crates/tenferro-linalg/src/gpu/linalg/rank_revealing_qr.rs
+++ b/crates/tenferro-linalg/src/gpu/linalg/rank_revealing_qr.rs
@@ -1,0 +1,883 @@
+use cubecl::prelude::{CubeCount, CubeDim, TensorBinding};
+
+use super::*;
+use crate::{rank_revealing_qr::validate_rank_revealing_qr_options, RankRevealingQrOptions};
+
+const OP: &str = "rank_revealing_qr";
+const RRQR_PLANE_WIDTH: u32 = 32;
+
+type CudaTensorBinding = TensorBinding<CubeclCudaRuntime>;
+
+trait CudaRrqrScalar: LinalgScalar + TensorScalar {
+    fn device_imaginary_unit(
+        backend: &mut CudaExecSession<'_>,
+    ) -> Result<Option<TypedTensor<Self>>>;
+
+    fn launch_norms(
+        cubecl: &CubeclSession<'_>,
+        work: &TypedTensor<Self>,
+        norms: &TypedTensor<<Self as LinalgScalar>::Real>,
+        count: CubeCount,
+        step: usize,
+        m: usize,
+        n: usize,
+    ) -> Result<()>;
+
+    fn launch_pivot(
+        cubecl: &CubeclSession<'_>,
+        norms: &TypedTensor<<Self as LinalgScalar>::Real>,
+        permutation: &TypedTensor<i64>,
+        pivots: &TypedTensor<i64>,
+        status: &TypedTensor<i64>,
+        count: CubeCount,
+        step: usize,
+        n: usize,
+    ) -> Result<()>;
+
+    fn launch_reflector(
+        cubecl: &CubeclSession<'_>,
+        work: &TypedTensor<Self>,
+        coeff: &TypedTensor<Self>,
+        count: CubeCount,
+        step: usize,
+        m: usize,
+        n: usize,
+        k: usize,
+    ) -> Result<()>;
+
+    #[allow(clippy::too_many_arguments)]
+    fn launch_apply(
+        cubecl: &CubeclSession<'_>,
+        packed: &TypedTensor<Self>,
+        target: &TypedTensor<Self>,
+        coeff: &TypedTensor<Self>,
+        imaginary_unit: Option<&TypedTensor<Self>>,
+        count: CubeCount,
+        step: usize,
+        first_column: usize,
+        column_count: usize,
+        m: usize,
+        packed_columns: usize,
+        target_columns: usize,
+        k: usize,
+    ) -> Result<()>;
+
+    #[allow(clippy::too_many_arguments)]
+    fn launch_rank(
+        cubecl: &CubeclSession<'_>,
+        r: &TypedTensor<Self>,
+        rank: &TypedTensor<i64>,
+        status: &TypedTensor<i64>,
+        count: CubeCount,
+        k: usize,
+        n: usize,
+        options: RankRevealingQrOptions,
+    ) -> Result<()>;
+}
+
+fn rrqr_binding<T>(cubecl: &CubeclSession<'_>, tensor: &TypedTensor<T>) -> Result<CudaTensorBinding>
+where
+    T: cubecl::prelude::CubeElement + TensorScalar + Clone,
+{
+    cubecl.tensor_binding(tensor, OP)
+}
+
+macro_rules! impl_cuda_rrqr_real {
+    ($scalar:ty, $variant:ident) => {
+        impl CudaRrqrScalar for $scalar {
+            fn device_imaginary_unit(
+                _backend: &mut CudaExecSession<'_>,
+            ) -> Result<Option<TypedTensor<Self>>> {
+                Ok(None)
+            }
+
+            fn launch_norms(
+                cubecl: &CubeclSession<'_>,
+                work: &TypedTensor<Self>,
+                norms: &TypedTensor<<Self as LinalgScalar>::Real>,
+                count: CubeCount,
+                step: usize,
+                m: usize,
+                n: usize,
+            ) -> Result<()> {
+                let work = rrqr_binding(cubecl, work)?;
+                let norms = rrqr_binding(cubecl, norms)?;
+                // SAFETY: dense same-runtime bindings are live for this launch;
+                // one plane owns each (trailing column, batch) norm.
+                unsafe {
+                    cubecl_linalg::column_norms_real::launch_unchecked::<Self, CubeclCudaRuntime>(
+                        cubecl.client(),
+                        count,
+                        rrqr_cube_dim(),
+                        work.into_tensor_arg(),
+                        norms.into_tensor_arg(),
+                        step,
+                        m,
+                        n,
+                    );
+                }
+                Ok(())
+            }
+
+            fn launch_pivot(
+                cubecl: &CubeclSession<'_>,
+                norms: &TypedTensor<<Self as LinalgScalar>::Real>,
+                permutation: &TypedTensor<i64>,
+                pivots: &TypedTensor<i64>,
+                status: &TypedTensor<i64>,
+                count: CubeCount,
+                step: usize,
+                n: usize,
+            ) -> Result<()> {
+                launch_pivot_real::<Self>(
+                    cubecl,
+                    norms,
+                    permutation,
+                    pivots,
+                    status,
+                    count,
+                    step,
+                    n,
+                )
+            }
+
+            fn launch_reflector(
+                cubecl: &CubeclSession<'_>,
+                work: &TypedTensor<Self>,
+                coeff: &TypedTensor<Self>,
+                count: CubeCount,
+                step: usize,
+                m: usize,
+                n: usize,
+                k: usize,
+            ) -> Result<()> {
+                let work = rrqr_binding(cubecl, work)?;
+                let coeff = rrqr_binding(cubecl, coeff)?;
+                // SAFETY: one plane owns each batch reflector and lanes write
+                // disjoint entries of its packed vector.
+                unsafe {
+                    cubecl_linalg::reflector_real::launch_unchecked::<Self, CubeclCudaRuntime>(
+                        cubecl.client(),
+                        count,
+                        rrqr_cube_dim(),
+                        work.into_tensor_arg(),
+                        coeff.into_tensor_arg(),
+                        step,
+                        m,
+                        n,
+                        k,
+                    );
+                }
+                Ok(())
+            }
+
+            fn launch_apply(
+                cubecl: &CubeclSession<'_>,
+                packed: &TypedTensor<Self>,
+                target: &TypedTensor<Self>,
+                coeff: &TypedTensor<Self>,
+                _imaginary_unit: Option<&TypedTensor<Self>>,
+                count: CubeCount,
+                step: usize,
+                first_column: usize,
+                column_count: usize,
+                m: usize,
+                packed_columns: usize,
+                target_columns: usize,
+                k: usize,
+            ) -> Result<()> {
+                let packed = rrqr_binding(cubecl, packed)?;
+                let target = rrqr_binding(cubecl, target)?;
+                let coeff = rrqr_binding(cubecl, coeff)?;
+                // SAFETY: one plane owns each (target column, batch) update;
+                // target columns never overlap the packed reflector column.
+                unsafe {
+                    cubecl_linalg::apply_reflector_real::launch_unchecked::<
+                        Self,
+                        CubeclCudaRuntime,
+                    >(
+                        cubecl.client(),
+                        count,
+                        rrqr_cube_dim(),
+                        packed.into_tensor_arg(),
+                        target.into_tensor_arg(),
+                        step,
+                        first_column,
+                        column_count,
+                        m,
+                        packed_columns,
+                        target_columns,
+                        k,
+                        coeff.into_tensor_arg(),
+                    );
+                }
+                Ok(())
+            }
+
+            fn launch_rank(
+                cubecl: &CubeclSession<'_>,
+                r: &TypedTensor<Self>,
+                rank: &TypedTensor<i64>,
+                status: &TypedTensor<i64>,
+                count: CubeCount,
+                k: usize,
+                n: usize,
+                options: RankRevealingQrOptions,
+            ) -> Result<()> {
+                let r = rrqr_binding(cubecl, r)?;
+                let rank = rrqr_binding(cubecl, rank)?;
+                let status = rrqr_binding(cubecl, status)?;
+                // SAFETY: one plane owns each batch rank and scans disjoint
+                // diagonal subsequences before a plane minimum reduction.
+                unsafe {
+                    cubecl_linalg::prefix_rank_real::launch_unchecked::<Self, CubeclCudaRuntime>(
+                        cubecl.client(),
+                        count,
+                        rrqr_cube_dim(),
+                        r.into_tensor_arg(),
+                        rank.into_tensor_arg(),
+                        status.into_tensor_arg(),
+                        k,
+                        n,
+                        options.rtol as $scalar,
+                        options.atol as $scalar,
+                    );
+                }
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_cuda_rrqr_real!(f32, F32);
+impl_cuda_rrqr_real!(f64, F64);
+
+fn launch_pivot_real<F>(
+    cubecl: &CubeclSession<'_>,
+    norms: &TypedTensor<F>,
+    permutation: &TypedTensor<i64>,
+    pivots: &TypedTensor<i64>,
+    status: &TypedTensor<i64>,
+    count: CubeCount,
+    step: usize,
+    n: usize,
+) -> Result<()>
+where
+    F: cubecl::prelude::Float
+        + cubecl::prelude::CubeElement
+        + cubecl::prelude::CubePrimitive<WithScalar<bool> = bool, WithScalar<F> = F>
+        + TensorScalar
+        + Clone,
+{
+    let norms = rrqr_binding(cubecl, norms)?;
+    let permutation = rrqr_binding(cubecl, permutation)?;
+    let pivots = rrqr_binding(cubecl, pivots)?;
+    let status = rrqr_binding(cubecl, status)?;
+    // SAFETY: one plane owns each batch pivot/status output; permutation is
+    // read-only and the lowest original index resolves exact norm ties.
+    unsafe {
+        cubecl_linalg::select_pivot::launch_unchecked::<F, CubeclCudaRuntime>(
+            cubecl.client(),
+            count,
+            rrqr_cube_dim(),
+            norms.into_tensor_arg(),
+            permutation.into_tensor_arg(),
+            pivots.into_tensor_arg(),
+            status.into_tensor_arg(),
+            step,
+            n,
+        );
+    }
+    Ok(())
+}
+
+macro_rules! impl_cuda_rrqr_complex {
+    ($scalar:ty, $variant:ident, $real:ty, $norms:ident, $reflector:ident, $apply:ident, $rank_kernel:ident) => {
+        impl CudaRrqrScalar for $scalar {
+            fn device_imaginary_unit(
+                backend: &mut CudaExecSession<'_>,
+            ) -> Result<Option<TypedTensor<Self>>> {
+                let host = Tensor::$variant(TypedTensor::from_vec_col_major(
+                    vec![1],
+                    vec![<$scalar>::new(0.0 as $real, 1.0 as $real)],
+                )?);
+                match tenferro_gpu::cuda::upload_tensor(backend.runtime(), &host)? {
+                    Tensor::$variant(tensor) => Ok(Some(tensor)),
+                    _ => Err(Error::Internal("RRQR constant upload changed dtype".into())),
+                }
+            }
+
+            fn launch_norms(
+                cubecl: &CubeclSession<'_>,
+                work: &TypedTensor<Self>,
+                norms: &TypedTensor<<Self as LinalgScalar>::Real>,
+                count: CubeCount,
+                step: usize,
+                m: usize,
+                n: usize,
+            ) -> Result<()> {
+                let work = rrqr_binding(cubecl, work)?;
+                let norms = rrqr_binding(cubecl, norms)?;
+                // SAFETY: one plane owns each (trailing column, batch) norm.
+                unsafe {
+                    cubecl_linalg::$norms::launch_unchecked::<CubeclCudaRuntime>(
+                        cubecl.client(),
+                        count,
+                        rrqr_cube_dim(),
+                        work.into_tensor_arg(),
+                        norms.into_tensor_arg(),
+                        step,
+                        m,
+                        n,
+                    );
+                }
+                Ok(())
+            }
+
+            fn launch_pivot(
+                cubecl: &CubeclSession<'_>,
+                norms: &TypedTensor<<Self as LinalgScalar>::Real>,
+                permutation: &TypedTensor<i64>,
+                pivots: &TypedTensor<i64>,
+                status: &TypedTensor<i64>,
+                count: CubeCount,
+                step: usize,
+                n: usize,
+            ) -> Result<()> {
+                launch_pivot_real::<$real>(
+                    cubecl,
+                    norms,
+                    permutation,
+                    pivots,
+                    status,
+                    count,
+                    step,
+                    n,
+                )
+            }
+
+            fn launch_reflector(
+                cubecl: &CubeclSession<'_>,
+                work: &TypedTensor<Self>,
+                coeff: &TypedTensor<Self>,
+                count: CubeCount,
+                step: usize,
+                m: usize,
+                n: usize,
+                k: usize,
+            ) -> Result<()> {
+                let work = rrqr_binding(cubecl, work)?;
+                let coeff = rrqr_binding(cubecl, coeff)?;
+                // SAFETY: one plane owns each batch reflector and lanes write
+                // disjoint entries of its packed vector.
+                unsafe {
+                    cubecl_linalg::$reflector::launch_unchecked::<CubeclCudaRuntime>(
+                        cubecl.client(),
+                        count,
+                        rrqr_cube_dim(),
+                        work.into_tensor_arg(),
+                        coeff.into_tensor_arg(),
+                        step,
+                        m,
+                        n,
+                        k,
+                    );
+                }
+                Ok(())
+            }
+
+            fn launch_apply(
+                cubecl: &CubeclSession<'_>,
+                packed: &TypedTensor<Self>,
+                target: &TypedTensor<Self>,
+                coeff: &TypedTensor<Self>,
+                imaginary_unit: Option<&TypedTensor<Self>>,
+                count: CubeCount,
+                step: usize,
+                first_column: usize,
+                column_count: usize,
+                m: usize,
+                packed_columns: usize,
+                target_columns: usize,
+                k: usize,
+            ) -> Result<()> {
+                let packed = rrqr_binding(cubecl, packed)?;
+                let target = rrqr_binding(cubecl, target)?;
+                let coeff = rrqr_binding(cubecl, coeff)?;
+                let imaginary_unit = imaginary_unit.ok_or_else(|| {
+                    Error::Internal("complex RRQR requires an imaginary-unit constant".into())
+                })?;
+                let imaginary_unit = rrqr_binding(cubecl, imaginary_unit)?;
+                // SAFETY: one plane owns each (target column, batch) update;
+                // target columns never overlap the packed reflector column.
+                unsafe {
+                    cubecl_linalg::$apply::launch_unchecked::<CubeclCudaRuntime>(
+                        cubecl.client(),
+                        count,
+                        rrqr_cube_dim(),
+                        packed.into_tensor_arg(),
+                        target.into_tensor_arg(),
+                        step,
+                        first_column,
+                        column_count,
+                        m,
+                        packed_columns,
+                        target_columns,
+                        k,
+                        coeff.into_tensor_arg(),
+                        imaginary_unit.into_tensor_arg(),
+                    );
+                }
+                Ok(())
+            }
+
+            fn launch_rank(
+                cubecl: &CubeclSession<'_>,
+                r: &TypedTensor<Self>,
+                rank: &TypedTensor<i64>,
+                status: &TypedTensor<i64>,
+                count: CubeCount,
+                k: usize,
+                n: usize,
+                options: RankRevealingQrOptions,
+            ) -> Result<()> {
+                let r = rrqr_binding(cubecl, r)?;
+                let rank = rrqr_binding(cubecl, rank)?;
+                let status = rrqr_binding(cubecl, status)?;
+                // SAFETY: one plane owns each batch rank and status output.
+                unsafe {
+                    cubecl_linalg::$rank_kernel::launch_unchecked::<CubeclCudaRuntime>(
+                        cubecl.client(),
+                        count,
+                        rrqr_cube_dim(),
+                        r.into_tensor_arg(),
+                        rank.into_tensor_arg(),
+                        status.into_tensor_arg(),
+                        k,
+                        n,
+                        options.rtol as $real,
+                        options.atol as $real,
+                    );
+                }
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_cuda_rrqr_complex!(
+    Complex32,
+    C32,
+    f32,
+    column_norms_c32,
+    reflector_c32,
+    apply_reflector_c32,
+    prefix_rank_c32
+);
+impl_cuda_rrqr_complex!(
+    Complex64,
+    C64,
+    f64,
+    column_norms_c64,
+    reflector_c64,
+    apply_reflector_c64,
+    prefix_rank_c64
+);
+
+pub(super) fn rank_revealing_qr(
+    backend: &mut CudaExecSession<'_>,
+    input: &Tensor,
+    options: RankRevealingQrOptions,
+) -> Result<Vec<Tensor>> {
+    validate_rank_revealing_qr_options(OP, options)?;
+    match input {
+        Tensor::F32(input) => {
+            rank_revealing_qr_typed(backend, input, options).map(|(q, r, p, rank)| {
+                vec![
+                    Tensor::F32(q),
+                    Tensor::F32(r),
+                    Tensor::I64(p),
+                    Tensor::I64(rank),
+                ]
+            })
+        }
+        Tensor::F64(input) => {
+            rank_revealing_qr_typed(backend, input, options).map(|(q, r, p, rank)| {
+                vec![
+                    Tensor::F64(q),
+                    Tensor::F64(r),
+                    Tensor::I64(p),
+                    Tensor::I64(rank),
+                ]
+            })
+        }
+        Tensor::C32(input) => {
+            rank_revealing_qr_typed(backend, input, options).map(|(q, r, p, rank)| {
+                vec![
+                    Tensor::C32(q),
+                    Tensor::C32(r),
+                    Tensor::I64(p),
+                    Tensor::I64(rank),
+                ]
+            })
+        }
+        Tensor::C64(input) => {
+            rank_revealing_qr_typed(backend, input, options).map(|(q, r, p, rank)| {
+                vec![
+                    Tensor::C64(q),
+                    Tensor::C64(r),
+                    Tensor::I64(p),
+                    Tensor::I64(rank),
+                ]
+            })
+        }
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
+            Err(unsupported_linalg_dtype(OP, input))
+        }
+    }
+}
+
+fn rank_revealing_qr_typed<T>(
+    backend: &mut CudaExecSession<'_>,
+    input: &TypedTensor<T>,
+    options: RankRevealingQrOptions,
+) -> Result<(
+    TypedTensor<T>,
+    TypedTensor<T>,
+    TypedTensor<i64>,
+    TypedTensor<i64>,
+)>
+where
+    T: CudaRrqrScalar + RrqrTensorVariant,
+{
+    ensure_cubecl_resident_typed(OP, input)?;
+    let (m, n) = matrix_dims(OP, input.shape())?;
+    let k = m.min(n);
+    let batch_shape = &input.shape()[2..];
+    let actual_batch_count = checked_shape_product(OP, "batch shape", batch_shape)?;
+    let batch_total = actual_batch_count.max(1);
+    u32::try_from(n).map_err(|_| {
+        Error::invalid_argument(OP, "column count", "column index exceeds u32 range")
+    })?;
+    u32::try_from(k).map_err(|_| Error::invalid_argument(OP, "rank", "rank exceeds u32 range"))?;
+
+    let q_shape = matrix_shape(m, k, batch_shape);
+    let r_shape = matrix_shape(k, n, batch_shape);
+    let permutation_shape = vector_shape(n, batch_shape);
+    let rank_shape = batch_shape.to_vec();
+
+    if m == 0 || n == 0 || actual_batch_count == 0 {
+        return backend.with_cubecl(OP, |cubecl| {
+            let q = cubecl.alloc_output::<T>(&q_shape)?;
+            let r = cubecl.alloc_output::<T>(&r_shape)?;
+            let permutation = cubecl.alloc_output::<i64>(&permutation_shape)?;
+            let rank = cubecl.alloc_zero_output::<i64>(&rank_shape)?;
+            if permutation.n_elements() > 0 {
+                launch_initialize_permutation(cubecl, &permutation, n)?;
+            }
+            Ok((q, r, permutation, rank))
+        });
+    }
+
+    let imaginary_unit = T::device_imaginary_unit(backend)?;
+    let work = clone_device_tensor(backend, input, OP)?;
+    let (q, r, permutation, rank, status) = backend.with_cubecl(OP, |cubecl| {
+        let coeff = cubecl.alloc_output::<T>(&vector_shape(k, batch_shape))?;
+        let norms =
+            cubecl.alloc_output::<<T as LinalgScalar>::Real>(&vector_shape(n, batch_shape))?;
+        let pivots = cubecl.alloc_output::<i64>(&rank_shape)?;
+        let status = cubecl.alloc_zero_output::<i64>(&rank_shape)?;
+        let permutation = cubecl.alloc_output::<i64>(&permutation_shape)?;
+        launch_initialize_permutation(cubecl, &permutation, n)?;
+
+        let batch_planes = rrqr_cube_count(batch_total)?;
+        for step in 0..k {
+            let norm_planes = rrqr_cube_count(checked_mul_usize(
+                OP,
+                "RRQR norm planes",
+                n - step,
+                batch_total,
+            )?)?;
+            T::launch_norms(cubecl, &work, &norms, norm_planes, step, m, n)?;
+            T::launch_pivot(
+                cubecl,
+                &norms,
+                &permutation,
+                &pivots,
+                &status,
+                batch_planes.clone(),
+                step,
+                n,
+            )?;
+            launch_swap_columns(
+                cubecl,
+                &work,
+                &permutation,
+                &pivots,
+                step,
+                m,
+                n,
+                batch_total,
+            )?;
+            T::launch_reflector(cubecl, &work, &coeff, batch_planes.clone(), step, m, n, k)?;
+            let trailing = n - step - 1;
+            if trailing > 0 {
+                let apply_planes = rrqr_cube_count(checked_mul_usize(
+                    OP,
+                    "RRQR trailing update planes",
+                    trailing,
+                    batch_total,
+                )?)?;
+                T::launch_apply(
+                    cubecl,
+                    &work,
+                    &work,
+                    &coeff,
+                    imaginary_unit.as_ref(),
+                    apply_planes,
+                    step,
+                    step + 1,
+                    trailing,
+                    m,
+                    n,
+                    n,
+                    k,
+                )?;
+            }
+        }
+
+        let r = cubecl.alloc_output::<T>(&r_shape)?;
+        launch_extract_r(cubecl, &work, &r, m, n, k)?;
+        let q = cubecl.alloc_output::<T>(&q_shape)?;
+        launch_initialize_q(cubecl, &q, m, k)?;
+        for step in (0..k).rev() {
+            let q_planes = rrqr_cube_count(checked_mul_usize(
+                OP,
+                "RRQR Q update planes",
+                k,
+                batch_total,
+            )?)?;
+            T::launch_apply(
+                cubecl,
+                &work,
+                &q,
+                &coeff,
+                imaginary_unit.as_ref(),
+                q_planes,
+                step,
+                0,
+                k,
+                m,
+                n,
+                k,
+                k,
+            )?;
+        }
+
+        let rank = cubecl.alloc_output::<i64>(&rank_shape)?;
+        T::launch_rank(cubecl, &r, &rank, &status, batch_planes, k, n, options)?;
+        Ok((q, r, permutation, rank, status))
+    })?;
+
+    // The only CUDA-to-host read is this bounded provider-status vector. Matrix
+    // payloads, norms, pivots, permutation, and rank remain device-resident.
+    backend.runtime().synchronize()?;
+    let host_status = download_tensor(backend.runtime(), &Tensor::I64(status))?;
+    let Tensor::I64(host_status) = host_status else {
+        return Err(Error::Internal(
+            "rank_revealing_qr: unexpected provider-status dtype".into(),
+        ));
+    };
+    if host_status.host_data()?.iter().any(|&value| value != 0) {
+        return Err(crate::error::into_tensor_error(
+            OP,
+            crate::Error::NonFinite {
+                op: OP,
+                role: "input or computed R diagonal",
+            },
+        ));
+    }
+
+    let mut factors = vec![wrap_tensor(q), wrap_tensor(r)];
+    if options.gauge == QrGauge::PositiveDiagonal {
+        apply_qr_gauge_device(backend, &mut factors, 0, OP)?;
+    }
+    let q = unwrap_tensor(factors.remove(0))?;
+    let r = unwrap_tensor(factors.remove(0))?;
+    Ok((q, r, permutation, rank))
+}
+
+fn launch_initialize_permutation(
+    cubecl: &CubeclSession<'_>,
+    permutation: &TypedTensor<i64>,
+    n: usize,
+) -> Result<()> {
+    let permutation_arg = rrqr_binding(cubecl, permutation)?;
+    let count = cubecl.cube_count_1d(permutation.n_elements())?;
+    // SAFETY: each worker initializes one distinct permutation element.
+    unsafe {
+        cubecl_linalg::initialize_permutation::launch_unchecked::<CubeclCudaRuntime>(
+            cubecl.client(),
+            count,
+            cubecl.cube_dim_1d(),
+            permutation_arg.into_tensor_arg(),
+            n,
+        );
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn launch_swap_columns<T>(
+    cubecl: &CubeclSession<'_>,
+    work: &TypedTensor<T>,
+    permutation: &TypedTensor<i64>,
+    pivots: &TypedTensor<i64>,
+    step: usize,
+    m: usize,
+    n: usize,
+    batch_total: usize,
+) -> Result<()>
+where
+    T: CudaRrqrScalar,
+{
+    let work_arg = rrqr_binding(cubecl, work)?;
+    let permutation_arg = rrqr_binding(cubecl, permutation)?;
+    let pivots_arg = rrqr_binding(cubecl, pivots)?;
+    let len = checked_mul_usize(OP, "RRQR swap domain", m, batch_total)?;
+    let count = cubecl.cube_count_1d(len)?;
+    // SAFETY: each worker swaps one row in one batch; only row zero updates
+    // that batch's permutation, and pivot indices came from the bounded scan.
+    unsafe {
+        cubecl_linalg::swap_columns::launch_unchecked::<T, CubeclCudaRuntime>(
+            cubecl.client(),
+            count,
+            cubecl.cube_dim_1d(),
+            work_arg.into_tensor_arg(),
+            permutation_arg.into_tensor_arg(),
+            pivots_arg.into_tensor_arg(),
+            step,
+            m,
+            n,
+        );
+    }
+    Ok(())
+}
+
+fn launch_initialize_q<T>(
+    cubecl: &CubeclSession<'_>,
+    q: &TypedTensor<T>,
+    m: usize,
+    k: usize,
+) -> Result<()>
+where
+    T: CudaRrqrScalar,
+{
+    let q_arg = rrqr_binding(cubecl, q)?;
+    let count = cubecl.cube_count_1d(q.n_elements())?;
+    // SAFETY: each worker initializes one distinct Q element.
+    unsafe {
+        cubecl_linalg::initialize_q::launch_unchecked::<T, CubeclCudaRuntime>(
+            cubecl.client(),
+            count,
+            cubecl.cube_dim_1d(),
+            q_arg.into_tensor_arg(),
+            m,
+            k,
+        );
+    }
+    Ok(())
+}
+
+fn launch_extract_r<T>(
+    cubecl: &CubeclSession<'_>,
+    work: &TypedTensor<T>,
+    r: &TypedTensor<T>,
+    m: usize,
+    n: usize,
+    k: usize,
+) -> Result<()>
+where
+    T: CudaRrqrScalar,
+{
+    let work_arg = rrqr_binding(cubecl, work)?;
+    let r_arg = rrqr_binding(cubecl, r)?;
+    let count = cubecl.cube_count_1d(r.n_elements())?;
+    // SAFETY: each worker writes one R element from the corresponding packed
+    // upper trapezoid or writes zero below it.
+    unsafe {
+        cubecl_linalg::extract_r::launch_unchecked::<T, CubeclCudaRuntime>(
+            cubecl.client(),
+            count,
+            cubecl.cube_dim_1d(),
+            work_arg.into_tensor_arg(),
+            r_arg.into_tensor_arg(),
+            m,
+            n,
+            k,
+        );
+    }
+    Ok(())
+}
+
+fn rrqr_cube_count(planes: usize) -> Result<CubeCount> {
+    let planes = u32::try_from(planes).map_err(|_| {
+        Error::invalid_argument(OP, "launch domain", "plane count exceeds u32 range")
+    })?;
+    Ok(CubeCount::Static(planes.max(1), 1, 1))
+}
+
+fn rrqr_cube_dim() -> CubeDim {
+    CubeDim::new_1d(RRQR_PLANE_WIDTH)
+}
+
+fn matrix_shape(rows: usize, columns: usize, batch_shape: &[usize]) -> Vec<usize> {
+    let mut shape = vec![rows, columns];
+    shape.extend_from_slice(batch_shape);
+    shape
+}
+
+fn vector_shape(length: usize, batch_shape: &[usize]) -> Vec<usize> {
+    let mut shape = vec![length];
+    shape.extend_from_slice(batch_shape);
+    shape
+}
+
+trait RrqrTensorVariant: Sized {
+    fn wrap(tensor: TypedTensor<Self>) -> Tensor;
+    fn unwrap(tensor: Tensor) -> Result<TypedTensor<Self>>;
+}
+
+macro_rules! impl_rrqr_tensor_variant {
+    ($scalar:ty, $variant:ident) => {
+        impl RrqrTensorVariant for $scalar {
+            fn wrap(tensor: TypedTensor<Self>) -> Tensor {
+                Tensor::$variant(tensor)
+            }
+
+            fn unwrap(tensor: Tensor) -> Result<TypedTensor<Self>> {
+                match tensor {
+                    Tensor::$variant(tensor) => Ok(tensor),
+                    other => Err(Error::dtype_mismatch(
+                        OP,
+                        <$scalar as TensorScalar>::dtype(),
+                        other.dtype(),
+                    )),
+                }
+            }
+        }
+    };
+}
+
+impl_rrqr_tensor_variant!(f32, F32);
+impl_rrqr_tensor_variant!(f64, F64);
+impl_rrqr_tensor_variant!(Complex32, C32);
+impl_rrqr_tensor_variant!(Complex64, C64);
+
+fn wrap_tensor<T: RrqrTensorVariant>(tensor: TypedTensor<T>) -> Tensor {
+    T::wrap(tensor)
+}
+
+fn unwrap_tensor<T: RrqrTensorVariant>(tensor: Tensor) -> Result<TypedTensor<T>> {
+    T::unwrap(tensor)
+}

--- a/crates/tenferro-linalg/src/gpu/mod.rs
+++ b/crates/tenferro-linalg/src/gpu/mod.rs
@@ -6,7 +6,7 @@ use tenferro_gpu::cuda::CudaExecSession;
 use tenferro_tensor::{Tensor, TensorRead, TensorView};
 
 use crate::backend::{unsupported_dtype, LinalgBackend};
-use crate::QrOptions;
+use crate::{QrOptions, RankRevealingQrOptions};
 
 impl LinalgBackend for CudaExecSession<'_> {
     fn cholesky(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
@@ -141,6 +141,39 @@ impl LinalgBackend for CudaExecSession<'_> {
             }
             TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
                 Err(unsupported_dtype("qr", input.dtype()))
+            }
+        }
+    }
+
+    fn rank_revealing_qr(
+        &mut self,
+        input: &Tensor,
+        options: RankRevealingQrOptions,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        linalg::rank_revealing_qr(self, input, options)
+    }
+
+    fn rank_revealing_qr_read(
+        &mut self,
+        input: TensorRead<'_>,
+        options: RankRevealingQrOptions,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
+        match input {
+            TensorView::F32(view) => self
+                .to_contiguous(&view)
+                .and_then(|input| self.rank_revealing_qr(&Tensor::F32(input), options)),
+            TensorView::F64(view) => self
+                .to_contiguous(&view)
+                .and_then(|input| self.rank_revealing_qr(&Tensor::F64(input), options)),
+            TensorView::C32(view) => self
+                .to_contiguous(&view)
+                .and_then(|input| self.rank_revealing_qr(&Tensor::C32(input), options)),
+            TensorView::C64(view) => self
+                .to_contiguous(&view)
+                .and_then(|input| self.rank_revealing_qr(&Tensor::C64(input), options)),
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("rank_revealing_qr", input.dtype()))
             }
         }
     }

--- a/crates/tenferro-linalg/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-linalg/tests/integration/eager_tensor.rs
@@ -1205,10 +1205,17 @@ fn cuda_eager_qr_and_svd_f64_stay_resident_and_reconstruct() {
     let input = EagerTensor::from_tensor_in(device, runtime.clone()).unwrap();
 
     let (q, r) = input.qr().unwrap();
+    let rrqr = input
+        .rank_revealing_qr(RankRevealingQrOptions::default().rtol(1.0e-12))
+        .unwrap();
     let (u, s, vt) = input.svd().unwrap();
-    for output in [&q, &r, &u, &s, &vt] {
+    for output in [&q, &r, &rrqr.q, &rrqr.r, &u, &s, &vt] {
         assert_eq!(output.runtime().id(), runtime.id());
         assert!(output.to_tensor().unwrap().as_slice::<f64>().is_err());
+    }
+    for output in [&rrqr.column_permutation, &rrqr.rank] {
+        assert_eq!(output.runtime().id(), runtime.id());
+        assert!(output.to_tensor().unwrap().as_slice::<i64>().is_err());
     }
 
     let download = |output: &EagerTensor| {
@@ -1216,6 +1223,7 @@ fn cuda_eager_qr_and_svd_f64_stay_resident_and_reconstruct() {
     };
     let q = download(&q);
     let r = download(&r);
+    assert_eq!(download(&rrqr.rank).as_slice::<i64>().unwrap(), &[2]);
     let u = download(&u);
     let s = download(&s);
     let vt = download(&vt);

--- a/crates/tenferro-linalg/tests/integration/gpu_linalg.rs
+++ b/crates/tenferro-linalg/tests/integration/gpu_linalg.rs
@@ -7,7 +7,9 @@ use tenferro_gpu::{
     cuda::download_tensor, cuda::gpu_available, cuda::upload_tensor, cuda::with_cuda_exec_session,
     cuda::CudaBackend, cuda::CudaDeviceId, cuda::CudaExecSession,
 };
-use tenferro_linalg::{HouseholderQr, LinalgBackend, QrGauge, QrOptions, TensorLinalgExt};
+use tenferro_linalg::{
+    HouseholderQr, LinalgBackend, QrGauge, QrOptions, RankRevealingQrOptions, TensorLinalgExt,
+};
 use tenferro_tensor::{BackendSessionHost, Error, Tensor, TensorRead, TypedTensor};
 
 fn cpu_backend() -> CpuBackend {
@@ -238,6 +240,13 @@ fn conj_transpose_c64(data: &[Complex64], rows: usize, cols: usize) -> Vec<Compl
 }
 
 fn assert_slice_close_f32(actual: &[f32], expected: &[f32], tol: f32) {
+    assert_eq!(actual.len(), expected.len());
+    for (lhs, rhs) in actual.iter().zip(expected.iter()) {
+        assert!((lhs - rhs).abs() <= tol, "lhs={lhs:?} rhs={rhs:?}");
+    }
+}
+
+fn assert_slice_close_f64(actual: &[f64], expected: &[f64], tol: f64) {
     assert_eq!(actual.len(), expected.len());
     for (lhs, rhs) in actual.iter().zip(expected.iter()) {
         assert!((lhs - rhs).abs() <= tol, "lhs={lhs:?} rhs={rhs:?}");
@@ -1262,6 +1271,217 @@ fn test_gpu_eig_returns_unsupported_error() {
 
     let err = with_cuda_linalg_session(&mut backend, |session| session.eig(&gpu)).unwrap_err();
     assert!(matches!(err, Error::Unsupported { op: "eig", .. }));
+}
+
+#[test]
+#[ignore = "requires an A100-class CUDA GPU"]
+fn test_cuda_rank_revealing_qr_f64_reconstructs_interspersed_rank_deficiency() {
+    if !gpu_available() {
+        eprintln!("skipping CUDA RRQR test: no CUDA device found");
+        return;
+    }
+    let input = tensor_f64(
+        vec![4, 5],
+        vec![
+            1.0, 0.0, 0.0, 0.0, // c0
+            0.0, 1.0, 0.0, 0.0, // c1
+            1.0, 0.0, 0.0, 0.0, // c2 duplicates c0
+            0.0, 0.0, 1.0, 0.0, // c3
+            0.0, 0.0, 0.0, 0.0, // c4
+        ],
+    );
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &input);
+    let outputs = with_cuda_linalg_session(&mut gpu, |session| {
+        session.rank_revealing_qr(&gpu_input, RankRevealingQrOptions::default().rtol(1.0e-12))
+    })
+    .unwrap();
+    assert_eq!(outputs.len(), 4);
+    for output in &outputs {
+        assert!(match output.dtype() {
+            tenferro_tensor::DType::F64 => output.as_slice::<f64>().is_err(),
+            tenferro_tensor::DType::I64 => output.as_slice::<i64>().is_err(),
+            dtype => panic!("unexpected RRQR dtype {dtype:?}"),
+        });
+    }
+    let q = download(&gpu, &outputs[0]);
+    let r = download(&gpu, &outputs[1]);
+    let permutation = download(&gpu, &outputs[2]);
+    let rank = download(&gpu, &outputs[3]);
+    assert_eq!(permutation.as_slice::<i64>().unwrap(), &[0, 1, 3, 2, 4]);
+    assert_eq!(rank.as_slice::<i64>().unwrap(), &[3]);
+    let reconstructed = matmul_f64(
+        q.as_slice::<f64>().unwrap(),
+        r.as_slice::<f64>().unwrap(),
+        4,
+        4,
+        5,
+    );
+    let p = permutation.as_slice::<i64>().unwrap();
+    let expected = p
+        .iter()
+        .flat_map(|&column| {
+            let start = column as usize * 4;
+            input.as_slice::<f64>().unwrap()[start..start + 4]
+                .iter()
+                .copied()
+        })
+        .collect::<Vec<_>>();
+    assert_slice_close_f64(&reconstructed, &expected, 1.0e-10);
+    let qtq = matmul_f64(
+        &transpose_f64(q.as_slice::<f64>().unwrap(), 4, 4),
+        q.as_slice::<f64>().unwrap(),
+        4,
+        4,
+        4,
+    );
+    let identity = vec![
+        1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+    ];
+    assert_slice_close_f64(&qtq, &identity, 1.0e-10);
+}
+
+#[test]
+#[ignore = "requires an A100-class CUDA GPU"]
+fn test_cuda_rank_revealing_qr_complex_dtypes_reconstruct() {
+    if !gpu_available() {
+        eprintln!("skipping CUDA complex RRQR test: no CUDA device found");
+        return;
+    }
+    let mut gpu = gpu_backend();
+    let input_c32 = tensor_c32(
+        vec![3, 3],
+        vec![
+            Complex32::new(1.0, 1.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(2.0, -1.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(1.0, 1.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+        ],
+    );
+    let gpu_input = upload(&gpu, &input_c32);
+    let outputs = with_cuda_linalg_session(&mut gpu, |session| {
+        session.rank_revealing_qr(
+            &gpu_input,
+            RankRevealingQrOptions::default()
+                .gauge(tenferro_linalg::QrGauge::PositiveDiagonal)
+                .rtol(1.0e-5),
+        )
+    })
+    .unwrap();
+    let q = download(&gpu, &outputs[0]);
+    let r = download(&gpu, &outputs[1]);
+    let permutation = download(&gpu, &outputs[2]);
+    let rank = download(&gpu, &outputs[3]);
+    assert_eq!(rank.as_slice::<i64>().unwrap(), &[2]);
+    let p = permutation.as_slice::<i64>().unwrap();
+    let expected = p
+        .iter()
+        .flat_map(|&column| {
+            let start = column as usize * 3;
+            input_c32.as_slice::<Complex32>().unwrap()[start..start + 3]
+                .iter()
+                .copied()
+        })
+        .collect::<Vec<_>>();
+    let reconstructed = matmul_c32(
+        q.as_slice::<Complex32>().unwrap(),
+        r.as_slice::<Complex32>().unwrap(),
+        3,
+        3,
+        3,
+    );
+    assert_slice_close_c32(&reconstructed, &expected, 2.0e-5);
+
+    let input_c64 = tensor_c64(
+        vec![3, 3],
+        vec![
+            Complex64::new(1.0, 1.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(2.0, -1.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(1.0, 1.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+        ],
+    );
+    let gpu_input = upload(&gpu, &input_c64);
+    let outputs = with_cuda_linalg_session(&mut gpu, |session| {
+        session.rank_revealing_qr(
+            &gpu_input,
+            RankRevealingQrOptions::default()
+                .gauge(tenferro_linalg::QrGauge::PositiveDiagonal)
+                .rtol(1.0e-12),
+        )
+    })
+    .unwrap();
+    let q = download(&gpu, &outputs[0]);
+    let r = download(&gpu, &outputs[1]);
+    let permutation = download(&gpu, &outputs[2]);
+    let rank = download(&gpu, &outputs[3]);
+    assert_eq!(rank.as_slice::<i64>().unwrap(), &[2]);
+    let p = permutation.as_slice::<i64>().unwrap();
+    let expected = p
+        .iter()
+        .flat_map(|&column| {
+            let start = column as usize * 3;
+            input_c64.as_slice::<Complex64>().unwrap()[start..start + 3]
+                .iter()
+                .copied()
+        })
+        .collect::<Vec<_>>();
+    let reconstructed = matmul_c64(
+        q.as_slice::<Complex64>().unwrap(),
+        r.as_slice::<Complex64>().unwrap(),
+        3,
+        3,
+        3,
+    );
+    assert_slice_close_c64(&reconstructed, &expected, 1.0e-11);
+    for diagonal in 0..3 {
+        let value = r.as_slice::<Complex64>().unwrap()[diagonal + diagonal * 3];
+        assert!(value.im.abs() <= 1.0e-12 && value.re >= 0.0);
+    }
+}
+
+#[test]
+#[ignore = "requires an A100-class CUDA GPU"]
+fn test_cuda_rank_revealing_qr_f32_batched_and_scaled_ranks() {
+    if !gpu_available() {
+        eprintln!("skipping CUDA batched RRQR test: no CUDA device found");
+        return;
+    }
+    // First 3x2 batch is full rank at large scale; second has duplicate columns.
+    let input = tensor_f32(
+        vec![3, 2, 2],
+        vec![
+            1.0e8, 0.0, 0.0, 0.0, 2.0e8, 0.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0,
+        ],
+    );
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &input);
+    let outputs = with_cuda_linalg_session(&mut gpu, |session| {
+        session.rank_revealing_qr(&gpu_input, RankRevealingQrOptions::default().rtol(1.0e-5))
+    })
+    .unwrap();
+    let permutation = download(&gpu, &outputs[2]);
+    let rank = download(&gpu, &outputs[3]);
+    assert_eq!(outputs[0].shape(), &[3, 2, 2]);
+    assert_eq!(outputs[1].shape(), &[2, 2, 2]);
+    assert_eq!(permutation.shape(), &[2, 2]);
+    assert_eq!(rank.shape(), &[2]);
+    assert_eq!(rank.as_slice::<i64>().unwrap(), &[2, 1]);
+    for batch in permutation.as_slice::<i64>().unwrap().chunks_exact(2) {
+        let mut columns = batch.to_vec();
+        columns.sort_unstable();
+        assert_eq!(columns, vec![0, 1]);
+    }
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/integration/gpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/integration/gpu_linalg_source_contract.rs
@@ -379,6 +379,29 @@ fn cuda_linalg_drop_paths_report_destroy_status() {
 }
 
 #[test]
+fn cuda_rrqr_has_no_payload_download_or_cpu_fallback() {
+    let source = read_workspace_source("tenferro-linalg/src/gpu/linalg/rank_revealing_qr.rs");
+    assert_eq!(
+        source.matches("download_tensor(").count(),
+        1,
+        "RRQR may download only its bounded provider-status vector"
+    );
+    assert_eq!(
+        source.matches("host_data()").count(),
+        1,
+        "only the downloaded provider-status tensor may use host_data"
+    );
+    for banned in ["CpuBackend", "CubeCount::new_single"] {
+        assert!(
+            !source.contains(banned),
+            "CUDA RRQR must not use payload host access, CPU fallback, or a single-worker launch: {banned}"
+        );
+    }
+    assert!(source.contains("Tensor::I64(status)"));
+    assert!(source.contains("rank remain device-resident"));
+}
+
+#[test]
 fn cubecl_linalg_overrides_svd_read_with_backend_canonicalization() {
     let source = gpu_mod_source();
     let svd_read_source = source_section(&source, "fn svd_read", "fn qr");

--- a/docs/worklogs/2026-09-05-rank-revealing-qr-cuda.md
+++ b/docs/worklogs/2026-09-05-rank-revealing-qr-cuda.md
@@ -1,0 +1,37 @@
+# Rank-revealing QR CUDA phase
+
+## Scope
+
+Adds native CUDA execution for issue #1754's fixed-four-output RRQR operation.
+The implementation uses same-device column-pivoted Householder steps because
+CUDA 12.4 cuSOLVER does not provide `GEQP3`.
+
+## Implementation
+
+- CubeCL kernels compute trailing column norms, deterministic lowest-index
+  pivots, device column/permutation swaps, Householder reflectors and updates,
+  Q initialization, R extraction, and prefix numerical rank.
+- The host controls the bounded `min(m,n)` launch sequence; tensor-sized work
+  is parallel over rows, columns, and trailing batches.
+- Q, R, permutation, rank, norms, pivots, and reflector state remain on the
+  active CUDA runtime. Only the bounded provider-status vector is downloaded;
+  the caller may later read rank metadata explicitly.
+- Complex reflector reductions use a one-element same-runtime imaginary-unit
+  constant. Gauge processing reuses the existing device QR gauge path and
+  touches only Q/R.
+- CUDA borrowed reads canonicalize on device and dispatch to the same owner
+  implementation. There is no CPU fallback.
+
+## Verification
+
+CUDA feature compilation and A100 hardware tests cover F64 interspersed
+rank-deficiency with reconstruction and orthogonality, F32 batched/scaled rank,
+and C32/C64 reconstruction, permutation, rank, and positive-diagonal gauge.
+A source-contract test rejects payload host access, CPU fallback, and
+single-worker launches.
+
+## Remaining
+
+After this phase merges, tensor4all-rs updates its tenferro pin and replaces its
+local resident QR rank heuristic with this RRQR operation. RRQR AD remains
+explicitly unsupported as approved by the design.


### PR DESCRIPTION
Implements the native CUDA phase of #1754.

- same-device column-pivoted Householder RRQR for F32/F64/C32/C64 and trailing batches
- fixed Q/R/permutation/rank outputs remain CUDA-resident
- deterministic lowest-original-column pivot ties
- active-stream CubeCL kernels; no matrix payload readback or CPU fallback
- bounded provider-status readback only; rank remains resident until caller explicitly reads metadata
- device gauge path affects Q/R only

A100 evidence: F64 interspersed-dependent reconstruction+orthogonality, F32 batched/scaled rank, C32/C64 reconstruction+gauge, eager runtime residency all pass. Source contract rejects payload host access, CPU fallback, and single-worker launches.

Worklog: `docs/worklogs/2026-09-05-rank-revealing-qr-cuda.md`.
Review: reviewer-flash Correct-to-merge, 0 blocking; redundant real constant upload fixed and re-reviewed.

Closes #1754.