### PR TITLE
docs: explain ordinary execution and compatible einsum plan reuse

### DIFF
--- a/.agents/skills/tenferro-compute/SKILL.md
+++ b/.agents/skills/tenferro-compute/SKILL.md
@@ -37,9 +37,15 @@ not when changing tenferro itself.
   rejected.
 - **No facade crate.** `cargo add tenferro` fails by design; depend on the
   crates you need (`tenferro-runtime`, `tenferro-cpu`, and operation crates).
-- **Explicit backend.** Direct operations take an explicit backend argument;
-  construct the backend/runtime once and reuse it — per-call construction
-  discards the buffer pool.
+- **Explicit execution owner.** Concrete operations take a borrowed session
+  inside `backend.with_backend_session(...)` (`BackendSessionHost` import).
+  Construct the backend/runtime once and reuse it — per-call construction
+  discards the buffer pool. Eager tensors retain their runtime instead.
+- **Representation is not reuse.** Integer einsum labels still plan. For a
+  repeated compatible equation/input count/dtype/shape, prepare a
+  `ConcreteEinsumPlan` once, even from a string; see
+  [performance idioms](references/performance-idioms.md). Do not flatten
+  parenthesized contraction order into label arrays.
 - **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`).
   Flat notation supports one right-aligned, broadcastable `...` ellipsis per
   term; `EinsumNotation` provides the programmatic form.

--- a/.agents/skills/tenferro-compute/references/performance-idioms.md
+++ b/.agents/skills/tenferro-compute/references/performance-idioms.md
@@ -7,6 +7,61 @@ threading, placement, pools, and runtime caches; repeatedly constructing it
 throws away those resources. For traced work, likewise reuse the compiler and
 runtime across executions when their shape and registration contracts match.
 
+## Ordinary versus prepared einsum
+
+Use ordinary `TensorEinsumExt::einsum` by default. Reuse a `ConcreteEinsumPlan`
+when equation, operand order, input count, dtypes and shapes match; values may
+change. The plan retains metadata/tree, not inputs or a session. Execution still
+validates and allocates; placement and backend capabilities still apply.
+`EinsumSubscripts` is a programmatic representation, not a cache. Strings are
+fine for one-time preparation. Preserve explicit contraction order rather than
+flattening parentheses into labels.
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#ordinary-and-prepared-einsum -->
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::{ConcreteEinsumPlan, EinsumSubscripts, TensorEinsumExt};
+use tenferro_tensor::{BackendSessionHost, Tensor};
+
+let lhs = Tensor::from_vec_col_major([2, 2], vec![1.0_f64, 2.0, 3.0, 4.0])?;
+let rhs = Tensor::from_vec_col_major([2, 2], vec![2.0_f64, 0.0, 1.0, 2.0])?;
+let mut backend = CpuBackend::new();
+// Ordinary execution: no explicit preparation needed.
+let ordinary = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum("ij,jk->ik", session)
+})?;
+assert_eq!(ordinary.as_slice::<f64>()?, &[2.0, 4.0, 7.0, 10.0]);
+
+// Strings are fine for one-time preparation. The plan does not retain inputs.
+let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik")?;
+for (data, expected) in [
+    (vec![1.0_f64, 2.0, 3.0, 4.0], [2.0, 4.0, 7.0, 10.0]),
+    (vec![2.0_f64, 4.0, 6.0, 8.0], [4.0, 8.0, 14.0, 20.0]),
+] {
+    let next_lhs = Tensor::from_vec_col_major([2, 2], data)?;
+    let result = backend.with_backend_session(|session| {
+        plan.execute([&next_lhs, &rhs], session)
+    })?;
+    assert_eq!(result.as_slice::<f64>()?, &expected);
+}
+
+// Integer labels describe the equation; this ordinary call still plans.
+let equation = EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+let structured = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum_subscripts(&equation, session)
+})?;
+assert_eq!(structured.as_slice::<f64>()?, &[2.0, 4.0, 7.0, 10.0]);
+```
+<!-- end-snippet-source -->
+
+See [Ordinary calls and prepared execution](../../../../docs/guides/ordinary-and-prepared-execution.md)
+for typed/read/output variants and historical measurements with exact provenance.
+Do not interpret ten-op chain times as one-call costs or CPU measurements as GPU
+budgets. `1 ms = 1000 us`; measure the complete caller-visible workflow, including
+final result observation. For overhead diagnosis explicitly configure and verify
+one worker separately from CPU affinity; do not change production defaults based
+on tiny-work measurements.
+
 ## Compile once, run many
 
 A traced graph is a reusable program. Build its input metadata, compile once,

--- a/.claude/skills/tenferro-compute/SKILL.md
+++ b/.claude/skills/tenferro-compute/SKILL.md
@@ -37,9 +37,15 @@ not when changing tenferro itself.
   rejected.
 - **No facade crate.** `cargo add tenferro` fails by design; depend on the
   crates you need (`tenferro-runtime`, `tenferro-cpu`, and operation crates).
-- **Explicit backend.** Direct operations take an explicit backend argument;
-  construct the backend/runtime once and reuse it — per-call construction
-  discards the buffer pool.
+- **Explicit execution owner.** Concrete operations take a borrowed session
+  inside `backend.with_backend_session(...)` (`BackendSessionHost` import).
+  Construct the backend/runtime once and reuse it — per-call construction
+  discards the buffer pool. Eager tensors retain their runtime instead.
+- **Representation is not reuse.** Integer einsum labels still plan. For a
+  repeated compatible equation/input count/dtype/shape, prepare a
+  `ConcreteEinsumPlan` once, even from a string; see
+  [performance idioms](references/performance-idioms.md). Do not flatten
+  parenthesized contraction order into label arrays.
 - **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`).
   Flat notation supports one right-aligned, broadcastable `...` ellipsis per
   term; `EinsumNotation` provides the programmatic form.

--- a/.claude/skills/tenferro-compute/references/performance-idioms.md
+++ b/.claude/skills/tenferro-compute/references/performance-idioms.md
@@ -7,6 +7,61 @@ threading, placement, pools, and runtime caches; repeatedly constructing it
 throws away those resources. For traced work, likewise reuse the compiler and
 runtime across executions when their shape and registration contracts match.
 
+## Ordinary versus prepared einsum
+
+Use ordinary `TensorEinsumExt::einsum` by default. Reuse a `ConcreteEinsumPlan`
+when equation, operand order, input count, dtypes and shapes match; values may
+change. The plan retains metadata/tree, not inputs or a session. Execution still
+validates and allocates; placement and backend capabilities still apply.
+`EinsumSubscripts` is a programmatic representation, not a cache. Strings are
+fine for one-time preparation. Preserve explicit contraction order rather than
+flattening parentheses into labels.
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#ordinary-and-prepared-einsum -->
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::{ConcreteEinsumPlan, EinsumSubscripts, TensorEinsumExt};
+use tenferro_tensor::{BackendSessionHost, Tensor};
+
+let lhs = Tensor::from_vec_col_major([2, 2], vec![1.0_f64, 2.0, 3.0, 4.0])?;
+let rhs = Tensor::from_vec_col_major([2, 2], vec![2.0_f64, 0.0, 1.0, 2.0])?;
+let mut backend = CpuBackend::new();
+// Ordinary execution: no explicit preparation needed.
+let ordinary = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum("ij,jk->ik", session)
+})?;
+assert_eq!(ordinary.as_slice::<f64>()?, &[2.0, 4.0, 7.0, 10.0]);
+
+// Strings are fine for one-time preparation. The plan does not retain inputs.
+let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik")?;
+for (data, expected) in [
+    (vec![1.0_f64, 2.0, 3.0, 4.0], [2.0, 4.0, 7.0, 10.0]),
+    (vec![2.0_f64, 4.0, 6.0, 8.0], [4.0, 8.0, 14.0, 20.0]),
+] {
+    let next_lhs = Tensor::from_vec_col_major([2, 2], data)?;
+    let result = backend.with_backend_session(|session| {
+        plan.execute([&next_lhs, &rhs], session)
+    })?;
+    assert_eq!(result.as_slice::<f64>()?, &expected);
+}
+
+// Integer labels describe the equation; this ordinary call still plans.
+let equation = EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+let structured = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum_subscripts(&equation, session)
+})?;
+assert_eq!(structured.as_slice::<f64>()?, &[2.0, 4.0, 7.0, 10.0]);
+```
+<!-- end-snippet-source -->
+
+See [Ordinary calls and prepared execution](../../../../docs/guides/ordinary-and-prepared-execution.md)
+for typed/read/output variants and historical measurements with exact provenance.
+Do not interpret ten-op chain times as one-call costs or CPU measurements as GPU
+budgets. `1 ms = 1000 us`; measure the complete caller-visible workflow, including
+final result observation. For overhead diagnosis explicitly configure and verify
+one worker separately from CPU affinity; do not change production defaults based
+on tiny-work measurements.
+
 ## Compile once, run many
 
 A traced graph is a reusable program. Build its input metadata, compile once,

--- a/.kimi/skills/tenferro-compute/SKILL.md
+++ b/.kimi/skills/tenferro-compute/SKILL.md
@@ -37,9 +37,15 @@ not when changing tenferro itself.
   rejected.
 - **No facade crate.** `cargo add tenferro` fails by design; depend on the
   crates you need (`tenferro-runtime`, `tenferro-cpu`, and operation crates).
-- **Explicit backend.** Direct operations take an explicit backend argument;
-  construct the backend/runtime once and reuse it — per-call construction
-  discards the buffer pool.
+- **Explicit execution owner.** Concrete operations take a borrowed session
+  inside `backend.with_backend_session(...)` (`BackendSessionHost` import).
+  Construct the backend/runtime once and reuse it — per-call construction
+  discards the buffer pool. Eager tensors retain their runtime instead.
+- **Representation is not reuse.** Integer einsum labels still plan. For a
+  repeated compatible equation/input count/dtype/shape, prepare a
+  `ConcreteEinsumPlan` once, even from a string; see
+  [performance idioms](references/performance-idioms.md). Do not flatten
+  parenthesized contraction order into label arrays.
 - **Einsum dialect.** Equations need the explicit arrow (`"ij,jk->ik"`).
   Flat notation supports one right-aligned, broadcastable `...` ellipsis per
   term; `EinsumNotation` provides the programmatic form.

--- a/.kimi/skills/tenferro-compute/references/performance-idioms.md
+++ b/.kimi/skills/tenferro-compute/references/performance-idioms.md
@@ -7,6 +7,61 @@ threading, placement, pools, and runtime caches; repeatedly constructing it
 throws away those resources. For traced work, likewise reuse the compiler and
 runtime across executions when their shape and registration contracts match.
 
+## Ordinary versus prepared einsum
+
+Use ordinary `TensorEinsumExt::einsum` by default. Reuse a `ConcreteEinsumPlan`
+when equation, operand order, input count, dtypes and shapes match; values may
+change. The plan retains metadata/tree, not inputs or a session. Execution still
+validates and allocates; placement and backend capabilities still apply.
+`EinsumSubscripts` is a programmatic representation, not a cache. Strings are
+fine for one-time preparation. Preserve explicit contraction order rather than
+flattening parentheses into labels.
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#ordinary-and-prepared-einsum -->
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::{ConcreteEinsumPlan, EinsumSubscripts, TensorEinsumExt};
+use tenferro_tensor::{BackendSessionHost, Tensor};
+
+let lhs = Tensor::from_vec_col_major([2, 2], vec![1.0_f64, 2.0, 3.0, 4.0])?;
+let rhs = Tensor::from_vec_col_major([2, 2], vec![2.0_f64, 0.0, 1.0, 2.0])?;
+let mut backend = CpuBackend::new();
+// Ordinary execution: no explicit preparation needed.
+let ordinary = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum("ij,jk->ik", session)
+})?;
+assert_eq!(ordinary.as_slice::<f64>()?, &[2.0, 4.0, 7.0, 10.0]);
+
+// Strings are fine for one-time preparation. The plan does not retain inputs.
+let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik")?;
+for (data, expected) in [
+    (vec![1.0_f64, 2.0, 3.0, 4.0], [2.0, 4.0, 7.0, 10.0]),
+    (vec![2.0_f64, 4.0, 6.0, 8.0], [4.0, 8.0, 14.0, 20.0]),
+] {
+    let next_lhs = Tensor::from_vec_col_major([2, 2], data)?;
+    let result = backend.with_backend_session(|session| {
+        plan.execute([&next_lhs, &rhs], session)
+    })?;
+    assert_eq!(result.as_slice::<f64>()?, &expected);
+}
+
+// Integer labels describe the equation; this ordinary call still plans.
+let equation = EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+let structured = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum_subscripts(&equation, session)
+})?;
+assert_eq!(structured.as_slice::<f64>()?, &[2.0, 4.0, 7.0, 10.0]);
+```
+<!-- end-snippet-source -->
+
+See [Ordinary calls and prepared execution](../../../../docs/guides/ordinary-and-prepared-execution.md)
+for typed/read/output variants and historical measurements with exact provenance.
+Do not interpret ten-op chain times as one-call costs or CPU measurements as GPU
+budgets. `1 ms = 1000 us`; measure the complete caller-visible workflow, including
+final result observation. For overhead diagnosis explicitly configure and verify
+one worker separately from CPU affinity; do not change production defaults based
+on tiny-work measurements.
+
 ## Compile once, run many
 
 A traced graph is a reusable program. Build its input metadata, compile once,

--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ Selected deep dives:
 - [Storage ownership](https://tensor4all.org/tenferro-rs/storage-ownership.html)
   — one physical owner, borrowed views, explicit copies/transfers, and prepared
   access boundaries.
+- [Ordinary calls and prepared execution](https://tensor4all.org/tenferro-rs/guides/ordinary-and-prepared-execution.html)
+  — choose ordinary einsum, compatible plan reuse, or programmatic equations;
+  interpret measured overhead with its actual timing scope.
 - [Views and slicing](https://tensor4all.org/tenferro-rs/guides/views-and-slicing.html)
   — static-rank views, mutable disjointness, and explicit `duplicate()`.
 - [Devices and GPU](https://tensor4all.org/tenferro-rs/guides/devices-and-gpu.html)

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -59,6 +59,7 @@ website:
           - guides/views-and-slicing.md
           - storage-ownership.md
           - guides/einsum.md
+          - guides/ordinary-and-prepared-execution.md
           - guides/linear-algebra.md
           - guides/external-linalg-interop.md
           - guides/custom-operations.md

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -1,5 +1,8 @@
 # Einsum
 
+For choosing between ordinary calls, compatible plan reuse and programmatic
+labels, start with [Ordinary calls and prepared execution](ordinary-and-prepared-execution.md).
+
 `einsum` is a standard extension, not part of `tenferro` core. Add the
 `tenferro-einsum` crate and import its extension traits. Concrete tensor
 execution uses `TensorEinsumExt` and `TypedTensorEinsumExt` for owned inputs,

--- a/docs/guides/ordinary-and-prepared-execution.md
+++ b/docs/guides/ordinary-and-prepared-execution.md
@@ -1,0 +1,140 @@
+# Ordinary calls and prepared execution
+
+Start with the ordinary API. Prepare explicitly when you repeat a compatible
+contraction, not merely because the equation is a string. Construct the
+backend/runtime once and reuse it. This page uses CPU tensors with **column-major**
+data; see [crate setup and full einsum examples](einsum.md) for dependencies.
+
+## Choose by need
+
+| Need | Supported recipe |
+|---|---|
+| Execute concrete tensors now, without AD | `TensorEinsumExt::einsum` on `[&lhs, &rhs]` inside `backend.with_backend_session(...)` |
+| Execute eager tensors with AD | Import `EagerEinsumExt` (`autodiff` feature), then `[&lhs, &rhs].einsum("ij,jk->ik")`; core ops use methods such as `lhs.dot_general(&rhs, config)` |
+| Repeat one compatible concrete contraction | Keep a `ConcreteEinsumPlan`; prepare once and execute with new inputs |
+| Repeat a traced computation | Compile once and reuse the program and configured runtime; see [traced execution](einsum.md#traced-matrix-multiply) |
+| Generate an equation in code | Use `EinsumSubscripts` integer labels; use `EinsumNotation` for unresolved ellipsis |
+
+Concrete calls require the `BackendSessionHost` import. The callback's session
+is borrowed from the backend; do not retain it or recursively open that same
+backend from inside its callback. Multiple compatible concrete operations can
+share a callback. Eager tensors instead retain their `EagerRuntime`; keep inputs
+in the same runtime and preserve AD/capture semantics. Do not replace eager work
+with concrete operations when gradients are needed. See the executable
+[eager example](einsum.md#eagertensor).
+
+## Ordinary, prepared, and programmatic recipes
+
+The following is extracted from the tested consumer-skill binary. To run it in
+this checkout: `cargo run --manifest-path docs/tutorial-code/Cargo.toml --bin tenferro_compute_skill`.
+For a standalone program, place the fragment inside
+`fn main() -> Result<(), Box<dyn std::error::Error>>` and finish with `Ok(())`.
+
+<!-- snippet-source: docs/tutorial-code/src/bin/tenferro_compute_skill.rs#ordinary-and-prepared-einsum -->
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::{ConcreteEinsumPlan, EinsumSubscripts, TensorEinsumExt};
+use tenferro_tensor::{BackendSessionHost, Tensor};
+
+let lhs = Tensor::from_vec_col_major([2, 2], vec![1.0_f64, 2.0, 3.0, 4.0])?;
+let rhs = Tensor::from_vec_col_major([2, 2], vec![2.0_f64, 0.0, 1.0, 2.0])?;
+let mut backend = CpuBackend::new();
+// Ordinary execution: no explicit preparation needed.
+let ordinary = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum("ij,jk->ik", session)
+})?;
+assert_eq!(ordinary.as_slice::<f64>()?, &[2.0, 4.0, 7.0, 10.0]);
+
+// Strings are fine for one-time preparation. The plan does not retain inputs.
+let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik")?;
+for (data, expected) in [
+    (vec![1.0_f64, 2.0, 3.0, 4.0], [2.0, 4.0, 7.0, 10.0]),
+    (vec![2.0_f64, 4.0, 6.0, 8.0], [4.0, 8.0, 14.0, 20.0]),
+] {
+    let next_lhs = Tensor::from_vec_col_major([2, 2], data)?;
+    let result = backend.with_backend_session(|session| {
+        plan.execute([&next_lhs, &rhs], session)
+    })?;
+    assert_eq!(result.as_slice::<f64>()?, &expected);
+}
+
+// Integer labels describe the equation; this ordinary call still plans.
+let equation = EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+let structured = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum_subscripts(&equation, session)
+})?;
+assert_eq!(structured.as_slice::<f64>()?, &[2.0, 4.0, 7.0, 10.0]);
+```
+<!-- end-snippet-source -->
+
+### Reuse contract
+
+Keep the equation, operand ordering, input count, dtypes and shapes compatible
+with the prepared plan. Values may change, as the second execution demonstrates.
+The plan owns its prepared contraction tree and metadata, not the input tensors
+or a backend session. Execution still validates inputs and performs backend
+work: preparation does not remove validation, allocation, dispatch or required
+materialization. Prepare a new plan when the equation or input metadata changes.
+Device placement and backend capabilities must still match; a plan does not
+transfer data or make an unsupported dtype/device executable. For repeated traced
+work, keep the compiled program and configured runtime, pass new concrete inputs
+to `Runtime::run_compiled`, and recompile if the program's input metadata contract
+changes; register its extension modules before execution.
+
+Typed owned inputs use `TypedTensorEinsumExt` and `prepare_typed` /
+`execute_typed`. Borrowed views use the `*ReadEinsumExt` traits and
+`prepare_read` / `execute_read` (or typed-read variants). Preallocated output
+uses the matching `*IntoExt` or plan `execute_into` / `execute_read_into` with a
+validated write destination; these overwrite rather than accumulate. Choosing
+`_read` or `_into` describes input/output ownership, not whether planning is
+cached. See [tested view and output recipes](einsum.md#tensorread-and-prepared-plans).
+
+### Representation is not reuse
+
+Integer labels avoid textual parsing; ordinary `einsum_subscripts` still plans.
+For repeated generated equations, prepare with `ConcreteEinsumPlan::prepare_subscripts`.
+For ellipsis, use `EinsumNotation` and `prepare_notation`. Strings are appropriate
+for one-time preparation; there is no general reason to ban them.
+
+**Do not flatten parenthesized contraction order into integer label arrays.**
+`EinsumSubscripts` expresses labels, not grouping. The flat ordinary/prepare
+recipes above do not accept parentheses. Preserve an intended order through the
+supported explicit path/tree controls on the traced route, described in
+[einsum optimization controls](einsum.md#optimization-controls), rather than
+silently discarding it. Parenthesized ellipsis is unsupported.
+
+## Interpret overhead without inventing a budget
+
+`1 ms = 1000 us = 1,000,000 ns`. Repeated cost is `N × per-call cost`.
+For illustration only, 5 us of setup contributes `5 / (1000 + 5) ≈ 0.5%`
+beside 1 ms of useful work, but `5 / (1 + 5) ≈ 83%` beside 1 us.
+These are arithmetic examples, not measured tenferro constants.
+
+Two fixed historical Linux records inform this guidance, not a maintained
+“latest benchmark” table:
+
+- [Binary einsum record](https://github.com/tensor4all/tenferro-rs/blob/7dfc01127f4a8752a8bb504641feb396683576c3/docs/worklogs/issue-1761-binary-einsum.md):
+  the accepted ordinary-string small-matrix aggregate candidate/base ratio was
+  0.6851, 95% CI [0.6661, 0.7046]. This is dimensionless, **not a per-call latency**.
+  The record retains rejected/inconclusive earlier experiments and the accepted
+  explicit-one-worker result, revisions, raw evidence and timing boundaries.
+- [Eager/session attribution, 2026-09-06](https://github.com/tensor4all/tenferro-rs/blob/552b4793/docs/worklogs/issue-1762-eager-session.md):
+  library `7dfc0112`, Linux `primerose`, AMD EPYC 7713P, Rust 1.97.1,
+  release/faer, explicit one worker and separate affinity to CPU 32. Ten dependent
+  2x2 F64 matmuls took median 25.182 us in one shared concrete session versus
+  191.056 us through ordinary no-AD eager, **per ten-op chain**, not per call.
+  Seven process medians had CV 2.5% and 2.4%; paired eager/shared ratio was
+  7.572 [7.414, 7.734] (95% CI). Initial input/backend/leaf construction was
+  excluded, final owned result observation included. The gap includes different
+  execution/ownership work, not just AD or session entry; production changes
+  were deferred.
+
+Follow the linked records for exact source and normalization. For broader or
+newer measurements consult [tenferro-benchmark](https://github.com/tensor4all/tenferro-benchmark).
+Neither these numbers nor historical Apple measurements are latency promises,
+execution thresholds, default-thread results or GPU budgets. GPU transfer and
+synchronization require their own measurements. Performance validity is separate
+from numerical correctness: INCONCLUSIVE demonstrates neither speedup nor
+non-regression. Revalidate examples and measurement provenance when upgrading.
+For overhead measurements explicitly configure and verify worker count; CPU
+pinning alone does not set it. See [parallelism and caching](parallelism-and-caching.md).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -28,6 +28,8 @@
 
 ## Guides
 
+- [Ordinary calls and prepared execution](https://tensor4all.org/tenferro-rs/guides/ordinary-and-prepared-execution.html): Choosing ordinary einsum, compatible ConcreteEinsumPlan reuse and programmatic labels, with scoped historical Linux measurements.
+
 - [Einsum](https://tensor4all.org/tenferro-rs/guides/einsum.html): WARNING — missing arrows and parenthesized ellipses are parse-time `Error::InvalidSubscripts` failures; use flat `...` ellipsis or `EinsumNotation`.
 - [Linear Algebra](https://tensor4all.org/tenferro-rs/guides/linear-algebra.html): Covers the `tenferro-linalg` operation crate and its direct, eager, and traced execution surfaces.
 - [External Linear Algebra Interop](https://tensor4all.org/tenferro-rs/guides/external-linalg-interop.html): Calling faer or BLAS/LAPACK directly on tenferro-owned storage: the direct-dependency contract, column-major leading dimensions, non-contiguous/non-host rejection, and provider thread control.

--- a/docs/tutorial-code/src/bin/tenferro_compute_skill.rs
+++ b/docs/tutorial-code/src/bin/tenferro_compute_skill.rs
@@ -146,7 +146,47 @@ assert_eq!(buffer[0], 7.0);
     Ok(())
 }
 
+#[rustfmt::skip]
+fn ordinary_and_prepared_einsum() -> Result<(), Box<dyn std::error::Error>> {
+    // snippet-start:ordinary-and-prepared-einsum
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::{ConcreteEinsumPlan, EinsumSubscripts, TensorEinsumExt};
+use tenferro_tensor::{BackendSessionHost, Tensor};
+
+let lhs = Tensor::from_vec_col_major([2, 2], vec![1.0_f64, 2.0, 3.0, 4.0])?;
+let rhs = Tensor::from_vec_col_major([2, 2], vec![2.0_f64, 0.0, 1.0, 2.0])?;
+let mut backend = CpuBackend::new();
+// Ordinary execution: no explicit preparation needed.
+let ordinary = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum("ij,jk->ik", session)
+})?;
+assert_eq!(ordinary.as_slice::<f64>()?, &[2.0, 4.0, 7.0, 10.0]);
+
+// Strings are fine for one-time preparation. The plan does not retain inputs.
+let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik")?;
+for (data, expected) in [
+    (vec![1.0_f64, 2.0, 3.0, 4.0], [2.0, 4.0, 7.0, 10.0]),
+    (vec![2.0_f64, 4.0, 6.0, 8.0], [4.0, 8.0, 14.0, 20.0]),
+] {
+    let next_lhs = Tensor::from_vec_col_major([2, 2], data)?;
+    let result = backend.with_backend_session(|session| {
+        plan.execute([&next_lhs, &rhs], session)
+    })?;
+    assert_eq!(result.as_slice::<f64>()?, &expected);
+}
+
+// Integer labels describe the equation; this ordinary call still plans.
+let equation = EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
+let structured = backend.with_backend_session(|session| {
+    [&lhs, &rhs].einsum_subscripts(&equation, session)
+})?;
+assert_eq!(structured.as_slice::<f64>()?, &[2.0, 4.0, 7.0, 10.0]);
+    // snippet-end:ordinary-and-prepared-einsum
+    Ok(())
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ordinary_and_prepared_einsum()?;
     concrete_operation_and_column_major()?;
     eager_operation()?;
     traced_operation_with_extension_registration()?;

--- a/docs/worklogs/issue-1763-consumer-guide.md
+++ b/docs/worklogs/issue-1763-consumer-guide.md
@@ -1,0 +1,69 @@
+# #1763: ordinary calls and prepared-execution consumer guidance
+
+## Outcome and scope
+
+Phase 3 of #1771 adds one guide, its README/sidebar/llms.txt routes, and updates
+the bundled consumer skill and both mirrors. It distinguishes ordinary calls,
+compatible `ConcreteEinsumPlan` reuse, and programmatic labels without changing
+library behavior or adding API aliases/caches. The existing tutorial binary and
+snippet synchronization mechanism own the executable recipe; no generator,
+benchmark framework or new testing API is introduced.
+
+#1771 supersedes #1758's broader infrastructure and consolidation requirements.
+Phase 2's explicit production-change deferral is respected. Its evidence is
+linked at immutable commit `552b4793`, independently of the evidence PR's merge
+timing. The guide reports historical observations with timing/worker/host scope,
+not a conflicting “latest results” table or a default/GPU performance promise.
+
+## Sources and decisions
+
+Read #1771/#1763, Phase 2's record, the repository/shared docs, consumer,
+performance and numerical rules, existing einsum guide and consumer references,
+`ConcreteEinsumPlan` preparation/execution, `EinsumSubscripts`/`EinsumNotation`,
+and the existing snippet/mirror/site checkers. Worktree started at current main
+`7dfc01127f4a8752a8bb504641feb396683576c3`; repository rules match the Phase 2
+checkout already read in this session.
+
+- The recipe performs ordinary string execution, prepares once, executes with
+  two different value sets under unchanged metadata, and constructs an integer
+  equation. It asserts every output element, not merely shape or finiteness.
+- Reuse constraints reflect stored input specs and execution validation, not a
+  claim that plans own inputs, sessions, device placement or results.
+- Flat notation rejects parentheses; the guide explicitly prevents flattening
+  grouping into integer labels and links the supported traced path controls.
+- Existing eager, typed/read/output and traced examples remain canonical; the
+  new page routes to them rather than copying every API family.
+- No independent agent review was requested. Direct executable consumer checks
+  and rendered-page inspection were used; do not call this an independent
+  source-blind audit.
+
+## Verification and corrections
+
+- `scripts/check-doc-snippets.py --check` and `scripts/check-agent-skills.py`:
+  passed; the new guide and skill share one extracted Rust source block.
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo run --manifest-path docs/tutorial-code/Cargo.toml --bin tenferro_compute_skill'`:
+  passed formatting, CI-parity clippy and all recipe numerical/AD assertions.
+  `CARGO_TARGET_DIR` reused the idle Phase 2 target serially; no concurrent Cargo
+  jobs used that target.
+- `scripts/check-guide-dependency-snippets.py`: passed all four existing guides.
+- `cargo doc --workspace --no-deps`: passed.
+- `quarto render docs`: rendered all 117 pages. Inspected the new page's HTML
+  headings, extracted recipe, numerical assertions, units and provenance links.
+  Only Quarto's existing output-directory cleanup/configuration warnings remain;
+  no unresolved link warning remains for the new guide.
+- `scripts/check-docs-site.py --doc-root <Phase-2-target>/doc`: passed after full
+  rendering and the canonical skill-reference copy step from
+  `build_docs_site.sh`; verifies site links, rustdoc inventory and llms.txt.
+- Initial partial site checks were not passes: a 60-second dependency-check
+  attempt timed out (no owned descendants remained), and a single-page render
+  lacked the site's republished references. The complete checks above supersede
+  those attempts. A virtual skill-reference link caused a render warning and
+  was replaced with the canonical traced guide link; the corrected page was
+  rerendered. HTML syntax-highlight spans required token-aware text inspection,
+  rather than an exact raw multi-number text match.
+- Diff self-review: no production code, dependency, feature, public API, AD rule,
+  transfer or ownership changes. Existing examples/README behavior is preserved.
+
+Required hosted CI and merge are checked on the submitted PR separately; local
+checks alone do not prove completion. This log records artifact verification,
+not new durable architecture or a mandate to optimize further routes.


### PR DESCRIPTION
## Type
- [x] Documentation
- [x] Implementation of accepted issue

## Related issue
Fixes #1763 under the bounded Phase 3 scope of #1771 (which supersedes #1758).

## Summary
- Add one concise guide distinguishing ordinary concrete/eager calls, compatible ConcreteEinsumPlan reuse and programmatic labels. Explain input/output variants, explicit order preservation, units and scoped historical measurements.
- Link it from README, existing einsum guide, sidebar and llms.txt.
- Update consumer skill and both mirrors; one existing tutorial-binary recipe owns the guide/skill snippets and verifies full output values for ordinary, changed-input prepared and structured calls.
- Preserve Phase 2's deferral; link immutable evidence without implementing more optimizations. No library/API/dependency/feature changes or new checking/generation framework.

## Work log
[Scope, source contracts, checks and corrected attempts](docs/worklogs/issue-1763-consumer-guide.md)

## Verification
- Local gate: `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo run --manifest-path docs/tutorial-code/Cargo.toml --bin tenferro_compute_skill'` PASS (formatting, CI-parity clippy and numerical recipe checks).
- Snippet sync and skill mirrors: PASS.
- Existing guide dependency snippets (4 guides): PASS.
- Workspace rustdoc: PASS.
- Full Quarto render (117 pages) and docs-site links/llms inventory (14 crates): PASS. Inspected new rendered HTML recipes, numerical assertions, normalization and provenance links.
- Committed-head deterministic repository-rules review: PASS; external LLM review deliberately disabled. No independent AI review requested or claimed.

## Checklist
- [x] Read CONTRIBUTING.md and relevant repository/shared rules.
- [x] Added/updated executable docs and synchronized mirrors.
- [x] Local gate and deterministic rules review passed; coherent diff self-reviewed.
- [x] Accepted issue scope, no new feature or bug-fix API change.
- [x] Work log included above.
- [ ] Required hosted checks and merge (auto-merge requested; not yet claimed complete).
