### PR TITLE
release: prepare tenferro v0.5.0

### DIFF
--- a/.github/releases/v0.5.0.md
+++ b/.github/releases/v0.5.0.md
@@ -1,0 +1,26 @@
+# tenferro v0.5.0
+
+## Migration
+
+- Update `tenferro-*` dependency requirements from `0.4` to `0.5` together.
+- Static-rank tensor constructors now require array and array-reference shapes to match the rank at compile time. Use a correctly sized array, or explicitly pass a slice/vector when runtime rank validation is intended. Dynamic-rank tensors continue to accept arbitrary-length arrays. ([#1778](https://github.com/tensor4all/tenferro-rs/pull/1778))
+
+## Features
+
+- Incremental Householder QR: retain a compact factorization, append columns, extract R, and materialize selected Q columns across concrete, eager, and traced surfaces. CPU-faer, CPU-BLAS/LAPACK, CUDA, and JVP/VJP support are included. ([#1742](https://github.com/tensor4all/tenferro-rs/pull/1742), [#1743](https://github.com/tensor4all/tenferro-rs/pull/1743), [#1745](https://github.com/tensor4all/tenferro-rs/pull/1745))
+- Rank-revealing QR on CPU and CUDA for F32/F64/C32/C64 and trailing batches, returning Q, R, and tensor-valued permutation/rank metadata. CUDA outputs remain device-resident; differentiation through rank-revealing QR is explicitly unsupported. ([#1756](https://github.com/tensor4all/tenferro-rs/pull/1756), [#1757](https://github.com/tensor4all/tenferro-rs/pull/1757))
+- Validated zero-copy column-major host views with checked element access, mutable views, and contiguous axis-0 lane traversal. ([#1741](https://github.com/tensor4all/tenferro-rs/pull/1741))
+
+## Fixes and execution improvements
+
+- Binary einsum bypasses the general contraction optimizer. ([#1772](https://github.com/tensor4all/tenferro-rs/pull/1772))
+- Prepared-cache synchronization no longer loses wakeups, and CUDA caches preserve small resources under cache pressure. ([#1746](https://github.com/tensor4all/tenferro-rs/pull/1746), [#1740](https://github.com/tensor4all/tenferro-rs/pull/1740))
+- Eager extension dispatch respects runtime placement. Public einsum and eager boundary error phases are aligned with their actual execution routes. ([#1753](https://github.com/tensor4all/tenferro-rs/pull/1753), [#1767](https://github.com/tensor4all/tenferro-rs/pull/1767), [#1768](https://github.com/tensor4all/tenferro-rs/pull/1768))
+- Spectral and minimum-singular-value norms preserve signed/complex matrix values, norm axis validation is shared across surfaces, and device-access errors retain their typed source chains. ([#1778](https://github.com/tensor4all/tenferro-rs/pull/1778))
+
+## Documentation
+
+- Guidance for ordinary tensor calls, prepared-operation reuse, and programmatic einsum. ([#1775](https://github.com/tensor4all/tenferro-rs/pull/1775))
+- CUDA library compatibility matrix. Unsupported operations still return explicit errors rather than silently transferring work to CPU. ([#1739](https://github.com/tensor4all/tenferro-rs/pull/1739))
+
+**Full changelog:** https://github.com/tensor4all/tenferro-rs/compare/v0.4.0...v0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 rust-version = "1.96"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Add the runtime, CPU backend, and linear algebra extension crates:
 
 ```toml
 [dependencies]
-tenferro-runtime = "0.4"
-tenferro-cpu = "0.4"
-tenferro-linalg = "0.4"
+tenferro-runtime = "0.5"
+tenferro-cpu = "0.5"
+tenferro-linalg = "0.5"
 ```
 
 <!-- snippet-source: docs/tutorial-code/src/bin/direct_linalg_quickstart.rs -->
@@ -113,9 +113,9 @@ or `jvp`:
 
 ```toml
 [dependencies]
-tenferro-runtime = "0.4"
-tenferro-cpu = "0.4"
-tenferro-ad = "0.4"
+tenferro-runtime = "0.5"
+tenferro-cpu = "0.5"
+tenferro-ad = "0.5"
 ```
 
 <!-- snippet-source: docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs -->

--- a/crates/tenferro-ad/Cargo.toml
+++ b/crates/tenferro-ad/Cargo.toml
@@ -44,11 +44,11 @@ webgpu = ["dep:tenferro-gpu", "tenferro-gpu/webgpu"]
 rocm = ["dep:tenferro-gpu", "tenferro-gpu/rocm"]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false, features = ["autodiff"] }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.5.0", default-features = false }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.5.0", default-features = false, features = ["autodiff"] }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.5.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.5.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.5.0", default-features = false, optional = true }
 computegraph.workspace = true
 lru.workspace = true
 num-complex.workspace = true

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -45,10 +45,10 @@ blas-mkl = [
 ]
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
-tenferro-internal-cpu-kernels = { path = "../tenferro-internal-cpu-kernels", version = "0.4.0" }
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0" }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.5.0" }
+tenferro-internal-cpu-kernels = { path = "../tenferro-internal-cpu-kernels", version = "0.5.0" }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.5.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.5.0" }
 num-complex.workspace = true
 num-traits.workspace = true
 rayon.workspace = true

--- a/crates/tenferro-einsum/Cargo.toml
+++ b/crates/tenferro-einsum/Cargo.toml
@@ -65,13 +65,13 @@ rocm = [
 ]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
-tenferro-ad = { path = "../tenferro-ad", version = "0.4.0", default-features = false, optional = true }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.5.0", default-features = false }
+tenferro-ad = { path = "../tenferro-ad", version = "0.5.0", default-features = false, optional = true }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.5.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.5.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.5.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.5.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.5.0", default-features = false, optional = true }
 computegraph.workspace = true
 lru.workspace = true
 omeco.workspace = true
@@ -79,7 +79,7 @@ smallvec.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.5.0", default-features = false }
 criterion.workspace = true
 num-complex.workspace = true
 

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -44,13 +44,13 @@ webgpu = [
 ]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
-tenferro-ad = { path = "../tenferro-ad", version = "0.4.0", default-features = false, optional = true }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.5.0", default-features = false }
+tenferro-ad = { path = "../tenferro-ad", version = "0.5.0", default-features = false, optional = true }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.5.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.5.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.5.0", default-features = false, optional = true }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.5.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.5.0", default-features = false }
 libloading = { workspace = true, optional = true }
 computegraph.workspace = true
 num-complex.workspace = true

--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -55,10 +55,10 @@ webgpu = [
 rocm = []
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.5.0" }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.5.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.5.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.5.0", default-features = false }
 cubecl = { workspace = true, optional = true }
 cubecl-cuda = { workspace = true, optional = true }
 cubecl-common = { workspace = true, optional = true }

--- a/crates/tenferro-internal-cpu-kernels/Cargo.toml
+++ b/crates/tenferro-internal-cpu-kernels/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 name = "tenferro_internal_cpu_kernels"
 
 [dependencies]
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0" }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.5.0" }
 num-complex.workspace = true
 num-traits.workspace = true
 strided-kernel.workspace = true

--- a/crates/tenferro-internal-ops/Cargo.toml
+++ b/crates/tenferro-internal-ops/Cargo.toml
@@ -29,9 +29,9 @@ webgpu = []
 rocm = []
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.5.0" }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.5.0", default-features = false }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.5.0" }
 computegraph.workspace = true
 num-complex.workspace = true
 thiserror.workspace = true

--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -74,13 +74,13 @@ rocm = ["tenferro-ad?/rocm", "tenferro-internal-ops/rocm"]
 webgpu = ["dep:tenferro-gpu", "tenferro-gpu/webgpu"]
 
 [dependencies]
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
-tenferro-ad = { path = "../tenferro-ad", version = "0.4.0", default-features = false, optional = true }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.4.0", default-features = false, optional = true }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.4.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.5.0", default-features = false }
+tenferro-ad = { path = "../tenferro-ad", version = "0.5.0", default-features = false, optional = true }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.5.0", default-features = false, optional = true }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.5.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.5.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.5.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.5.0", default-features = false }
 cblas-sys = { workspace = true, optional = true }
 cblas-inject = { workspace = true, optional = true }
 computegraph = { workspace = true, optional = true }

--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -31,10 +31,10 @@ blas-accelerate = ["tenferro-cpu/blas-accelerate"]
 blas-mkl = ["tenferro-cpu/blas-mkl"]
 
 [dependencies]
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
-tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.4.0" }
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.5.0" }
+tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.5.0" }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.5.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.5.0", default-features = false }
 computegraph.workspace = true
 lru.workspace = true
 num-complex.workspace = true

--- a/crates/tenferro-tensor/Cargo.toml
+++ b/crates/tenferro-tensor/Cargo.toml
@@ -25,12 +25,12 @@ name = "tenferro_tensor"
 default = []
 
 [dependencies]
-tenferro-tensor-core = { path = "../tenferro-tensor-core", version = "0.4.0" }
+tenferro-tensor-core = { path = "../tenferro-tensor-core", version = "0.5.0" }
 num-traits.workspace = true
 num-complex.workspace = true
 smallvec.workspace = true
 strided-kernel.workspace = true
-tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.4.0" }
+tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.5.0" }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/tenferro-xla/Cargo.toml
+++ b/crates/tenferro-xla/Cargo.toml
@@ -27,9 +27,9 @@ default = []
 pjrt = ["dep:libloading"]
 
 [dependencies]
-tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.4.0", default-features = false }
-tenferro-runtime = { path = "../tenferro-runtime", version = "0.4.0", default-features = false }
-tenferro-tensor = { path = "../tenferro-tensor", version = "0.4.0", default-features = false }
+tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.5.0", default-features = false }
+tenferro-runtime = { path = "../tenferro-runtime", version = "0.5.0", default-features = false }
+tenferro-tensor = { path = "../tenferro-tensor", version = "0.5.0", default-features = false }
 computegraph.workspace = true
 libloading = { workspace = true, optional = true }
 sha2.workspace = true

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -38,9 +38,9 @@ extension from crates.io:
 
 ```toml
 [dependencies]
-tenferro-runtime = "0.4"
-tenferro-cpu = "0.4"
-tenferro-linalg = "0.4"
+tenferro-runtime = "0.5"
+tenferro-cpu = "0.5"
+tenferro-linalg = "0.5"
 ```
 
 For development against a local checkout of this repository, use path
@@ -188,9 +188,9 @@ Add `tenferro-ad` when the same tensor stack needs graph-based derivatives:
 
 ```toml
 [dependencies]
-tenferro-runtime = "0.4"
-tenferro-cpu = "0.4"
-tenferro-ad = "0.4"
+tenferro-runtime = "0.5"
+tenferro-cpu = "0.5"
+tenferro-ad = "0.5"
 ```
 
 <!-- snippet-source: docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs -->


### PR DESCRIPTION
## Summary

Prepare the maintainer-requested tenferro v0.5.0 release from current main.

- Bump the workspace and all versioned internal tenferro dependencies to 0.5.0.
- Update README/getting-started crates.io requirements to 0.5.
- Add curated release notes in `.github/releases/v0.5.0.md`, including the static-rank shape migration and shipped QR features.
- No Rust implementation, feature, external dependency, or API changes in this PR.

## SemVer and provenance

All 14 publishable workspace crates report latest stable 0.4.0. Every downloaded 0.4.0 archive records `7c04b43b8cfe603385ae05f961058e7a04692e35`, the v0.4.0 tag commit. Merged additions include incremental Householder QR (#1742/#1743/#1745), column-major host views (#1741), and CPU/CUDA rank-revealing QR (#1756/#1757); #1778 also changes the static-rank array shape contract. Under the pre-1.0 release policy, 0.5.0 is the matching next minor and matches the requested target.

All git dependency package/version requirements exist on crates.io and are not yanked. Exact pinned-manifest validation and final tagged-package checks remain part of the release helper preflight.

## Verification

- `cargo metadata --format-version 1`
- `python3 scripts/check-publish-layout.py`
- `OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 bash scripts/check-pr-fast.sh --coverage-reviewed --test 'python3 scripts/check-publish-layout.py'` — passed, including repository formatting, root/standalone CI-parity clippy and snippet synchronization.
- Main-agent coherent diff self-review; committed-head deterministic repository-rules review — passed (external LLM intentionally skipped).

The base main commit `2e09107444f071ecb3bb43660677220882eccb96` has successful normal workspace/backend, coverage, docs and macOS CI. Required PR checks and exact release-commit CI remain mandatory; no bypass is requested.

## Publication boundary

After merge: tag the merged commit, publish the reviewed GitHub notes, validate a clean detached tag checkout, and generate the guarded human handoff. crates.io publication is human-only and has **not** been executed.

Original user worktree changes are untouched and are not included in this PR.
