### PR TITLE
fix: align einsum boundary contracts with public routes

### DIFF
--- a/docs/design/einsum-route-contract-correction.md
+++ b/docs/design/einsum-route-contract-correction.md
@@ -1,0 +1,89 @@
+# Einsum route-contract correction before benchmark expansion
+
+Status: Flash design review completed before implementation. Initial review
+approved the source corrections subject to clarifying successful prepare evidence;
+the clarified data-only design received **Correct-to-merge** with no findings.
+Source inspected: tenferro-rs aa68a0d7703b8f38700f9f3234e8f06ed757fb05.
+This is a data/documentation correction, not a new API or performance outcome.
+
+## Evidence and problem
+
+The canonical export contains only einsum.einsum.ordinary.concrete and
+ einsum.einsum.prepared.traced. Neither is an EagerTensor route. A concrete
+ConcreteEinsumPlan execution must not be called traced merely to satisfy binding.
+
+The ordinary.concrete case currently cites an EagerTensor integration test.
+The prepared.traced case cites a generic binary planning test, not an executing
+compiled graph. Concrete/eager surface ownership currently overstates
+execute_einsum_extension as the universal owner.
+
+Actual source boundaries:
+- concrete.rs::ConcreteEinsumPlan::prepare(inputs, subscripts) parses notation;
+  prepare_subscripts_internal captures input specs and calls plan_subscripts.
+- execute(inputs, session) validates specs then calls eager_einsum_exec; its
+  BackendSession is supplied by its caller, not opened by ExtensionEngine here.
+- eager_ad.rs::einsum_subscripts_with_broadcast dispatches first to direct binary
+  dot_general, then untracked whole-program / expanded standard operations, with
+  EinsumExtensionOp only as fallback. Rank2 matrix multiplication therefore does
+  not isolate extension-owner overhead.
+
+## Bounded change
+
+Keep schema v1, existing IDs and phases. Add exactly three execution/setup route
+contracts under the existing einsum selector:
+1. einsum.einsum.ordinary.eager — eager / execution, real EagerTensor entry.
+2. einsum.einsum.prepare.concrete — concrete / setup, public plan creation only.
+3. einsum.einsum.prepared.concrete — concrete / execution, existing plan execution
+   with dtype/shape revalidation and caller-owned session; no replanning.
+
+Expected export count184 from181. No private parse/revalidation probe may use these
+whole-public-operation IDs as its primary component contract. No aliases, new
+registry, runtime code, dependencies, caches, or public methods.
+
+Correct the two existing test references and new references using real numerical
+or public-error tests, whose bodies must be read before editing:
+- concrete_tests.rs::public_tensor_einsum_ext_executes_dtype_erased_inputs;
+- concrete_tests.rs::public_typed_tensor_einsum_ext_preserves_complex_dtype as
+  additional C64 evidence, not a substitute for dtype-erased route evidence;
+- concrete_tests.rs::concrete_einsum_plan_executes_without_replanning_contract;
+- concrete_tests.rs::concrete_einsum_plan_rejects_shape_and_dtype_mismatches;
+- tests/integration/eager_tensor.rs::eager_tensor_einsum_matmul_primal_matches_expected_values;
+- tests/integration/traced_correctness.rs::explicit_path_matmul_executes_numerically.
+The prepare case is a successful public setup route, not an invalid-prepare
+scenario. Cite concrete_einsum_plan_executes_without_replanning_contract: it
+invokes public prepare, unwraps successful construction, executes that plan and
+asserts numerical results. This proves success-path setup, not prepare-error
+coverage. No cited test currently asserts a public prepare error; do not claim
+otherwise. Retain existing execution-mismatch/error evidence separately. No new
+Rust test or runtime code is authorized in this correction; broader
+error-path measurement coverage remains a separate #95/#1760 requirement.
+
+Correct concrete/eager source ownership and prose to these real dispatch paths.
+For concrete admission explicitly describe the borrowed caller session; do not
+replace one false session owner with another. Use actual existing source anchors.
+For eager list the dispatcher/branches and distinguish direct standard operations
+from extension fallback; do not state all einsum calls use the fallback.
+Retain follow-up dispositions: source classification is not measured evidence.
+Do not silently reclassify unrelated families or claim their final audit complete.
+
+## Verification and rollout
+
+Design and full deliverable require user-selected Flash verdicts. Generate export
+with the maintained checker; verify exact184 ID set, unchanged181 IDs, all
+surface/phase matches, preserved unrelated metadata, and mutation-test freshness.
+Update the existing Python inventory mutation-test expectation from the old
+181-row set to the exact184-row set, explicitly asserting the three new IDs and
+retention of previous IDs. Update both the count assertion and the ordinary.eager
+operation assertion in test_current_inventory_is_exhaustive: eager routes now
+include add and einsum rather than add alone. This is the sole authorized
+test-code change: no
+generator behavior or Rust tests change. The parent reproduced the stale-count
+failure in test_current_inventory_is_exhaustive before authorizing this update.
+Run repository data/CI-helper rules and fast gates, focused referenced Rust tests where
+needed, docs/format gates and all required hosted CI. Preserve user work in a new
+worktree; no benchmark or existing probe-worktree edits in this change.
+
+Merge library correction first; verify merged revision and checks, then update
+benchmark's owned library pin and revalidate existing24 cases before adding new
+producers. Benchmark expansion and its independent design/review remain separate.
+No timers, performance assertions or parent-completion claim belong to this task.

--- a/docs/internals/public-boundary-benchmarks.json
+++ b/docs/internals/public-boundary-benchmarks.json
@@ -107,6 +107,9 @@
         "core.triu.ordinary.concrete",
         "core.triu.prepared.traced",
         "einsum.einsum.ordinary.concrete",
+        "einsum.einsum.ordinary.eager",
+        "einsum.einsum.prepare.concrete",
+        "einsum.einsum.prepared.concrete",
         "einsum.einsum.prepared.traced",
         "fft.c2c_forward.ordinary.concrete",
         "fft.c2c_forward.prepared.traced",
@@ -295,6 +298,9 @@
         "core.triu.ordinary.concrete",
         "core.triu.prepared.traced",
         "einsum.einsum.ordinary.concrete",
+        "einsum.einsum.ordinary.eager",
+        "einsum.einsum.prepare.concrete",
+        "einsum.einsum.prepared.concrete",
         "einsum.einsum.prepared.traced",
         "fft.c2c_forward.ordinary.concrete",
         "fft.c2c_forward.prepared.traced",
@@ -1418,6 +1424,36 @@
       "status": "pending",
       "surface": "concrete",
       "workflow": "validate -> metadata -> optional plan -> session/provider -> result/AD wrapping"
+    },
+    {
+      "family": "einsum",
+      "id": "einsum.einsum.ordinary.eager",
+      "operation": "einsum",
+      "phase": "execution",
+      "setup_boundary": "ordinary public workflow",
+      "status": "pending",
+      "surface": "eager",
+      "workflow": "validate -> metadata -> optional plan -> session/provider -> result/AD wrapping"
+    },
+    {
+      "family": "einsum",
+      "id": "einsum.einsum.prepare.concrete",
+      "operation": "einsum",
+      "phase": "setup",
+      "setup_boundary": "concrete plan preparation",
+      "status": "pending",
+      "surface": "concrete",
+      "workflow": "validate -> parse notation -> capture input specs -> plan contraction tree"
+    },
+    {
+      "family": "einsum",
+      "id": "einsum.einsum.prepared.concrete",
+      "operation": "einsum",
+      "phase": "execution",
+      "setup_boundary": "prepared concrete workflow",
+      "status": "pending",
+      "surface": "concrete",
+      "workflow": "validate prepared input specs -> caller-owned backend session -> execute without replanning"
     },
     {
       "family": "einsum",

--- a/docs/internals/public-boundary-overhead-inventory.json
+++ b/docs/internals/public-boundary-overhead-inventory.json
@@ -1703,8 +1703,12 @@
               "surface": "concrete",
               "tests": [
                 {
-                  "path": "crates/tenferro-einsum/tests/integration/eager_tensor.rs",
-                  "symbol": "eager_tensor_einsum_matmul_primal_matches_expected_values"
+                  "path": "crates/tenferro-einsum/src/concrete_tests.rs",
+                  "symbol": "public_tensor_einsum_ext_executes_dtype_erased_inputs"
+                },
+                {
+                  "path": "crates/tenferro-einsum/src/concrete_tests.rs",
+                  "symbol": "public_typed_tensor_einsum_ext_preserves_complex_dtype"
                 }
               ],
               "workflow": "validate -> metadata -> optional plan -> session/provider -> result/AD wrapping"
@@ -1717,11 +1721,57 @@
               "surface": "traced",
               "tests": [
                 {
-                  "path": "crates/tenferro-einsum/src/eager/tests.rs",
-                  "symbol": "generic_binary_contract_reduces_then_builds_dot_config"
+                  "path": "crates/tenferro-einsum/tests/integration/traced_correctness.rs",
+                  "symbol": "explicit_path_matmul_executes_numerically"
                 }
               ],
               "workflow": "reuse compatible preparation while retaining setup cost as a distinct case"
+            },
+            {
+              "component": "einsum",
+              "workflow": "validate -> metadata -> optional plan -> session/provider -> result/AD wrapping",
+              "id": "{family}.{operation}.ordinary.eager",
+              "phase": "execution",
+              "setup_boundary": "ordinary public workflow",
+              "surface": "eager",
+              "tests": [
+                {
+                  "path": "crates/tenferro-einsum/tests/integration/eager_tensor.rs",
+                  "symbol": "eager_tensor_einsum_matmul_primal_matches_expected_values"
+                }
+              ]
+            },
+            {
+              "component": "einsum",
+              "workflow": "validate -> parse notation -> capture input specs -> plan contraction tree",
+              "id": "{family}.{operation}.prepare.concrete",
+              "phase": "setup",
+              "setup_boundary": "concrete plan preparation",
+              "surface": "concrete",
+              "tests": [
+                {
+                  "path": "crates/tenferro-einsum/src/concrete_tests.rs",
+                  "symbol": "concrete_einsum_plan_executes_without_replanning_contract"
+                }
+              ]
+            },
+            {
+              "component": "einsum",
+              "workflow": "validate prepared input specs -> caller-owned backend session -> execute without replanning",
+              "id": "{family}.{operation}.prepared.concrete",
+              "phase": "execution",
+              "setup_boundary": "prepared concrete workflow",
+              "surface": "concrete",
+              "tests": [
+                {
+                  "path": "crates/tenferro-einsum/src/concrete_tests.rs",
+                  "symbol": "concrete_einsum_plan_executes_without_replanning_contract"
+                },
+                {
+                  "path": "crates/tenferro-einsum/src/concrete_tests.rs",
+                  "symbol": "concrete_einsum_plan_rejects_shape_and_dtype_mismatches"
+                }
+              ]
             }
           ],
           "category": "extension",
@@ -1736,45 +1786,43 @@
               "reason": "borrowed route has no published timing evidence and its owner/setup contract remains unresolved; benchmark #95 follow-up required"
             },
             "concrete": {
-              "contract": "concrete route is explicitly classified; setup and execution boundaries remain separate",
+              "contract": "concrete routes distinguish public plan preparation from prepared execution; execution validates specs and uses the caller-supplied backend session",
               "contracts": {
                 "allocation": "source-observed allocation/materialization is explicit and is not a measured count",
-                "allocation_source": "crates/tenferro-einsum/src/extension.rs::execute_einsum_extension",
-                "metadata": "concrete reuses validated shape/dtype/layout/config metadata before dispatch",
-                "owner_lifetime": "concrete inputs remain valid through its owning session; output reuse requires exclusive write ownership",
-                "payload_boundary": "crates/tenferro-einsum/src/extension.rs::execute_einsum_extension -> concrete Tensor return (no wrapping owner)",
+                "allocation_source": "crates/tenferro-einsum/src/concrete.rs::execute",
+                "metadata": "ConcreteEinsumPlan::prepare captures input specs; execute revalidates rank, shape, and dtype before dispatch",
+                "owner_lifetime": "concrete inputs remain valid through the caller-owned backend session; output reuse requires exclusive write ownership",
+                "payload_boundary": "crates/tenferro-einsum/src/concrete.rs::execute -> crate::eager::eager_einsum_exec -> concrete Tensor return (no wrapping owner)",
                 "placement": "concrete placement is explicit; transfers occur only at the existing backend boundary"
               },
               "disposition": "follow-up",
               "owners": {
-                "admission": [
-                  {
-                    "path": "crates/tenferro-runtime/src/runtime/extension_provider.rs",
-                    "symbol": "ExtensionEngine"
-                  }
-                ],
+                "admission": {
+                  "reason": "These concrete entries borrow a caller-owned BackendSession; plan preparation does not admit a session.",
+                  "status": "not-applicable"
+                },
                 "execution": [
                   {
-                    "path": "crates/tenferro-einsum/src/extension.rs",
-                    "symbol": "execute_einsum_extension"
+                    "path": "crates/tenferro-einsum/src/concrete.rs",
+                    "symbol": "execute"
                   }
                 ],
                 "metadata": [
                   {
-                    "path": "crates/tenferro-einsum/src/util.rs",
-                    "symbol": "compute_output_shape"
+                    "path": "crates/tenferro-einsum/src/concrete.rs",
+                    "symbol": "input_specs"
                   }
                 ],
                 "planning": [
                   {
-                    "path": "crates/tenferro-einsum/src/builder.rs",
-                    "symbol": "binary_contract"
+                    "path": "crates/tenferro-einsum/src/concrete.rs",
+                    "symbol": "prepare_subscripts_internal"
                   }
                 ],
                 "validation": [
                   {
-                    "path": "crates/tenferro-einsum/src/subscripts.rs",
-                    "symbol": "parse_einsum_subscripts"
+                    "path": "crates/tenferro-einsum/src/concrete.rs",
+                    "symbol": "validate_inputs"
                   }
                 ],
                 "wrapping": {
@@ -1785,13 +1833,13 @@
               "reason": "concrete route has no published timing evidence; benchmark #95 must measure the existing owner path"
             },
             "eager": {
-              "contract": "eager route is explicitly classified; setup and execution boundaries remain separate",
+              "contract": "eager dispatch checks direct binary dot_general, optional whole-program and expanded standard-operation paths, then uses the einsum extension only as fallback",
               "contracts": {
                 "allocation": "source-observed allocation/materialization is explicit and is not a measured count",
-                "allocation_source": "crates/tenferro-einsum/src/extension.rs::execute_einsum_extension",
-                "metadata": "eager reuses validated shape/dtype/layout/config metadata before dispatch",
-                "owner_lifetime": "eager inputs remain valid through its owning session; output reuse requires exclusive write ownership",
-                "payload_boundary": "crates/tenferro-einsum/src/extension.rs::execute_einsum_extension -> crates/tenferro-einsum/src/typed_eager.rs::typed_eager_einsum",
+                "allocation_source": "crates/tenferro-einsum/src/eager_ad.rs::einsum_subscripts_with_broadcast",
+                "metadata": "eager dispatch infers output metadata before selecting standard-operation or extension branches",
+                "owner_lifetime": "eager inputs remain valid through their runtime execution session; output reuse requires exclusive write ownership",
+                "payload_boundary": "crates/tenferro-einsum/src/eager_ad.rs::einsum_subscripts_with_broadcast -> EagerTensor result/AD carrier (tracked or untracked)",
                 "placement": "eager placement is explicit; transfers occur only at the existing backend boundary"
               },
               "disposition": "follow-up",
@@ -1804,32 +1852,44 @@
                 ],
                 "execution": [
                   {
-                    "path": "crates/tenferro-einsum/src/extension.rs",
-                    "symbol": "execute_einsum_extension"
+                    "path": "crates/tenferro-einsum/src/eager_ad.rs",
+                    "symbol": "einsum_subscripts_with_broadcast"
+                  },
+                  {
+                    "path": "crates/tenferro-einsum/src/eager_ad.rs",
+                    "symbol": "try_direct_binary_dot_general"
+                  },
+                  {
+                    "path": "crates/tenferro-einsum/src/eager_ad.rs",
+                    "symbol": "try_whole_program_untracked"
+                  },
+                  {
+                    "path": "crates/tenferro-einsum/src/eager_ad.rs",
+                    "symbol": "try_expand_eager_einsum"
                   }
                 ],
                 "metadata": [
                   {
-                    "path": "crates/tenferro-einsum/src/util.rs",
-                    "symbol": "compute_output_shape"
+                    "path": "crates/tenferro-einsum/src/eager_ad.rs",
+                    "symbol": "infer_eager_output_shape"
                   }
                 ],
                 "planning": [
                   {
-                    "path": "crates/tenferro-einsum/src/builder.rs",
-                    "symbol": "binary_contract"
+                    "path": "crates/tenferro-einsum/src/eager_ad.rs",
+                    "symbol": "try_expand_eager_einsum"
                   }
                 ],
                 "validation": [
                   {
-                    "path": "crates/tenferro-einsum/src/subscripts.rs",
-                    "symbol": "parse_einsum_subscripts"
+                    "path": "crates/tenferro-einsum/src/eager_ad.rs",
+                    "symbol": "einsum_subscripts_with_broadcast"
                   }
                 ],
                 "wrapping": [
                   {
-                    "path": "crates/tenferro-einsum/src/typed_eager.rs",
-                    "symbol": "typed_eager_einsum"
+                    "path": "crates/tenferro-ad/src/eager.rs",
+                    "symbol": "EagerTensor"
                   }
                 ]
               },

--- a/docs/internals/public-boundary-overhead-inventory.md
+++ b/docs/internals/public-boundary-overhead-inventory.md
@@ -3,7 +3,7 @@
 
 - Baseline revision: `0457a2ed0aeea21b14f4297f7f4731e09b3a0507`
 - Generation provenance: `source-derived from the current checkout; overlay/source digest is the freshness key`
-- Overlay/source digest: `1cdcca0ebfc25fa2031edb38f115f694fc20cf93bd5317dd89c617d5aa778b8b`
+- Overlay/source digest: `7a304fccad0187826eb6bec105d107ae31702b6b48cb99990743709dfed0110f`
 
 | Family | Operation | Category | Surfaces (disposition) | Case contracts |
 |---|---|---|---|---|
@@ -111,6 +111,9 @@
 | core | `triu` | structural | concrete: follow-up, typed: follow-up, borrowed: follow-up, output_reuse: follow-up, eager: follow-up, traced: follow-up | core.triu.ordinary.concrete |
 | core | `triu` | structural | concrete: follow-up, typed: follow-up, borrowed: follow-up, output_reuse: follow-up, eager: follow-up, traced: follow-up | core.triu.prepared.traced |
 | einsum | `einsum` | extension | concrete: follow-up, typed: follow-up, borrowed: follow-up, output_reuse: follow-up, eager: follow-up, traced: follow-up | einsum.einsum.ordinary.concrete |
+| einsum | `einsum` | extension | concrete: follow-up, typed: follow-up, borrowed: follow-up, output_reuse: follow-up, eager: follow-up, traced: follow-up | einsum.einsum.ordinary.eager |
+| einsum | `einsum` | extension | concrete: follow-up, typed: follow-up, borrowed: follow-up, output_reuse: follow-up, eager: follow-up, traced: follow-up | einsum.einsum.prepare.concrete |
+| einsum | `einsum` | extension | concrete: follow-up, typed: follow-up, borrowed: follow-up, output_reuse: follow-up, eager: follow-up, traced: follow-up | einsum.einsum.prepared.concrete |
 | einsum | `einsum` | extension | concrete: follow-up, typed: follow-up, borrowed: follow-up, output_reuse: follow-up, eager: follow-up, traced: follow-up | einsum.einsum.prepared.traced |
 | fft | `c2c_forward` | extension | concrete: follow-up, typed: unsupported, borrowed: unsupported, output_reuse: unsupported, eager: follow-up, traced: follow-up | fft.c2c_forward.ordinary.concrete |
 | fft | `c2c_forward` | extension | concrete: follow-up, typed: unsupported, borrowed: unsupported, output_reuse: unsupported, eager: follow-up, traced: follow-up | fft.c2c_forward.prepared.traced |

--- a/docs/worklogs/issue-1758-case-contracts.md
+++ b/docs/worklogs/issue-1758-case-contracts.md
@@ -29,3 +29,30 @@ instead of `integration`; no Rust-test execution is claimed. No Rust code change
 the new reference was traced to its actual EagerTensor.add test body.
 
 Flash full-diff review, committed-head rules check and hosted CI/merge remain pending.
+
+## Einsum route-contract correction
+
+Applied the Flash-approved data-only correction from
+[`einsum-route-contract-correction`](../design/einsum-route-contract-correction.md):
+184 exported cases now retain the prior 181 IDs and add only
+`einsum.einsum.ordinary.eager`, `einsum.einsum.prepare.concrete`, and
+`einsum.einsum.prepared.concrete`. Concrete ownership now records public plan
+preparation, input-spec revalidation, and the caller-owned backend session;
+eager ownership records direct `dot_general`, optional whole-program,
+expanded standard-operation, and extension-fallback branches. Existing einsum
+anchors were replaced with numerical/public-contract tests, including complex
+and mismatch evidence. No Rust, dependency, API, timer, or benchmark-producer
+code changed; benchmark statuses remain pending/follow-up.
+
+The initial mutation run exposed stale fixed-count and eager-operation assertions.
+Flash approved the design amendment before changing the existing Python test:
+it now checks184 rows, the three exact new IDs/surfaces/phases, and add/einsum eager
+operations. Parent independently verified no old ID was removed and all other
+families remained byte-for-byte equivalent as parsed data. The inventory checker,
+mutation script and CI-only fast gate passed. The stale-snapshot diagnostic is
+intentional mutation-test output, not a gate failure. Final Flash full-six-file
+review returned Correct-to-merge after correcting concrete admission to
+not-applicable/caller-borrowed and Eager wrapping to tracked/untracked EagerTensor.
+An earlier mutation-test finding referenced nonexistent code and was explicitly
+retracted against the actual rejection helper and tests; no bypass was added.
+Exact-head rules check and hosted CI/merge remain pending for this correction.

--- a/scripts/test-public-boundary-inventory.py
+++ b/scripts/test-public-boundary-inventory.py
@@ -38,8 +38,22 @@ def rejects(mutator, phrase: str) -> None:
 
 def test_current_inventory_is_exhaustive() -> None:
     _, auth, rows = inventory()
-    assert len(rows) == sum(len(item.operations) * 2 for item in auth.values()) + 1
-    assert [row["operation"] for row in rows if row["id"].endswith("ordinary.eager")] == ["add"]
+    assert len(rows) == 184
+    assert [row["operation"] for row in rows if row["id"].endswith("ordinary.eager")] == ["add", "einsum"]
+    new_routes = {
+        row["id"]: (row["surface"], row["phase"])
+        for row in rows
+        if row["id"] in {
+            "einsum.einsum.ordinary.eager",
+            "einsum.einsum.prepare.concrete",
+            "einsum.einsum.prepared.concrete",
+        }
+    }
+    assert new_routes == {
+        "einsum.einsum.ordinary.eager": ("eager", "execution"),
+        "einsum.einsum.prepare.concrete": ("concrete", "setup"),
+        "einsum.einsum.prepared.concrete": ("concrete", "execution"),
+    }
 
 
 def test_case_filters_reject_malformed_uncovered_and_duplicate_contracts() -> None:


### PR DESCRIPTION
## Type
- [x] Bug fix
- [x] Documentation
- [x] Implementation of accepted issue

## Related issue
Refs #1758, #1760 and tensor4all/tenferro-benchmark#95. Does **not** close the parent or declare measurement acceptance.

## Summary
Correct the existing einsum boundary-contract annotations before extending the benchmark consumer:
- Add exactly three existing-public-route declarations: ordinary EagerTensor execution, successful concrete plan creation, and concrete prepared execution. Preserve all181 IDs; export now184.
- Correct numerical test links and concrete/eager owner descriptions. Concrete operations borrow caller sessions; `prepare` is not session admission. Eager direct/expanded paths are not universally extension fallback.
- Update the existing mutation test for184 rows, exact new IDs/surfaces/phases, and add/einsum eager operations.

No Rust implementation, public API, dependency, generator behavior, timing or backend policy changes. Declarations remain pending/follow-up, not performance evidence. Successful plan-creation evidence does not claim invalid-prepare coverage.

## Work log
[Work log](docs/worklogs/issue-1758-case-contracts.md#einsum-route-contract-correction)
[Approved design](docs/design/einsum-route-contract-correction.md)

Flash approved design before edits, including the Python expectation amendment before its implementation; final six-file full-diff review: **Correct-to-merge**. Parent independently corrected admission/wrapping wording and verified it in the final review.

## Verification
- Inventory checker:184 contracts / six families.
- Independent comparison: exactly three new IDs, no removed IDs, unrelated family data unchanged.
- `python3 scripts/test-public-boundary-inventory.py`: pass. Stale-snapshot diagnostic is an intentional negative test.
- `bash scripts/check-pr-fast.sh --test 'python3 scripts/test-public-boundary-inventory.py'`: pass, CI-only classification; doc snippets and diff checks passed.
- Committed-head deterministic repository-rules review: pass (external LLM disabled by repository policy).
- Hosted comprehensive checks remain required; no local Rust rebuild or performance measurement claimed for this data/CI-helper-only change.

Neighborhood scope: concrete/eager/traced einsum annotation links and dispatch owners corrected together. Other families' deeper ownership audit, remaining benchmark cases, private-probe integration and actual measurements remain under #1758; this PR does not waive them. Reused existing checker and mutation machinery rather than adding another registry or audit rule.

## Checklist
- [x] Read contributing and applicable repository rules.
- [x] Updated tests/docs.
- [x] Deterministic committed-head rules review passed.
- [x] AI-assisted bug-fix scope gate applied: existing intended annotation behavior only.
- [x] Work log and design linked.
