### PR TITLE
perf(cpu): avoid binary copies and reuse parallel FFT outputs

### DIFF
--- a/crates/tenferro-ad/src/extension.rs
+++ b/crates/tenferro-ad/src/extension.rs
@@ -79,6 +79,52 @@ pub struct EagerExtensionTarget {
 #[cfg(test)]
 mod tests;
 
+/// Validate recording eligibility before a consuming extension mutation.
+/// This does not grant write authority: callers must still consume the input
+/// through `EagerTensor::into_value` and obtain an exclusive tensor borrow.
+///
+/// # Errors
+/// Returns `Error::RuntimeState` for gradient-tracked values, legacy AD traces,
+/// or active capture, including capture nested inside no_grad. Saved-value
+/// ownership must additionally pass the structural into_value check.
+/// Input-signature validation, module-factory and installation errors are
+/// propagated unchanged.
+///
+/// # Examples
+/// ```
+/// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+/// use tenferro_ad::extension::prepare_eager_in_place_input;
+/// let input = EagerTensor::requires_grad_in(
+///     Tensor::from_vec_col_major([1], vec![1.0_f64])?, EagerRuntime::new()?)?;
+/// let result = prepare_eager_in_place_input(&input, "example", |_| {
+///     panic!("tracked inputs must be rejected before module construction")
+/// });
+/// assert!(result.is_err());
+/// assert_eq!(input.shape(), &[1]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[doc(hidden)]
+pub fn prepare_eager_in_place_input(
+    input: &EagerTensor,
+    family_id: &'static str,
+    module_factory: impl FnOnce(EagerExtensionTarget) -> Result<Arc<dyn ExtensionModule>>,
+) -> Result<()> {
+    if input.requires_grad || input.trace.is_some() || eager_capture_active() {
+        return Err(Error::runtime_state(
+            "eager in-place",
+            ErrorPhase::Execution,
+            "in-place execution requires an untracked value outside trace capture",
+        ));
+    }
+    let target = input.ctx.eager_extension_target()?;
+    validate_eager_extension_input_signature(&input.ctx, &target, &[input.tensor_read()])?;
+    let module = module_factory(target.clone())?;
+    input
+        .ctx
+        .ensure_extension_module_for_engine(module, family_id, &target.engine_id)?;
+    Ok(())
+}
+
 /// Adopt an untracked eager tensor value produced by this runtime's backend.
 ///
 /// This is a low-level extension contract for eager composite operations that

--- a/crates/tenferro-ad/src/extension/tests.rs
+++ b/crates/tenferro-ad/src/extension/tests.rs
@@ -387,6 +387,45 @@ fn eager_extension_cpu_input_signature_is_accepted_before_factory() {
 }
 
 #[test]
+fn consuming_preparation_checks_recording_and_installs_without_taking_ownership() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1).unwrap()).unwrap();
+    let value = input(&ctx);
+    let family = BridgeProbe::one().family_id();
+    let before = ctx.runtime().epoch().unwrap();
+    let error = super::prepare_eager_in_place_input(&value, family, |_| {
+        Err(Error::runtime_state(
+            "test factory",
+            ErrorPhase::Execution,
+            "factory failure",
+        ))
+    })
+    .unwrap_err();
+    assert!(error.to_string().contains("factory failure"));
+    assert_eq!(ctx.runtime().epoch().unwrap(), before);
+    for _ in 0..2 {
+        super::prepare_eager_in_place_input(&value, family, |target| {
+            Ok(BridgeModule::for_engine(target.engine_id))
+        })
+        .unwrap();
+    }
+    assert!(ctx.runtime().epoch().unwrap() > before);
+    // Preparation only checks eligibility; the caller still owns a usable value.
+    assert!(value.to_tensor().is_ok());
+    let tracked = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major([1], vec![1.0_f64]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let epoch = ctx.runtime().epoch().unwrap();
+    assert!(super::prepare_eager_in_place_input(&tracked, family, |_| {
+        panic!("tracked input must be rejected before the factory")
+    })
+    .is_err());
+    assert_eq!(ctx.runtime().epoch().unwrap(), epoch);
+    assert!(tracked.to_tensor().is_ok());
+}
+
+#[test]
 fn eager_extension_targeted_install_is_idempotent_for_fresh_modules() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new()).unwrap();
     let input = input(&ctx);

--- a/crates/tenferro-cpu/src/provider.rs
+++ b/crates/tenferro-cpu/src/provider.rs
@@ -383,6 +383,28 @@ impl<'a> CpuExecutionContext<'a> {
         }
     }
 
+    /// Effective native-kernel degree inside this already-entered CPU context.
+    /// Non-Rayon executors and sequential/nested policy use one thread.
+    ///
+    /// # Examples
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// let mut backend = CpuBackend::with_threads(1)?;
+    /// let threads = backend.with_linalg_pool(|context, _| Ok(context.native_thread_count()))?;
+    /// assert_eq!(threads, 1);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[doc(hidden)]
+    pub fn native_thread_count(&self) -> usize {
+        match (
+            self.parallel_mode,
+            self.domain.executor_capabilities().inner_parallelism,
+        ) {
+            (ParallelMode::Inner, CpuInnerParallelism::Rayon) => self.thread_budget().get(),
+            _ => 1,
+        }
+    }
+
     pub(crate) fn strided_exec_context(&self) -> strided_kernel::ExecContext {
         match (
             self.parallel_mode,

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -54,6 +54,7 @@ tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.5.0", 
 libloading = { workspace = true, optional = true }
 computegraph.workspace = true
 num-complex.workspace = true
+rayon.workspace = true
 num-traits.workspace = true
 rustfft = "6"
 thiserror.workspace = true

--- a/crates/tenferro-fft/src/backend.rs
+++ b/crates/tenferro-fft/src/backend.rs
@@ -195,31 +195,4 @@ pub trait FftBackend: BackendSession {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn execution_cache_debug_identifies_both_owners_and_exposes_the_store() {
-        let mut caller = FftPlanCache::default();
-        let mut caller_cache = FftExecutionCache::caller_owned(&mut caller);
-        assert!(format!("{caller_cache:?}").contains("CallerOwned"));
-        assert_eq!(
-            caller_cache
-                .store_mut()
-                .stats(tenferro_runtime::ExtensionCacheSelector::All)
-                .entries,
-            0
-        );
-
-        let mut runtime = ExtensionCacheStore::default();
-        let mut runtime_cache = FftExecutionCache::runtime_owned(&mut runtime);
-        assert!(format!("{runtime_cache:?}").contains("RuntimeOwned"));
-        assert_eq!(
-            runtime_cache
-                .store_mut()
-                .stats(tenferro_runtime::ExtensionCacheSelector::All)
-                .entries,
-            0
-        );
-    }
-}
+mod tests;

--- a/crates/tenferro-fft/src/backend.rs
+++ b/crates/tenferro-fft/src/backend.rs
@@ -135,6 +135,48 @@ pub trait FftBackend: BackendSession {
         Ok(())
     }
 
+    /// Execute a validated FFT from borrowed storage.
+    ///
+    /// The default explicitly canonicalizes view inputs. Backends supporting
+    /// compact borrowed storage override this method to avoid input copies.
+    ///
+    /// # Examples
+    /// The borrowed public surface dispatches through this backend hook:
+    /// ```
+    /// use num_complex::Complex64;
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_fft::{FftNorm, TensorReadFftExt};
+    /// use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead};
+    /// let input = Tensor::from_vec_col_major([2], vec![Complex64::new(1., 0.); 2])?;
+    /// let mut backend = CpuBackend::with_threads(1)?;
+    /// let output = backend.with_backend_session(|session| {
+    ///     TensorRead::Tensor(&input).fft_read(None, 0, FftNorm::Backward, session)
+    /// })?;
+    /// assert_eq!(output.as_slice::<Complex64>()?, &[Complex64::new(2., 0.), Complex64::new(0., 0.)]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for unsupported dtype,
+    /// layout, or placement, and [`tenferro_tensor::Error::Validation`] when
+    /// input metadata disagrees with the validated spec. Same-placement
+    /// canonicalization, plan creation, and execution failures preserve the
+    /// selected backend's typed error source; no implicit transfer is performed.
+    fn execute_fft_read(
+        &mut self,
+        input: TensorRead<'_>,
+        spec: &FftPlanSpec,
+        cache: FftExecutionCache<'_>,
+    ) -> tenferro_tensor::Result<Tensor> {
+        match input {
+            TensorRead::Tensor(input) => self.execute_fft(input, spec, cache),
+            input => {
+                let owned = self.to_contiguous_read(input)?;
+                self.execute_fft(&owned, spec, cache)
+            }
+        }
+    }
+
     /// Execute one validated FFT request on `input`'s existing placement.
     ///
     /// # Errors

--- a/crates/tenferro-fft/src/backend/tests.rs
+++ b/crates/tenferro-fft/src/backend/tests.rs
@@ -1,0 +1,84 @@
+use super::*;
+
+#[test]
+fn execution_cache_debug_identifies_both_owners_and_exposes_the_store() {
+    let mut caller = FftPlanCache::default();
+    let mut caller_cache = FftExecutionCache::caller_owned(&mut caller);
+    assert!(format!("{caller_cache:?}").contains("CallerOwned"));
+    assert_eq!(
+        caller_cache
+            .store_mut()
+            .stats(tenferro_runtime::ExtensionCacheSelector::All)
+            .entries,
+        0
+    );
+
+    let mut runtime = ExtensionCacheStore::default();
+    let mut runtime_cache = FftExecutionCache::runtime_owned(&mut runtime);
+    assert!(format!("{runtime_cache:?}").contains("RuntimeOwned"));
+    assert_eq!(
+        runtime_cache
+            .store_mut()
+            .stats(tenferro_runtime::ExtensionCacheSelector::All)
+            .entries,
+        0
+    );
+}
+
+// Exercise the trait defaults with the existing backend's real structural
+// operations; only the final FFT execution delegates to its CPU session.
+impl FftBackend for tenferro_cpu::CpuBackend {
+    fn execute_fft(
+        &mut self,
+        input: &Tensor,
+        spec: &FftPlanSpec,
+        cache: FftExecutionCache<'_>,
+    ) -> tenferro_tensor::Result<Tensor> {
+        use tenferro_tensor::BackendSessionHost;
+        self.with_backend_session(|session| {
+            tenferro_cpu::with_cpu_exec_session(session, |cpu| cpu.execute_fft(input, spec, cache))
+                .unwrap()
+        })
+    }
+}
+
+#[test]
+fn default_read_execution_preserves_owned_input_and_canonicalizes_a_view() {
+    use crate::{FftNorm, FftOperation};
+    use num_complex::Complex64;
+    use tenferro_tensor::{DType, TensorView, TypedTensorView};
+    let data = [1., 2., 3., 4.].map(|x| Complex64::new(x, 0.));
+    let input = Tensor::from_vec_col_major([2, 2], data.to_vec()).unwrap();
+    let view = TensorRead::from_view(TensorView::C64(
+        TypedTensorView::from_col_major(&[2, 2], &data)
+            .unwrap()
+            .transpose_view([1, 0])
+            .unwrap(),
+    ));
+    let spec = crate::concrete_fft_spec(
+        "fft",
+        FftOperation::C2cForward,
+        DType::C64,
+        &[2, 2],
+        None,
+        0,
+        FftNorm::Backward,
+    )
+    .unwrap();
+    let mut backend = tenferro_cpu::CpuBackend::with_threads(1).unwrap();
+    let mut cache = FftPlanCache::default();
+    for (read, expected) in [
+        (TensorRead::from_tensor(&input), [3., -1., 7., -1.]),
+        (view, [4., -2., 6., -2.]),
+    ] {
+        backend.validate_fft_read_input("fft", &read).unwrap();
+        let output = backend
+            .execute_fft_read(read, &spec, FftExecutionCache::caller_owned(&mut cache))
+            .unwrap();
+        assert_eq!(
+            output.as_slice::<Complex64>().unwrap(),
+            expected.map(|x| Complex64::new(x, 0.))
+        );
+    }
+    assert_eq!(input.as_slice::<Complex64>().unwrap(), data);
+}

--- a/crates/tenferro-fft/src/concrete_tests.rs
+++ b/crates/tenferro-fft/src/concrete_tests.rs
@@ -7,6 +7,60 @@ use tenferro_tensor::{ErrorKind, Tensor, TensorRead, TensorView, TypedTensorView
 
 use crate::{FftExecutor, FftNorm, FftPlanCache, TensorFftExt, TensorReadFftExt};
 
+#[test]
+fn cpu_fft_spec_rejects_changed_dtype_and_shape_before_execution() {
+    let spec = crate::concrete_fft_spec(
+        "fft",
+        crate::FftOperation::C2cForward,
+        tenferro_tensor::DType::C64,
+        &[2],
+        None,
+        0,
+        FftNorm::Backward,
+    )
+    .unwrap();
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    let mut plans = FftPlanCache::default();
+    for input in [
+        Tensor::from_vec_col_major([2], vec![1.0_f64; 2]).unwrap(),
+        Tensor::from_vec_col_major([3], vec![Complex64::new(1., 0.); 3]).unwrap(),
+    ] {
+        let error = backend
+            .with_backend_session(|session| {
+                tenferro_cpu::with_cpu_exec_session(session, |cpu| {
+                    crate::FftBackend::execute_fft(
+                        cpu,
+                        &input,
+                        &spec,
+                        crate::FftExecutionCache::caller_owned(&mut plans),
+                    )
+                })
+                .unwrap()
+            })
+            .unwrap_err();
+        assert!(matches!(error, tenferro_tensor::Error::Validation { .. }));
+    }
+    let data = [1.0_f64, 2.0];
+    let view = TensorRead::from_view(TensorView::F64(
+        TypedTensorView::from_slice([2], [1], 0, &data).unwrap(),
+    ));
+    let error = backend
+        .with_backend_session(|session| {
+            tenferro_cpu::with_cpu_exec_session(session, |cpu| {
+                crate::FftBackend::execute_fft_read(
+                    cpu,
+                    view,
+                    &spec,
+                    crate::FftExecutionCache::caller_owned(&mut plans),
+                )
+            })
+            .unwrap()
+        })
+        .unwrap_err();
+    assert!(matches!(error, tenferro_tensor::Error::Validation { .. }));
+    assert_eq!(backend.buffer_pool_stats().unwrap().buffers, 0);
+}
+
 fn assert_complex_close(actual: &[Complex64], expected: &[Complex64]) {
     assert_eq!(actual.len(), expected.len());
     for (actual, expected) in actual.iter().zip(expected) {

--- a/crates/tenferro-fft/src/cpu.rs
+++ b/crates/tenferro-fft/src/cpu.rs
@@ -1,18 +1,21 @@
-use std::mem::MaybeUninit;
-
-use num_complex::Complex;
-use num_traits::{Float, FromPrimitive, Zero};
-use tenferro_cpu::CpuExecSession;
-use tenferro_tensor::{
-    AllocationDomainId, DType, DeviceKind, HostAccessError, MemoryKind, Placement,
-    SharedTensorAllocationDomain, Tensor, TensorRead, TensorScalar, TensorView, TypedTensor,
-};
+mod lanes;
 
 use crate::backend::FftExecutionCache;
-use crate::cache::{cached_fft_plan, CachedFftPlanScalar, ExtensionFftPlanCache, FftPlanProvider};
+use crate::cache::{CachedFftPlanScalar, ExtensionFftPlanCache, FftPlanProvider};
 use crate::{
     expected_dtype_description, fft_op_name, output_shape_c2c, output_shape_c2r, output_shape_r2c,
     transform_len, validate_c2r_spectrum_len, FftBackend, FftNorm, FftOperation, FftPlanSpec,
+};
+use num_complex::Complex;
+use num_traits::{Float, FromPrimitive};
+#[cfg(feature = "autodiff")]
+use std::mem::MaybeUninit;
+use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar, PooledUninitOutput};
+use tenferro_cpu::CpuExecSession;
+use tenferro_tensor::{
+    AllocationDomainId, DeviceKind, HostAccessError, MemoryKind, Placement,
+    SharedTensorAllocationDomain, Tensor, TensorRead, TensorScalar, TensorStructural, TensorView,
+    TypedTensor,
 };
 
 impl FftBackend for CpuExecSession<'_> {
@@ -24,6 +27,69 @@ impl FftBackend for CpuExecSession<'_> {
         validate_host_fft_read_input(op, input)
     }
 
+    fn execute_fft_read(
+        &mut self,
+        input: TensorRead<'_>,
+        spec: &FftPlanSpec,
+        mut cache: FftExecutionCache<'_>,
+    ) -> tenferro_tensor::Result<Tensor> {
+        let view = match input {
+            TensorRead::Tensor(input) => return self.execute_fft(input, spec, cache),
+            TensorRead::View(view) => view,
+        };
+        validate_host_fft_read_input(
+            fft_op_name(spec.operation()),
+            &TensorRead::View(view.clone()),
+        )?;
+        validate_spec_metadata(view.dtype(), view.shape(), spec)?;
+        if !view.is_col_major_contiguous()? {
+            let owned = self.to_contiguous_read(TensorRead::View(view))?;
+            return self.execute_fft(&owned, spec, cache);
+        }
+        let mut plans = ExtensionFftPlanCache::new(cache.store_mut());
+        self.with_linalg_pool(|context, buffers| {
+            macro_rules! transform {
+                ($input:expr, $kind:ident, $variant:ident, $project:expr) => {
+                    pooled_transform(
+                        lanes::Input::$kind($input.as_slice()?),
+                        $input.shape(),
+                        spec,
+                        &mut plans,
+                        buffers,
+                        context.native_thread_count(),
+                        $project,
+                    )
+                    .map(Tensor::$variant)
+                };
+            }
+            match (spec.operation(), view) {
+                (FftOperation::C2cForward | FftOperation::C2cInverse, TensorView::C64(x)) => {
+                    transform!(x, Complex, C64, |v| v)
+                }
+                (FftOperation::C2cForward | FftOperation::C2cInverse, TensorView::C32(x)) => {
+                    transform!(x, Complex, C32, |v| v)
+                }
+                (FftOperation::R2cFull | FftOperation::R2cOnesided, TensorView::F64(x)) => {
+                    transform!(x, Real, C64, |v| v)
+                }
+                (FftOperation::R2cFull | FftOperation::R2cOnesided, TensorView::F32(x)) => {
+                    transform!(x, Real, C32, |v| v)
+                }
+                (FftOperation::C2r, TensorView::C64(x)) => {
+                    transform!(x, Complex, F64, |v: Complex<f64>| v.re)
+                }
+                (FftOperation::C2r, TensorView::C32(x)) => {
+                    transform!(x, Complex, F32, |v: Complex<f32>| v.re)
+                }
+                (operation, other) => Err(crate::tensor_unsupported_dtype(
+                    fft_op_name(operation),
+                    other.dtype(),
+                    expected_dtype_description(operation),
+                )),
+            }
+        })
+    }
+
     fn execute_fft(
         &mut self,
         input: &Tensor,
@@ -32,33 +98,126 @@ impl FftBackend for CpuExecSession<'_> {
     ) -> tenferro_tensor::Result<Tensor> {
         validate_spec_input(input, spec)?;
         let mut plans = ExtensionFftPlanCache::new(cache.store_mut());
-        let allocation_domain = self.shared_allocation_domain();
-        if input.is_backend_buffer() {
-            if let Some(domain) = allocation_domain.as_deref() {
-                return execute_managed_fft_with_plans(input, spec, domain, &mut plans);
-            }
+        let domain = self.shared_allocation_domain();
+        let managed = if input.is_backend_buffer() {
+            domain.as_deref()
+        } else {
+            None
+        };
+        if managed.is_none() {
+            validate_host_fft_input(fft_op_name(spec.operation()), input)?;
         }
-        validate_host_fft_input(fft_op_name(spec.operation()), input)?;
-        execute_fft_with_plans(input, spec, &mut plans)
+        self.with_linalg_pool(|context, buffers| {
+            execute_fft_with_plans(
+                input,
+                spec,
+                &mut plans,
+                buffers,
+                managed,
+                context.native_thread_count(),
+            )
+        })
     }
 }
 
+#[cfg(feature = "autodiff")]
+pub(crate) fn execute_in_place(
+    session: &mut CpuExecSession<'_>,
+    input: &mut Tensor,
+    spec: &FftPlanSpec,
+    mut cache: FftExecutionCache<'_>,
+) -> tenferro_tensor::Result<()> {
+    validate_spec_input(input, spec)?;
+    validate_host_fft_input("fft_in_place", input)?;
+    if !matches!(
+        spec.operation(),
+        FftOperation::C2cForward | FftOperation::C2cInverse
+    ) || spec
+        .requested_len()
+        .is_some_and(|n| n != input.shape()[spec.normalized_axis()])
+    {
+        return Err(tenferro_tensor::Error::unsupported(
+            "fft_in_place",
+            "in-place FFT requires shape-preserving complex input",
+        ));
+    }
+    let mut plans = ExtensionFftPlanCache::new(cache.store_mut());
+    session.with_linalg_pool(|context, _| match input {
+        Tensor::C64(x) => in_place_typed(x, spec, &mut plans, context.native_thread_count()),
+        Tensor::C32(x) => in_place_typed(x, spec, &mut plans, context.native_thread_count()),
+        other => Err(crate::tensor_unsupported_dtype(
+            "fft_in_place",
+            other.dtype(),
+            "C32 or C64",
+        )),
+    })
+}
+
+#[cfg(feature = "autodiff")]
+fn in_place_typed<T: CachedFftPlanScalar + TensorScalar>(
+    input: &mut TypedTensor<Complex<T>>,
+    spec: &FftPlanSpec,
+    plans: &mut (impl FftPlanProvider + ?Sized),
+    threads: usize,
+) -> tenferro_tensor::Result<()>
+where
+    Complex<T>: TensorScalar,
+{
+    let shape = input.shape().to_vec();
+    let axis = spec.normalized_axis();
+    let len = shape[axis];
+    // Use the descriptor-bounded write guard, not the whole root allocation:
+    // compact slices may have a nonzero offset or a smaller logical extent.
+    input.with_host_write(|values| {
+        // SAFETY: this is an exclusive borrow of initialized Complex<T> storage.
+        // Shape-preserving c2c with identity projection writes only valid Complex<T>
+        // values; on error or unwind unwritten values also remain initialized.
+        unsafe {
+            let output = std::slice::from_raw_parts_mut(
+                values.as_mut_ptr().cast::<MaybeUninit<Complex<T>>>(),
+                values.len(),
+            );
+            lanes::execute::<T, Complex<T>>(
+                None,
+                &shape,
+                axis,
+                len,
+                len,
+                spec.operation(),
+                spec.norm(),
+                plans,
+                output,
+                threads,
+                |v| v,
+            )
+        }
+    })?
+}
+
 fn validate_spec_input(input: &Tensor, spec: &FftPlanSpec) -> tenferro_tensor::Result<()> {
-    if input.dtype() != spec.input_dtype() {
+    validate_spec_metadata(input.dtype(), input.shape(), spec)
+}
+
+fn validate_spec_metadata(
+    dtype: tenferro_tensor::DType,
+    shape: &[usize],
+    spec: &FftPlanSpec,
+) -> tenferro_tensor::Result<()> {
+    if dtype != spec.input_dtype() {
         return Err(tenferro_tensor::Error::dtype_mismatch(
             fft_op_name(spec.operation()),
             spec.input_dtype(),
-            input.dtype(),
+            dtype,
         ));
     }
-    if input.shape() != spec.input_shape() {
+    if shape != spec.input_shape() {
         return Err(tenferro_tensor::Error::invalid_argument(
             fft_op_name(spec.operation()),
             "input shape",
             format!(
                 "validated FFT spec shape {:?} does not match execution input shape {:?}",
                 spec.input_shape(),
-                input.shape()
+                shape
             ),
         ));
     }
@@ -71,178 +230,186 @@ fn validate_spec_input(input: &Tensor, spec: &FftPlanSpec) -> tenferro_tensor::R
     Ok(())
 }
 
-pub(crate) fn execute_fft_with_plans(
+fn execute_fft_with_plans(
     input: &Tensor,
     spec: &FftPlanSpec,
     plans: &mut (impl FftPlanProvider + ?Sized),
+    buffers: &mut BufferPool,
+    domain: Option<&dyn SharedTensorAllocationDomain>,
+    threads: usize,
 ) -> tenferro_tensor::Result<Tensor> {
-    let operation = spec.operation();
-    let axis = spec.normalized_axis();
-    let n = spec.requested_len();
-    let norm = spec.norm();
-
-    let output = match (operation, input) {
-        (FftOperation::C2cForward, Tensor::C64(input))
-        | (FftOperation::C2cInverse, Tensor::C64(input)) => {
-            Tensor::C64(TypedTensor::from_vec_col_major(
-                output_shape_c2c(input.shape(), axis, n)?,
-                execute_c2c(input, axis, n, operation.is_forward(), norm, plans)?,
-            )?)
+    macro_rules! transform {
+        ($input:expr, $kind:ident, $variant:ident, $project:expr) => {
+            transform(
+                $input,
+                spec,
+                plans,
+                buffers,
+                domain,
+                threads,
+                |values| lanes::Input::$kind(values),
+                $project,
+            )
+            .map(Tensor::$variant)
+        };
+    }
+    match (spec.operation(), input) {
+        (FftOperation::C2cForward | FftOperation::C2cInverse, Tensor::C64(x)) => {
+            transform!(x, Complex, C64, |v| v)
         }
-        (FftOperation::C2cForward, Tensor::C32(input))
-        | (FftOperation::C2cInverse, Tensor::C32(input)) => {
-            Tensor::C32(TypedTensor::from_vec_col_major(
-                output_shape_c2c(input.shape(), axis, n)?,
-                execute_c2c(input, axis, n, operation.is_forward(), norm, plans)?,
-            )?)
+        (FftOperation::C2cForward | FftOperation::C2cInverse, Tensor::C32(x)) => {
+            transform!(x, Complex, C32, |v| v)
         }
-        (FftOperation::R2cFull, Tensor::F64(input))
-        | (FftOperation::R2cOnesided, Tensor::F64(input)) => {
-            Tensor::C64(TypedTensor::from_vec_col_major(
-                output_shape_r2c(input.shape(), axis, n, operation.is_onesided())?,
-                execute_r2c(input, axis, n, operation.is_onesided(), norm, plans)?,
-            )?)
+        (FftOperation::R2cFull | FftOperation::R2cOnesided, Tensor::F64(x)) => {
+            transform!(x, Real, C64, |v| v)
         }
-        (FftOperation::R2cFull, Tensor::F32(input))
-        | (FftOperation::R2cOnesided, Tensor::F32(input)) => {
-            Tensor::C32(TypedTensor::from_vec_col_major(
-                output_shape_r2c(input.shape(), axis, n, operation.is_onesided())?,
-                execute_r2c(input, axis, n, operation.is_onesided(), norm, plans)?,
-            )?)
+        (FftOperation::R2cFull | FftOperation::R2cOnesided, Tensor::F32(x)) => {
+            transform!(x, Real, C32, |v| v)
         }
-        (FftOperation::C2r, Tensor::C64(input)) => Tensor::F64(TypedTensor::from_vec_col_major(
-            output_shape_c2r(input.shape(), axis, n)?,
-            execute_c2r(input, axis, n, norm, plans)?,
-        )?),
-        (FftOperation::C2r, Tensor::C32(input)) => Tensor::F32(TypedTensor::from_vec_col_major(
-            output_shape_c2r(input.shape(), axis, n)?,
-            execute_c2r(input, axis, n, norm, plans)?,
-        )?),
-        (operation, other) => {
-            return Err(crate::tensor_unsupported_dtype(
-                fft_op_name(operation),
-                other.dtype(),
-                expected_dtype_description(operation),
-            ));
-        }
-    };
-    Ok(output)
-}
-
-fn execute_managed_fft_with_plans(
-    input: &Tensor,
-    spec: &FftPlanSpec,
-    domain: &dyn SharedTensorAllocationDomain,
-    plans: &mut (impl FftPlanProvider + ?Sized),
-) -> tenferro_tensor::Result<Tensor> {
-    let operation = spec.operation();
-    let op = fft_op_name(operation);
-    let axis = spec.normalized_axis();
-    let n = spec.requested_len();
-    let norm = spec.norm();
-
-    match (operation, input) {
-        (FftOperation::C2cForward, Tensor::C64(input))
-        | (FftOperation::C2cInverse, Tensor::C64(input)) => {
-            let shape = output_shape_c2c(input.shape(), axis, n)?;
-            let values = with_managed_read(input, domain.id(), op, |input_data| {
-                execute_c2c_data(
-                    input.shape(),
-                    input_data,
-                    axis,
-                    n,
-                    operation.is_forward(),
-                    norm,
-                    plans,
-                )
-            })?;
-            let output = domain.allocate(DType::C64, &shape)?;
-            write_managed_output_c64(output, domain.id(), op, &values)
-        }
-        (FftOperation::C2cForward, Tensor::C32(input))
-        | (FftOperation::C2cInverse, Tensor::C32(input)) => {
-            let shape = output_shape_c2c(input.shape(), axis, n)?;
-            let values = with_managed_read(input, domain.id(), op, |input_data| {
-                execute_c2c_data(
-                    input.shape(),
-                    input_data,
-                    axis,
-                    n,
-                    operation.is_forward(),
-                    norm,
-                    plans,
-                )
-            })?;
-            let output = domain.allocate(DType::C32, &shape)?;
-            write_managed_output_c32(output, domain.id(), op, &values)
-        }
-        (FftOperation::R2cFull, Tensor::F64(input))
-        | (FftOperation::R2cOnesided, Tensor::F64(input)) => {
-            let shape = output_shape_r2c(input.shape(), axis, n, operation.is_onesided())?;
-            let values = with_managed_read(input, domain.id(), op, |input_data| {
-                execute_r2c_data(
-                    input.shape(),
-                    input_data,
-                    axis,
-                    n,
-                    operation.is_onesided(),
-                    norm,
-                    plans,
-                )
-            })?;
-            let output = domain.allocate(DType::C64, &shape)?;
-            write_managed_output_c64(output, domain.id(), op, &values)
-        }
-        (FftOperation::R2cFull, Tensor::F32(input))
-        | (FftOperation::R2cOnesided, Tensor::F32(input)) => {
-            let shape = output_shape_r2c(input.shape(), axis, n, operation.is_onesided())?;
-            let values = with_managed_read(input, domain.id(), op, |input_data| {
-                execute_r2c_data(
-                    input.shape(),
-                    input_data,
-                    axis,
-                    n,
-                    operation.is_onesided(),
-                    norm,
-                    plans,
-                )
-            })?;
-            let output = domain.allocate(DType::C32, &shape)?;
-            write_managed_output_c32(output, domain.id(), op, &values)
-        }
-        (FftOperation::C2r, Tensor::C64(input)) => {
-            let shape = output_shape_c2r(input.shape(), axis, n)?;
-            let values = with_managed_read(input, domain.id(), op, |input_data| {
-                execute_c2r_data(input.shape(), input_data, axis, n, norm, plans)
-            })?;
-            let output = domain.allocate(DType::F64, &shape)?;
-            write_managed_output_f64(output, domain.id(), op, &values)
-        }
-        (FftOperation::C2r, Tensor::C32(input)) => {
-            let shape = output_shape_c2r(input.shape(), axis, n)?;
-            let values = with_managed_read(input, domain.id(), op, |input_data| {
-                execute_c2r_data(input.shape(), input_data, axis, n, norm, plans)
-            })?;
-            let output = domain.allocate(DType::F32, &shape)?;
-            write_managed_output_f32(output, domain.id(), op, &values)
-        }
+        (FftOperation::C2r, Tensor::C64(x)) => transform!(x, Complex, F64, |v: Complex<f64>| v.re),
+        (FftOperation::C2r, Tensor::C32(x)) => transform!(x, Complex, F32, |v: Complex<f32>| v.re),
         (operation, other) => Err(crate::tensor_unsupported_dtype(
-            op,
+            fft_op_name(operation),
             other.dtype(),
             expected_dtype_description(operation),
         )),
     }
 }
 
-fn with_managed_read<T, R>(
+fn output_shape(in_shape: &[usize], spec: &FftPlanSpec) -> tenferro_tensor::Result<Vec<usize>> {
+    let axis = spec.normalized_axis();
+    let n = spec.requested_len();
+    match spec.operation() {
+        FftOperation::C2cForward | FftOperation::C2cInverse => output_shape_c2c(in_shape, axis, n),
+        FftOperation::R2cFull | FftOperation::R2cOnesided => {
+            output_shape_r2c(in_shape, axis, n, spec.operation().is_onesided())
+        }
+        FftOperation::C2r => output_shape_c2r(in_shape, axis, n),
+    }
+}
+
+// INVARIANT: this scalar-dispatched helper carries the validated spec and the
+// existing execution resources; it does not define a second public descriptor.
+#[allow(clippy::too_many_arguments)]
+fn transform<I: TensorScalar, T: CachedFftPlanScalar, O: PoolScalar>(
+    input: &TypedTensor<I>,
+    spec: &FftPlanSpec,
+    plans: &mut (impl FftPlanProvider + ?Sized),
+    buffers: &mut BufferPool,
+    domain: Option<&dyn SharedTensorAllocationDomain>,
+    threads: usize,
+    wrap: for<'a> fn(&'a [I]) -> lanes::Input<'a, T>,
+    project: impl Fn(Complex<T>) -> O + Sync,
+) -> tenferro_tensor::Result<TypedTensor<O>> {
+    let mut produce = |read: &[I]| {
+        pooled_transform(
+            wrap(read),
+            input.shape(),
+            spec,
+            plans,
+            buffers,
+            threads,
+            &project,
+        )
+    };
+    if let Some(domain) = domain {
+        let op = fft_op_name(spec.operation());
+        // Validate the input domain before allocating or mapping the output.
+        with_managed_read(input, domain.id(), op, |read| {
+            let output = domain.allocate(O::dtype(), &output_shape(input.shape(), spec)?)?;
+            let mut output = O::into_typed(output).map_err(|_| {
+                tenferro_tensor::Error::runtime_state(
+                    op,
+                    "shared allocation owner returned an output with the wrong dtype",
+                )
+            })?;
+            if output.allocation_domain() != Some(domain.id()) {
+                return Err(tenferro_tensor::Error::runtime_state(
+                    op,
+                    "shared allocation owner returned an output outside its domain",
+                ));
+            }
+            if output.placement().memory_kind != MemoryKind::Managed {
+                return Err(tenferro_tensor::Error::runtime_state(
+                    op,
+                    "shared allocation owner returned a non-managed output",
+                ));
+            }
+            // INVARIANT: BackendStorage::map_write exposes only a full-buffer
+            // copy callback, not a writable span. Preserve that explicit provider
+            // boundary; the host staging allocation is recycled, not recreated.
+            let staging = produce(read)?;
+            if let Some(buffer) = output.backend_buffer_mut() {
+                buffer
+                    .map_write()
+                    .map_err(|source| tenferro_tensor::Error::host_access(op, source))?
+                    .copy_from_slice(staging.host_data()?)
+                    .map_err(|source| tenferro_tensor::Error::host_access(op, source))?;
+            } else {
+                output.with_host_write(|write| {
+                    if write.len() != staging.host_data()?.len() {
+                        return Err(tenferro_tensor::Error::runtime_state(
+                            op,
+                            "shared allocation owner returned an output with the wrong length",
+                        ));
+                    }
+                    write.copy_from_slice(staging.host_data()?);
+                    Ok(())
+                })??;
+            }
+            Ok(output)
+        })
+    } else {
+        produce(input.host_data()?)
+    }
+}
+
+fn pooled_transform<T: CachedFftPlanScalar, O: PoolScalar>(
+    input: lanes::Input<'_, T>,
+    in_shape: &[usize],
+    spec: &FftPlanSpec,
+    plans: &mut (impl FftPlanProvider + ?Sized),
+    buffers: &mut BufferPool,
+    threads: usize,
+    project: impl Fn(Complex<T>) -> O + Sync,
+) -> tenferro_tensor::Result<TypedTensor<O>> {
+    let shape = output_shape(in_shape, spec)?;
+    let axis = spec.normalized_axis();
+    let out_axis_len = shape[axis];
+    let fft_len = if spec.operation() == FftOperation::C2r {
+        validate_c2r_spectrum_len(in_shape[axis], out_axis_len)?;
+        out_axis_len
+    } else {
+        transform_len(in_shape, axis, spec.requested_len())?
+    };
+    let mut output = PooledUninitOutput::<O>::new(buffers, shape)?;
+    // SAFETY: Some(input) selects the out-of-place path with borrowed reads and
+    // a disjoint fresh destination. Successful execution joins all writers and
+    // initializes every element before the owning handoff.
+    unsafe {
+        lanes::execute(
+            Some(input),
+            in_shape,
+            axis,
+            fft_len,
+            out_axis_len,
+            spec.operation(),
+            spec.norm(),
+            plans,
+            output.as_uninit_slice_mut(),
+            threads,
+            project,
+        )?;
+        output.assume_init_recycled()
+    }
+}
+
+fn with_managed_read<T: TensorScalar, R>(
     input: &TypedTensor<T>,
     expected_domain: AllocationDomainId,
     op: &'static str,
     execute: impl FnOnce(&[T]) -> tenferro_tensor::Result<R>,
-) -> tenferro_tensor::Result<R>
-where
-    T: TensorScalar + Send + Sync + 'static,
-{
+) -> tenferro_tensor::Result<R> {
     if input.placement().memory_kind != MemoryKind::Managed {
         return Err(tenferro_tensor::Error::host_access(
             op,
@@ -267,13 +434,13 @@ where
                     expected: expected_domain,
                     actual,
                 },
-            ));
+            ))
         }
         None => {
             return Err(tenferro_tensor::Error::host_access(
                 op,
                 HostAccessError::Unsupported { backend: "backend" },
-            ));
+            ))
         }
     }
     if let Some(buffer) = input.backend_buffer() {
@@ -285,76 +452,6 @@ where
         input.with_host_read(execute)?
     }
 }
-
-fn write_managed_output<T>(
-    output: &mut TypedTensor<T>,
-    expected_domain: AllocationDomainId,
-    op: &'static str,
-    values: &[T],
-) -> tenferro_tensor::Result<()>
-where
-    T: TensorScalar + Send + Sync + 'static,
-{
-    if output.allocation_domain() != Some(expected_domain) {
-        return Err(tenferro_tensor::Error::runtime_state(
-            op,
-            "shared allocation owner returned an output outside its domain",
-        ));
-    }
-    if output.placement().memory_kind != MemoryKind::Managed {
-        return Err(tenferro_tensor::Error::runtime_state(
-            op,
-            "shared allocation owner returned a non-managed output",
-        ));
-    }
-    if let Some(buffer) = output.backend_buffer_mut() {
-        let mut write = buffer
-            .map_write()
-            .map_err(|source| tenferro_tensor::Error::host_access(op, source))?;
-        return write
-            .copy_from_slice(values)
-            .map_err(|source| tenferro_tensor::Error::host_access(op, source));
-    }
-    output.with_host_write(|write| {
-        if write.len() != values.len() {
-            return Err(tenferro_tensor::Error::runtime_state(
-                op,
-                "shared allocation owner returned an output with the wrong length",
-            ));
-        }
-        write.copy_from_slice(values);
-        Ok(())
-    })?
-}
-
-macro_rules! write_managed_output {
-    ($name:ident, $variant:ident, $scalar:ty) => {
-        fn $name(
-            output: Tensor,
-            expected_domain: AllocationDomainId,
-            op: &'static str,
-            values: &[$scalar],
-        ) -> tenferro_tensor::Result<Tensor> {
-            let Tensor::$variant(mut output) = output else {
-                return Err(tenferro_tensor::Error::runtime_state(
-                    op,
-                    concat!(
-                        "shared allocation owner returned a non-",
-                        stringify!($variant),
-                        " output"
-                    ),
-                ));
-            };
-            write_managed_output(&mut output, expected_domain, op, values)?;
-            Ok(Tensor::$variant(output))
-        }
-    };
-}
-
-write_managed_output!(write_managed_output_f32, F32, f32);
-write_managed_output!(write_managed_output_f64, F64, f64);
-write_managed_output!(write_managed_output_c32, C32, num_complex::Complex32);
-write_managed_output!(write_managed_output_c64, C64, num_complex::Complex64);
 
 pub(crate) fn validate_host_fft_input(
     op: &'static str,
@@ -369,35 +466,21 @@ pub(crate) fn validate_host_fft_read_input(
 ) -> tenferro_tensor::Result<()> {
     match input {
         TensorRead::Tensor(tensor) => validate_host_fft_input(op, tensor),
-        TensorRead::View(view) => validate_host_fft_view_input(op, view),
-    }
-}
-
-fn validate_host_fft_view_input(
-    op: &'static str,
-    view: &TensorView<'_>,
-) -> tenferro_tensor::Result<()> {
-    match view {
-        TensorView::F32(view) => {
-            validate_host_fft_placement(op, view.placement(), view.backend_buffer().is_some())
-        }
-        TensorView::F64(view) => {
-            validate_host_fft_placement(op, view.placement(), view.backend_buffer().is_some())
-        }
-        TensorView::I32(view) => {
-            validate_host_fft_placement(op, view.placement(), view.backend_buffer().is_some())
-        }
-        TensorView::I64(view) => {
-            validate_host_fft_placement(op, view.placement(), view.backend_buffer().is_some())
-        }
-        TensorView::Bool(view) => {
-            validate_host_fft_placement(op, view.placement(), view.backend_buffer().is_some())
-        }
-        TensorView::C32(view) => {
-            validate_host_fft_placement(op, view.placement(), view.backend_buffer().is_some())
-        }
-        TensorView::C64(view) => {
-            validate_host_fft_placement(op, view.placement(), view.backend_buffer().is_some())
+        TensorRead::View(view) => {
+            macro_rules! validate {
+                ($v:expr) => {
+                    validate_host_fft_placement(op, $v.placement(), $v.backend_buffer().is_some())
+                };
+            }
+            match view {
+                TensorView::F32(v) => validate!(v),
+                TensorView::F64(v) => validate!(v),
+                TensorView::I32(v) => validate!(v),
+                TensorView::I64(v) => validate!(v),
+                TensorView::Bool(v) => validate!(v),
+                TensorView::C32(v) => validate!(v),
+                TensorView::C64(v) => validate!(v),
+            }
         }
     }
 }
@@ -411,238 +494,21 @@ fn validate_host_fft_placement(
     if !is_device && !is_backend_buffer {
         return Ok(());
     }
-
     let location = match placement.device.as_ref().map(|device| &device.kind) {
         Some(DeviceKind::Gpu(kind)) => format!("GPU backend {kind:?}"),
         Some(kind) => format!("device kind {kind:?}"),
         None if is_device => "device tensor without device metadata".to_string(),
         None => "backend buffer".to_string(),
     };
-    Err(tenferro_tensor::Error::unsupported(
-        op,
-        format!(
-            "tenferro-fft CpuBackend supports host tensors only; unsupported {location} input; \
-             download the tensor to CPU before FFT"
-        ),
-    ))
+    Err(tenferro_tensor::Error::unsupported(op, format!(
+        "tenferro-fft CpuBackend supports host tensors only; unsupported {location} input; download the tensor to CPU before FFT")))
 }
 
-fn execute_c2c<T>(
-    input: &TypedTensor<Complex<T>>,
-    axis: usize,
-    n: Option<usize>,
+fn scale_for<T: Float + FromPrimitive>(
+    norm: FftNorm,
     forward: bool,
-    norm: FftNorm,
-    plans: &mut (impl FftPlanProvider + ?Sized),
-) -> tenferro_tensor::Result<Vec<Complex<T>>>
-where
-    T: CachedFftPlanScalar + TensorScalar,
-    Complex<T>: TensorScalar,
-{
-    let input_data = input.host_data()?;
-    execute_c2c_data(input.shape(), input_data, axis, n, forward, norm, plans)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn execute_c2c_data<T>(
-    in_shape: &[usize],
-    input_data: &[Complex<T>],
-    axis: usize,
-    n: Option<usize>,
-    forward: bool,
-    norm: FftNorm,
-    plans: &mut (impl FftPlanProvider + ?Sized),
-) -> tenferro_tensor::Result<Vec<Complex<T>>>
-where
-    T: CachedFftPlanScalar + TensorScalar,
-{
-    let fft_len = transform_len(in_shape, axis, n)?;
-    let out_shape = output_shape_c2c(in_shape, axis, n)?;
-    let out_axis_len = out_shape[axis];
-    let output_len = checked_shape_product("fft", "output", &out_shape)?;
-    let mut output = uninit_output_vec(output_len);
-    let fft_plan = cached_fft_plan::<T, _>(plans, fft_len, forward);
-    let scale: T = scale_for(norm, forward, fft_len)?;
-    let mut lane = vec![Complex::zero(); fft_len];
-
-    for_axis_lane(in_shape, axis, out_axis_len, |lane_ctx| {
-        // INVARIANT: zero-fill is transform padding semantics when the input
-        // lane is shorter than `fft_len`; it is not redundant initialization.
-        lane.fill(Complex::zero());
-        let copy_len = lane_ctx.in_axis_len.min(fft_len);
-        for (slot, offset) in lane
-            .iter_mut()
-            .take(copy_len)
-            .zip(lane_ctx.input_offsets(copy_len))
-        {
-            *slot = input_data[offset];
-        }
-        fft_plan.process(&mut lane);
-        if scale != T::one() {
-            for value in &mut lane {
-                *value = *value * scale;
-            }
-        }
-        for (value, offset) in lane
-            .iter()
-            .take(out_axis_len)
-            .copied()
-            .zip(lane_ctx.output_offsets(out_axis_len))
-        {
-            output[offset].write(value);
-        }
-        Ok(())
-    })?;
-
-    // SAFETY: `for_axis_lane` covers every element in the compact column-major
-    // output exactly once, and each lane writes all `out_axis_len` positions.
-    Ok(unsafe { assume_init_output_vec(output) })
-}
-
-fn execute_r2c<T>(
-    input: &TypedTensor<T>,
-    axis: usize,
-    n: Option<usize>,
-    onesided: bool,
-    norm: FftNorm,
-    plans: &mut (impl FftPlanProvider + ?Sized),
-) -> tenferro_tensor::Result<Vec<Complex<T>>>
-where
-    T: CachedFftPlanScalar + TensorScalar,
-    Complex<T>: TensorScalar,
-{
-    let input_data = input.host_data()?;
-    execute_r2c_data(input.shape(), input_data, axis, n, onesided, norm, plans)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn execute_r2c_data<T>(
-    in_shape: &[usize],
-    input_data: &[T],
-    axis: usize,
-    n: Option<usize>,
-    onesided: bool,
-    norm: FftNorm,
-    plans: &mut (impl FftPlanProvider + ?Sized),
-) -> tenferro_tensor::Result<Vec<Complex<T>>>
-where
-    T: CachedFftPlanScalar,
-{
-    let fft_len = transform_len(in_shape, axis, n)?;
-    let out_shape = output_shape_r2c(in_shape, axis, n, onesided)?;
-    let out_axis_len = out_shape[axis];
-    let output_len = checked_shape_product("rfft", "output", &out_shape)?;
-    let mut output = uninit_output_vec(output_len);
-    let fft_plan = cached_fft_plan::<T, _>(plans, fft_len, true);
-    let scale: T = scale_for(norm, true, fft_len)?;
-    let mut lane = vec![Complex::zero(); fft_len];
-
-    for_axis_lane(in_shape, axis, out_axis_len, |lane_ctx| {
-        // INVARIANT: zero-fill is rfft padding semantics when the real input
-        // lane is shorter than `fft_len`; later writes cover only `copy_len`.
-        lane.fill(Complex::zero());
-        let copy_len = lane_ctx.in_axis_len.min(fft_len);
-        for (slot, offset) in lane
-            .iter_mut()
-            .take(copy_len)
-            .zip(lane_ctx.input_offsets(copy_len))
-        {
-            *slot = Complex::new(input_data[offset], T::zero());
-        }
-        fft_plan.process(&mut lane);
-        if scale != T::one() {
-            for value in &mut lane {
-                *value = *value * scale;
-            }
-        }
-        for (value, offset) in lane
-            .iter()
-            .take(out_axis_len)
-            .copied()
-            .zip(lane_ctx.output_offsets(out_axis_len))
-        {
-            output[offset].write(value);
-        }
-        Ok(())
-    })?;
-
-    // SAFETY: `for_axis_lane` covers every element in the compact column-major
-    // output exactly once, and each lane writes all `out_axis_len` positions.
-    Ok(unsafe { assume_init_output_vec(output) })
-}
-
-fn execute_c2r<T>(
-    input: &TypedTensor<Complex<T>>,
-    axis: usize,
-    n: Option<usize>,
-    norm: FftNorm,
-    plans: &mut (impl FftPlanProvider + ?Sized),
-) -> tenferro_tensor::Result<Vec<T>>
-where
-    T: CachedFftPlanScalar + TensorScalar,
-    Complex<T>: TensorScalar,
-{
-    let input_data = input.host_data()?;
-    execute_c2r_data(input.shape(), input_data, axis, n, norm, plans)
-}
-
-fn execute_c2r_data<T>(
-    in_shape: &[usize],
-    input_data: &[Complex<T>],
-    axis: usize,
-    n: Option<usize>,
-    norm: FftNorm,
-    plans: &mut (impl FftPlanProvider + ?Sized),
-) -> tenferro_tensor::Result<Vec<T>>
-where
-    T: CachedFftPlanScalar,
-{
-    let out_shape = output_shape_c2r(in_shape, axis, n)?;
-    let out_axis_len = out_shape[axis];
-    let expected_half = validate_c2r_spectrum_len(in_shape[axis], out_axis_len)?;
-    let output_len = checked_shape_product("irfft", "output", &out_shape)?;
-    let mut output = uninit_output_vec(output_len);
-    let fft_plan = cached_fft_plan::<T, _>(plans, out_axis_len, false);
-    let scale: T = scale_for(norm, false, out_axis_len)?;
-    let mut lane = vec![Complex::zero(); out_axis_len];
-
-    for_axis_lane(in_shape, axis, out_axis_len, |lane_ctx| {
-        // INVARIANT: zero-fill clears the inverse lane before writing the
-        // one-sided spectrum and mirrored tail for this lane.
-        lane.fill(Complex::zero());
-        for (slot, offset) in lane
-            .iter_mut()
-            .take(expected_half)
-            .zip(lane_ctx.input_offsets(expected_half))
-        {
-            *slot = input_data[offset];
-        }
-        for k in expected_half..out_axis_len {
-            let mirror = out_axis_len - k;
-            if mirror < lane.len() {
-                lane[k] = lane[mirror].conj();
-            }
-        }
-        fft_plan.process(&mut lane);
-        for (value, offset) in lane
-            .iter()
-            .take(out_axis_len)
-            .zip(lane_ctx.output_offsets(out_axis_len))
-        {
-            output[offset].write(value.re * scale);
-        }
-        Ok(())
-    })?;
-
-    // SAFETY: `for_axis_lane` covers every element in the compact column-major
-    // output exactly once, and each lane writes all `out_axis_len` positions.
-    Ok(unsafe { assume_init_output_vec(output) })
-}
-
-fn scale_for<T>(norm: FftNorm, forward: bool, n: usize) -> tenferro_tensor::Result<T>
-where
-    T: Float + FromPrimitive,
-{
+    n: usize,
+) -> tenferro_tensor::Result<T> {
     let len = T::from_usize(n).ok_or_else(|| {
         tenferro_tensor::Error::invalid_argument(
             "tenferro_fft::scale_for",
@@ -657,85 +523,34 @@ where
     })
 }
 
-fn uninit_output_vec<T>(len: usize) -> Vec<MaybeUninit<T>> {
-    let mut output = Vec::with_capacity(len);
-    // SAFETY: Uninitialized bytes are valid for `MaybeUninit<T>` slots. The
-    // slots are converted to `T` only after all output positions are written.
-    unsafe { output.set_len(len) };
-    output
+#[derive(Debug)]
+pub(crate) struct LaneLayout {
+    stride: usize,
+    in_block: usize,
+    out_block: usize,
+    lanes: usize,
+    input_len: usize,
+    output_len: usize,
 }
-
-unsafe fn assume_init_output_vec<T>(mut output: Vec<MaybeUninit<T>>) -> Vec<T> {
-    let len = output.len();
-    let capacity = output.capacity();
-    let ptr = output.as_mut_ptr().cast::<T>();
-    std::mem::forget(output);
-    // SAFETY: `MaybeUninit<T>` has the same layout as `T`; the caller
-    // guarantees every slot has been initialized exactly once.
-    unsafe { Vec::from_raw_parts(ptr, len, capacity) }
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct LaneContext {
-    input_base: usize,
-    output_base: usize,
-    axis_stride: usize,
-    in_axis_len: usize,
-    out_axis_len: usize,
-}
-
-impl LaneContext {
-    fn input_offsets(self, count: usize) -> impl Iterator<Item = usize> {
-        debug_assert!(count <= self.in_axis_len);
-        lane_offsets(self.input_base, self.axis_stride, count)
+impl LaneLayout {
+    pub(crate) fn new(
+        in_shape: &[usize],
+        axis: usize,
+        out_axis_len: usize,
+    ) -> tenferro_tensor::Result<Self> {
+        let stride = checked_shape_product("fft", "axis stride", &in_shape[..axis])?;
+        let outer = checked_shape_product("fft", "outer lanes", &in_shape[axis + 1..])?;
+        let in_block = checked_mul("fft", "input block", stride, in_shape[axis])?;
+        let out_block = checked_mul("fft", "output block", stride, out_axis_len)?;
+        Ok(Self {
+            stride,
+            in_block,
+            out_block,
+            lanes: checked_mul("fft", "lane count", outer, stride)?,
+            input_len: checked_mul("fft", "input coverage", outer, in_block)?,
+            output_len: checked_mul("fft", "output coverage", outer, out_block)?,
+        })
     }
-
-    fn output_offsets(self, count: usize) -> impl Iterator<Item = usize> {
-        debug_assert!(count <= self.out_axis_len);
-        lane_offsets(self.output_base, self.axis_stride, count)
-    }
-}
-
-fn lane_offsets(base: usize, stride: usize, count: usize) -> impl Iterator<Item = usize> {
-    // INVARIANT: `for_axis_lane` checks input/output lane coverage before it
-    // constructs any `LaneContext`, so every `base + k * stride` for
-    // `k < count` stays within the compact column-major buffer.
-    (0..count).map(move |k| base + k * stride)
-}
-
-pub(crate) fn for_axis_lane(
-    in_shape: &[usize],
-    axis: usize,
-    out_axis_len: usize,
-    mut f: impl FnMut(LaneContext) -> tenferro_tensor::Result<()>,
-) -> tenferro_tensor::Result<()> {
-    let in_axis_len = in_shape[axis];
-    let axis_stride = checked_shape_product("fft", "axis stride", &in_shape[..axis])?;
-    let outer = checked_shape_product("fft", "outer lane count", &in_shape[axis + 1..])?;
-    let in_block = checked_mul("fft", "input lane block", axis_stride, in_axis_len)?;
-    let out_block = checked_mul("fft", "output lane block", axis_stride, out_axis_len)?;
-    let _input_len = checked_mul("fft", "input lane coverage", outer, in_block)?;
-    let _output_len = checked_mul("fft", "output lane coverage", outer, out_block)?;
-
-    // INVARIANT: lanes are processed sequentially so one scratch lane can be
-    // reused while writing into a single `MaybeUninit` output buffer. Parallel
-    // lane execution needs disjoint output splitting plus per-worker scratch.
-    for outer_idx in 0..outer {
-        let in_outer_base = checked_mul("fft", "input outer base", outer_idx, in_block)?;
-        let out_outer_base = checked_mul("fft", "output outer base", outer_idx, out_block)?;
-        for inner in 0..axis_stride {
-            let input_base = checked_add("fft", "input lane base", in_outer_base, inner)?;
-            let output_base = checked_add("fft", "output lane base", out_outer_base, inner)?;
-            f(LaneContext {
-                input_base,
-                output_base,
-                axis_stride,
-                in_axis_len,
-                out_axis_len,
-            })?;
-        }
-    }
-    Ok(())
 }
 
 pub(crate) fn checked_shape_product(
@@ -754,7 +569,6 @@ pub(crate) fn checked_shape_product(
             )
         })
 }
-
 fn checked_mul(
     op: &'static str,
     role: &'static str,
@@ -762,21 +576,6 @@ fn checked_mul(
     rhs: usize,
 ) -> tenferro_tensor::Result<usize> {
     lhs.checked_mul(rhs).ok_or_else(|| {
-        tenferro_tensor::Error::invalid_argument(
-            op,
-            "arithmetic",
-            format!("{role} overflows usize"),
-        )
-    })
-}
-
-fn checked_add(
-    op: &'static str,
-    role: &'static str,
-    lhs: usize,
-    rhs: usize,
-) -> tenferro_tensor::Result<usize> {
-    lhs.checked_add(rhs).ok_or_else(|| {
         tenferro_tensor::Error::invalid_argument(
             op,
             "arithmetic",

--- a/crates/tenferro-fft/src/cpu/lanes.rs
+++ b/crates/tenferro-fft/src/cpu/lanes.rs
@@ -1,0 +1,202 @@
+//! CPU FFT lane execution over disjoint output index sets.
+#[cfg(test)]
+mod tests;
+use super::{scale_for, LaneLayout};
+use crate::cache::{cached_fft_plan, CachedFftPlanScalar, FftPlanProvider};
+use crate::{FftNorm, FftOperation};
+use num_complex::Complex;
+use num_traits::Zero;
+use rayon::prelude::*;
+use std::{marker::PhantomData, mem::MaybeUninit};
+
+pub(super) enum Input<'a, T> {
+    Complex(&'a [Complex<T>]),
+    Real(&'a [T]),
+}
+
+struct Output<'a, T> {
+    pointer: *mut MaybeUninit<T>,
+    _borrow: PhantomData<&'a mut [MaybeUninit<T>]>,
+}
+// SAFETY: execute partitions the complete lane domain among jobs. Distinct lanes
+// write disjoint indices, and the scoped parallel iterator joins before return.
+unsafe impl<T: Send> Send for Output<'_, T> {}
+// SAFETY: shared access is used only for the disjoint writes proven above.
+unsafe impl<T: Send> Sync for Output<'_, T> {}
+impl<T> Output<'_, T> {
+    unsafe fn read_complex<U>(&self, index: usize) -> Complex<U> {
+        // SAFETY: the in-place caller proves T=Complex<U>, initialized storage,
+        // and that this bounded index belongs exclusively to the current lane.
+        unsafe { self.pointer.cast::<Complex<U>>().add(index).read() }
+    }
+
+    unsafe fn write(&self, index: usize, value: T) {
+        // SAFETY: the caller proves index is in the output span and uniquely
+        // assigned to its lane for the duration of this scoped execution.
+        unsafe {
+            self.pointer.add(index).write(MaybeUninit::new(value));
+        }
+    }
+}
+
+// FFT work includes gather/scatter and the transform, unlike elementwise maps.
+// Below this grain spawning jobs costs more than the representative small FFTs.
+const MIN_PARALLEL_ELEMENTS: usize = 32 * 1024;
+
+#[allow(clippy::too_many_arguments)]
+// INVARIANT: these arguments are validated FFT metadata and the two borrowed
+// buffers; no public configurable operation descriptor is duplicated here.
+/// # Safety
+/// For absent input (in-place), O must be Complex<T>, the output must initially contain valid
+/// complex values, and the operation must be shape-preserving c2c with identity
+/// projection. Out-of-place variants have no additional unsafe preconditions.
+pub(super) unsafe fn execute<T, O>(
+    input: Option<Input<'_, T>>,
+    in_shape: &[usize],
+    axis: usize,
+    fft_len: usize,
+    out_axis_len: usize,
+    operation: FftOperation,
+    norm: FftNorm,
+    plans: &mut (impl FftPlanProvider + ?Sized),
+    output: &mut [MaybeUninit<O>],
+    threads: usize,
+    project: impl Fn(Complex<T>) -> O + Sync,
+) -> tenferro_tensor::Result<()>
+where
+    T: CachedFftPlanScalar,
+    O: Send,
+{
+    let LaneLayout {
+        stride,
+        in_block,
+        out_block,
+        lanes,
+        input_len,
+        output_len,
+    } = LaneLayout::new(in_shape, axis, out_axis_len)?;
+    let in_len = in_shape[axis];
+    let input_actual = match &input {
+        Some(Input::Complex(x)) => x.len(),
+        Some(Input::Real(x)) => x.len(),
+        None => output.len(),
+    };
+    if input_actual != input_len || output.len() != output_len {
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "fft",
+            "buffer length",
+            "FFT buffers do not match validated lane coverage",
+        ));
+    }
+    if lanes == 0 {
+        return Ok(());
+    }
+    let plan = cached_fft_plan::<T, _>(plans, fft_len, operation.is_forward());
+    let scale = scale_for::<T>(norm, operation.is_forward(), fft_len)?;
+    let jobs = if output_len < MIN_PARALLEL_ELEMENTS {
+        1
+    } else {
+        threads.max(1).min(lanes)
+    };
+    let per_job = lanes.div_ceil(jobs);
+    let out = Output {
+        pointer: output.as_mut_ptr(),
+        _borrow: PhantomData,
+    };
+    let run = |job: usize| {
+        let start = job * per_job;
+        let end = start.saturating_add(per_job).min(lanes);
+        if start >= end {
+            return;
+        }
+        let mut lane = vec![Complex::<T>::zero(); fft_len];
+        let mut scratch = vec![Complex::<T>::zero(); plan.get_inplace_scratch_len()];
+        // INVARIANT: nonzero lanes proves stride > 0. Advance within each
+        // checked block rather than divide every lane index by runtime stride.
+        let mut outer_index = start / stride;
+        let mut inner = start % stride;
+        let mut input_base = outer_index * in_block + inner;
+        let mut output_base = outer_index * out_block + inner;
+        let copy_len = in_len.min(fft_len);
+        for _ in start..end {
+            match &input {
+                None => {
+                    for (slot, offset) in lane
+                        .iter_mut()
+                        .take(copy_len)
+                        .zip((input_base..).step_by(stride))
+                    {
+                        // SAFETY: the in-place caller proves O=Complex<T> and
+                        // initialized input. Jobs read/write only their own lane;
+                        // gather completes before that lane is overwritten.
+                        *slot = unsafe { out.read_complex::<T>(offset) };
+                    }
+                }
+                Some(Input::Complex(values)) => {
+                    for (slot, offset) in lane
+                        .iter_mut()
+                        .take(copy_len)
+                        .zip((input_base..).step_by(stride))
+                    {
+                        *slot = values[offset];
+                    }
+                }
+                Some(Input::Real(values)) => {
+                    for (slot, offset) in lane
+                        .iter_mut()
+                        .take(copy_len)
+                        .zip((input_base..).step_by(stride))
+                    {
+                        *slot = Complex::new(values[offset], T::zero());
+                    }
+                }
+            }
+            if operation == FftOperation::C2r {
+                for k in copy_len..fft_len {
+                    lane[k] = lane[fft_len - k].conj();
+                }
+            } else {
+                // INVARIANT: only missing input positions are padding; all other
+                // slots were overwritten above, including real-input imaginary parts.
+                lane[copy_len..].fill(Complex::zero());
+            }
+            plan.process_with_scratch(&mut lane, &mut scratch);
+            // Preserve the existing identity-normalization fast path. Scaling
+            // contiguous scratch also avoids arithmetic in the strided scatter.
+            if scale != T::one() {
+                for value in &mut lane {
+                    *value = *value * scale;
+                }
+            }
+            for (value, offset) in lane
+                .iter()
+                .take(out_axis_len)
+                .zip((output_base..).step_by(stride))
+            {
+                // SAFETY: each lane owns indices base + k*stride, k<out_axis_len.
+                // Unique (outer_index,inner) pairs exactly tile checked output_len.
+                unsafe {
+                    out.write(offset, project(*value));
+                }
+            }
+            inner += 1;
+            if inner == stride {
+                inner = 0;
+                outer_index += 1;
+                // INVARIANT: advancing after the last lane reaches at most
+                // the checked input/output length, never a dereferenced offset.
+                input_base = outer_index * in_block;
+                output_base = outer_index * out_block;
+            } else {
+                input_base += 1;
+                output_base += 1;
+            }
+        }
+    };
+    if jobs == 1 {
+        run(0);
+    } else {
+        (0..jobs).into_par_iter().for_each(run);
+    }
+    Ok(())
+}

--- a/crates/tenferro-fft/src/cpu/lanes/tests.rs
+++ b/crates/tenferro-fft/src/cpu/lanes/tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+use crate::FftPlanCache;
+use num_complex::Complex64;
+
+#[test]
+fn impulse_reference_covers_borrowed_and_consuming_lane_modes() {
+    let impulse = [
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ];
+    let real = [1., 0., 0., 0.];
+    let mut plans = FftPlanCache::default();
+    for mode in 0..4 {
+        for norm in [FftNorm::Backward, FftNorm::Forward, FftNorm::Ortho] {
+            let (input, shape, operation) = match mode {
+                0 => (
+                    Some(Input::Complex(&impulse[..])),
+                    [4],
+                    FftOperation::C2cForward,
+                ),
+                1 => (Some(Input::Real(&real[..])), [4], FftOperation::R2cFull),
+                2 => (None, [4], FftOperation::C2cForward),
+                _ => (Some(Input::Complex(&impulse[..3])), [3], FftOperation::C2r),
+            };
+            let mut output = impulse.map(MaybeUninit::new);
+            // SAFETY: borrowed modes use disjoint arrays. Absent input uses
+            // initialized Complex64 storage, shape-preserving c2c, identity
+            // projection, and no other reference to the output allocation.
+            unsafe {
+                execute(
+                    input,
+                    &shape,
+                    0,
+                    4,
+                    4,
+                    operation,
+                    norm,
+                    &mut plans,
+                    &mut output,
+                    1,
+                    std::convert::identity,
+                )
+                .unwrap();
+            }
+            // DFT of a unit impulse is all ones. The inverse DFT of a unit DC
+            // coefficient is also constant, with the inverse normalization.
+            let expected = match norm {
+                FftNorm::Ortho => 0.5,
+                FftNorm::Backward if mode == 3 => 0.25,
+                FftNorm::Forward if mode != 3 => 0.25,
+                _ => 1.0,
+            };
+            for value in output {
+                // SAFETY: initialized before execution; successful execution
+                // preserves initialization and overwrites the complete output.
+                let value = unsafe { value.assume_init() };
+                assert_eq!(
+                    value,
+                    Complex64::new(expected, 0.),
+                    "mode={mode} norm={norm:?}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn checked_lane_boundary_rejects_mismatched_spans_and_overflow_before_writes() {
+    for (shape, input_len, output_len, valid) in [
+        ([1, 2], 2, 2, true),
+        ([1, 2], 1, 2, false),
+        ([1, 2], 2, 1, false),
+        ([usize::MAX, 2], 0, 0, false),
+        ([0, 2], 0, 0, true),
+    ] {
+        let input = vec![Complex64::new(1., 0.); input_len];
+        let mut output = vec![MaybeUninit::uninit(); output_len];
+        let mut plans = FftPlanCache::default();
+        // SAFETY: Some(input) selects the disjoint borrowed-input path. The
+        // kernel must reject invalid spans before any unchecked output access.
+        let result = unsafe {
+            execute(
+                Some(Input::Complex(&input)),
+                &shape,
+                1,
+                2,
+                2,
+                FftOperation::C2cForward,
+                FftNorm::Backward,
+                &mut plans,
+                &mut output,
+                8,
+                |value| value,
+            )
+        };
+        assert_eq!(
+            result.is_ok(),
+            valid,
+            "shape={shape:?} input={input_len} output={output_len}"
+        );
+    }
+}

--- a/crates/tenferro-fft/src/cpu/managed_tests.rs
+++ b/crates/tenferro-fft/src/cpu/managed_tests.rs
@@ -160,6 +160,82 @@ impl SharedTensorAllocationDomain for FakeDomain {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+enum OutputFault {
+    AllocationError,
+    WrongDtype,
+    ForeignDomain,
+    WrongLength,
+}
+
+#[derive(Debug)]
+struct FaultyOutputDomain {
+    input_domain: Arc<FakeDomain>,
+    fault: OutputFault,
+}
+
+impl SharedTensorAllocationDomain for FaultyOutputDomain {
+    fn id(&self) -> AllocationDomainId {
+        self.input_domain.id
+    }
+
+    fn allocate(&self, dtype: DType, shape: &[usize]) -> tenferro_tensor::Result<Tensor> {
+        match self.fault {
+            OutputFault::AllocationError => Err(tenferro_tensor::Error::runtime_state(
+                "FaultyOutputDomain::allocate",
+                "allocation unavailable",
+            )),
+            OutputFault::WrongDtype => self.input_domain.allocate(DType::F32, shape),
+            OutputFault::ForeignDomain => FakeDomain::new().allocate(dtype, shape),
+            OutputFault::WrongLength => self.input_domain.allocate(dtype, &[1]),
+        }
+    }
+}
+
+#[test]
+fn managed_output_failures_return_errors_and_leave_input_usable() {
+    for fault in [
+        OutputFault::AllocationError,
+        OutputFault::WrongDtype,
+        OutputFault::ForeignDomain,
+        OutputFault::WrongLength,
+    ] {
+        let domain = FakeDomain::new();
+        let input = Tensor::F64(domain.tensor(&[4], vec![1., 2., 3., 4.]));
+        let mut failing = CpuBackend::with_threads(1)
+            .unwrap()
+            .with_allocation_domain(Arc::new(FaultyOutputDomain {
+                input_domain: domain.clone(),
+                fault,
+            }));
+        let error = failing
+            .with_backend_session(|s| input.rfft(None, 0, FftNorm::Backward, s))
+            .unwrap_err();
+        match fault {
+            OutputFault::WrongLength => {
+                assert!(matches!(error, tenferro_tensor::Error::HostAccess { .. }))
+            }
+            _ => assert!(matches!(error, tenferro_tensor::Error::RuntimeState { .. })),
+        }
+        let mut valid = backend(&domain);
+        let result = valid
+            .with_backend_session(|s| input.rfft(None, 0, FftNorm::Backward, s))
+            .unwrap();
+        let Tensor::C64(result) = result else {
+            panic!("expected complex result")
+        };
+        let guard = result.backend_buffer().unwrap().map_read().unwrap();
+        assert_eq!(
+            &*guard,
+            &[
+                Complex64::new(10., 0.),
+                Complex64::new(-2., 2.),
+                Complex64::new(-2., 0.)
+            ]
+        );
+    }
+}
+
 fn backend(domain: &Arc<FakeDomain>) -> CpuBackend {
     let erased: Arc<dyn SharedTensorAllocationDomain> = domain.clone();
     CpuBackend::new().with_allocation_domain(erased)

--- a/crates/tenferro-fft/src/eager_ext.rs
+++ b/crates/tenferro-fft/src/eager_ext.rs
@@ -20,6 +20,63 @@ use crate::{
 
 /// FFT extension methods for [`EagerTensor`].
 pub trait EagerTensorFftExt {
+    /// Consume a uniquely owned, untracked, compact column-major CPU complex
+    /// tensor and overwrite it with its FFT. Shape and allocation are preserved; no implicit copy occurs.
+    /// Gradient-tracked inputs and active trace capture are rejected even under no_grad.
+    ///
+    /// # Errors
+    /// Returns `EagerFftInPlaceError::Rejected` with the unchanged input for an
+    /// invalid axis, non-complex/device input, noncompact layout, recording
+    /// state, or shared owner.
+    /// `EagerFftInPlaceError::Execution` consumes the input if execution fails
+    /// after ownership acquisition; the operation does not promise rollback.
+    ///
+    /// # Examples
+    /// ```
+    /// use num_complex::Complex64;
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_fft::{EagerTensorFftExt, FftNorm};
+    /// let runtime = EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1)?)?;
+    /// let input = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major([2], vec![Complex64::new(1., 0.), Complex64::new(2., 0.)])?, runtime)?;
+    /// let output = input.fft_in_place(0, FftNorm::Backward)?;
+    /// assert_eq!(output.value()?.as_slice::<Complex64>()?, &[Complex64::new(3., 0.), Complex64::new(-1., 0.)]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    fn fft_in_place(
+        self,
+        axis: isize,
+        norm: FftNorm,
+    ) -> std::result::Result<EagerTensor, crate::EagerFftInPlaceError>;
+
+    /// Consume an untracked, compact column-major CPU C32/C64 tensor and perform a shape-preserving
+    /// inverse FFT in its original allocation. Ownership rules match fft_in_place.
+    ///
+    /// # Errors
+    /// Returns `EagerFftInPlaceError::Rejected` with the original input when
+    /// validation or exclusive ownership fails, or `Execution` after ownership
+    /// acquisition. Active capture and tracked inputs are not supported.
+    ///
+    /// # Examples
+    /// ```
+    /// use num_complex::Complex64;
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_fft::{EagerTensorFftExt, FftNorm};
+    /// let runtime = EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1)?)?;
+    /// let input = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major([2], vec![Complex64::new(3., 0.), Complex64::new(-1., 0.)])?, runtime)?;
+    /// let output = input.ifft_in_place(0, FftNorm::Backward)?;
+    /// assert_eq!(output.value()?.as_slice::<Complex64>()?, &[Complex64::new(1., 0.), Complex64::new(2., 0.)]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    fn ifft_in_place(
+        self,
+        axis: isize,
+        norm: FftNorm,
+    ) -> std::result::Result<EagerTensor, crate::EagerFftInPlaceError>;
+
     /// Execute a complex FFT, or a full-spectrum FFT for real input.
     ///
     /// # Examples
@@ -122,6 +179,22 @@ pub trait EagerTensorFftExt {
 }
 
 impl EagerTensorFftExt for EagerTensor {
+    fn fft_in_place(
+        self,
+        axis: isize,
+        norm: FftNorm,
+    ) -> std::result::Result<EagerTensor, crate::EagerFftInPlaceError> {
+        crate::eager_in_place::apply(self, FftOperation::C2cForward, axis, norm)
+    }
+
+    fn ifft_in_place(
+        self,
+        axis: isize,
+        norm: FftNorm,
+    ) -> std::result::Result<EagerTensor, crate::EagerFftInPlaceError> {
+        crate::eager_in_place::apply(self, FftOperation::C2cInverse, axis, norm)
+    }
+
     fn fft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<EagerTensor> {
         let operation = runtime_forward_fft_operation(self.dtype())?;
         apply_eager_fft("fft", self, operation, n, axis, norm)
@@ -188,7 +261,9 @@ fn apply_eager_fft(
     }
 }
 
-fn eager_extension_module(target: EagerExtensionTarget) -> Result<Arc<dyn ExtensionModule>> {
+pub(crate) fn eager_extension_module(
+    target: EagerExtensionTarget,
+) -> Result<Arc<dyn ExtensionModule>> {
     let EagerExtensionTarget {
         engine_id,
         backend_kind,

--- a/crates/tenferro-fft/src/eager_in_place.rs
+++ b/crates/tenferro-fft/src/eager_in_place.rs
@@ -1,0 +1,125 @@
+use crate::{FftExecutionCache, FftNorm, FftOperation};
+use std::sync::Arc;
+use tenferro_ad::extension::{
+    adopt_untracked_eager_value, prepare_eager_in_place_input, EagerExtensionBackendKind,
+};
+use tenferro_ad::{EagerTensor, IntoValueError};
+use tenferro_runtime::{Error, ErrorPhase};
+use tenferro_tensor::{DType, TensorValue};
+
+/// Failure of a consuming eager FFT.
+///
+/// Rejected inputs are returned unchanged. After successful ownership acquisition,
+/// an execution failure consumes the input; no rollback or hidden copy is made.
+///
+/// # Examples
+/// ```
+/// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_fft::{EagerFftInPlaceError, EagerTensorFftExt, FftNorm};
+/// let runtime = EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1)?)?;
+/// let input = EagerTensor::from_tensor_in(Tensor::from_vec_col_major([1], vec![1.0_f64])?, runtime)?;
+/// match input.fft_in_place(0, FftNorm::Backward) {
+///     Err(EagerFftInPlaceError::Rejected { input, .. }) => assert_eq!(input.shape(), &[1]),
+///     other => panic!("real input must be rejected: {other:?}"),
+/// }
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, thiserror::Error)]
+pub enum EagerFftInPlaceError {
+    /// Validation or ownership acquisition failed before any mutation.
+    #[error("in-place FFT input rejected: {source}")]
+    Rejected {
+        input: Box<EagerTensor>,
+        #[source]
+        source: Error,
+    },
+    /// Failure after ownership acquisition; the input has been consumed.
+    #[error(transparent)]
+    Execution(#[from] Error),
+}
+
+pub(crate) fn apply(
+    input: EagerTensor,
+    operation: FftOperation,
+    axis: isize,
+    norm: FftNorm,
+) -> Result<EagerTensor, EagerFftInPlaceError> {
+    let runtime = Arc::clone(input.runtime());
+    let validate = || -> Result<_, Error> {
+        crate::require_runtime_dtype(
+            "fft_in_place",
+            input.dtype(),
+            &[DType::C32, DType::C64],
+            "C32 or C64",
+        )?;
+        let spec = crate::concrete_fft_spec(
+            "fft_in_place",
+            operation,
+            input.dtype(),
+            input.shape(),
+            None,
+            axis,
+            norm,
+        )?;
+        let read = input.tensor_read();
+        crate::cpu::validate_host_fft_read_input("fft_in_place", &read)?;
+        // Structural ownership extraction preserves layout; it does not turn
+        // a lazy transpose into compact storage for the dense lane kernel.
+        if !read.is_col_major_contiguous()? {
+            return Err(tenferro_tensor::Error::unsupported(
+                "fft_in_place", "in-place FFT requires compact column-major input; use the borrowed FFT for strided views",
+            ).into());
+        }
+        prepare_eager_in_place_input(&input, crate::FFT_EXTENSION_FAMILY_ID, |target| {
+            if !matches!(target.backend_kind, EagerExtensionBackendKind::Cpu) {
+                return Err(Error::runtime_state(
+                    "fft_in_place",
+                    ErrorPhase::Execution,
+                    "in-place FFT requires a CPU eager runtime",
+                ));
+            }
+            crate::eager_ext::eager_extension_module(target)
+        })?;
+        Ok(spec)
+    };
+    let spec = match validate() {
+        Ok(spec) => spec,
+        Err(source) => {
+            return Err(EagerFftInPlaceError::Rejected {
+                input: Box::new(input),
+                source,
+            })
+        }
+    };
+    let mut tensor = match input.into_value() {
+        Ok(tensor) => tensor,
+        Err(IntoValueError::NotUnique(input)) => return Err(EagerFftInPlaceError::Rejected {
+            input: Box::new(input), source: Error::runtime_state("fft_in_place", ErrorPhase::Execution,
+                "the input is retained by another handle or saved value; release the other handle or explicitly duplicate the input"),
+        }),
+        Err(IntoValueError::Extract { value: input, error }) => return Err(EagerFftInPlaceError::Rejected {
+            input: Box::new(input), source: Error::runtime_state_source("fft_in_place", ErrorPhase::Execution, error),
+        }),
+    };
+    runtime.with_extension_execution_context(|context| {
+        let (session, caches) = context.parts_mut();
+        tenferro_cpu::with_cpu_exec_session(session, |session| {
+            crate::cpu::execute_in_place(
+                session,
+                &mut tensor,
+                &spec,
+                FftExecutionCache::runtime_owned(caches),
+            )
+        })
+        .ok_or_else(|| {
+            Error::runtime_state(
+                "fft_in_place",
+                ErrorPhase::Execution,
+                "the runtime does not expose a CPU execution session",
+            )
+        })?
+        .map_err(Error::from)
+    })??;
+    adopt_untracked_eager_value(runtime, TensorValue::from_tensor(tensor)).map_err(Into::into)
+}

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -141,6 +141,8 @@ mod cpu;
 mod cuda;
 #[cfg(feature = "autodiff")]
 mod eager_ext;
+#[cfg(feature = "autodiff")]
+mod eager_in_place;
 pub mod prelude;
 mod spec;
 #[cfg(feature = "webgpu")]
@@ -152,6 +154,8 @@ pub use cache::{
 };
 #[cfg(feature = "autodiff")]
 pub use eager_ext::EagerTensorFftExt;
+#[cfg(feature = "autodiff")]
+pub use eager_in_place::EagerFftInPlaceError;
 pub use spec::{FftNorm, FftOperation, FftPlanSpec};
 
 /// Extension family id used by the tenferro FFT extension.
@@ -1036,10 +1040,9 @@ fn execute_concrete_fft_read_op(
         axis,
         norm,
     )?;
-    let materialized = backend.to_contiguous_read(input.clone())?;
     let mut plans = FftPlanCache::with_capacity(NonZeroUsize::MIN);
-    backend.execute_fft(
-        &materialized,
+    backend.execute_fft_read(
+        input.clone(),
         &spec,
         FftExecutionCache::caller_owned(&mut plans),
     )
@@ -1476,9 +1479,9 @@ pub(crate) fn execute_fft_extension_reads_session(
     execute_fft_extension_reads_on_session(op, inputs, session, caches)
 }
 
-fn execute_fft_extension_for_capability<B: FftBackend + ?Sized>(
+fn execute_fft_extension_reads_for_capability<B: FftBackend + ?Sized>(
     op: &FftOp,
-    inputs: &[&Tensor],
+    inputs: &[TensorRead<'_>],
     session: &mut B,
     caches: &mut ExtensionCacheStore,
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -1489,7 +1492,8 @@ fn execute_fft_extension_for_capability<B: FftBackend + ?Sized>(
             format!("expected 1 input, got {}", inputs.len()),
         ));
     }
-    let input = inputs[0];
+    let input = &inputs[0];
+    session.validate_fft_read_input(fft_op_name(op.operation), input)?;
     let spec = validated_fft_plan_spec(
         fft_op_name(op.operation),
         op.operation,
@@ -1499,7 +1503,11 @@ fn execute_fft_extension_for_capability<B: FftBackend + ?Sized>(
         op.axis,
         op.norm,
     )?;
-    let output = session.execute_fft(input, &spec, FftExecutionCache::runtime_owned(caches))?;
+    let output = session.execute_fft_read(
+        input.clone(),
+        &spec,
+        FftExecutionCache::runtime_owned(caches),
+    )?;
     Ok(vec![output])
 }
 
@@ -1530,25 +1538,6 @@ fn execute_fft_extension_reads_on_session(
         fft_op_name(op.operation),
         "selected backend session does not expose an FFT execution capability",
     ))
-}
-
-fn execute_fft_extension_reads_for_capability<B: FftBackend + ?Sized>(
-    op: &FftOp,
-    inputs: &[TensorRead<'_>],
-    session: &mut B,
-    caches: &mut ExtensionCacheStore,
-) -> tenferro_tensor::Result<Vec<Tensor>> {
-    let op_name = fft_op_name(op.operation);
-    for input in inputs {
-        session.validate_fft_read_input(op_name, input)?;
-    }
-    let materialized_inputs = inputs
-        .iter()
-        .cloned()
-        .map(|input| session.to_contiguous_read(input))
-        .collect::<tenferro_tensor::Result<Vec<_>>>()?;
-    let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
-    execute_fft_extension_for_capability(op, &input_refs, session, caches)
 }
 
 define_extension_runtime! {
@@ -2129,7 +2118,7 @@ mod tests {
 
     #[test]
     fn axis_lane_layout_rejects_stride_overflow() {
-        let err = cpu::for_axis_lane(&[usize::MAX, 2], 1, 2, |_| Ok(()))
+        let err = cpu::LaneLayout::new(&[usize::MAX, 2], 1, 2)
             .expect_err("lane layout should reject stride overflow");
 
         assert!(err.to_string().contains("overflows usize"), "{err}");

--- a/crates/tenferro-fft/tests/cpu_reuse.rs
+++ b/crates/tenferro-fft/tests/cpu_reuse.rs
@@ -13,7 +13,8 @@ fn compact_real_reads_roundtrip_on_all_axes_and_thread_counts() {
                 TypedTensorView::from_slice(shape, [1, 64, 2048], 0, &data).unwrap()));
             for threads in [1, 8] {
                 let mut backend = CpuBackend::with_threads(threads).unwrap();
-                assert_eq!(backend.num_threads(), threads);
+                // Managed backends clamp the request to the process CPU set.
+                assert!((1..=threads).contains(&backend.num_threads()));
                 for (axis, &length) in shape.iter().enumerate() {
                     for norm in [FftNorm::Backward, FftNorm::Forward, FftNorm::Ortho] {
                         backend.with_backend_session(|session| {
@@ -160,7 +161,8 @@ fn parallel_lanes_match_serial_on_every_axis_with_padding_and_truncation() {
     let mut serial = CpuBackend::with_threads(1).unwrap();
     let mut parallel = CpuBackend::with_threads(8).unwrap();
     assert_eq!(serial.num_threads(), 1);
-    assert_eq!(parallel.num_threads(), 8);
+    // CI may expose fewer than eight CPUs; keep testing its effective budget.
+    assert!((1..=8).contains(&parallel.num_threads()));
     for (axis, &length) in shape.iter().enumerate() {
         for n in [None, Some(length + 3), Some(length - 1)] {
             for norm in [FftNorm::Backward, FftNorm::Forward, FftNorm::Ortho] {

--- a/crates/tenferro-fft/tests/cpu_reuse.rs
+++ b/crates/tenferro-fft/tests/cpu_reuse.rs
@@ -1,0 +1,191 @@
+use num_complex::Complex64;
+use tenferro_cpu::CpuBackend;
+use tenferro_fft::{FftNorm, TensorFftExt, TensorReadFftExt};
+use tenferro_tensor::{BackendSessionHost, Tensor, TensorRead, TensorView, TypedTensorView};
+
+#[test]
+fn compact_real_reads_roundtrip_on_all_axes_and_thread_counts() {
+    macro_rules! check {
+        ($real:ty, $complex:ty, $variant:ident, $complex_variant:ident, $tolerance:expr) => {{
+            let shape = [64, 32, 32];
+            let data: Vec<$real> = (0..65536).map(|i| (i % 17) as $real).collect();
+            let read = TensorRead::from_view(TensorView::$variant(
+                TypedTensorView::from_slice(shape, [1, 64, 2048], 0, &data).unwrap()));
+            for threads in [1, 8] {
+                let mut backend = CpuBackend::with_threads(threads).unwrap();
+                assert_eq!(backend.num_threads(), threads);
+                for (axis, &length) in shape.iter().enumerate() {
+                    for norm in [FftNorm::Backward, FftNorm::Forward, FftNorm::Ortho] {
+                        backend.with_backend_session(|session| {
+                            let spectrum = read.rfft_read(None, axis as isize, norm, session).unwrap();
+                            let dims = spectrum.shape();
+                            let spectrum_view = TensorRead::from_view(TensorView::$complex_variant(
+                                TypedTensorView::from_slice(dims,
+                                    [1, dims[0] as isize, (dims[0] * dims[1]) as isize],
+                                    0, spectrum.as_slice::<$complex>().unwrap()).unwrap()));
+                            let restored = spectrum_view.irfft_read(Some(length), axis as isize, norm, session).unwrap();
+                            let error = restored.as_slice::<$real>().unwrap().iter().zip(&data)
+                                .map(|(a, b)| (*a - *b).abs()).fold(0.0 as $real, <$real>::max);
+                            assert!(error < $tolerance, "real roundtrip threads={threads} axis={axis} norm={norm:?} max_error={error}");
+                            let full = read.fft_read(None, axis as isize, norm, session).unwrap();
+                            let full_view = TensorRead::from_view(TensorView::$complex_variant(
+                                TypedTensorView::from_slice(shape, [1, 64, 2048], 0,
+                                    full.as_slice::<$complex>().unwrap()).unwrap()));
+                            let restored = full_view.ifft_read(None, axis as isize, norm, session).unwrap();
+                            let error = restored.as_slice::<$complex>().unwrap().iter().zip(&data)
+                                .map(|(a, b)| (a.re - *b).abs().max(a.im.abs()))
+                                .fold(0.0 as $real, <$real>::max);
+                            assert!(error < $tolerance, "full roundtrip threads={threads} axis={axis} norm={norm:?} max_error={error}");
+                        });
+                    }
+                }
+            }
+        }};
+    }
+    check!(f32, num_complex::Complex32, F32, C32, 1e-4);
+    check!(f64, Complex64, F64, C64, 1e-10);
+}
+
+#[test]
+fn explicit_reclaim_to_another_backend_does_not_also_return_to_origin() {
+    let input = Tensor::from_vec_col_major([4], vec![Complex64::new(1., 0.); 4]).unwrap();
+    let mut origin = CpuBackend::with_threads(1).unwrap();
+    let mut destination = CpuBackend::with_threads(1).unwrap();
+    let output = origin
+        .with_backend_session(|s| input.fft(None, 0, FftNorm::Backward, s))
+        .unwrap();
+    let pointer = output.as_slice::<Complex64>().unwrap().as_ptr();
+    destination.with_backend_session(|s| s.reclaim_buffer(output));
+    assert_eq!(origin.buffer_pool_stats().unwrap().buffers, 0);
+    assert_eq!(destination.buffer_pool_stats().unwrap().buffers, 1);
+    let reused = destination
+        .with_backend_session(|s| input.fft(None, 0, FftNorm::Backward, s))
+        .unwrap();
+    assert_eq!(reused.as_slice::<Complex64>().unwrap().as_ptr(), pointer);
+    assert_eq!(destination.buffer_pool_stats().unwrap().buffers, 0);
+    drop(reused);
+    assert_eq!(origin.buffer_pool_stats().unwrap().buffers, 0);
+    assert_eq!(destination.buffer_pool_stats().unwrap().buffers, 1);
+}
+
+#[test]
+fn output_drop_recycles_while_session_remains_active() {
+    let input = Tensor::from_vec_col_major([32, 32], vec![Complex64::new(1., 0.); 1024]).unwrap();
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    backend.with_backend_session(|session| {
+        let first = input.fft(None, 0, FftNorm::Backward, session).unwrap();
+        let first_pointer = first.as_slice::<Complex64>().unwrap().as_ptr();
+        let second = input.fft(None, 0, FftNorm::Backward, session).unwrap();
+        assert_ne!(
+            second.as_slice::<Complex64>().unwrap().as_ptr(),
+            first_pointer
+        );
+        drop(first);
+        let third = input.fft(None, 0, FftNorm::Backward, session).unwrap();
+        assert_eq!(
+            third.as_slice::<Complex64>().unwrap().as_ptr(),
+            first_pointer
+        );
+        assert_eq!(
+            second.as_slice::<Complex64>().unwrap(),
+            third.as_slice::<Complex64>().unwrap()
+        );
+    });
+    assert!(backend.buffer_pool_stats().unwrap().buffers >= 2);
+}
+
+#[test]
+fn nested_fft_session_is_rejected_and_backend_remains_usable() {
+    let mut backend = CpuBackend::with_threads(8).unwrap();
+    let mut nested = backend.clone();
+    let input = Tensor::from_vec_col_major([2], vec![Complex64::new(1., 0.); 2]).unwrap();
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.with_backend_session(|_| {
+            nested.with_backend_session(|s| input.fft(None, 0, FftNorm::Backward, s))
+        })
+    }));
+    let payload = outcome.expect_err("CPU admission must reject a nested execution");
+    let message = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())
+        .unwrap();
+    assert!(
+        message.contains("another CPU backend execution"),
+        "{message}"
+    );
+    let result = backend
+        .with_backend_session(|s| input.fft(None, 0, FftNorm::Backward, s))
+        .unwrap();
+    assert_eq!(
+        result.as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(2., 0.), Complex64::new(0., 0.)]
+    );
+}
+
+#[test]
+fn uneven_parallel_lane_partition_matches_serial() {
+    // Nine lanes over eight jobs leaves both a short final job and empty jobs.
+    let input = Tensor::from_vec_col_major(
+        [3, 3, 4096],
+        (0..36864)
+            .map(|i| Complex64::new((i % 17) as f64, (i % 23) as f64))
+            .collect(),
+    )
+    .unwrap();
+    let mut serial = CpuBackend::with_threads(1).unwrap();
+    let mut parallel = CpuBackend::with_threads(8).unwrap();
+    let expected = serial
+        .with_backend_session(|s| input.fft(None, 2, FftNorm::Backward, s))
+        .unwrap();
+    let actual = parallel
+        .with_backend_session(|s| input.fft(None, 2, FftNorm::Backward, s))
+        .unwrap();
+    assert_eq!(
+        actual.as_slice::<Complex64>().unwrap(),
+        expected.as_slice::<Complex64>().unwrap()
+    );
+}
+
+#[test]
+fn parallel_lanes_match_serial_on_every_axis_with_padding_and_truncation() {
+    let shape = [64, 32, 32];
+    let input = Tensor::from_vec_col_major(
+        shape,
+        (0..65536)
+            .map(|i| Complex64::new((i % 17) as f64, (i % 23) as f64))
+            .collect(),
+    )
+    .unwrap();
+    let mut serial = CpuBackend::with_threads(1).unwrap();
+    let mut parallel = CpuBackend::with_threads(8).unwrap();
+    assert_eq!(serial.num_threads(), 1);
+    assert_eq!(parallel.num_threads(), 8);
+    for (axis, &length) in shape.iter().enumerate() {
+        for n in [None, Some(length + 3), Some(length - 1)] {
+            for norm in [FftNorm::Backward, FftNorm::Forward, FftNorm::Ortho] {
+                let expected = serial
+                    .with_backend_session(|s| input.fft(n, axis as isize, norm, s))
+                    .unwrap();
+                let actual = parallel
+                    .with_backend_session(|s| input.fft(n, axis as isize, norm, s))
+                    .unwrap();
+                assert_eq!(
+                    actual.as_slice::<Complex64>().unwrap(),
+                    expected.as_slice::<Complex64>().unwrap(),
+                    "axis={axis} n={n:?} norm={norm:?}"
+                );
+                let expected = serial
+                    .with_backend_session(|s| input.ifft(n, axis as isize, norm, s))
+                    .unwrap();
+                let actual = parallel
+                    .with_backend_session(|s| input.ifft(n, axis as isize, norm, s))
+                    .unwrap();
+                assert_eq!(
+                    actual.as_slice::<Complex64>().unwrap(),
+                    expected.as_slice::<Complex64>().unwrap()
+                );
+            }
+        }
+    }
+}

--- a/crates/tenferro-fft/tests/eager_allocations.rs
+++ b/crates/tenferro-fft/tests/eager_allocations.rs
@@ -1,0 +1,161 @@
+#![cfg(feature = "autodiff")]
+
+use num_complex::Complex64;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use tenferro_ad::{EagerRuntime, EagerTensor};
+use tenferro_cpu::CpuBackend;
+use tenferro_fft::{EagerTensorFftExt, FftNorm};
+use tenferro_tensor::{BackendSessionHost, Tensor};
+
+const LEN: usize = 4096;
+const INPUT_BYTES: usize = LEN * size_of::<Complex64>();
+static ENABLED: AtomicBool = AtomicBool::new(false);
+static COUNT: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+static TOTAL_COUNT: AtomicUsize = AtomicUsize::new(0);
+static TOTAL_BYTES: AtomicUsize = AtomicUsize::new(0);
+struct Allocator;
+fn record(size: usize) {
+    if ENABLED.load(Ordering::Relaxed) {
+        TOTAL_COUNT.fetch_add(1, Ordering::Relaxed);
+        TOTAL_BYTES.fetch_add(size, Ordering::Relaxed);
+        if size >= INPUT_BYTES {
+            COUNT.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(size, Ordering::Relaxed);
+        }
+    }
+}
+// SAFETY: original allocator arguments are forwarded unchanged to System.
+unsafe impl GlobalAlloc for Allocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        record(layout.size());
+        // SAFETY: original allocation layout.
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: allocation originated from System.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        record(size);
+        // SAFETY: allocation and requested size are forwarded unchanged.
+        unsafe { System.realloc(ptr, layout, size) }
+    }
+}
+#[global_allocator]
+static ALLOCATOR: Allocator = Allocator;
+
+fn measured<T>(expected: (usize, usize), f: impl FnOnce() -> T) -> T {
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            ENABLED.store(false, Ordering::SeqCst);
+        }
+    }
+    COUNT.store(0, Ordering::Relaxed);
+    BYTES.store(0, Ordering::Relaxed);
+    TOTAL_COUNT.store(0, Ordering::Relaxed);
+    TOTAL_BYTES.store(0, Ordering::Relaxed);
+    ENABLED.store(true, Ordering::SeqCst);
+    let reset = Reset;
+    let output = f();
+    drop(reset);
+    assert_eq!(
+        (COUNT.load(Ordering::Relaxed), BYTES.load(Ordering::Relaxed)),
+        expected,
+        "unexpected input/output-sized allocation count and bytes"
+    );
+    eprintln!(
+        "input-sized count/bytes={expected:?}; total count/bytes={:?}",
+        (
+            TOTAL_COUNT.load(Ordering::Relaxed),
+            TOTAL_BYTES.load(Ordering::Relaxed)
+        )
+    );
+    output
+}
+
+#[test]
+fn ordinary_eager_drop_and_consuming_fft_reuse_without_input_sized_allocations() {
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    assert_eq!(backend.num_threads(), 1);
+    let runtime = EagerRuntime::with_cpu_backend(backend.clone()).unwrap();
+    let input = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major([64, 64], vec![Complex64::new(1., 0.); LEN]).unwrap(),
+        runtime,
+    )
+    .unwrap();
+    let first = measured((1, INPUT_BYTES), || {
+        input.fft(None, 1, FftNorm::Backward).unwrap()
+    });
+    let second = measured((1, INPUT_BYTES), || {
+        input.fft(None, 1, FftNorm::Backward).unwrap()
+    });
+    assert_ne!(
+        first
+            .value()
+            .unwrap()
+            .as_slice::<Complex64>()
+            .unwrap()
+            .as_ptr(),
+        second
+            .value()
+            .unwrap()
+            .as_slice::<Complex64>()
+            .unwrap()
+            .as_ptr()
+    );
+    drop(first);
+    drop(second);
+    let output = measured((0, 0), || input.fft(None, 1, FftNorm::Backward).unwrap());
+    let pointer = output
+        .value()
+        .unwrap()
+        .as_slice::<Complex64>()
+        .unwrap()
+        .as_ptr();
+    drop(output);
+    let output = measured((0, 0), || input.fft(None, 1, FftNorm::Backward).unwrap());
+    assert_eq!(
+        output
+            .value()
+            .unwrap()
+            .as_slice::<Complex64>()
+            .unwrap()
+            .as_ptr(),
+        pointer
+    );
+    assert_eq!(
+        input.value().unwrap().as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(1., 0.); LEN]
+    );
+    measured((0, 0), || {
+        let owned = output.into_value().unwrap();
+        backend.with_backend_session(|s| s.reclaim_buffer(owned));
+    });
+    let output = measured((0, 0), || input.fft(None, 1, FftNorm::Backward).unwrap());
+    assert_eq!(
+        output
+            .value()
+            .unwrap()
+            .as_slice::<Complex64>()
+            .unwrap()
+            .as_ptr(),
+        pointer
+    );
+    let output = measured((0, 0), || {
+        output.fft_in_place(1, FftNorm::Backward).unwrap()
+    });
+    assert_eq!(
+        output
+            .value()
+            .unwrap()
+            .as_slice::<Complex64>()
+            .unwrap()
+            .as_ptr(),
+        pointer
+    );
+    drop(output);
+    assert!(backend.buffer_pool_stats().unwrap().buffers >= 1);
+}

--- a/crates/tenferro-fft/tests/eager_in_place.rs
+++ b/crates/tenferro-fft/tests/eager_in_place.rs
@@ -1,0 +1,277 @@
+#![cfg(feature = "autodiff")]
+
+use num_complex::{Complex32, Complex64};
+use tenferro_ad::{EagerRuntime, EagerTensor};
+use tenferro_cpu::CpuBackend;
+use tenferro_fft::{EagerFftInPlaceError, EagerTensorFftExt, FftNorm};
+use tenferro_tensor::Tensor;
+
+fn input(runtime: &std::sync::Arc<EagerRuntime>) -> EagerTensor {
+    EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major([2], vec![Complex64::new(1., 0.), Complex64::new(2., 0.)])
+            .unwrap(),
+        runtime.clone(),
+    )
+    .unwrap()
+}
+fn rejected(result: Result<EagerTensor, EagerFftInPlaceError>) -> EagerTensor {
+    match result {
+        Err(EagerFftInPlaceError::Rejected { input, .. }) => *input,
+        other => panic!("expected unchanged rejected input, got {other:?}"),
+    }
+}
+
+#[test]
+fn consuming_fft_preserves_allocation_and_matches_borrowed_fft_on_every_axis() {
+    let shape = [32, 32, 32];
+    for threads in [1, 8] {
+        let runtime =
+            EagerRuntime::with_cpu_backend(CpuBackend::with_threads(threads).unwrap()).unwrap();
+        for axis in 0..3 {
+            for norm in [FftNorm::Backward, FftNorm::Forward, FftNorm::Ortho] {
+                let source = Tensor::from_vec_col_major(
+                    shape,
+                    (0..32768)
+                        .map(|i| Complex64::new((i % 13) as f64, (i % 11) as f64))
+                        .collect(),
+                )
+                .unwrap();
+                let x = EagerTensor::from_tensor_in(source, runtime.clone()).unwrap();
+                let expected = x.fft(None, axis, norm).unwrap();
+                let pointer = x.value().unwrap().as_slice::<Complex64>().unwrap().as_ptr();
+                let y = x.fft_in_place(axis, norm).unwrap();
+                assert_eq!(
+                    y.value().unwrap().as_slice::<Complex64>().unwrap().as_ptr(),
+                    pointer
+                );
+                assert_eq!(
+                    y.value().unwrap().as_slice::<Complex64>().unwrap(),
+                    expected.value().unwrap().as_slice::<Complex64>().unwrap()
+                );
+                let expected = y.ifft(None, axis, norm).unwrap();
+                let z = y.ifft_in_place(axis, norm).unwrap();
+                assert_eq!(
+                    z.value().unwrap().as_slice::<Complex64>().unwrap().as_ptr(),
+                    pointer
+                );
+                assert_eq!(
+                    z.value().unwrap().as_slice::<Complex64>().unwrap(),
+                    expected.value().unwrap().as_slice::<Complex64>().unwrap()
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn consuming_fft_respects_compact_slice_extent_and_offset() {
+    for start in [0, 1] {
+        let runtime = EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1).unwrap()).unwrap();
+        let source = EagerTensor::from_tensor_in(
+            Tensor::from_vec_col_major(
+                [4],
+                (1..=4).map(|x| Complex64::new(x as f64, 0.)).collect(),
+            )
+            .unwrap(),
+            runtime,
+        )
+        .unwrap();
+        let slice = source
+            .slice(tenferro_ad::SliceConfig {
+                starts: vec![start],
+                limits: vec![start + 2],
+                strides: vec![1],
+            })
+            .unwrap();
+        drop(source);
+        let pointer = slice
+            .tensor_read()
+            .as_slice::<Complex64>()
+            .unwrap()
+            .as_ptr();
+        let output = slice.fft_in_place(0, FftNorm::Backward).unwrap();
+        assert_eq!(
+            output
+                .tensor_read()
+                .as_slice::<Complex64>()
+                .unwrap()
+                .as_ptr(),
+            pointer
+        );
+        assert_eq!(
+            output.tensor_read().as_slice::<Complex64>().unwrap(),
+            &[
+                Complex64::new((2 * start + 3) as f64, 0.),
+                Complex64::new(-1., 0.)
+            ]
+        );
+        let Tensor::C64(root) = output.into_value().unwrap() else {
+            unreachable!()
+        };
+        let mut expected: Vec<_> = (1..=4).map(|x| Complex64::new(x as f64, 0.)).collect();
+        expected[start] = Complex64::new((2 * start + 3) as f64, 0.);
+        expected[start + 1] = Complex64::new(-1., 0.);
+        assert_eq!(
+            root.host_data().unwrap(),
+            expected,
+            "outside the slice must remain unchanged"
+        );
+    }
+}
+
+#[test]
+fn consuming_fft_rejects_noncompact_layout_before_ownership_extraction() {
+    let runtime = EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1).unwrap()).unwrap();
+    let source = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(
+            [2, 3],
+            (1..=6).map(|x| Complex64::new(x as f64, 0.)).collect(),
+        )
+        .unwrap(),
+        runtime,
+    )
+    .unwrap();
+    let view = source.transpose(&[1, 0]).unwrap();
+    drop(source);
+    let view = match view.fft_in_place(0, FftNorm::Backward) {
+        Err(EagerFftInPlaceError::Rejected { input, source }) => {
+            assert!(source.to_string().contains("compact column-major"));
+            *input
+        }
+        other => panic!("noncompact ownership extraction must fail: {other:?}"),
+    };
+    assert_eq!(
+        view.to_tensor().unwrap().as_slice::<Complex64>().unwrap(),
+        &[1., 3., 5., 2., 4., 6.].map(|x| Complex64::new(x, 0.))
+    );
+    assert_eq!(
+        view.fft(None, 0, FftNorm::Backward).unwrap().shape(),
+        &[3, 2]
+    );
+}
+
+#[test]
+fn consuming_fft_preserves_a_retained_reshape_source() {
+    let runtime = EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1).unwrap()).unwrap();
+    let source = input(&runtime);
+    let reshaped = source.reshape([1, 2]).unwrap();
+    // A reshape may share the physical owner or materialize independently.
+    // Mutation must never change the retained source in either representation.
+    match reshaped.fft_in_place(1, FftNorm::Backward) {
+        Ok(result) => assert_eq!(
+            result.value().unwrap().as_slice::<Complex64>().unwrap(),
+            &[Complex64::new(3., 0.), Complex64::new(-1., 0.)]
+        ),
+        Err(EagerFftInPlaceError::Rejected { input, .. }) => assert_eq!(input.shape(), &[1, 2]),
+        Err(error) => panic!("unexpected execution failure: {error}"),
+    }
+    assert_eq!(
+        source.value().unwrap().as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(1., 0.), Complex64::new(2., 0.)]
+    );
+}
+
+#[test]
+fn consuming_fft_preserves_values_needed_by_later_backward() {
+    let runtime = EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1).unwrap()).unwrap();
+    let coefficient = input(&runtime).fft(None, 0, FftNorm::Backward).unwrap();
+    let variable = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major([2], vec![Complex64::new(1., 0.); 2]).unwrap(),
+        runtime.clone(),
+    )
+    .unwrap();
+    let product = variable.mul(&coefficient).unwrap();
+    // A separately saved value permits mutation; a retained physical owner
+    // requires rejection. Either way backward must observe the original data.
+    match coefficient.fft_in_place(0, FftNorm::Backward) {
+        Ok(changed) => assert_eq!(
+            changed.value().unwrap().as_slice::<Complex64>().unwrap(),
+            &[Complex64::new(2., 0.), Complex64::new(4., 0.)]
+        ),
+        Err(EagerFftInPlaceError::Rejected { input, .. }) => {
+            assert_eq!(
+                input.value().unwrap().as_slice::<Complex64>().unwrap(),
+                &[Complex64::new(3., 0.), Complex64::new(-1., 0.)]
+            );
+        }
+        Err(error) => panic!("unexpected execution failure: {error}"),
+    }
+    let seed = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major([2], vec![Complex64::new(1., 0.); 2]).unwrap(),
+        runtime,
+    )
+    .unwrap();
+    product.backward_with(&seed).unwrap();
+    assert_eq!(
+        variable
+            .grad()
+            .unwrap()
+            .unwrap()
+            .as_slice::<Complex64>()
+            .unwrap(),
+        &[Complex64::new(3., 0.), Complex64::new(-1., 0.)]
+    );
+}
+
+#[test]
+fn consuming_fft_c32_and_rejected_alias_remain_usable() {
+    let runtime = EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1).unwrap()).unwrap();
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major([2], vec![Complex32::new(1., 0.), Complex32::new(2., 0.)])
+            .unwrap(),
+        runtime,
+    )
+    .unwrap();
+    let alias = x.clone();
+    let x = rejected(x.fft_in_place(0, FftNorm::Backward));
+    assert_eq!(
+        alias.value().unwrap().as_slice::<Complex32>().unwrap(),
+        &[Complex32::new(1., 0.), Complex32::new(2., 0.)]
+    );
+    drop(alias);
+    let x = x
+        .fft_in_place(0, FftNorm::Backward)
+        .unwrap()
+        .ifft_in_place(0, FftNorm::Backward)
+        .unwrap();
+    assert_eq!(
+        x.value().unwrap().as_slice::<Complex32>().unwrap(),
+        &[Complex32::new(1., 0.), Complex32::new(2., 0.)]
+    );
+}
+
+#[test]
+fn consuming_fft_rejects_invalid_axis_dtype_tracking_and_capture_before_mutation() {
+    let runtime = EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1).unwrap()).unwrap();
+    let x = input(&runtime);
+    let x = rejected(x.fft_in_place(2, FftNorm::Backward));
+    let capture = runtime.capture_trace();
+    let no_grad = runtime.no_grad();
+    let x = rejected(x.fft_in_place(0, FftNorm::Backward));
+    drop(no_grad);
+    drop(capture);
+    assert_eq!(
+        x.value().unwrap().as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(1., 0.), Complex64::new(2., 0.)]
+    );
+    x.fft_in_place(0, FftNorm::Backward).unwrap();
+    let real = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major([1], vec![1.0_f64]).unwrap(),
+        runtime.clone(),
+    )
+    .unwrap();
+    let real = rejected(real.fft_in_place(0, FftNorm::Backward));
+    assert_eq!(real.value().unwrap().as_slice::<f64>().unwrap(), &[1.]);
+    let tracked = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major([1], vec![Complex64::new(2., 0.)]).unwrap(),
+        runtime.clone(),
+    )
+    .unwrap();
+    let _no_grad = runtime.no_grad();
+    let tracked = rejected(tracked.ifft_in_place(0, FftNorm::Backward));
+    assert!(tracked.tracks_grad());
+    assert_eq!(
+        tracked.value().unwrap().as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(2., 0.)]
+    );
+}

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -72,16 +72,6 @@ fn assert_f32_close(actual: &[f32], expected: &[f32]) {
     }
 }
 
-fn source_section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
-    let (_, after_start) = source
-        .split_once(start)
-        .unwrap_or_else(|| panic!("missing source section start {start}"));
-    let (section, _) = after_start
-        .split_once(end)
-        .unwrap_or_else(|| panic!("missing source section end {end}"));
-    section
-}
-
 #[cfg(feature = "autodiff")]
 fn fft_ad_context() -> tenferro_ad::AdContext {
     tenferro_ad::AdContext::builder()
@@ -208,67 +198,39 @@ fn fft_cpu_output_buffers_avoid_zero_fill_but_keep_lane_padding() {
         !source.contains("let mut output = vec![T::zero(); out_shape.iter().product()]"),
         "FFT CPU real output buffers are fully overwritten and should not be zero-filled"
     );
+    let lanes = include_str!("../src/cpu/lanes.rs");
+    assert!(source.contains("PooledUninitOutput::<O>::new"));
     assert!(
-        source.contains("let mut lane = vec![Complex::zero(); fft_len]")
-            && source.contains("// INVARIANT: zero-fill is transform padding semantics")
-            && source.contains("lane.fill(Complex::zero())"),
-        "FFT CPU scratch lanes must stay zero-filled for transform padding and carry an invariant marker"
+        lanes.contains("lane[copy_len..].fill(Complex::zero())")
+            && lanes.contains("// INVARIANT: only missing input positions are padding"),
+        "FFT padding must explicitly initialize only missing input positions"
     );
 }
 
 #[test]
 fn fft_cpu_execution_reuses_cached_rustfft_plans() {
-    let source = include_str!("../src/cpu.rs");
     let cache_source = include_str!("../src/cache.rs");
-    let c2c = source_section(source, "fn execute_c2c<T>(", "fn execute_r2c<T>(");
-    let r2c = source_section(source, "fn execute_r2c<T>(", "fn execute_c2r<T>(");
-    let c2r = source_section(source, "fn execute_c2r<T>(", "fn scale_for<T>(");
-
-    assert!(
-        cache_source.contains("trait FftPlanProvider"),
-        "FFT CPU execution should obtain plans from an explicit owner"
-    );
-    for (name, section) in [
-        ("execute_c2c", c2c),
-        ("execute_r2c", r2c),
-        ("execute_c2r", c2r),
+    assert!(cache_source.contains("trait FftPlanProvider"));
+    for source in [
+        include_str!("../src/cpu.rs"),
+        include_str!("../src/cpu/lanes.rs"),
     ] {
         assert!(
-            !section.contains("FftPlanner::<T>::new()"),
-            "{name} must not rebuild a RustFFT planner per call"
+            !source.contains("FftPlanner::<T>::new()"),
+            "CPU kernels must reuse owned plans"
         );
     }
 }
 
 #[test]
 fn fft_cpu_execution_uses_explicit_plan_provider() {
-    let source = include_str!("../src/cpu.rs");
-    let c2c = source_section(source, "fn execute_c2c<T>(", "fn execute_r2c<T>(");
-    let r2c = source_section(source, "fn execute_r2c<T>(", "fn execute_c2r<T>(");
-    let c2r = source_section(source, "fn execute_c2r<T>(", "fn scale_for<T>(");
-
-    for (name, section) in [
-        ("execute_c2c", c2c),
-        ("execute_r2c", r2c),
-        ("execute_c2r", c2r),
-    ] {
-        let call_start = section
-            .find("cached_fft_plan::<T, _>(plans")
-            .unwrap_or_else(|| panic!("{name} must use its explicit plan provider"));
-        let call_end = section[call_start..]
-            .find(';')
-            .map(|offset| call_start + offset + 1)
-            .unwrap_or_else(|| panic!("{name} cached_fft_plan call must end in a statement"));
-        let normalized_call = section[call_start..call_end]
-            .split_whitespace()
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        assert!(
-            normalized_call.ends_with(");"),
-            "unexpected plan call: {normalized_call}"
-        );
-    }
+    let source = include_str!("../src/cpu/lanes.rs");
+    assert!(source.contains("cached_fft_plan::<T, _>(plans"));
+    assert!(source.contains("plan.process_with_scratch(&mut lane, &mut scratch)"));
+    assert!(
+        source.find("let mut scratch =").unwrap() < source.find("for _ in start..end").unwrap(),
+        "scratch must be reused across each job's lanes"
+    );
 }
 
 #[test]
@@ -277,6 +239,7 @@ fn fft_source_has_no_process_global_plan_cache() {
         include_str!("../src/lib.rs"),
         include_str!("../src/cache.rs"),
         include_str!("../src/cpu.rs"),
+        include_str!("../src/cpu/lanes.rs"),
     ];
 
     for source in sources {
@@ -498,7 +461,7 @@ fn eager_fft_matches_traced_fft() {
         ],
     )
     .unwrap();
-    let traced = TracedTensor::from_tensor_concrete_shape(input.clone())
+    let traced = TracedTensor::from_tensor_concrete_shape(input.duplicate().unwrap())
         .unwrap()
         .fft(Some(3), -1, FftNorm::Ortho)
         .unwrap();
@@ -523,7 +486,7 @@ fn eager_ifft_matches_traced_ifft() {
         ],
     )
     .unwrap();
-    let traced = TracedTensor::from_tensor_concrete_shape(input.clone())
+    let traced = TracedTensor::from_tensor_concrete_shape(input.duplicate().unwrap())
         .unwrap()
         .ifft(None, 0, FftNorm::Forward)
         .unwrap();
@@ -539,7 +502,7 @@ fn eager_ifft_matches_traced_ifft() {
 #[cfg(feature = "autodiff")]
 fn eager_rfft_matches_traced_rfft() {
     let input = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
-    let traced = TracedTensor::from_tensor_concrete_shape(input.clone())
+    let traced = TracedTensor::from_tensor_concrete_shape(input.duplicate().unwrap())
         .unwrap()
         .rfft(None, -1, FftNorm::Backward)
         .unwrap();
@@ -563,7 +526,7 @@ fn eager_irfft_matches_traced_irfft() {
         ],
     )
     .unwrap();
-    let traced = TracedTensor::from_tensor_concrete_shape(input.clone())
+    let traced = TracedTensor::from_tensor_concrete_shape(input.duplicate().unwrap())
         .unwrap()
         .irfft(Some(4), -1, FftNorm::Backward)
         .unwrap();

--- a/crates/tenferro-internal-cpu-kernels/src/buffer_pool.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/buffer_pool.rs
@@ -17,7 +17,8 @@ use std::env;
 use std::ffi::OsString;
 use std::fmt;
 use std::mem::{size_of, ManuallyDrop, MaybeUninit};
-use std::sync::OnceLock;
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock, Weak};
+use tenferro_tensor::HostBufferRecycler;
 
 use num_complex::{Complex32, Complex64};
 
@@ -79,6 +80,14 @@ pub struct BufferPoolStats {
 /// assert_eq!(pool.len(), 1);
 /// ```
 pub struct BufferPool {
+    state: Arc<SharedPool>,
+}
+
+#[derive(Debug)]
+struct SharedPool(Mutex<PoolState>);
+
+#[derive(Debug)]
+struct PoolState {
     f64_pool: BTreeMap<usize, Vec<Vec<f64>>>,
     f32_pool: BTreeMap<usize, Vec<Vec<f32>>>,
     i32_pool: BTreeMap<usize, Vec<Vec<i32>>>,
@@ -103,7 +112,7 @@ impl fmt::Debug for BufferPool {
             .field("stats", &self.stats())
             .field(
                 "max_retained_capacity_bytes",
-                &self.max_retained_capacity_bytes,
+                &self.max_retained_capacity_bytes(),
             )
             .finish_non_exhaustive()
     }
@@ -183,6 +192,13 @@ pub(crate) mod private {
         ) -> crate::Result<(Vec<MaybeUninit<Self>>, super::UninitCheckoutToken)>
         where
             Self: Sized;
+        fn pool_finish_recycled(
+            pool: &mut super::BufferPool,
+            checkout: super::UninitCheckoutToken,
+        ) -> std::sync::Weak<dyn tenferro_tensor::HostBufferRecycler<Self>>
+        where
+            Self: Sized;
+
         fn pool_discard_uninit(
             pool: &mut super::BufferPool,
             data: Vec<MaybeUninit<Self>>,
@@ -287,6 +303,8 @@ macro_rules! impl_pool_scalar {
                 pool: &mut BufferPool,
                 len: usize,
             ) -> crate::Result<(Vec<MaybeUninit<Self>>, UninitCheckoutToken)> {
+                let mut state = lock_pool(&pool.state);
+                let pool = &mut *state;
                 match take_best_fit(&mut pool.$field, len) {
                     Some(buf) => {
                         let cap = buf.capacity();
@@ -322,12 +340,25 @@ macro_rules! impl_pool_scalar {
                 }
             }
 
+            fn pool_finish_recycled(
+                pool: &mut BufferPool,
+                checkout: UninitCheckoutToken,
+            ) -> Weak<dyn HostBufferRecycler<Self>> {
+                if let UninitCheckoutToken::Reused { actual_capacity } = checkout {
+                    decrement_in_flight(&mut lock_pool(&pool.state).$in_flight, actual_capacity);
+                }
+                let owner: Arc<dyn HostBufferRecycler<Self>> = pool.state.clone();
+                Arc::downgrade(&owner)
+            }
+
             fn pool_discard_uninit(
                 pool: &mut BufferPool,
                 data: Vec<MaybeUninit<Self>>,
                 checkout: UninitCheckoutToken,
             ) {
                 drop(data);
+                let mut state = lock_pool(&pool.state);
+                let pool = &mut *state;
                 if let UninitCheckoutToken::Reused { actual_capacity } = checkout {
                     decrement_in_flight(&mut pool.$in_flight, actual_capacity);
                 }
@@ -340,6 +371,8 @@ macro_rules! impl_pool_scalar {
             }
 
             fn pool_acquire_zeroed(pool: &mut BufferPool, len: usize) -> Vec<Self> {
+                let mut state = lock_pool(&pool.state);
+                let pool = &mut *state;
                 match take_best_fit(&mut pool.$field, len) {
                     Some(mut buf) => {
                         pool.retained_capacity_bytes = pool
@@ -355,12 +388,20 @@ macro_rules! impl_pool_scalar {
             }
 
             fn pool_release(pool: &mut BufferPool, buf: Vec<Self>) {
+                decrement_in_flight(&mut lock_pool(&pool.state).$in_flight, buf.capacity());
+                pool.state.recycle(buf);
+            }
+        }
+
+        impl HostBufferRecycler<$ty> for SharedPool {
+            fn recycle(&self, buf: Vec<$ty>) {
+                let mut state = lock_pool(self);
+                let pool = &mut *state;
                 let cap = buf.capacity();
                 if cap > 0 {
-                    decrement_in_flight(&mut pool.$in_flight, cap);
                     pool.retained_capacity_bytes = pool
                         .retained_capacity_bytes
-                        .saturating_add(cap.saturating_mul(size_of::<Self>()));
+                        .saturating_add(cap.saturating_mul(size_of::<$ty>()));
                     pool.$field.entry(cap).or_default().push(buf);
                     pool.enforce_retention_limit();
                 }
@@ -380,13 +421,14 @@ impl_pool_scalar!(Complex32, c32_pool, c32_in_flight, Complex32::new(0.0, 0.0));
 impl BufferPool {
     #[cfg(test)]
     pub(crate) fn in_flight_is_empty(&self) -> bool {
-        self.f64_in_flight.is_empty()
-            && self.f32_in_flight.is_empty()
-            && self.i32_in_flight.is_empty()
-            && self.i64_in_flight.is_empty()
-            && self.bool_in_flight.is_empty()
-            && self.c64_in_flight.is_empty()
-            && self.c32_in_flight.is_empty()
+        let state = lock_pool(&self.state);
+        state.f64_in_flight.is_empty()
+            && state.f32_in_flight.is_empty()
+            && state.i32_in_flight.is_empty()
+            && state.i64_in_flight.is_empty()
+            && state.bool_in_flight.is_empty()
+            && state.c64_in_flight.is_empty()
+            && state.c32_in_flight.is_empty()
     }
     /// Create an empty typed buffer pool.
     ///
@@ -417,22 +459,24 @@ impl BufferPool {
     /// ```
     pub fn with_max_retained_capacity_bytes(max_retained_capacity_bytes: usize) -> Self {
         Self {
-            f64_pool: BTreeMap::new(),
-            f32_pool: BTreeMap::new(),
-            i32_pool: BTreeMap::new(),
-            i64_pool: BTreeMap::new(),
-            bool_pool: BTreeMap::new(),
-            c64_pool: BTreeMap::new(),
-            c32_pool: BTreeMap::new(),
-            f64_in_flight: BTreeMap::new(),
-            f32_in_flight: BTreeMap::new(),
-            i32_in_flight: BTreeMap::new(),
-            i64_in_flight: BTreeMap::new(),
-            bool_in_flight: BTreeMap::new(),
-            c64_in_flight: BTreeMap::new(),
-            c32_in_flight: BTreeMap::new(),
-            retained_capacity_bytes: 0,
-            max_retained_capacity_bytes,
+            state: Arc::new(SharedPool(Mutex::new(PoolState {
+                f64_pool: BTreeMap::new(),
+                f32_pool: BTreeMap::new(),
+                i32_pool: BTreeMap::new(),
+                i64_pool: BTreeMap::new(),
+                bool_pool: BTreeMap::new(),
+                c64_pool: BTreeMap::new(),
+                c32_pool: BTreeMap::new(),
+                f64_in_flight: BTreeMap::new(),
+                f32_in_flight: BTreeMap::new(),
+                i32_in_flight: BTreeMap::new(),
+                i64_in_flight: BTreeMap::new(),
+                bool_in_flight: BTreeMap::new(),
+                c64_in_flight: BTreeMap::new(),
+                c32_in_flight: BTreeMap::new(),
+                retained_capacity_bytes: 0,
+                max_retained_capacity_bytes,
+            }))),
         }
     }
 
@@ -464,7 +508,7 @@ impl BufferPool {
     /// assert_eq!(pool.max_retained_capacity_bytes(), 4096);
     /// ```
     pub fn max_retained_capacity_bytes(&self) -> usize {
-        self.max_retained_capacity_bytes
+        lock_pool(&self.state).max_retained_capacity_bytes
     }
 
     /// Update the maximum retained typed host-buffer capacity in bytes.
@@ -485,8 +529,9 @@ impl BufferPool {
     /// assert!(pool.is_empty());
     /// ```
     pub fn set_max_retained_capacity_bytes(&mut self, max_retained_capacity_bytes: usize) {
-        self.max_retained_capacity_bytes = max_retained_capacity_bytes;
-        self.enforce_retention_limit();
+        let mut state = lock_pool(&self.state);
+        state.max_retained_capacity_bytes = max_retained_capacity_bytes;
+        state.enforce_retention_limit();
     }
 
     /// Number of retained buffers across all typed pools.
@@ -537,15 +582,16 @@ impl BufferPool {
     /// assert_eq!(stats.capacity_bytes, 16);
     /// ```
     pub fn stats(&self) -> BufferPoolStats {
+        let state = lock_pool(&self.state);
         BufferPoolStats {
-            buffers: pool_len(&self.f64_pool)
-                + pool_len(&self.f32_pool)
-                + pool_len(&self.i32_pool)
-                + pool_len(&self.i64_pool)
-                + pool_len(&self.bool_pool)
-                + pool_len(&self.c64_pool)
-                + pool_len(&self.c32_pool),
-            capacity_bytes: self.retained_capacity_bytes,
+            buffers: pool_len(&state.f64_pool)
+                + pool_len(&state.f32_pool)
+                + pool_len(&state.i32_pool)
+                + pool_len(&state.i64_pool)
+                + pool_len(&state.bool_pool)
+                + pool_len(&state.c64_pool)
+                + pool_len(&state.c32_pool),
+            capacity_bytes: state.retained_capacity_bytes,
         }
     }
 
@@ -638,13 +684,7 @@ impl BufferPool {
     /// assert!(pool.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
-        self.f64_pool.is_empty()
-            && self.f32_pool.is_empty()
-            && self.i32_pool.is_empty()
-            && self.i64_pool.is_empty()
-            && self.bool_pool.is_empty()
-            && self.c64_pool.is_empty()
-            && self.c32_pool.is_empty()
+        self.len() == 0
     }
 
     /// Drop all retained buffers from the pool.
@@ -664,6 +704,32 @@ impl BufferPool {
     /// assert!(pool.is_empty());
     /// ```
     pub fn clear(&mut self) {
+        let mut state = lock_pool(&self.state);
+        state.clear();
+    }
+
+    #[doc(hidden)]
+    pub fn clear_in_flight_retained(&mut self) {
+        lock_pool(&self.state).clear_in_flight_retained();
+    }
+
+    #[doc(hidden)]
+    pub fn replenish_in_flight_retained(&mut self) {
+        lock_pool(&self.state).replenish_in_flight_retained();
+    }
+}
+
+// INVARIANT: no user callback or tensor destructor runs under this lock; it
+// protects only scalar Vec bins and their accounting, never execution admission.
+fn lock_pool(state: &SharedPool) -> MutexGuard<'_, PoolState> {
+    state
+        .0
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+impl PoolState {
+    fn clear(&mut self) {
         self.f64_pool.clear();
         self.f32_pool.clear();
         self.i32_pool.clear();
@@ -733,7 +799,7 @@ impl BufferPool {
                 return;
             };
             if evicted_bytes == 0 {
-                if self.is_empty() {
+                if self.retained_capacity_bytes == 0 {
                     self.retained_capacity_bytes = 0;
                     return;
                 }

--- a/crates/tenferro-internal-cpu-kernels/src/buffer_pool/tests.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/buffer_pool/tests.rs
@@ -286,13 +286,13 @@ fn pooled_uninit_guard_keeps_unrelated_dtype_markers_untouched() {
     let mut pool = BufferPool::new();
     <f64 as PoolScalar>::pool_release(&mut pool, vec![0.0; 8]);
     let unrelated = pool.acquire_with_capacity::<f64>(8);
-    let marker_before = pool.f64_in_flight.clone();
+    let marker_before = super::lock_pool(&pool.state).f64_in_flight.clone();
     assert_eq!(marker_before.get(&8), Some(&1));
     <f64 as PoolScalar>::pool_release(&mut pool, vec![0.0; 16]);
     {
         let _output = PooledUninitOutput::<f64>::new(&mut pool, vec![3]).unwrap();
     }
-    assert_eq!(pool.f64_in_flight, marker_before);
+    assert_eq!(super::lock_pool(&pool.state).f64_in_flight, marker_before);
     drop(unrelated);
     pool.clear_in_flight_retained();
 }
@@ -307,9 +307,9 @@ fn pooled_uninit_guard_bool_invalid_byte_error_drops_without_typed_read() {
         panic!("invalid bool partial panic");
     }));
     assert!(result.is_err());
-    assert!(pool.bool_in_flight.is_empty());
+    assert!(super::lock_pool(&pool.state).bool_in_flight.is_empty());
     assert_eq!(pool.retained_capacity_bytes(), 0);
-    assert!(!pool.bool_pool.contains_key(&8));
+    assert!(!super::lock_pool(&pool.state).bool_pool.contains_key(&8));
 }
 
 #[test]
@@ -328,11 +328,17 @@ fn pooled_uninit_guard_reused_success_handoff_reclaims_exact_capacity() {
     let tensor = unsafe { output.assume_init() }.unwrap();
     assert_eq!(tensor.as_slice().unwrap(), &[1.0, 2.0, 3.0]);
     assert_eq!(pool.retained_capacity_bytes(), 0);
-    assert_eq!(pool.f64_in_flight.get(&8), Some(&1));
+    assert_eq!(
+        super::lock_pool(&pool.state).f64_in_flight.get(&8),
+        Some(&1)
+    );
     pool.replenish_in_flight_retained();
-    assert!(pool.f64_in_flight.is_empty());
+    assert!(super::lock_pool(&pool.state).f64_in_flight.is_empty());
     assert_eq!(pool.retained_capacity_bytes(), 8 * size_of::<f64>());
-    assert_eq!(pool.f64_pool.get(&8).map(Vec::len), Some(1));
+    assert_eq!(
+        super::lock_pool(&pool.state).f64_pool.get(&8).map(Vec::len),
+        Some(1)
+    );
 }
 
 #[test]
@@ -342,7 +348,7 @@ fn pooled_uninit_guard_reused_error_discards_exact_capacity() {
     let output = PooledUninitOutput::<f64>::new(&mut pool, vec![3]).unwrap();
     let error = unsafe { output.assume_init_as::<tenferro_tensor::Rank<2>>() }.unwrap_err();
     assert!(error.to_string().contains("pooled_uninit_output"));
-    assert!(pool.f64_in_flight.is_empty());
+    assert!(super::lock_pool(&pool.state).f64_in_flight.is_empty());
     assert_eq!(pool.retained_capacity_bytes(), 0);
 }
 
@@ -357,9 +363,9 @@ fn pooled_uninit_guard_reused_partial_panic_discards_exact_capacity() {
         panic!("partial reused C>len panic");
     }));
     assert!(result.is_err());
-    assert!(pool.f64_in_flight.is_empty());
+    assert!(super::lock_pool(&pool.state).f64_in_flight.is_empty());
     assert_eq!(pool.retained_capacity_bytes(), 0);
-    assert!(!pool.f64_pool.contains_key(&8));
+    assert!(!super::lock_pool(&pool.state).f64_pool.contains_key(&8));
 }
 
 #[test]

--- a/crates/tenferro-internal-cpu-kernels/src/pooled_uninit_output.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/pooled_uninit_output.rs
@@ -212,10 +212,47 @@ impl<'pool, T: PoolScalar> PooledUninitOutput<'pool, T> {
     /// let tensor = unsafe { output.assume_init_as::<Rank<1>>() }.unwrap();
     /// assert_eq!(tensor.as_slice().unwrap(), &[7]);
     /// ```
-    pub unsafe fn assume_init_as<R: TensorRank>(mut self) -> Result<TypedTensor<T, R>>
+    pub unsafe fn assume_init_as<R: TensorRank>(self) -> Result<TypedTensor<T, R>>
     where
         T: TensorScalar,
     {
+        // SAFETY: the caller guarantees complete initialization.
+        unsafe { self.finish(false) }
+    }
+
+    /// Transfer a fully initialized output with automatic original-pool return.
+    /// The pool is retained weakly; dropping the pool first frees later outputs
+    /// normally. Dropping an output never acquires a CPU session lock.
+    ///
+    /// # Safety
+    /// Every logical element must be initialized and no kernel may retain a
+    /// destination view. This is the same full-overwrite contract as assume_init.
+    ///
+    /// # Errors
+    /// Returns [`Error::Validation`] if the output shape and initialized buffer
+    /// length disagree, or [`Error::RuntimeState`] if recycler attachment cannot
+    /// obtain the host allocation. Shape conversion failures retain their typed
+    /// source as [`Error::BackendSource`].
+    ///
+    /// # Examples
+    /// ```
+    /// use tenferro_internal_cpu_kernels::{buffer_pool::BufferPool, PooledUninitOutput};
+    /// let mut pool = BufferPool::new();
+    /// let mut output = PooledUninitOutput::<f64>::new(&mut pool, vec![1])?;
+    /// output.as_uninit_slice_mut()[0].write(2.0);
+    /// // SAFETY: the only element has been initialized.
+    /// let tensor = unsafe { output.assume_init_recycled() }?;
+    /// assert_eq!(tensor.as_slice()?, &[2.0]);
+    /// drop(tensor);
+    /// assert_eq!(pool.len(), 1);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub unsafe fn assume_init_recycled(self) -> Result<TypedTensor<T>> {
+        // SAFETY: the caller guarantees complete initialization.
+        unsafe { self.finish(true) }
+    }
+
+    unsafe fn finish<R: TensorRank>(mut self, recycle: bool) -> Result<TypedTensor<T, R>> {
         let shape = R::shape_from_vec(std::mem::take(&mut self.shape).into())
             .map_err(|err| Error::backend_source("pooled_uninit_output", err))?;
         let data = std::mem::take(&mut self.data);
@@ -224,9 +261,21 @@ impl<'pool, T: PoolScalar> PooledUninitOutput<'pool, T> {
         let data = unsafe {
             Vec::from_raw_parts(data.as_mut_ptr().cast::<T>(), data.len(), data.capacity())
         };
-        let tensor = TypedTensor::from_vec_col_major(shape, data)?;
-        self.checkout = None;
-        Ok(tensor)
+        if recycle {
+            // INVARIANT: only successful completion takes the checkout, and this
+            // method consumes self, so a live output always owns its token here.
+            let Some(checkout) = self.checkout.take() else {
+                unreachable!("a live pooled output owns its checkout");
+            };
+            let recycler = <T as crate::buffer_pool::private::Sealed>::pool_finish_recycled(
+                self.pool, checkout,
+            );
+            TypedTensor::from_vec_col_major_with_recycler(shape, data, recycler)
+        } else {
+            let tensor = TypedTensor::from_vec_col_major(shape, data)?;
+            self.checkout = None;
+            Ok(tensor)
+        }
     }
 }
 

--- a/crates/tenferro-internal-cpu-kernels/src/pooled_uninit_output/tests.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/pooled_uninit_output/tests.rs
@@ -1,6 +1,118 @@
 use super::{checked_compact_strides, PooledUninitOutput};
 use crate::buffer_pool::BufferPool;
 
+fn recycled(pool: &mut BufferPool) -> tenferro_tensor::TypedTensor<f64> {
+    let mut output = PooledUninitOutput::<f64>::new(pool, vec![4]).unwrap();
+    for (i, value) in output.as_uninit_slice_mut().iter_mut().enumerate() {
+        value.write(i as f64);
+    }
+    // SAFETY: every logical element was written above.
+    unsafe { output.assume_init_recycled() }.unwrap()
+}
+
+#[test]
+fn recycled_output_returns_only_after_final_group_owner_drops() {
+    let mut pool = BufferPool::new();
+    let tensor = recycled(&mut pool);
+    let pointer = tensor.as_slice().unwrap().as_ptr();
+    let (group, slots) =
+        tenferro_tensor::AllocationGroup::from_tensors(vec![tenferro_tensor::Tensor::F64(tensor)])
+            .unwrap();
+    assert!(pool.is_empty());
+    {
+        let reads = group.read_views(&slots).unwrap();
+        assert_eq!(reads[0].shape(), &[4]);
+        assert!(pool.is_empty());
+    }
+    drop(group);
+    assert_eq!(pool.len(), 1);
+    let tensor = recycled(&mut pool);
+    assert_eq!(tensor.as_slice().unwrap().as_ptr(), pointer);
+    pool.replenish_in_flight_retained();
+    assert!(
+        pool.is_empty(),
+        "live recycled outputs must not allocate replacements"
+    );
+    drop(tensor);
+    assert_eq!(pool.len(), 1);
+}
+
+#[test]
+fn recycled_drop_during_another_checkout_does_not_reenter_the_execution_lock() {
+    let mut pool = BufferPool::new();
+    let tensor = recycled(&mut pool);
+    let output = PooledUninitOutput::<f64>::new(&mut pool, vec![4]).unwrap();
+    drop(tensor);
+    drop(output);
+    assert_eq!(pool.len(), 1);
+}
+
+#[test]
+fn recycled_output_extraction_disarms_return_and_pool_may_drop_first() {
+    let mut pool = BufferPool::new();
+    let tensor = recycled(&mut pool);
+    let pointer = tensor.as_slice().unwrap().as_ptr();
+    let data = tensor.into_host_vec().unwrap();
+    assert_eq!(data.as_ptr(), pointer);
+    assert!(pool.is_empty());
+    drop(data);
+    assert!(pool.is_empty());
+    let tensor = recycled(&mut pool);
+    drop(pool);
+    assert_eq!(tensor.as_slice().unwrap(), &[0., 1., 2., 3.]);
+    drop(tensor);
+}
+
+#[test]
+fn partial_output_is_discarded_on_error_and_unwind() {
+    let mut pool = BufferPool::new();
+    for unwind in [false, true] {
+        drop(recycled(&mut pool));
+        assert_eq!(pool.len(), 1);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut output = PooledUninitOutput::<f64>::new(&mut pool, vec![4]).unwrap();
+            output.as_uninit_slice_mut()[0].write(f64::NAN);
+            if unwind {
+                panic!("kernel stopped after a partial write");
+            }
+            Err::<(), _>("kernel returned an error after a partial write")
+        }));
+        if unwind {
+            assert!(outcome.is_err());
+        } else {
+            assert!(outcome.unwrap().is_err());
+        }
+        assert!(
+            pool.is_empty(),
+            "partial initialization cannot become a retained tensor"
+        );
+        pool.replenish_in_flight_retained();
+        assert!(
+            pool.is_empty(),
+            "aborted checkout must cancel replacement accounting"
+        );
+        let tensor = recycled(&mut pool);
+        assert_eq!(tensor.as_slice().unwrap(), &[0., 1., 2., 3.]);
+        drop(tensor);
+        pool.clear();
+    }
+}
+
+#[test]
+fn recycled_output_respects_current_limit_and_clear() {
+    let mut pool = BufferPool::new();
+    let tensor = recycled(&mut pool);
+    pool.set_max_retained_capacity_bytes(0);
+    drop(tensor);
+    assert!(pool.is_empty());
+    pool.set_max_retained_capacity_bytes(1024);
+    drop(recycled(&mut pool));
+    assert_eq!(pool.len(), 1);
+    pool.clear();
+    assert!(pool.is_empty());
+    assert_eq!(pool.retained_capacity_bytes(), 0);
+}
+
 #[test]
 fn compact_stride_validation_reports_dimension_and_product_overflow() {
     let dimension_error = checked_compact_strides(&[isize::MAX as usize + 1]).unwrap_err();

--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -65,3 +65,7 @@ path = "tests/integration.rs"
 [[test]]
 name = "prelude"
 path = "tests/prelude.rs"
+
+[[test]]
+name = "binary_allocations"
+path = "tests/binary_allocations.rs"

--- a/crates/tenferro-runtime/src/tensor.rs
+++ b/crates/tenferro-runtime/src/tensor.rs
@@ -4,11 +4,11 @@
 //! provides backend-parametric session-explicit operation methods through
 //! [`TensorSessionOpsExt`].
 
-use tenferro_ops::broadcast::{
-    broadcast_error_to_validation, broadcast_input_plan, broadcast_shape, broadcast_shapes,
-};
+use tenferro_ops::broadcast::{broadcast_error_to_validation, broadcast_shape, broadcast_shapes};
 use tenferro_tensor::validate::matmul_config_for_shapes;
-use tenferro_tensor::{BackendSession, CompareDir, DType, Error, Result};
+use tenferro_tensor::{BackendSession, CompareDir, DType, Error, Result, TensorRead};
+
+use crate::typed_tensor::{broadcast_to_in_read, ReadInput};
 
 use crate::TensorSessionOpsExt;
 use tenferro_tensor::Tensor;
@@ -16,12 +16,12 @@ use tenferro_tensor::Tensor;
 impl TensorSessionOpsExt for Tensor {
     fn add(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
-        session.add(&lhs, &rhs)
+        session.add_read(lhs.tensor_read(), rhs.tensor_read())
     }
 
     fn mul(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
-        session.mul(&lhs, &rhs)
+        session.mul_read(lhs.tensor_read(), rhs.tensor_read())
     }
 
     fn exp(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
@@ -42,32 +42,32 @@ impl TensorSessionOpsExt for Tensor {
 
     fn sub(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
-        session.sub(&lhs, &rhs)
+        session.sub_read(lhs.tensor_read(), rhs.tensor_read())
     }
 
     fn div(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
-        session.div(&lhs, &rhs)
+        session.div_read(lhs.tensor_read(), rhs.tensor_read())
     }
 
     fn rem(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
-        session.rem(&lhs, &rhs)
+        session.rem_read(lhs.tensor_read(), rhs.tensor_read())
     }
 
     fn pow(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
-        session.pow(&lhs, &rhs)
+        session.pow_read(lhs.tensor_read(), rhs.tensor_read())
     }
 
     fn maximum(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
-        session.maximum(&lhs, &rhs)
+        session.maximum_read(lhs.tensor_read(), rhs.tensor_read())
     }
 
     fn minimum(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
-        session.minimum(&lhs, &rhs)
+        session.minimum_read(lhs.tensor_read(), rhs.tensor_read())
     }
 
     fn neg(&self, session: &mut dyn BackendSession) -> Result<Tensor> {
@@ -125,7 +125,7 @@ impl TensorSessionOpsExt for Tensor {
         session: &mut dyn BackendSession,
     ) -> Result<Tensor> {
         let (lhs, rhs) = broadcast_binary_in(self, rhs, session)?;
-        session.compare(&lhs, &rhs, &dir)
+        session.compare_read(lhs.tensor_read(), rhs.tensor_read(), &dir)
     }
 
     fn where_select(
@@ -136,7 +136,11 @@ impl TensorSessionOpsExt for Tensor {
     ) -> Result<Tensor> {
         let (condition, on_true, on_false) =
             broadcast_ternary_in(self, on_true, on_false, session)?;
-        session.select(&condition, &on_true, &on_false)
+        session.select_read(
+            condition.tensor_read(),
+            on_true.tensor_read(),
+            on_false.tensor_read(),
+        )
     }
 
     fn clamp(
@@ -146,7 +150,11 @@ impl TensorSessionOpsExt for Tensor {
         session: &mut dyn BackendSession,
     ) -> Result<Tensor> {
         let (input, lower, upper) = broadcast_ternary_in(self, lower, upper, session)?;
-        session.clamp(&input, &lower, &upper)
+        session.clamp_read(
+            input.tensor_read(),
+            lower.tensor_read(),
+            upper.tensor_read(),
+        )
     }
 
     fn matmul(&self, rhs: &Tensor, session: &mut dyn BackendSession) -> Result<Tensor> {
@@ -163,49 +171,30 @@ impl TensorSessionOpsExt for Tensor {
     }
 }
 
-fn broadcast_to_in(
-    input: &Tensor,
-    target_shape: &[usize],
+fn broadcast_binary_in<'a>(
+    lhs: &'a Tensor,
+    rhs: &'a Tensor,
     session: &mut dyn BackendSession,
-) -> Result<Tensor> {
-    let input_shape = input.shape();
-    if input_shape == target_shape {
-        return input.duplicate();
-    }
-
-    let plan = broadcast_input_plan(input_shape, target_shape).map_err(broadcast_error)?;
-    let source = if plan.source_shape == input_shape {
-        input.duplicate()?
-    } else {
-        session.reshape(input, &plan.source_shape)?
-    };
-    session.broadcast_in_dim(&source, target_shape, &plan.dims)
-}
-
-fn broadcast_binary_in(
-    lhs: &Tensor,
-    rhs: &Tensor,
-    session: &mut dyn BackendSession,
-) -> Result<(Tensor, Tensor)> {
+) -> Result<(ReadInput<'a>, ReadInput<'a>)> {
     let shape = broadcast_shape(lhs.shape(), rhs.shape()).map_err(broadcast_error)?;
     Ok((
-        broadcast_to_in(lhs, &shape, session)?,
-        broadcast_to_in(rhs, &shape, session)?,
+        broadcast_to_in_read(TensorRead::from_tensor(lhs), &shape, session)?,
+        broadcast_to_in_read(TensorRead::from_tensor(rhs), &shape, session)?,
     ))
 }
 
-fn broadcast_ternary_in(
-    first: &Tensor,
-    second: &Tensor,
-    third: &Tensor,
+fn broadcast_ternary_in<'a>(
+    first: &'a Tensor,
+    second: &'a Tensor,
+    third: &'a Tensor,
     session: &mut dyn BackendSession,
-) -> Result<(Tensor, Tensor, Tensor)> {
+) -> Result<(ReadInput<'a>, ReadInput<'a>, ReadInput<'a>)> {
     let shape = broadcast_shapes([first.shape(), second.shape(), third.shape()])
         .map_err(broadcast_error)?;
     Ok((
-        broadcast_to_in(first, &shape, session)?,
-        broadcast_to_in(second, &shape, session)?,
-        broadcast_to_in(third, &shape, session)?,
+        broadcast_to_in_read(TensorRead::from_tensor(first), &shape, session)?,
+        broadcast_to_in_read(TensorRead::from_tensor(second), &shape, session)?,
+        broadcast_to_in_read(TensorRead::from_tensor(third), &shape, session)?,
     ))
 }
 

--- a/crates/tenferro-runtime/src/typed_tensor.rs
+++ b/crates/tenferro-runtime/src/typed_tensor.rs
@@ -252,13 +252,13 @@ impl TypedTensorMaskSessionOpsExt for TypedTensor<bool> {
 // INVARIANT: this private adapter keeps borrowed reads borrowed and owns only
 // the explicit fallback tensor; it is never exposed or cloned.
 #[allow(clippy::large_enum_variant)]
-enum ReadInput<'a> {
+pub(crate) enum ReadInput<'a> {
     Borrowed(TensorRead<'a>),
     Owned(Tensor),
 }
 
 impl ReadInput<'_> {
-    fn tensor_read(&self) -> TensorRead<'_> {
+    pub(crate) fn tensor_read(&self) -> TensorRead<'_> {
         match self {
             Self::Borrowed(read) => read.clone(),
             Self::Owned(tensor) => TensorRead::from_tensor(tensor),
@@ -266,20 +266,20 @@ impl ReadInput<'_> {
     }
 }
 
-fn broadcast_to_in_read<'a, T: TensorScalar>(
-    input: &'a TypedTensor<T>,
+pub(crate) fn broadcast_to_in_read<'a>(
+    input: TensorRead<'a>,
     target_shape: &[usize],
     session: &mut dyn BackendSession,
 ) -> Result<ReadInput<'a>> {
     if input.shape() == target_shape {
-        return Ok(ReadInput::Borrowed(T::tensor_read(input)));
+        return Ok(ReadInput::Borrowed(input));
     }
 
     let plan = broadcast_input_plan(input.shape(), target_shape).map_err(broadcast_error)?;
     let source = if plan.source_shape == input.shape() {
-        ReadInput::Borrowed(T::tensor_read(input))
+        ReadInput::Borrowed(input)
     } else {
-        let reshaped = session.reshape_read(T::tensor_read(input), &plan.source_shape)?;
+        let reshaped = session.reshape_read(input, &plan.source_shape)?;
         ReadInput::Owned(reshaped)
     };
     let out = session.broadcast_in_dim_read(source.tensor_read(), target_shape, &plan.dims)?;
@@ -293,8 +293,8 @@ fn broadcast_binary_in_read<'a, T: TensorScalar>(
 ) -> Result<(ReadInput<'a>, ReadInput<'a>)> {
     let shape = broadcast_shape(lhs.shape(), rhs.shape()).map_err(broadcast_error)?;
     Ok((
-        broadcast_to_in_read(lhs, &shape, session)?,
-        broadcast_to_in_read(rhs, &shape, session)?,
+        broadcast_to_in_read(T::tensor_read(lhs), &shape, session)?,
+        broadcast_to_in_read(T::tensor_read(rhs), &shape, session)?,
     ))
 }
 
@@ -307,9 +307,9 @@ fn broadcast_ternary_in_read<'a, C: TensorScalar, T: TensorScalar>(
     let shape = broadcast_shapes([first.shape(), second.shape(), third.shape()])
         .map_err(broadcast_error)?;
     Ok((
-        broadcast_to_in_read(first, &shape, session)?,
-        broadcast_to_in_read(second, &shape, session)?,
-        broadcast_to_in_read(third, &shape, session)?,
+        broadcast_to_in_read(C::tensor_read(first), &shape, session)?,
+        broadcast_to_in_read(T::tensor_read(second), &shape, session)?,
+        broadcast_to_in_read(T::tensor_read(third), &shape, session)?,
     ))
 }
 

--- a/crates/tenferro-runtime/tests/binary_allocations.rs
+++ b/crates/tenferro-runtime/tests/binary_allocations.rs
@@ -1,0 +1,142 @@
+//! Public same-shape wrappers must not allocate input-sized temporaries.
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::TensorSessionOpsExt;
+use tenferro_tensor::{BackendSession, BackendSessionHost, CompareDir, Tensor};
+
+const LEN: usize = 4096;
+const INPUT_BYTES: usize = LEN * size_of::<f64>();
+static ENABLED: AtomicBool = AtomicBool::new(false);
+static LARGE_ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static TOTAL_ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static TOTAL_BYTES: AtomicUsize = AtomicUsize::new(0);
+struct Allocator;
+
+// SAFETY: all allocations and deallocations are forwarded unchanged to System.
+unsafe impl GlobalAlloc for Allocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if ENABLED.load(Ordering::Relaxed) {
+            TOTAL_ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            TOTAL_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+            if layout.size() >= INPUT_BYTES {
+                LARGE_ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        // SAFETY: the original allocation layout is passed to System.
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: ptr and layout originate from System.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        if ENABLED.load(Ordering::Relaxed) {
+            TOTAL_ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            TOTAL_BYTES.fetch_add(size, Ordering::Relaxed);
+            if size >= INPUT_BYTES {
+                LARGE_ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        // SAFETY: the original allocation and requested size are forwarded.
+        unsafe { System.realloc(ptr, layout, size) }
+    }
+}
+#[global_allocator]
+static ALLOCATOR: Allocator = Allocator;
+
+fn allocations(f: impl FnOnce() -> Tensor) -> (Tensor, usize) {
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            ENABLED.store(false, Ordering::SeqCst);
+        }
+    }
+    LARGE_ALLOCATIONS.store(0, Ordering::Relaxed);
+    TOTAL_ALLOCATIONS.store(0, Ordering::Relaxed);
+    TOTAL_BYTES.store(0, Ordering::Relaxed);
+    ENABLED.store(true, Ordering::SeqCst);
+    let reset = Reset;
+    let result = f();
+    drop(reset);
+    eprintln!(
+        "payload-sized={}, total_count={}, requested_bytes={}",
+        LARGE_ALLOCATIONS.load(Ordering::Relaxed),
+        TOTAL_ALLOCATIONS.load(Ordering::Relaxed),
+        TOTAL_BYTES.load(Ordering::Relaxed)
+    );
+    (result, LARGE_ALLOCATIONS.load(Ordering::Relaxed))
+}
+
+#[test]
+fn same_shape_wrappers_do_not_allocate_operand_copies() {
+    let a = Tensor::from_vec_col_major([LEN], vec![2.0_f64; LEN]).unwrap();
+    let b = Tensor::from_vec_col_major([LEN], vec![3.0_f64; LEN]).unwrap();
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    assert_eq!(backend.num_threads(), 1);
+    backend.with_backend_session(|session: &mut dyn BackendSession| {
+        macro_rules! check {
+            ($name:ident) => {{
+                drop(session.$name(&a, &b).unwrap());
+                eprintln!(
+                    "{}: raw then public (effective backend threads=1)",
+                    stringify!($name)
+                );
+                let (raw, baseline) = allocations(|| session.$name(&a, &b).unwrap());
+                let (public, actual) = allocations(|| a.$name(&b, session).unwrap());
+                assert_eq!(
+                    public.as_slice::<f64>().unwrap(),
+                    raw.as_slice::<f64>().unwrap()
+                );
+                assert!(
+                    actual <= baseline,
+                    "{}: public={actual}, backend={baseline}",
+                    stringify!($name)
+                );
+            }};
+        }
+        check!(add);
+        check!(sub);
+        check!(mul);
+        check!(div);
+        check!(rem);
+        check!(pow);
+        check!(maximum);
+        check!(minimum);
+        eprintln!("compare: raw then public");
+        let (raw, baseline) = allocations(|| session.compare(&a, &b, &CompareDir::Lt).unwrap());
+        let (public, actual) = allocations(|| a.compare(&b, CompareDir::Lt, session).unwrap());
+        assert_eq!(
+            public.as_slice::<bool>().unwrap(),
+            raw.as_slice::<bool>().unwrap()
+        );
+        assert!(
+            actual <= baseline,
+            "compare: public={actual}, backend={baseline}"
+        );
+        eprintln!("clamp: raw then public");
+        let (raw, baseline) = allocations(|| session.clamp(&a, &a, &b).unwrap());
+        let (public, actual) = allocations(|| a.clamp(&a, &b, session).unwrap());
+        assert_eq!(
+            public.as_slice::<f64>().unwrap(),
+            raw.as_slice::<f64>().unwrap()
+        );
+        assert!(
+            actual <= baseline,
+            "clamp: public={actual}, backend={baseline}"
+        );
+        let condition = Tensor::from_vec_col_major([LEN], vec![true; LEN]).unwrap();
+        eprintln!("select: raw then public");
+        let (raw, baseline) = allocations(|| session.select(&condition, &a, &b).unwrap());
+        let (public, actual) = allocations(|| condition.where_select(&a, &b, session).unwrap());
+        assert_eq!(
+            public.as_slice::<f64>().unwrap(),
+            raw.as_slice::<f64>().unwrap()
+        );
+        assert!(
+            actual <= baseline,
+            "select: public={actual}, backend={baseline}"
+        );
+    });
+}

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -92,9 +92,9 @@ mod storage;
 
 #[doc(hidden)]
 pub use storage::{
-    AccessError, AllocationKey, BackendAllocation, ProviderCapabilities, ProviderKind,
-    ProviderReadMapping, ProviderWriteMapping, RootBoundSpan, RootResourceExtent, RootResourceId,
-    SpanValidationError,
+    AccessError, AllocationKey, BackendAllocation, HostBufferRecycler, ProviderCapabilities,
+    ProviderKind, ProviderReadMapping, ProviderWriteMapping, RootBoundSpan, RootResourceExtent,
+    RootResourceId, SpanValidationError,
 };
 pub use storage::{AllocationGroup, DescriptorSlot, GroupError};
 

--- a/crates/tenferro-tensor/src/storage/group.rs
+++ b/crates/tenferro-tensor/src/storage/group.rs
@@ -1125,6 +1125,21 @@ impl AllocationGroup {
         Ok(self.resolve_descriptor(slot)?.1.allocation.index())
     }
 
+    pub(crate) fn set_host_recycler<T: TensorScalar>(
+        &mut self,
+        allocation_index: usize,
+        recycler: std::sync::Weak<dyn super::root::HostBufferRecycler<T>>,
+    ) -> Result<(), AccessError> {
+        let owner = self
+            .allocations
+            .get_mut(allocation_index)
+            .and_then(Option::as_mut)
+            .ok_or(AccessError::Unsupported {
+                backend: "missing host allocation",
+            })?;
+        owner.set_host_recycler(recycler)
+    }
+
     pub(crate) fn host_buffer_at<T: 'static>(
         &self,
         allocation_index: usize,

--- a/crates/tenferro-tensor/src/storage/mod.rs
+++ b/crates/tenferro-tensor/src/storage/mod.rs
@@ -17,7 +17,7 @@ pub use identity::{AllocationKey, RootResourceId};
 #[doc(hidden)]
 pub use prepared::{AccessError, ProviderReadMapping, ProviderWriteMapping};
 #[doc(hidden)]
-pub use root::{BackendAllocation, ProviderCapabilities, ProviderKind};
+pub use root::{BackendAllocation, HostBufferRecycler, ProviderCapabilities, ProviderKind};
 #[doc(hidden)]
 pub use span::{RootBoundSpan, RootResourceExtent, SpanValidationError};
 

--- a/crates/tenferro-tensor/src/storage/root.rs
+++ b/crates/tenferro-tensor/src/storage/root.rs
@@ -176,6 +176,46 @@ pub(crate) struct StorageMut<'a> {
 pub(crate) struct HostAllocation<T> {
     extent: RootResourceExtent,
     data: UnsafeCell<crate::StorageBuffer<T>>,
+    recycler: Option<std::sync::Weak<dyn HostBufferRecycler<T>>>,
+}
+
+/// Backend-owned reclamation of a fully initialized host allocation.
+///
+/// This extension contract transfers a vector only after its final storage owner
+/// is destroyed. Implementations must not panic or acquire execution-admission
+/// locks; destruction can occur inside an active backend session.
+#[doc(hidden)]
+pub trait HostBufferRecycler<T>: std::fmt::Debug + Send + Sync {
+    /// Accept exclusive ownership of an initialized vector for reuse or release.
+    ///
+    /// # Examples
+    /// ```
+    /// use std::sync::atomic::{AtomicUsize, Ordering};
+    /// use tenferro_tensor::HostBufferRecycler;
+    /// #[derive(Debug, Default)]
+    /// struct ReleaseCounter(AtomicUsize);
+    /// impl HostBufferRecycler<f64> for ReleaseCounter {
+    ///     fn recycle(&self, data: Vec<f64>) {
+    ///         self.0.fetch_add(data.len(), Ordering::Relaxed);
+    ///         drop(data);
+    ///     }
+    /// }
+    /// let recycler = ReleaseCounter::default();
+    /// recycler.recycle(vec![1.0, 2.0]);
+    /// assert_eq!(recycler.0.load(Ordering::Relaxed), 2);
+    /// ```
+    fn recycle(&self, data: Vec<T>);
+}
+
+impl<T> Drop for HostAllocation<T> {
+    fn drop(&mut self) {
+        let Some(recycler) = self.recycler.take().and_then(|owner| owner.upgrade()) else {
+            return;
+        };
+        if let crate::StorageBuffer::Host(data) = self.data.get_mut() {
+            recycler.recycle(std::mem::take(data));
+        }
+    }
 }
 
 /// Root-bound owner for a provider buffer supplied through the backend storage
@@ -570,30 +610,37 @@ impl<T: TensorScalar> HostRoot for T {
     fn into_pin(extent: RootResourceExtent, data: Vec<Self>) -> RootResourcePin {
         match T::dtype() {
             DType::F32 => RootResourcePin::HostF32(HostAllocation {
+                recycler: None,
                 extent,
                 data: UnsafeCell::new(crate::StorageBuffer::Host(cast_host_vec(data))),
             }),
             DType::F64 => RootResourcePin::HostF64(HostAllocation {
+                recycler: None,
                 extent,
                 data: UnsafeCell::new(crate::StorageBuffer::Host(cast_host_vec(data))),
             }),
             DType::I32 => RootResourcePin::HostI32(HostAllocation {
+                recycler: None,
                 extent,
                 data: UnsafeCell::new(crate::StorageBuffer::Host(cast_host_vec(data))),
             }),
             DType::I64 => RootResourcePin::HostI64(HostAllocation {
+                recycler: None,
                 extent,
                 data: UnsafeCell::new(crate::StorageBuffer::Host(cast_host_vec(data))),
             }),
             DType::Bool => RootResourcePin::HostBool(HostAllocation {
+                recycler: None,
                 extent,
                 data: UnsafeCell::new(crate::StorageBuffer::Host(cast_host_vec(data))),
             }),
             DType::C32 => RootResourcePin::HostC32(HostAllocation {
+                recycler: None,
                 extent,
                 data: UnsafeCell::new(crate::StorageBuffer::Host(cast_host_vec(data))),
             }),
             DType::C64 => RootResourcePin::HostC64(HostAllocation {
+                recycler: None,
                 extent,
                 data: UnsafeCell::new(crate::StorageBuffer::Host(cast_host_vec(data))),
             }),
@@ -1017,6 +1064,21 @@ impl OwnedStorage {
         self.pin.backend_buffer_mut::<T>()
     }
 
+    pub(crate) fn set_host_recycler<T: TensorScalar>(
+        &mut self,
+        recycler: std::sync::Weak<dyn HostBufferRecycler<T>>,
+    ) -> Result<(), AccessError> {
+        let allocation = self
+            .pin
+            .as_any_mut()
+            .downcast_mut::<HostAllocation<T>>()
+            .ok_or(AccessError::Unsupported {
+                backend: "non-host",
+            })?;
+        allocation.recycler = Some(recycler);
+        Ok(())
+    }
+
     pub(crate) fn into_host_vec<T: TensorScalar>(mut self) -> Result<Vec<T>, AccessError> {
         let allocation = self
             .pin
@@ -1032,7 +1094,9 @@ impl OwnedStorage {
                 backend: "non-host",
             });
         };
-        Ok(std::mem::take(data))
+        let data = std::mem::take(data);
+        allocation.recycler = None;
+        Ok(data)
     }
 }
 

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -7195,6 +7195,28 @@ impl<T: TensorScalar, R: TensorRank> TypedTensor<T, R> {
         typed_tensor_from_vec_col_major(shape, data, "from_vec_col_major")
     }
 
+    /// Construct a backend-pooled host tensor with weak final-owner reclamation.
+    /// Explicit Vec extraction disarms reclamation; aliases and retained groups
+    /// keep the original root alive. The recycler must not acquire session locks.
+    ///
+    /// # Errors
+    /// Returns validation errors for invalid shape/length and runtime-state errors
+    /// if the freshly created host root cannot attach its recycler.
+    #[doc(hidden)]
+    pub fn from_vec_col_major_with_recycler(
+        shape: impl tenferro_tensor_core::IntoRankShape<R>,
+        data: Vec<T>,
+        recycler: std::sync::Weak<dyn crate::HostBufferRecycler<T>>,
+    ) -> crate::Result<Self> {
+        let mut tensor = Self::from_vec_col_major(shape, data)?;
+        tensor
+            .group
+            .group
+            .set_host_recycler(tensor.group.allocation_index, recycler)
+            .map_err(|error| crate::Error::runtime_state_source("pooled host tensor", error))?;
+        Ok(tensor)
+    }
+
     /// Make an explicit owning copy of this tensor.
     ///
     /// Host storage is copied into a fresh allocation. Backend-owned storage

--- a/docs/design/cpu-fft-output-reuse.md
+++ b/docs/design/cpu-fft-output-reuse.md
@@ -1,0 +1,87 @@
+# CPU FFT output reuse and consuming eager execution
+
+Accepted scope: #1765 and #1766; implementation is in progress. The maintainer
+approved the host-reclamation/CPU-pool synchronization changes as part of the
+same performance PR. See the linked [work log](../worklogs/1765-1766-cpu-performance.md)
+for evidence and verification status.
+
+## Ownership and reclamation
+
+Reuse the existing CPU BufferPool and its retention limits, clearing and stats.
+Separate its short pool-state lock from CPU execution admission and the engine
+resource lock. Acquiring or returning a vector holds only the short state lock;
+never hold that lock while invoking a numerical kernel, returning a tensor,
+or destroying a tensor with a recycler. Do not introduce a second pool or a
+queue of indefinitely retained buffers.
+
+A completed pooled host allocation carries a weak typed reference to its
+original recycler. The host allocation remains the sole owner of the vector.
+Its final destruction transfers the vector back to the original pool if that
+pool still exists, otherwise normal destruction frees it. The weak reference
+must not prolong backend lifetime or create a cycle. AD containers, views and
+capture keep the existing ownership/borrow semantics: recycling is a consequence
+of final root destruction, not eager-handle count or a separate liveness table.
+
+Explicit extraction to Vec transfers responsibility to the caller and disarms
+the recycler. Explicit reclaim must not return the same allocation twice.
+Partial uninitialized outputs remain MaybeUninit until successful full overwrite;
+errors and unwind must not expose uninitialized scalar values. Automatic return
+must not trigger the legacy loan's replacement allocation for a live output.
+Pool bounds and clear/stat operations apply to the one shared retained state.
+Changing this boundary requires tests for drop during execution, backend-first
+drop, live aliases/AD records, explicit extraction, limits and clearing.
+
+## FFT execution
+
+The CPU FFT kernel writes directly into its final host output destination using
+the canonical pooled uninitialized owner.
+
+The maintainer approved retaining the managed output copy boundary for this PR,
+including Apple CPU/Metal shared allocations. Inspection and the managed
+regression test show that legacy BackendStorage::map_write returns a copy-only
+HostWriteGuard, not a writable span. SharedTensorAllocationDomain::allocate also
+permits uninitialized output, so treating its storage as an initialized mutable
+slice is invalid. The current implementation preserves this provider boundary
+with pooled staging and a single copy, while sharing the parallel lane kernel.
+Removing that copy requires a separately specified provider-owned uninitialized
+write/completion capability; the host recycler alone cannot supply it. Direct
+managed writes, synchronization and Apple hardware validation are separate
+future work, not prerequisites or performance claims of this PR.
+
+Padding and c2r reconstruction initialize every scratch element that is read.
+Plans remain in the existing extension cache; no global plan or scratch cache.
+
+Lane jobs are executed inside the existing CPU session context and obey its
+thread budget and nested policy. The one-thread path remains sequential.
+Partition the lane domain, including noncontiguous lanes of the last axis;
+prove disjoint output index sets before parallel execution. Reuse lane and
+RustFFT scratch within each job rather than allocate per lane.
+
+## Consuming eager in-place
+
+Expose explicitly named consuming in-place operations for CPU C32/C64,
+shape-preserving c2c forward/inverse transforms on compact column-major storage
+only. Check actual input compactness before ownership extraction: into_value
+preserves a descriptor's layout and must not be mistaken for canonicalization.
+Use the existing descriptor-bounded host write guard after extraction, not a
+whole-root mutable slice. This preserves the offset and extent of compact
+slices while leaving elements outside the logical tensor untouched.
+Existing borrowed fft/ifft
+remain nondestructive. Validate dtype, axis and backend before taking ownership.
+Reject active grad/capture participation; do not infer safety from no_grad alone.
+Normal untracked leaves carry a separate semantic leaf value in the current AD
+implementation; the presence of that metadata alone is not a mutation ban.
+Saved physical values remain protected by structural ownership extraction.
+Use existing into_value structural extraction to reject shared handles or
+retained containers without implicit duplication. Obtain write access through
+the extracted tensor's exclusive borrow. Do not form overlapping input/output
+views for an out-of-place kernel. A rejected ownership acquisition must preserve
+a usable original value (boxed only on the error path); subsequent execution
+errors consume the acquired input without rollback. No r2c/c2r or resizing in-place in this contract.
+
+## Binary operand preparation
+
+Share borrowed/owned broadcast preparation between dynamic and typed runtime
+surfaces. Same-shape and identity source-shape operands remain borrowed; only
+actual reshape/broadcast results need owners. Keep validation, error categories,
+dtype promotion and backend dispatch intact, including compare/select/clamp.

--- a/docs/guides/tenferro-fft.md
+++ b/docs/guides/tenferro-fft.md
@@ -322,9 +322,10 @@ contracts need a separate design.
 ### Eager Tensors
 
 Use `EagerTensorFftExt` for immediate execution in an `EagerRuntime`. The
-methods have the same names and arguments as `TracedTensorFftExt`, register the
-FFT execution runtime on demand, and record the existing extension operation
-when gradients are enabled.
+borrowed `fft`, `ifft`, `rfft`, and `irfft` methods have the same names and
+arguments as `TracedTensorFftExt`, register the FFT execution runtime on demand,
+and record the existing extension operation when gradients are enabled.
+These methods do not modify their input.
 
 <!-- snippet-source: docs/tutorial-code/src/bin/math_snippets.rs#tenferro_fft_23 -->
 ```rust
@@ -343,6 +344,31 @@ assert_eq!(spectrum.shape(), &[3]);
 assert_eq!(restored.to_tensor()?.as_slice::<f64>()?, &[1.0, 2.0, 3.0, 4.0]);
 ```
 <!-- end-snippet-source -->
+
+### CPU output reuse and consuming FFT
+
+Ordinary CPU host FFT results use the backend's existing buffer pool. Dropping
+the final storage owner returns the allocation to its original pool, subject to
+that pool's retention limit. A live result, alias, or retained AD value prevents
+premature reuse. If the pool has already been destroyed, the allocation is freed
+normally. This avoids repeated payload allocation; small metadata allocations
+can still occur.
+
+With `autodiff`, `fft_in_place(axis, norm)` and `ifft_in_place(axis, norm)` consume
+an eager, compact column-major CPU host `C32` or `C64` tensor and transform its
+existing allocation. Noncontiguous views are rejected unchanged; use the
+borrowed FFT methods for those layouts.
+They preserve shape and do not accept a requested transform length. Real
+transforms, device/managed storage, active capture, and gradient-tracked inputs
+are not supported by this consuming contract. `no_grad` does not make a tracked
+input eligible. Exclusive ownership must be obtainable without an implicit
+copy; release other owners or explicitly create an independent copy if needed.
+
+`EagerFftInPlaceError::Rejected` returns the unchanged input in a `Box`, along
+with its error source. `Execution` reports failure after ownership acquisition;
+the input is consumed and no rollback is promised. Keep using the borrowed
+methods when the original value must remain available or gradients are needed.
+The `EagerTensorFftExt` rustdoc includes executable consuming-FFT examples.
 
 ### Apple shared CPU and Metal execution
 
@@ -380,7 +406,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 <!-- end-snippet-source -->
 
-RustFFT supports managed `F32`, `F64`, `C32`, and `C64` tensors. The initial
+RustFFT supports managed `F32`, `F64`, `C32`, and `C64` tensors. Its CPU lane
+kernel uses reusable host staging followed by a copy into the provider-owned
+shared allocation: the current managed write API exposes a copy callback, not
+a writable span. Preserving shared residency does not imply zero CPU copies.
+The consuming host in-place API does not extend this managed-storage contract.
+
+The initial
 CubeK Metal implementation supports C32 CFFT/IFFT, F32 one-sided RFFT, and C32
 IRFFT for power-of-two transform lengths of at least 2. RFFT/IRFFT may pad or
 truncate to a supported requested length; CFFT cannot change the input-axis

--- a/docs/worklogs/1765-1766-cpu-performance.md
+++ b/docs/worklogs/1765-1766-cpu-performance.md
@@ -122,3 +122,18 @@ Detailed local evidence is retained outside the PR under
 `committed-gate-rebuilt.log`, and the archived `investigation-history.md`.
 The checked-in regression tests are the reproducible correctness/allocation
 artifacts; temporary diagnostic probes are not part of the shipped API or PR.
+
+## PR CI corrections
+
+CI exposed an invalid test assumption: on a four-CPU Linux runner, an eight-thread
+request correctly resolves to four. Reproduced with a four-CPU affinity mask;
+changed only thread-budget assertions, preserving all numerical checks. All six
+cpu_reuse tests then passed. Subsequent hosted coverage completed tests but
+reported two enforced file thresholds: AD extension 53.2% < 56%, FFT backend
+68.9% < 80%. Added direct tests for consuming preparation and default FFT
+owned/view dispatch using existing backend operations; moved the growing FFT
+unit tests into their module-local file. FFT backend reaches 100% in focused
+unit coverage. No production behavior or coverage thresholds changed.
+A broad local AD run encountered an existing trybuild underline-format mismatch
+for the private EagerBackend import diagnostic; its expected snapshot was not
+modified. Focused new tests pass; hosted CI remains the final coverage gate.

--- a/docs/worklogs/1765-1766-cpu-performance.md
+++ b/docs/worklogs/1765-1766-cpu-performance.md
@@ -1,0 +1,491 @@
+# CPU binary and FFT performance batch (#1765, #1766)
+
+## Scope and decisions
+
+Baseline: `a096f280ab0dd774f92f533aa0f38b663a4c94d3`.
+One implementation PR, with coherent commits and non-squash merge.
+The maintainer approved binary copy avoidance, FFT pooled output and lane
+parallelism, ordinary eager-drop recycling, and consuming eager CPU c2c
+in-place execution. The maintainer subsequently approved changes to host
+storage reclamation and CPU pool synchronization when source inspection showed
+that normal drop cannot currently return host storage to the pool.
+The maintainer also explicitly approved retaining the managed/Apple shared
+output copy boundary in this PR, while applying lane parallelism and staging
+reuse. Direct managed writes, their synchronization contract, and Apple hardware
+validation belong to a separate improvement.
+
+Classification: #1766 is an existing-contract fix; #1765 lane parallelism and
+output reuse are accepted performance work; consuming eager in-place and host
+reclamation are explicitly approved contract changes. None is completed yet.
+
+## Source evidence and implementation direction
+
+- Runtime `tensor.rs` duplicates both same-shape inputs; `typed_tensor.rs`
+  already has borrowed/owned input preparation. Share that implementation.
+- FFT `cpu.rs` builds a fresh output Vec and visits lanes sequentially.
+  Write the final pooled destination directly, retain full-overwrite safety,
+  and execute lane jobs under the session's existing CPU context.
+- `HostAllocation` owns storage but no recycler. `CpuEngine.resources` holds
+  the pool under the execution-resource lock. A destructor must not reacquire
+  that lock. Separate short-lived pool-state synchronization from execution
+  admission; keep the existing bounded pool, not a second cache or queue.
+- A host root may carry a weak typed recycler. Final destruction returns the
+  allocation only if its original pool still exists. Explicit extraction must
+  disarm recycling, preventing duplicate return. Retention remains owned by
+  AllocationGroup, so AD/capture/aliases keep the allocation alive normally.
+  Exact integration and error handling are still under investigation.
+- Existing `EagerTensor::into_value` checks record/container ownership and
+  extracts through AllocationGroup. Reuse it for consuming in-place c2c;
+  additionally reject grad/capture participation. Do not infer write authority
+  from root-reference counts. Preserve errors rather than silently copying.
+
+## Verification protocol (declared before candidate measurements)
+
+Use release, default cpu-faer, explicit backend thread counts, value-dependent
+black_box inputs/outputs, and record effective thread counts and CPU affinity.
+Baseline and candidate run as paired complete suites, five repetitions after
+warmup; report medians and all samples plus bootstrap 95% intervals. No selective
+case retries. Record hardware, load and affinity before/after. A repetition
+spread exceeding 20% of the median or changed CPU affinity makes the complete
+paired timing experiment inconclusive; rerun the full pair, not selected cases.
+
+Cases: binary public versus raw session mul at C64 lengths 8, 32768 and 128^3
+with 1T; FFT C64 three-axis transforms at 8^3, 32^3, 128^3 with 1T and 8T, with
+per-axis timings. Separate normal eager result drop, explicit reclamation and
+consuming in-place. Separate cold allocation from warmed reuse; allocation
+counts/bytes and pointer reuse are checked outside timed runs, including outputs
+kept alive. Include F32/F64 and C32/C64 correctness, norms, padding/truncation,
+strided-axis traversal, AD/capture/alias and failure cases in focused tests.
+
+Primary gates: eliminate the two input-sized copies for same-shape binary ops;
+large 1T public mul within 10% of raw session mul; warm 128^3 8T FFT at least
+1.5x faster than baseline 8T and at least 1.5x faster than candidate 1T.
+Non-regression gate: no median slowdown over 10% for larger ordinary cases;
+small cases allow 2 microseconds absolute overhead. Normal drop must demonstrate
+actual original-pool reuse, not just successful pool allocation. In-place must
+preserve the input allocation. Timings do not substitute for correctness.
+
+Run focused tests and the required local check-pr-fast gate, deterministic
+repository-rules review, changed-file coverage review, documentation checks and
+release evidence before PR creation; hosted CI and approvals gate merging.
+
+## Progress
+
+Read workspace and repository rules, shared common/Rust rules, contribution
+workflows, and the relevant runtime/FFT/eager/storage/pool entry points.
+Implemented (not yet PR-ready): shared binary borrowed preparation; weak
+host-root recycling and a short independently synchronized existing pool;
+recycled uninitialized output handoff; host FFT pooled direct output and scoped
+Rayon lanes with per-job scratch. Managed FFT now shares the same kernel and
+recycles its staging allocation, but retains its copy-only provider boundary.
+A direct mapping attempt failed the managed regression test: HostWriteGuard
+exposes only copy_from_slice, and the provider root has no writable mapping.
+Its allocation contract also allows uninitialized values, so exposing it as
+initialized &mut[T] is not a valid shortcut. The design now records the approved
+scope: retain this managed copy boundary.
+
+Consuming eager fft_in_place/ifft_in_place and compact borrowed FFT inputs are
+implemented. In-place uses the normal targeted extension registration/ingress
+validation, rejects active recording, structurally extracts the original owner,
+and returns unchanged rejected inputs (boxed on the error path). Execution
+errors after ownership acquisition consume the input. Four existing autodiff
+parity tests used the removed Tensor::clone API; they now explicitly duplicate
+their independent reference inputs.
+
+Fresh focused evidence after these changes: FFT integration targets passed
+40 tests (2 CPU reuse, 1 eager allocation, 3 consuming in-place, 34 existing FFT
+checks), and FFT autodiff all-target clippy passed with -D warnings. The eager
+allocation test verifies zero input/output-sized allocations after warmup for
+normal drop/reuse and consuming FFT. Internal CPU kernels passed 59 unit tests
+and 25 doctests; tensor storage passed 43 focused tests. FFT doctests previously
+passed 25 tests and need their affected final-state rerun. Complete paired
+timing, remaining safety/coverage checks, documentation,
+local PR gates and merge remain unfinished.
+
+Passed focused checks:
+- runtime `binary_allocations`: 1 test; restoring the two input duplicates
+  intentionally failed this test (exit 101), and restoring the fix passed again.
+- runtime integration `session_ops`: 24 tests.
+- internal CPU kernels `buffer_pool`: passed.
+- internal CPU kernels `pooled_uninit_output`: 6 tests, including final group
+  ownership, drop during another checkout, explicit extraction, owner-first
+  drop, limit changes and clear.
+- FFT library: 18 tests.
+- FFT integration `cpu_reuse`: 2 tests, proving same-session drop/reuse without
+  reusing live results and exact 1T/8T agreement across every axis, all norms,
+  padding and truncation.
+These are partial checks, not the full local gate or completion evidence.
+
+Baseline probe is `/tmp/tenferro-1765-1766-probe`, with preserved baseline binary
+`/tmp/tenferro-1765-1766-baseline` and raw log
+`/tmp/tenferro-1765-1766-baseline.log`. Host: Linux primerose, EPYC 7713P,
+affinity 0-63, effective configured threads asserted as 1 and 8. Baseline only:
+large C64 mul public ~62 ms versus raw ~22 ms at 1T. Small-case spread exceeds
+the declared 20% validity gate, so these samples are diagnostic, not an accepted
+paired performance result. The final complete pair remains required. The first
+release build timed out; inspected the owned descendants, waited for its
+compiler to terminate, then completed the build with RUSTC_WRAPPER unset and
+-j4. No unrelated processes were terminated. External issue benchmarks remain
+reported evidence, not reproduced ratios or copied implementations.
+
+Candidate diagnostic probe completed in release mode. Its lockfile change only
+adds the already-resolved rayon dependency to tenferro-fft. Large 1T public/raw
+mul medians were 21.30/20.94 ms; 128^3 three-axis FFT medians were 42.75 ms (1T)
+and 9.41 ms (8T). These are NOT accepted speedups: the full diagnostic experiment
+is INCONCLUSIVE, with several spreads above 20% and small 8T FFT overhead
+requiring further examination. Raw candidate samples are preserved in
+/tmp/tenferro-1765-1766-candidate-diagnostic.log.
+
+Before the next complete experiment, amend the inadequate single-call warmup
+and five-call measurement windows: every case now warms for at least 100 ms
+and measures whole batches for at least 50 ms. Rebuild BOTH baseline and
+candidate from this identical probe source; do not compare the new timings
+against old diagnostic samples. Keep all cases, five repetitions, confidence
+intervals, primary/non-regression thresholds and the 20% spread validity gate
+unchanged. Pin both processes to CPUs 0-7, separately asserting backend 1T/8T;
+record environment and source identity alongside the complete pair. This is
+measurement stabilization, not a relaxation of the acceptance criteria.
+
+The complete stabilized baseline/candidate pair ran on CPUs 0-7, with identical
+probe SHA256 54a3b2265bc8da4ceebb9835a921938c2ab26352de43874120b52759de26323f.
+Baseline source is the detached original commit in /tmp/tenferro-1765-1766-baseline-src;
+candidate is the current uncommitted implementation. Raw samples, environment,
+and all case medians/spreads/bootstrap intervals are retained at
+/tmp/tenferro-1765-1766-{baseline-stable.log,candidate-stable.log,stable-environment.log,stable-summary.json}.
+Status remains INCONCLUSIVE: 32^3 axis-2 candidate spreads are 36.6% at 1T and
+30.0% at 8T, violating the unchanged 20% full-experiment validity gate. Do not
+promote favorable large-case ratios as accepted improvements. Also investigate
+observed 1T 32^3 axes 0/1 median regressions (15.6%/12.8%) and 8^3 three-axis
+1T overhead (2.096 us), which exceed the stated non-regression allowances.
+Final-state FFT library tests passed 20 cases and FFT doctests passed 25 cases.
+No PR or merge has been performed.
+
+A second COMPLETE pair used unchanged binaries, probe, affinity and thresholds;
+/tmp/tenferro-1765-1766-pair2-{baseline.log,candidate.log,environment.log,summary.json}
+retain all samples and bootstrap intervals. This pair is also INCONCLUSIVE:
+32^3 axis-2 spreads exceed 20% again. The 1T 32^3 axis-1 median regression also
+recurs (95.059 -> 106.412 us, +11.9%). Small three-axis overhead is now within
+its allowance (10.934 -> 12.519 us). Do not repeatedly rerun unchanged timing
+in search of a pass. Inspect strided gather/scatter locality and pool-reused
+buffer alignment as hypotheses; neither cache conflict nor host noise is yet
+established as the cause. The next change must address a demonstrated kernel
+cost and rerun correctness plus the complete performance pair.
+
+Kernel follow-up: perf hardware counters are unavailable (perf_event_paranoid=4);
+no shared system settings were changed. Comparing original source identified
+identity normalization that the rewrite unnecessarily multiplied into every
+scatter element. Restored the original scale!=1 guard and contiguous scratch
+scaling. Full pair3 remained INCONCLUSIVE with the axis-1 regression unresolved.
+Then removed per-lane runtime division/remainder by advancing lane bases within
+validated blocks (division only at job entry). Full pair4 has no observed median
+non-regression failures: 1T 32^3 axes 0/1 are 81.620->79.376 and 96.185->90.093 us.
+However the WHOLE pair remains INCONCLUSIVE because 1T 32^3 axis-2 spread is
+26.6%; do not declare the performance gate passed. All pair3/pair4 samples,
+bootstrap intervals and environment are /tmp/tenferro-1765-1766-pair{3,4}-*;
+the reusable analysis script is /tmp/tenferro-1765-1766-analyze.py.
+
+Added an empty-job guard before initial lane-base computation and a numerical
+9-lane/8-job test for partial and empty jobs. Latest FFT integration checks pass
+41 tests and autodiff all-target clippy passes with -D warnings. Pair4 predates
+this final empty-job guard, so final-state performance evidence remains due.
+
+Public error-documentation audit found two insufficient # Errors descriptions
+(execute_fft_read and assume_init_recycled); both now name the actual typed
+failure categories. The focused audit over eight affected API/owner files
+passes, and the FFT library passes 20 tests on the latest lane implementation.
+Added a downstream backward regression: an untracked pooled FFT coefficient is
+used by a tracked multiplication, then consumed by in-place FFT (or returned
+unchanged if retained), and dropped before backward. The gradient still equals
+the original coefficient. This focused saved-value test passes; it does not
+substitute for the other required gates.
+
+Added and passed focused nested FFT admission/recovery and partial-write failure
+tests. Existing CPU policy rejects a nested execution scope (rather than
+silently starting another pool); FFT preserves the existing panic boundary and
+the backend remains usable afterwards. A partially initialized pooled output
+is discarded on both ordinary error return and unwind, and its replacement
+accounting is cancelled before the pool is reused.
+
+Ran the shared CI clippy profile for the root workspace plus standalone tropical,
+sparse and TBLIS manifests. It first found an autodiff-only MaybeUninit import
+that was unconditional; feature-gated that import. The complete clippy profile
+then passed. This is broader lint evidence, not completion of check-pr-fast,
+coverage review, final performance, or hosted CI.
+
+Full formatting profile passed. Worktree deterministic rules review identified
+missing method examples for execute_fft_read and HostBufferRecycler::recycle.
+Added executable examples; both focused doctests pass (the borrowed method is
+fft_read, corrected after the initial example compile check). The deterministic
+worktree review was rerun after correction. A committed-head review is still
+required before PR creation; no independent LLM review was requested or run.
+
+Expanded the isolated eager allocation regression to cold execution, a second
+output while the first remains live, ordinary drop reuse, explicit reclaim and
+consuming in-place. All checks pass with effective backend threads=1 and C64
+shape 64x64 (65536-byte payload). The allocator also reports all allocation/
+reallocation requests, not only payload-sized ones; these are debug-build
+requested-byte totals, not retained bytes or release timing:
+
+| Path | Payload-sized count / bytes | Total count / requested bytes |
+|---|---:|---:|
+| Cold eager FFT | 1 / 65536 | 83 / 102805 |
+| Eager FFT with previous result live | 1 / 65536 | 38 / 79701 |
+| Ordinary drop reuse | 0 / 0 | 38 / 14357 |
+| Second ordinary drop reuse | 0 / 0 | 38 / 14357 |
+| Explicit extraction and reclaim | 0 / 0 | 0 / 0 |
+| FFT after explicit reclaim | 0 / 0 | 38 / 14357 |
+| Consuming in-place FFT | 0 / 0 | 21 / 6473 |
+
+The test checks distinct live output pointers and preserves the pointer across
+ordinary return, explicit return, and consuming mutation. Metadata allocations
+remain: this is not a claim of zero total allocations. Raw output is
+/tmp/tenferro-1765-1766-allocation-paths.log.
+
+The complete FFT package with autodiff passes. Ran focused package coverage with
+cargo llvm-cov --lib --tests: report /tmp/tenferro-1765-1766-fft-coverage.json.
+Initial line coverage includes lanes.rs 79.29%, eager_in_place.rs 81.08%, cpu.rs
+78.49%, and lib.rs 88.16%; these are NOT a passed 90% per-file coverage gate.
+Added private kernel boundary tests for mismatched input/output spans, checked
+shape overflow and zero lanes, plus a retained-reshape-source mutation test.
+Both focused tests and the rerun instrumented package pass. The numerical and
+buffer-error paths execute, but exported line summaries remain below target;
+coverage interpretation and remaining reachable ownership-failure branches
+still require review rather than an unsupported coverage acknowledgement.
+
+Inspected llvm-cov's annotated text and re-exported the same merged profile:
+lanes.rs shows positive execution counts for every substantive branch, including
+error exits and empty jobs, while its exported line summary still reports
+79.29% (47/70 generic instantiations covered). The discrepancy is unresolved;
+no threshold, exclusion, or coverage checker was changed. Annotated output is
+/tmp/tenferro-1765-1766-coverage-text and refreshed JSON is
+/tmp/tenferro-1765-1766-fft-coverage-refreshed.json.
+Added meaningful coverage independent of that discrepancy: compact F32/F64
+borrowed reads, full and one-sided spectra, C32/C64 borrowed inverse reads,
+all axes and norms with asserted 1T/8T backends. Roundtrip maximum-error checks
+pass with tolerances 1e-4 (f32) and 1e-10 (f64); log is
+/tmp/tenferro-1765-1766-real-parallel-tests.log.
+
+Further inspection identified unexecuted monomorphizations, including the
+private boundary test's job closure (its original cases only returned early).
+Added a valid-span control case and reran the instrumented package including
+real-read tests. All tests pass; lib.rs coverage is now 90.97%, lanes.rs 81.43%,
+while cpu.rs remains 78.49% and eager_in_place.rs 81.08%. Remaining file-level
+coverage deficits are still open. This evidence does not establish a coverage
+tool bug and no such claim or exemption is used.
+
+Added an analytical impulse/DC reference test through the same generic kernel
+entry for real, complex, consuming in-place and Hermitian inverse inputs, with
+all three normalization conventions. Tests and instrumented package pass;
+lanes.rs now measures 131/140 lines (93.57%) without changing coverage tooling
+or thresholds. Other file deficits remain open.
+Also added managed-provider failure regressions for allocation failure, wrong
+dtype, foreign output domain and wrong output length. Each produces the typed
+error and the original input remains numerically usable on a valid domain-bound
+backend. Focused test passes; /tmp/tenferro-1765-1766-managed-errors.log records
+it. This retains the approved managed copy boundary.
+
+Separate alignment diagnostics (not the frozen comparison probe) show a strong
+within-run association at 1T 32^3 axis 2: the same input and output offset +16
+modulo 64 KiB produced 363/365 us; +32 produced 316/316 us; +48 produced 287 us.
+Raw addresses and all cases are /tmp/tenferro-1765-1766-alignment.log. This
+supports investigating memory locality, not labeling all variation host noise.
+Before the next candidate comparison, group at most four adjacent strided lanes
+in the existing per-job scratch, process their complete transforms together via
+RustFFT, then scatter. Never cross a stride block or job boundary; gather the
+whole group before any in-place writes. Contiguous lanes remain single. No
+allocator padding, extra pool, threshold relaxation, or selected-case retry.
+The full frozen baseline/candidate suite and correctness checks remain required.
+
+The grouped-lane candidate passes the full FFT/autodiff package. Complete pair5
+is INCONCLUSIVE: many spreads exceed 20%, larger raw mul regresses despite no
+change to that kernel, and 1T 32^3 axes 0/1 exceed 10%. All raw cases and CIs are
+/tmp/tenferro-1765-1766-pair5-*. No favorable subset is promoted.
+A subsequent /proc/stat sample found CPUs 1,3,6 at 100% busy without our probe;
+a second sample confirmed it. No other processes or shared settings were
+changed. Before another COMPLETE pair, move BOTH executables to CPUs 40-47
+(the sampled maximum utilization there was 0.7%). Keep the frozen probe,
+repetitions, primary/non-regression limits and spread gate unchanged. Record
+this affinity change as a new experiment; do not compare times across CPU sets.
+
+Complete pair6 on CPUs 40-47 still fails non-regression for 1T 32^3 axes 0/1
+and is INCONCLUSIVE due to an 8T 128^3 axis-0 spread above 20%. A bounded
+follow-up replaced tile chunk iterators with checked-by-construction slices;
+complete pair7 still fails those two serial cases (90.506->139.731 us and
+102.829->149.143 us), with an additional spread failure at 8T 128^3 axis 1.
+Both complete experiments, including unfavorable cases and CIs, remain in
+/tmp/tenferro-1765-1766-pair{6,7}-*. The four-lane experiment is REJECTED, not
+promoted: removed the tiling changes and restored the simpler incremental
+single-lane kernel. Its full FFT/autodiff package passes again; see
+/tmp/tenferro-1765-1766-restored-tests.log. Keep the analytical/boundary tests.
+Alignment dependence remains a supported diagnostic observation, not a proven
+microarchitectural cause or a solved performance gate.
+
+Complete pair8 measures the RESTORED single-lane candidate on CPUs 40-47, not
+the rejected tiled candidate. Larger serial 32^3 axes 0/1 again meet the
+non-regression bound. The complete experiment remains INCONCLUSIVE: 1T 32^3
+axis-2 spread is 20.1%, above the unchanged 20% threshold, and small 8T
+three-axis FFT overhead is 2.286 us, above the 2 us allowance. No rounding,
+case exclusion or mixing with tiled samples is used. All cases/CIs/environment
+are /tmp/tenferro-1765-1766-pair8-*. Final performance acceptance is still open.
+
+Ownership self-review traced production completion and both reclamation routes:
+PooledUninitOutput::finish -> host root attachment -> final HostAllocation::drop
+for automatic return, versus CpuBackend reclaim_typed -> into_host_vec (disarm)
+-> pool_release for explicit return. Pool bins contain scalar Vecs, not tensor
+owners, and the root holds only a Weak recycler, so the reviewed path has no
+ownership cycle or second destructor return after extraction. This is a scoped
+review, not the final whole-diff signoff. Added and passed a public integration
+test transferring explicit reclamation to a different backend: the origin pool
+stays empty, the destination reuses the exact pointer, and later drop returns
+only to the destination. Log: /tmp/tenferro-1765-1766-cross-pool.log.
+Runtime integration suite also passes 146 tests with four test workers; log:
+/tmp/tenferro-1765-1766-runtime-integration.log.
+
+Updated docs/guides/tenferro-fft.md to distinguish borrowed/non-destructive
+operations from consuming host-only FFT, document final-owner pool return and
+error ownership, and explicitly state that managed shared residency still uses
+a CPU staging copy. Shipped compute-skill mirrors contain no FFT mutation advice
+that conflicts with the addition, so no redundant mirror edits were made.
+Doc snippet synchronization and git diff --check pass. The guide dependency
+smoke build first hit an undersized 30-second deadline; no owned descendants
+remained. Reran with RUSTC_WRAPPER unset, four build jobs and a 600-second
+budget; the guide dependency smoke checks pass. Logs are
+/tmp/tenferro-1765-1766-{doc-snippets,guide-dependencies}.log.
+
+Added and passed CPU FFT capability tests for a valid saved spec paired with
+wrong-dtype and wrong-shape owned tensors, and a wrong-dtype compact borrowed
+view. Existing validation returns Error::Validation and leaves the fresh pool
+empty. No production validation branches or test-only production hooks were
+added. Log: /tmp/tenferro-1765-1766-spec-mismatch.log.
+
+Fresh focused coverage after managed/spec tests: cpu.rs 83.98%, lanes.rs 93.57%,
+lib.rs 90.97%, eager_in_place.rs 81.08%; not a full coverage-gate pass.
+A subsequent lazy-transpose regression exposed a real missing precondition:
+into_value structurally extracts ownership but preserves noncompact layouts.
+The consuming FFT previously accepted that view instead of rejecting it before
+the compact lane kernel. The test failed before the fix. Added actual input
+compactness validation before ownership extraction, documented the compact
+host contract, and verified unchanged returned values plus successful borrowed
+FFT on the rejected view. Full FFT/autodiff package and all-target FFT clippy
+pass after the correction. Logs: /tmp/tenferro-1765-1766-layout-fix-{tests,clippy}.log.
+This test covers layout rejection, not IntoValueError::Extract; the earlier
+assumption that noncompact extraction itself must fail was incorrect.
+
+The repository-local gate now passes on the layout-corrected worktree:
+`RUSTC_WRAPPER= CARGO_BUILD_JOBS=4 bash scripts/check-pr-fast.sh
+--coverage-reviewed --test 'cargo test -p tenferro-fft --features autodiff
+--test eager_in_place'`. The gate fetched origin/main (still a096f280), ran
+its formatting/docs checks, CI-parity clippy including standalone extensions,
+and all six consuming-FFT integration tests. `git diff --check` also passes.
+Full log: /tmp/tenferro-1765-1766-local-gate.log. The coverage acknowledgement
+means reviewed, not threshold compliance. Performance acceptance, remaining
+coverage, final integrated review and committed-head rules check, PR, hosted
+CI/approval and non-squash merge remain outstanding.
+
+After the layout correction, focused coverage is cpu.rs 84.44% and
+eager_in_place.rs 82.50% (layout-coverage.json/log under the same /tmp prefix).
+Investigated a concrete small-FFT overhead hypothesis: with_linalg_pool might
+re-enter the CPU executor on every transform. Source tracing shows an already
+entered managed session reuses its context and only sets the native policy.
+A standalone diagnostic, pinned to CPU 40 with backend and effective native
+thread counts both asserted to be 1, measured five 100ms-warmed/50ms batches:
+15.27–17.01ns per empty native scope versus 0.62–0.68ns for the empty control.
+This does not justify bypassing required CPU policy to address microsecond-scale
+FFT overhead. It is a 1T diagnostic, not an 8T or full performance-gate result.
+Source: /tmp/tenferro-1765-1766-probe/src/bin/scope.rs; build and results:
+/tmp/tenferro-1765-1766-scope-build.log and /tmp/tenferro-1765-1766-scope.log.
+No production policy changes or repeated full comparison were made.
+
+Follow-up ownership review found that compactness does not imply zero offset
+or a full-root extent. A compact eager slice reproduced Execution(buffer-length
+validation failure) because host_data_mut exposed the root rather than the
+logical descriptor. Replaced that borrow with the existing with_host_write
+prepared guard in in_place_typed, preserving descriptor offset and bounds;
+no new ownership API or copy was introduced. Regression tests cover prefix
+and offset slices, stable logical data pointer, exact FFT output, and unchanged
+root elements outside the selected slice. The pre-fix test fails; the full FFT
+package including allocation tests and focused bounds test pass afterward,
+as does all-target FFT clippy. Logs: /tmp/tenferro-1765-1766-slice-before.log,
+slice-after.log, slice-bounds.log and slice-clippy.log (same prefix for all).
+The earlier local gate predates this correction; final-state checks remain due.
+
+Release-mode verification after the descriptor-bounded borrow change passes:
+seven consuming-FFT tests plus the allocation regression (RUSTC_WRAPPER unset,
+four build jobs). Log: /tmp/tenferro-1765-1766-slice-release.log.
+Captured updated allocation totals from the optimized allocation executable:
+cold 83 calls/102805 bytes; second simultaneously live output 38/79701;
+ordinary-drop reuse 38/14357 on both measured repetitions; explicit reclamation
+0/0; post-reclamation FFT 38/14357; consuming FFT 22/6505. Only cold and second
+live outputs allocate a 65536-byte input-sized buffer; all reuse and consuming
+measurements allocate zero input-sized buffers. The prepared guard adds one
+small allocation (32 bytes) to the previously recorded consuming totals;
+this is not zero-total-allocation FFT. The fixture asserts effective backend
+1T and live-pointer separation/reuse. Log:
+/tmp/tenferro-1765-1766-slice-release-allocations.log.
+
+Scoped binary diff review: dynamic operands remain TensorRead::Tensor, so the
+existing default backend *_read hooks delegate to owned-tensor methods without
+introducing a new view requirement. The shared broadcast planner/error mapper
+is unchanged; reshapes/broadcasts still retain their owned temporaries through
+execution. Existing session_ops tests cover full dtype-error payloads,
+binary/ternary broadcasting and values, typed results and single-session entry;
+the earlier successful run remains applicable (no production binary changes).
+
+Filled an evidence gap in binary_allocations: retain the original large-buffer
+regression criterion, but also count/report total allocation calls and requested
+bytes with logging outside the measured interval. The updated 1T test passes.
+For 4096 F64 elements, raw mul is 11 calls/32944 bytes, public mul 12/32952;
+both allocate one payload-sized buffer (the output). Add/sub match those totals;
+public div/rem/pow/min/max are 10/32936 versus raw 11/32944. Compare is public
+10/4264 versus raw 9/4256 with no F64-payload-sized allocations. Clamp/select
+are each 14/33000 on both paths. These are requested allocation bytes, not live
+or retained memory, and do not claim zero metadata allocation. Log:
+/tmp/tenferro-1765-1766-binary-allocation-totals.log.
+
+Created the first coherent local commit, b7b53232615a63767e6a35924978a26b32ef254d
+(perf(runtime): borrow binary operands through shared read preparation), containing
+only the runtime manifest, two runtime implementation files and allocation test.
+It was reviewed against the existing typed path and default backend read hooks.
+Tests cited above ran in the integrated worktree, not a clean binary-only checkout.
+FFT/recycler/docs changes remain uncommitted. Nothing has been pushed, no PR has
+been opened, and this commit is not a claim that performance acceptance is complete.
+
+Verified b7b53232615a63767e6a35924978a26b32ef254d independently in the clean detached
+worktree /tmp/tenferro-1765-1766-binary-verify, without any uncommitted FFT or
+recycler changes. The allocation regression and all 24 session_ops integration
+tests pass; reported allocation counts/bytes match the integrated worktree.
+The untracked Cargo.lock was newly resolved (notably zerocopy 0.8.57 rather
+than the integrated lock's 0.8.56); retained it in that worktree. This is an
+independent correctness/allocation check, not a controlled performance pair.
+Logs: /tmp/tenferro-1765-1766-binary-isolated.log and
+/tmp/tenferro-1765-1766-binary-isolated-session.log. Git status is clean.
+
+Committed the reviewed storage/pool slice as
+a2fc6e9493738eb5b69d29ad64bb2d8af902f19f (feat(cpu): recycle initialized host
+outputs on final owner drop). Reused the clean detached verification worktree
+at /tmp/tenferro-1765-1766-binary-verify, advancing it from b7b5323 to a2fc6e9.
+Without uncommitted FFT integration, internal-cpu-kernels passes 60 unit tests
+and 25 doctests; the tensor `storage::` filter passes 36 tests (other integration
+tests are filtered, not claimed as run). Logs:
+/tmp/tenferro-1765-1766-recycler-isolated.log and
+/tmp/tenferro-1765-1766-storage-isolated.log. Both commits remain local;
+FFT integration and docs remain uncommitted, with performance/coverage and
+final submitted-state validation still outstanding.
+
+Committed FFT integration as 0edb0d93f9e0197a7c2e272175bff3658944cde3. Review
+covered recording/ingress checks before extraction, preserved structural error
+ownership, descriptor-bounded mutation, disjoint lane writes and joining before
+borrow release, and policy-derived thread counts. Added runnable doctests for
+the new hidden public preparation/thread-count helpers; both pass (logs:
+/tmp/tenferro-1765-1766-preparation-doctest.log and thread-count-doctest.log,
+with the same prefix). Also documented propagation of factory/install errors.
+Latest focused coverage after slice handling remains insufficient: cpu.rs
+84.32%, eager_in_place.rs 82.50%, backend.rs 68.85%, eager_ext.rs 85.00%; lanes
+93.57% and lib 90.97%. Evidence: /tmp/tenferro-1765-1766-slice-coverage.json/log.
+
+The deterministic committed-head repository-rules review passes for 0edb0d9,
+with the expected external-LLM-skipped warning (per repository policy).
+Logs: /tmp/tenferro-1765-1766-committed-rules.{log,json}. This does not resolve
+performance/coverage or validate a future head containing the pending docs.
+All three code commits remain local; guide/design/worklog changes are not yet
+committed, and no PR/push/merge has occurred.

--- a/docs/worklogs/1765-1766-cpu-performance.md
+++ b/docs/worklogs/1765-1766-cpu-performance.md
@@ -1,491 +1,124 @@
-# CPU binary and FFT performance batch (#1765, #1766)
+# CPU binary copies and FFT output reuse (#1765, #1766)
 
 ## Scope and decisions
 
-Baseline: `a096f280ab0dd774f92f533aa0f38b663a4c94d3`.
-One implementation PR, with coherent commits and non-squash merge.
-The maintainer approved binary copy avoidance, FFT pooled output and lane
-parallelism, ordinary eager-drop recycling, and consuming eager CPU c2c
-in-place execution. The maintainer subsequently approved changes to host
-storage reclamation and CPU pool synchronization when source inspection showed
-that normal drop cannot currently return host storage to the pool.
-The maintainer also explicitly approved retaining the managed/Apple shared
-output copy boundary in this PR, while applying lane parallelism and staging
-reuse. Direct managed writes, their synchronization contract, and Apple hardware
-validation belong to a separate improvement.
+Base: `a096f280ab0dd774f92f533aa0f38b663a4c94d3`; branch:
+`perf/1765-1766-fft-binary`. Work was isolated from the user's original checkout.
 
-Classification: #1766 is an existing-contract fix; #1765 lane parallelism and
-output reuse are accepted performance work; consuming eager in-place and host
-reclamation are explicitly approved contract changes. None is completed yet.
+The maintainer requested one PR containing the necessary approved changes, not
+an open-ended small-transform optimization project. This PR retains:
 
-## Source evidence and implementation direction
+| Item | Classification | Resolution |
+| --- | --- | --- |
+| #1766 unnecessary operand copies | Auto Fix | Reuse typed borrowed/owned broadcast preparation for dynamic binary and ternary wrappers. |
+| #1765 sequential CPU FFT lanes | Approved implementation | Disjoint lane jobs use the backend CPU context and its effective thread policy. |
+| Final FFT output reuse | Approved ownership change | Existing pool, weak final-root recycler, separate short pool-state mutex. |
+| Consuming eager c2c FFT | Approved API addition | Host C32/C64, shape-preserving, explicit ownership/error contract. |
+| Managed output writes | Approved scope boundary | Keep pooled host staging and the provider's copy callback. |
+| Small-transform/locality tuning | Out of scope | No tiling or experimental move-capture optimization included. |
 
-- Runtime `tensor.rs` duplicates both same-shape inputs; `typed_tensor.rs`
-  already has borrowed/owned input preparation. Share that implementation.
-- FFT `cpu.rs` builds a fresh output Vec and visits lanes sequentially.
-  Write the final pooled destination directly, retain full-overwrite safety,
-  and execute lane jobs under the session's existing CPU context.
-- `HostAllocation` owns storage but no recycler. `CpuEngine.resources` holds
-  the pool under the execution-resource lock. A destructor must not reacquire
-  that lock. Separate short-lived pool-state synchronization from execution
-  admission; keep the existing bounded pool, not a second cache or queue.
-- A host root may carry a weak typed recycler. Final destruction returns the
-  allocation only if its original pool still exists. Explicit extraction must
-  disarm recycling, preventing duplicate return. Retention remains owned by
-  AllocationGroup, so AD/capture/aliases keep the allocation alive normally.
-  Exact integration and error handling are still under investigation.
-- Existing `EagerTensor::into_value` checks record/container ownership and
-  extracts through AllocationGroup. Reuse it for consuming in-place c2c;
-  additionally reject grad/capture participation. Do not infer write authority
-  from root-reference counts. Preserve errors rather than silently copying.
+See [the design contract](../design/cpu-fft-output-reuse.md) and
+[the user guide](../guides/tenferro-fft.md). RustFFT is unchanged. There is no
+new pool, global cache, provider synchronization API, or implicit device transfer.
 
-## Verification protocol (declared before candidate measurements)
+## Contracts reviewed
 
-Use release, default cpu-faer, explicit backend thread counts, value-dependent
-black_box inputs/outputs, and record effective thread counts and CPU affinity.
-Baseline and candidate run as paired complete suites, five repetitions after
-warmup; report medians and all samples plus bootstrap 95% intervals. No selective
-case retries. Record hardware, load and affinity before/after. A repetition
-spread exceeding 20% of the median or changed CPU affinity makes the complete
-paired timing experiment inconclusive; rerun the full pair, not selected cases.
+Read the workspace/shared rules, AGENTS.md, REPOSITORY_RULES.md,
+PERFORMANCE_TIPS.md, contribution/remediation workflows and storage ownership
+contracts. Reference code was the existing typed broadcast helper, BufferPool,
+PooledUninitOutput, HostAllocation, eager structural extraction and CPU context.
+Issue reproducers supplied the performance use cases; no external algorithm
+implementation was imported.
 
-Cases: binary public versus raw session mul at C64 lengths 8, 32768 and 128^3
-with 1T; FFT C64 three-axis transforms at 8^3, 32^3, 128^3 with 1T and 8T, with
-per-axis timings. Separate normal eager result drop, explicit reclamation and
-consuming in-place. Separate cold allocation from warmed reuse; allocation
-counts/bytes and pointer reuse are checked outside timed runs, including outputs
-kept alive. Include F32/F64 and C32/C64 correctness, norms, padding/truncation,
-strided-axis traversal, AD/capture/alias and failure cases in focused tests.
+- Default backend read hooks still receive owned-tensor reads from dynamic
+  wrappers; broadcasting temporaries remain alive through execution.
+- A weak recycler neither retains the backend nor forms an ownership cycle.
+  Final-root drop, not eager handle count, controls return. Explicit Vec
+  extraction disarms return; recycled publication cancels replacement accounting.
+- Incomplete output is never published. Parallel jobs own disjoint indices and
+  join before releasing their output borrow; scratch is per job, not per lane.
+- Recording/capture checks precede consuming ownership acquisition. Actual saved
+  values and aliases remain protected by structural ownership.
+- Regression tests exposed two necessary safety/correctness preconditions:
+  extraction preserves layout, so noncompact inputs must be rejected unchanged;
+  compact slices require the existing descriptor-bounded write guard rather
+  than a whole-root slice. Offset, pointer identity and untouched surrounding
+  elements are tested.
+- Managed allocation permits uninitialized storage and its legacy write guard
+  is copy-only. Direct managed writes and Apple hardware validation were
+  explicitly deferred, not advertised as implemented.
+- Shipped compute-skill mirrors were reviewed; none had conflicting FFT guidance.
 
-Primary gates: eliminate the two input-sized copies for same-shape binary ops;
-large 1T public mul within 10% of raw session mul; warm 128^3 8T FFT at least
-1.5x faster than baseline 8T and at least 1.5x faster than candidate 1T.
-Non-regression gate: no median slowdown over 10% for larger ordinary cases;
-small cases allow 2 microseconds absolute overhead. Normal drop must demonstrate
-actual original-pool reuse, not just successful pool allocation. In-place must
-preserve the input allocation. Timings do not substitute for correctness.
+## Verification evidence
 
-Run focused tests and the required local check-pr-fast gate, deterministic
-repository-rules review, changed-file coverage review, documentation checks and
-release evidence before PR creation; hosted CI and approvals gate merging.
+Focused checks passed in the integrated worktree:
 
-## Progress
+- Full `tenferro-fft` tests and doctests with `autodiff`: C32/C64 and real
+  transforms, axes/norms, padding/truncation, 1T/8T, retained outputs, ordinary
+  drop, explicit/cross-backend reclaim, backend-first drop, AD saved values,
+  alias/capture rejection, nested execution and managed failure paths.
+- Release-mode consuming FFT: seven tests plus the allocation regression.
+- Runtime integration: 146 tests. The binary commit independently passed its
+  allocation test and all 24 session_ops tests without the FFT changes.
+- Recycler commit independently passed 60 kernel tests, 25 doctests and 36
+  storage-filtered tests.
+- Standard local gate: formatting, snippet synchronization, CI-parity clippy
+  (workspace and standalone extensions), FFT and binary focused checks.
+- Runnable examples for the new APIs/helpers and guide dependency smoke checks.
+- Deterministic committed-head rules check; external LLM review skipped as
+  prescribed by repository policy. No independent AI review is claimed.
 
-Read workspace and repository rules, shared common/Rust rules, contribution
-workflows, and the relevant runtime/FFT/eager/storage/pool entry points.
-Implemented (not yet PR-ready): shared binary borrowed preparation; weak
-host-root recycling and a short independently synchronized existing pool;
-recycled uninitialized output handoff; host FFT pooled direct output and scoped
-Rayon lanes with per-job scratch. Managed FFT now shares the same kernel and
-recycles its staging allocation, but retains its copy-only provider boundary.
-A direct mapping attempt failed the managed regression test: HostWriteGuard
-exposes only copy_from_slice, and the provider root has no writable mapping.
-Its allocation contract also allows uninitialized values, so exposing it as
-initialized &mut[T] is not a valid shortcut. The design now records the approved
-scope: retain this managed copy boundary.
+A shared build target caused a suspected stale-artifact failure during an
+independent-checkout verification. Rebuilding the three affected local packages
+resolved it without code changes. Separate targets are used for performance
+baseline/candidate builds. Required hosted CI and human review remain in force.
 
-Consuming eager fft_in_place/ifft_in_place and compact borrowed FFT inputs are
-implemented. In-place uses the normal targeted extension registration/ingress
-validation, rejects active recording, structurally extracts the original owner,
-and returns unchanged rejected inputs (boxed on the error path). Execution
-errors after ownership acquisition consume the input. Four existing autodiff
-parity tests used the removed Tensor::clone API; they now explicitly duplicate
-their independent reference inputs.
+### Allocation observations
 
-Fresh focused evidence after these changes: FFT integration targets passed
-40 tests (2 CPU reuse, 1 eager allocation, 3 consuming in-place, 34 existing FFT
-checks), and FFT autodiff all-target clippy passed with -D warnings. The eager
-allocation test verifies zero input/output-sized allocations after warmup for
-normal drop/reuse and consuming FFT. Internal CPU kernels passed 59 unit tests
-and 25 doctests; tensor storage passed 43 focused tests. FFT doctests previously
-passed 25 tests and need their affected final-state rerun. Complete paired
-timing, remaining safety/coverage checks, documentation,
-local PR gates and merge remain unfinished.
+Explicit CPU backend 1T, requested allocation bytes (not retained memory):
 
-Passed focused checks:
-- runtime `binary_allocations`: 1 test; restoring the two input duplicates
-  intentionally failed this test (exit 101), and restoring the fix passed again.
-- runtime integration `session_ops`: 24 tests.
-- internal CPU kernels `buffer_pool`: passed.
-- internal CPU kernels `pooled_uninit_output`: 6 tests, including final group
-  ownership, drop during another checkout, explicit extraction, owner-first
-  drop, limit changes and clear.
-- FFT library: 18 tests.
-- FFT integration `cpu_reuse`: 2 tests, proving same-session drop/reuse without
-  reusing live results and exact 1T/8T agreement across every axis, all norms,
-  padding and truncation.
-These are partial checks, not the full local gate or completion evidence.
+| Path | Total calls / bytes | Payload-sized allocations |
+| --- | ---: | ---: |
+| F64 mul, 4096 elements: backend | 11 / 32944 | 1 |
+| F64 mul, 4096 elements: public | 12 / 32952 | 1 |
+| C64 FFT, 64x64: cold | 83 / 102805 | 1 |
+| Second simultaneously live FFT output | 38 / 79701 | 1 |
+| Ordinary-drop FFT reuse | 38 / 14357 | 0 |
+| Explicit reclamation | 0 / 0 | 0 |
+| FFT after explicit reclamation | 38 / 14357 | 0 |
+| Consuming FFT | 22 / 6505 | 0 |
 
-Baseline probe is `/tmp/tenferro-1765-1766-probe`, with preserved baseline binary
-`/tmp/tenferro-1765-1766-baseline` and raw log
-`/tmp/tenferro-1765-1766-baseline.log`. Host: Linux primerose, EPYC 7713P,
-affinity 0-63, effective configured threads asserted as 1 and 8. Baseline only:
-large C64 mul public ~62 ms versus raw ~22 ms at 1T. Small-case spread exceeds
-the declared 20% validity gate, so these samples are diagnostic, not an accepted
-paired performance result. The final complete pair remains required. The first
-release build timed out; inspected the owned descendants, waited for its
-compiler to terminate, then completed the build with RUSTC_WRAPPER unset and
--j4. No unrelated processes were terminated. External issue benchmarks remain
-reported evidence, not reproduced ratios or copied implementations.
+Thus payload copies/allocations are avoided where claimed; total allocation is
+not zero. Reintroducing binary copies failed the allocation regression. The
+layout/slice regressions failed before their fixes. Live-output separation and
+reused data pointers are asserted by checked-in tests.
 
-Candidate diagnostic probe completed in release mode. Its lockfile change only
-adds the already-resolved rayon dependency to tenferro-fft. Large 1T public/raw
-mul medians were 21.30/20.94 ms; 128^3 three-axis FFT medians were 42.75 ms (1T)
-and 9.41 ms (8T). These are NOT accepted speedups: the full diagnostic experiment
-is INCONCLUSIVE, with several spreads above 20% and small 8T FFT overhead
-requiring further examination. Raw candidate samples are preserved in
-/tmp/tenferro-1765-1766-candidate-diagnostic.log.
+## Performance uncertainty and exclusions
 
-Before the next complete experiment, amend the inadequate single-call warmup
-and five-call measurement windows: every case now warms for at least 100 ms
-and measures whole batches for at least 50 ms. Rebuild BOTH baseline and
-candidate from this identical probe source; do not compare the new timings
-against old diagnostic samples. Keep all cases, five repetitions, confidence
-intervals, primary/non-regression thresholds and the 20% spread validity gate
-unchanged. Pin both processes to CPUs 0-7, separately asserting backend 1T/8T;
-record environment and source identity alongside the complete pair. This is
-measurement stabilization, not a relaxation of the acceptance criteria.
+Release comparisons used an AMD EPYC 7713P, explicit 1T/8T backends, the same
+CPU affinity for baseline/candidate, five samples, 100ms warmup and 50ms batches.
+The investigation's broad validity/non-regression gate was **not passed**.
+For the retained implementation, pair8 was inconclusive: 32-cubed axis-2 spread
+exceeded 20%, and small 8T three-axis overhead exceeded the experimental 2us
+allowance. These observations are not proof of an implementation defect.
+Other processes' CPU contention was observed; allocation-position correlation
+was also observed. Environment and implementation effects were not fully
+separated. No overall speedup or universal non-regression claim is made.
 
-The complete stabilized baseline/candidate pair ran on CPUs 0-7, with identical
-probe SHA256 54a3b2265bc8da4ceebb9835a921938c2ab26352de43874120b52759de26323f.
-Baseline source is the detached original commit in /tmp/tenferro-1765-1766-baseline-src;
-candidate is the current uncommitted implementation. Raw samples, environment,
-and all case medians/spreads/bootstrap intervals are retained at
-/tmp/tenferro-1765-1766-{baseline-stable.log,candidate-stable.log,stable-environment.log,stable-summary.json}.
-Status remains INCONCLUSIVE: 32^3 axis-2 candidate spreads are 36.6% at 1T and
-30.0% at 8T, violating the unchanged 20% full-experiment validity gate. Do not
-promote favorable large-case ratios as accepted improvements. Also investigate
-observed 1T 32^3 axes 0/1 median regressions (15.6%/12.8%) and 8^3 three-axis
-1T overhead (2.096 us), which exceed the stated non-regression allowances.
-Final-state FFT library tests passed 20 cases and FFT doctests passed 25 cases.
-No PR or merge has been performed.
+Tiling trials were rejected. A later move-capture trial also had an inconclusive
+whole-suite result and was removed before this PR. No favorable trial subset
+is presented as acceptance evidence. The maintainer explicitly requested that
+additional small-size optimization stop and the necessary changes be submitted.
+This scope decision does not relabel failed/inconclusive measurements as passes.
 
-A second COMPLETE pair used unchanged binaries, probe, affinity and thresholds;
-/tmp/tenferro-1765-1766-pair2-{baseline.log,candidate.log,environment.log,summary.json}
-retain all samples and bootstrap intervals. This pair is also INCONCLUSIVE:
-32^3 axis-2 spreads exceed 20% again. The 1T 32^3 axis-1 median regression also
-recurs (95.059 -> 106.412 us, +11.9%). Small three-axis overhead is now within
-its allowance (10.934 -> 12.519 us). Do not repeatedly rerun unchanged timing
-in search of a pass. Inspect strided gather/scatter locality and pool-reused
-buffer alignment as hypotheses; neither cache conflict nor host noise is yet
-established as the cause. The next change must address a demonstrated kernel
-cost and rerun correctness plus the complete performance pair.
+Focused coverage is not a repository-wide coverage pass: CPU 84.32%, eager
+in-place 82.50%, backend 68.85%, eager extension 85%; lanes 93.57%, lib 90.97%.
+Thresholds/exclusions were not changed. Hosted CI owns the complete coverage,
+backend and docs matrix; GPU hardware tests were not run locally.
 
-Kernel follow-up: perf hardware counters are unavailable (perf_event_paranoid=4);
-no shared system settings were changed. Comparing original source identified
-identity normalization that the rewrite unnecessarily multiplied into every
-scatter element. Restored the original scale!=1 guard and contiguous scratch
-scaling. Full pair3 remained INCONCLUSIVE with the axis-1 regression unresolved.
-Then removed per-lane runtime division/remainder by advancing lane bases within
-validated blocks (division only at job entry). Full pair4 has no observed median
-non-regression failures: 1T 32^3 axes 0/1 are 81.620->79.376 and 96.185->90.093 us.
-However the WHOLE pair remains INCONCLUSIVE because 1T 32^3 axis-2 spread is
-26.6%; do not declare the performance gate passed. All pair3/pair4 samples,
-bootstrap intervals and environment are /tmp/tenferro-1765-1766-pair{3,4}-*;
-the reusable analysis script is /tmp/tenferro-1765-1766-analyze.py.
-
-Added an empty-job guard before initial lane-base computation and a numerical
-9-lane/8-job test for partial and empty jobs. Latest FFT integration checks pass
-41 tests and autodiff all-target clippy passes with -D warnings. Pair4 predates
-this final empty-job guard, so final-state performance evidence remains due.
-
-Public error-documentation audit found two insufficient # Errors descriptions
-(execute_fft_read and assume_init_recycled); both now name the actual typed
-failure categories. The focused audit over eight affected API/owner files
-passes, and the FFT library passes 20 tests on the latest lane implementation.
-Added a downstream backward regression: an untracked pooled FFT coefficient is
-used by a tracked multiplication, then consumed by in-place FFT (or returned
-unchanged if retained), and dropped before backward. The gradient still equals
-the original coefficient. This focused saved-value test passes; it does not
-substitute for the other required gates.
-
-Added and passed focused nested FFT admission/recovery and partial-write failure
-tests. Existing CPU policy rejects a nested execution scope (rather than
-silently starting another pool); FFT preserves the existing panic boundary and
-the backend remains usable afterwards. A partially initialized pooled output
-is discarded on both ordinary error return and unwind, and its replacement
-accounting is cancelled before the pool is reused.
-
-Ran the shared CI clippy profile for the root workspace plus standalone tropical,
-sparse and TBLIS manifests. It first found an autodiff-only MaybeUninit import
-that was unconditional; feature-gated that import. The complete clippy profile
-then passed. This is broader lint evidence, not completion of check-pr-fast,
-coverage review, final performance, or hosted CI.
-
-Full formatting profile passed. Worktree deterministic rules review identified
-missing method examples for execute_fft_read and HostBufferRecycler::recycle.
-Added executable examples; both focused doctests pass (the borrowed method is
-fft_read, corrected after the initial example compile check). The deterministic
-worktree review was rerun after correction. A committed-head review is still
-required before PR creation; no independent LLM review was requested or run.
-
-Expanded the isolated eager allocation regression to cold execution, a second
-output while the first remains live, ordinary drop reuse, explicit reclaim and
-consuming in-place. All checks pass with effective backend threads=1 and C64
-shape 64x64 (65536-byte payload). The allocator also reports all allocation/
-reallocation requests, not only payload-sized ones; these are debug-build
-requested-byte totals, not retained bytes or release timing:
-
-| Path | Payload-sized count / bytes | Total count / requested bytes |
-|---|---:|---:|
-| Cold eager FFT | 1 / 65536 | 83 / 102805 |
-| Eager FFT with previous result live | 1 / 65536 | 38 / 79701 |
-| Ordinary drop reuse | 0 / 0 | 38 / 14357 |
-| Second ordinary drop reuse | 0 / 0 | 38 / 14357 |
-| Explicit extraction and reclaim | 0 / 0 | 0 / 0 |
-| FFT after explicit reclaim | 0 / 0 | 38 / 14357 |
-| Consuming in-place FFT | 0 / 0 | 21 / 6473 |
-
-The test checks distinct live output pointers and preserves the pointer across
-ordinary return, explicit return, and consuming mutation. Metadata allocations
-remain: this is not a claim of zero total allocations. Raw output is
-/tmp/tenferro-1765-1766-allocation-paths.log.
-
-The complete FFT package with autodiff passes. Ran focused package coverage with
-cargo llvm-cov --lib --tests: report /tmp/tenferro-1765-1766-fft-coverage.json.
-Initial line coverage includes lanes.rs 79.29%, eager_in_place.rs 81.08%, cpu.rs
-78.49%, and lib.rs 88.16%; these are NOT a passed 90% per-file coverage gate.
-Added private kernel boundary tests for mismatched input/output spans, checked
-shape overflow and zero lanes, plus a retained-reshape-source mutation test.
-Both focused tests and the rerun instrumented package pass. The numerical and
-buffer-error paths execute, but exported line summaries remain below target;
-coverage interpretation and remaining reachable ownership-failure branches
-still require review rather than an unsupported coverage acknowledgement.
-
-Inspected llvm-cov's annotated text and re-exported the same merged profile:
-lanes.rs shows positive execution counts for every substantive branch, including
-error exits and empty jobs, while its exported line summary still reports
-79.29% (47/70 generic instantiations covered). The discrepancy is unresolved;
-no threshold, exclusion, or coverage checker was changed. Annotated output is
-/tmp/tenferro-1765-1766-coverage-text and refreshed JSON is
-/tmp/tenferro-1765-1766-fft-coverage-refreshed.json.
-Added meaningful coverage independent of that discrepancy: compact F32/F64
-borrowed reads, full and one-sided spectra, C32/C64 borrowed inverse reads,
-all axes and norms with asserted 1T/8T backends. Roundtrip maximum-error checks
-pass with tolerances 1e-4 (f32) and 1e-10 (f64); log is
-/tmp/tenferro-1765-1766-real-parallel-tests.log.
-
-Further inspection identified unexecuted monomorphizations, including the
-private boundary test's job closure (its original cases only returned early).
-Added a valid-span control case and reran the instrumented package including
-real-read tests. All tests pass; lib.rs coverage is now 90.97%, lanes.rs 81.43%,
-while cpu.rs remains 78.49% and eager_in_place.rs 81.08%. Remaining file-level
-coverage deficits are still open. This evidence does not establish a coverage
-tool bug and no such claim or exemption is used.
-
-Added an analytical impulse/DC reference test through the same generic kernel
-entry for real, complex, consuming in-place and Hermitian inverse inputs, with
-all three normalization conventions. Tests and instrumented package pass;
-lanes.rs now measures 131/140 lines (93.57%) without changing coverage tooling
-or thresholds. Other file deficits remain open.
-Also added managed-provider failure regressions for allocation failure, wrong
-dtype, foreign output domain and wrong output length. Each produces the typed
-error and the original input remains numerically usable on a valid domain-bound
-backend. Focused test passes; /tmp/tenferro-1765-1766-managed-errors.log records
-it. This retains the approved managed copy boundary.
-
-Separate alignment diagnostics (not the frozen comparison probe) show a strong
-within-run association at 1T 32^3 axis 2: the same input and output offset +16
-modulo 64 KiB produced 363/365 us; +32 produced 316/316 us; +48 produced 287 us.
-Raw addresses and all cases are /tmp/tenferro-1765-1766-alignment.log. This
-supports investigating memory locality, not labeling all variation host noise.
-Before the next candidate comparison, group at most four adjacent strided lanes
-in the existing per-job scratch, process their complete transforms together via
-RustFFT, then scatter. Never cross a stride block or job boundary; gather the
-whole group before any in-place writes. Contiguous lanes remain single. No
-allocator padding, extra pool, threshold relaxation, or selected-case retry.
-The full frozen baseline/candidate suite and correctness checks remain required.
-
-The grouped-lane candidate passes the full FFT/autodiff package. Complete pair5
-is INCONCLUSIVE: many spreads exceed 20%, larger raw mul regresses despite no
-change to that kernel, and 1T 32^3 axes 0/1 exceed 10%. All raw cases and CIs are
-/tmp/tenferro-1765-1766-pair5-*. No favorable subset is promoted.
-A subsequent /proc/stat sample found CPUs 1,3,6 at 100% busy without our probe;
-a second sample confirmed it. No other processes or shared settings were
-changed. Before another COMPLETE pair, move BOTH executables to CPUs 40-47
-(the sampled maximum utilization there was 0.7%). Keep the frozen probe,
-repetitions, primary/non-regression limits and spread gate unchanged. Record
-this affinity change as a new experiment; do not compare times across CPU sets.
-
-Complete pair6 on CPUs 40-47 still fails non-regression for 1T 32^3 axes 0/1
-and is INCONCLUSIVE due to an 8T 128^3 axis-0 spread above 20%. A bounded
-follow-up replaced tile chunk iterators with checked-by-construction slices;
-complete pair7 still fails those two serial cases (90.506->139.731 us and
-102.829->149.143 us), with an additional spread failure at 8T 128^3 axis 1.
-Both complete experiments, including unfavorable cases and CIs, remain in
-/tmp/tenferro-1765-1766-pair{6,7}-*. The four-lane experiment is REJECTED, not
-promoted: removed the tiling changes and restored the simpler incremental
-single-lane kernel. Its full FFT/autodiff package passes again; see
-/tmp/tenferro-1765-1766-restored-tests.log. Keep the analytical/boundary tests.
-Alignment dependence remains a supported diagnostic observation, not a proven
-microarchitectural cause or a solved performance gate.
-
-Complete pair8 measures the RESTORED single-lane candidate on CPUs 40-47, not
-the rejected tiled candidate. Larger serial 32^3 axes 0/1 again meet the
-non-regression bound. The complete experiment remains INCONCLUSIVE: 1T 32^3
-axis-2 spread is 20.1%, above the unchanged 20% threshold, and small 8T
-three-axis FFT overhead is 2.286 us, above the 2 us allowance. No rounding,
-case exclusion or mixing with tiled samples is used. All cases/CIs/environment
-are /tmp/tenferro-1765-1766-pair8-*. Final performance acceptance is still open.
-
-Ownership self-review traced production completion and both reclamation routes:
-PooledUninitOutput::finish -> host root attachment -> final HostAllocation::drop
-for automatic return, versus CpuBackend reclaim_typed -> into_host_vec (disarm)
--> pool_release for explicit return. Pool bins contain scalar Vecs, not tensor
-owners, and the root holds only a Weak recycler, so the reviewed path has no
-ownership cycle or second destructor return after extraction. This is a scoped
-review, not the final whole-diff signoff. Added and passed a public integration
-test transferring explicit reclamation to a different backend: the origin pool
-stays empty, the destination reuses the exact pointer, and later drop returns
-only to the destination. Log: /tmp/tenferro-1765-1766-cross-pool.log.
-Runtime integration suite also passes 146 tests with four test workers; log:
-/tmp/tenferro-1765-1766-runtime-integration.log.
-
-Updated docs/guides/tenferro-fft.md to distinguish borrowed/non-destructive
-operations from consuming host-only FFT, document final-owner pool return and
-error ownership, and explicitly state that managed shared residency still uses
-a CPU staging copy. Shipped compute-skill mirrors contain no FFT mutation advice
-that conflicts with the addition, so no redundant mirror edits were made.
-Doc snippet synchronization and git diff --check pass. The guide dependency
-smoke build first hit an undersized 30-second deadline; no owned descendants
-remained. Reran with RUSTC_WRAPPER unset, four build jobs and a 600-second
-budget; the guide dependency smoke checks pass. Logs are
-/tmp/tenferro-1765-1766-{doc-snippets,guide-dependencies}.log.
-
-Added and passed CPU FFT capability tests for a valid saved spec paired with
-wrong-dtype and wrong-shape owned tensors, and a wrong-dtype compact borrowed
-view. Existing validation returns Error::Validation and leaves the fresh pool
-empty. No production validation branches or test-only production hooks were
-added. Log: /tmp/tenferro-1765-1766-spec-mismatch.log.
-
-Fresh focused coverage after managed/spec tests: cpu.rs 83.98%, lanes.rs 93.57%,
-lib.rs 90.97%, eager_in_place.rs 81.08%; not a full coverage-gate pass.
-A subsequent lazy-transpose regression exposed a real missing precondition:
-into_value structurally extracts ownership but preserves noncompact layouts.
-The consuming FFT previously accepted that view instead of rejecting it before
-the compact lane kernel. The test failed before the fix. Added actual input
-compactness validation before ownership extraction, documented the compact
-host contract, and verified unchanged returned values plus successful borrowed
-FFT on the rejected view. Full FFT/autodiff package and all-target FFT clippy
-pass after the correction. Logs: /tmp/tenferro-1765-1766-layout-fix-{tests,clippy}.log.
-This test covers layout rejection, not IntoValueError::Extract; the earlier
-assumption that noncompact extraction itself must fail was incorrect.
-
-The repository-local gate now passes on the layout-corrected worktree:
-`RUSTC_WRAPPER= CARGO_BUILD_JOBS=4 bash scripts/check-pr-fast.sh
---coverage-reviewed --test 'cargo test -p tenferro-fft --features autodiff
---test eager_in_place'`. The gate fetched origin/main (still a096f280), ran
-its formatting/docs checks, CI-parity clippy including standalone extensions,
-and all six consuming-FFT integration tests. `git diff --check` also passes.
-Full log: /tmp/tenferro-1765-1766-local-gate.log. The coverage acknowledgement
-means reviewed, not threshold compliance. Performance acceptance, remaining
-coverage, final integrated review and committed-head rules check, PR, hosted
-CI/approval and non-squash merge remain outstanding.
-
-After the layout correction, focused coverage is cpu.rs 84.44% and
-eager_in_place.rs 82.50% (layout-coverage.json/log under the same /tmp prefix).
-Investigated a concrete small-FFT overhead hypothesis: with_linalg_pool might
-re-enter the CPU executor on every transform. Source tracing shows an already
-entered managed session reuses its context and only sets the native policy.
-A standalone diagnostic, pinned to CPU 40 with backend and effective native
-thread counts both asserted to be 1, measured five 100ms-warmed/50ms batches:
-15.27–17.01ns per empty native scope versus 0.62–0.68ns for the empty control.
-This does not justify bypassing required CPU policy to address microsecond-scale
-FFT overhead. It is a 1T diagnostic, not an 8T or full performance-gate result.
-Source: /tmp/tenferro-1765-1766-probe/src/bin/scope.rs; build and results:
-/tmp/tenferro-1765-1766-scope-build.log and /tmp/tenferro-1765-1766-scope.log.
-No production policy changes or repeated full comparison were made.
-
-Follow-up ownership review found that compactness does not imply zero offset
-or a full-root extent. A compact eager slice reproduced Execution(buffer-length
-validation failure) because host_data_mut exposed the root rather than the
-logical descriptor. Replaced that borrow with the existing with_host_write
-prepared guard in in_place_typed, preserving descriptor offset and bounds;
-no new ownership API or copy was introduced. Regression tests cover prefix
-and offset slices, stable logical data pointer, exact FFT output, and unchanged
-root elements outside the selected slice. The pre-fix test fails; the full FFT
-package including allocation tests and focused bounds test pass afterward,
-as does all-target FFT clippy. Logs: /tmp/tenferro-1765-1766-slice-before.log,
-slice-after.log, slice-bounds.log and slice-clippy.log (same prefix for all).
-The earlier local gate predates this correction; final-state checks remain due.
-
-Release-mode verification after the descriptor-bounded borrow change passes:
-seven consuming-FFT tests plus the allocation regression (RUSTC_WRAPPER unset,
-four build jobs). Log: /tmp/tenferro-1765-1766-slice-release.log.
-Captured updated allocation totals from the optimized allocation executable:
-cold 83 calls/102805 bytes; second simultaneously live output 38/79701;
-ordinary-drop reuse 38/14357 on both measured repetitions; explicit reclamation
-0/0; post-reclamation FFT 38/14357; consuming FFT 22/6505. Only cold and second
-live outputs allocate a 65536-byte input-sized buffer; all reuse and consuming
-measurements allocate zero input-sized buffers. The prepared guard adds one
-small allocation (32 bytes) to the previously recorded consuming totals;
-this is not zero-total-allocation FFT. The fixture asserts effective backend
-1T and live-pointer separation/reuse. Log:
-/tmp/tenferro-1765-1766-slice-release-allocations.log.
-
-Scoped binary diff review: dynamic operands remain TensorRead::Tensor, so the
-existing default backend *_read hooks delegate to owned-tensor methods without
-introducing a new view requirement. The shared broadcast planner/error mapper
-is unchanged; reshapes/broadcasts still retain their owned temporaries through
-execution. Existing session_ops tests cover full dtype-error payloads,
-binary/ternary broadcasting and values, typed results and single-session entry;
-the earlier successful run remains applicable (no production binary changes).
-
-Filled an evidence gap in binary_allocations: retain the original large-buffer
-regression criterion, but also count/report total allocation calls and requested
-bytes with logging outside the measured interval. The updated 1T test passes.
-For 4096 F64 elements, raw mul is 11 calls/32944 bytes, public mul 12/32952;
-both allocate one payload-sized buffer (the output). Add/sub match those totals;
-public div/rem/pow/min/max are 10/32936 versus raw 11/32944. Compare is public
-10/4264 versus raw 9/4256 with no F64-payload-sized allocations. Clamp/select
-are each 14/33000 on both paths. These are requested allocation bytes, not live
-or retained memory, and do not claim zero metadata allocation. Log:
-/tmp/tenferro-1765-1766-binary-allocation-totals.log.
-
-Created the first coherent local commit, b7b53232615a63767e6a35924978a26b32ef254d
-(perf(runtime): borrow binary operands through shared read preparation), containing
-only the runtime manifest, two runtime implementation files and allocation test.
-It was reviewed against the existing typed path and default backend read hooks.
-Tests cited above ran in the integrated worktree, not a clean binary-only checkout.
-FFT/recycler/docs changes remain uncommitted. Nothing has been pushed, no PR has
-been opened, and this commit is not a claim that performance acceptance is complete.
-
-Verified b7b53232615a63767e6a35924978a26b32ef254d independently in the clean detached
-worktree /tmp/tenferro-1765-1766-binary-verify, without any uncommitted FFT or
-recycler changes. The allocation regression and all 24 session_ops integration
-tests pass; reported allocation counts/bytes match the integrated worktree.
-The untracked Cargo.lock was newly resolved (notably zerocopy 0.8.57 rather
-than the integrated lock's 0.8.56); retained it in that worktree. This is an
-independent correctness/allocation check, not a controlled performance pair.
-Logs: /tmp/tenferro-1765-1766-binary-isolated.log and
-/tmp/tenferro-1765-1766-binary-isolated-session.log. Git status is clean.
-
-Committed the reviewed storage/pool slice as
-a2fc6e9493738eb5b69d29ad64bb2d8af902f19f (feat(cpu): recycle initialized host
-outputs on final owner drop). Reused the clean detached verification worktree
-at /tmp/tenferro-1765-1766-binary-verify, advancing it from b7b5323 to a2fc6e9.
-Without uncommitted FFT integration, internal-cpu-kernels passes 60 unit tests
-and 25 doctests; the tensor `storage::` filter passes 36 tests (other integration
-tests are filtered, not claimed as run). Logs:
-/tmp/tenferro-1765-1766-recycler-isolated.log and
-/tmp/tenferro-1765-1766-storage-isolated.log. Both commits remain local;
-FFT integration and docs remain uncommitted, with performance/coverage and
-final submitted-state validation still outstanding.
-
-Committed FFT integration as 0edb0d93f9e0197a7c2e272175bff3658944cde3. Review
-covered recording/ingress checks before extraction, preserved structural error
-ownership, descriptor-bounded mutation, disjoint lane writes and joining before
-borrow release, and policy-derived thread counts. Added runnable doctests for
-the new hidden public preparation/thread-count helpers; both pass (logs:
-/tmp/tenferro-1765-1766-preparation-doctest.log and thread-count-doctest.log,
-with the same prefix). Also documented propagation of factory/install errors.
-Latest focused coverage after slice handling remains insufficient: cpu.rs
-84.32%, eager_in_place.rs 82.50%, backend.rs 68.85%, eager_ext.rs 85.00%; lanes
-93.57% and lib 90.97%. Evidence: /tmp/tenferro-1765-1766-slice-coverage.json/log.
-
-The deterministic committed-head repository-rules review passes for 0edb0d9,
-with the expected external-LLM-skipped warning (per repository policy).
-Logs: /tmp/tenferro-1765-1766-committed-rules.{log,json}. This does not resolve
-performance/coverage or validate a future head containing the pending docs.
-All three code commits remain local; guide/design/worklog changes are not yet
-committed, and no PR/push/merge has occurred.
+Detailed local evidence is retained outside the PR under
+`/tmp/tenferro-1765-1766-*`: `pair8-*`, `pair9-*` (excluded trial),
+`slice-release*`, `binary-allocation-totals.log`, `slice-coverage.json`,
+`committed-gate-rebuilt.log`, and the archived `investigation-history.md`.
+The checked-in regression tests are the reproducible correctness/allocation
+artifacts; temporary diagnostic probes are not part of the shipped API or PR.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] Documentation
- [x] Refactor / cleanup
- [x] Implementation of accepted issue

## Related issue

Fixes #1766. Refs #1765. Both issues are assigned to @shinaoka.

Base: `a096f280ab0dd774f92f533aa0f38b663a4c94d3`.
Branch: `perf/1765-1766-fft-binary`.

## Summary

Keep this batch to the maintainer-approved functionality:

- Reuse borrowed/owned broadcast preparation so dynamic binary operands are not copied on the identity path; preserve the existing compare/select/clamp behavior.
- Write CPU host FFT results directly into the existing buffer pool's output and recycle on final-owner drop. A weak recycler and a separate short pool mutex preserve backend lifetime and avoid session-lock reentrancy; explicit extraction disarms automatic return.
- Execute disjoint FFT lanes within the backend's CPU thread/nested policy, reusing per-job scratch. Keep RustFFT and the sequential 1T path.
- Add the separately approved consuming eager host C32/C64 `fft_in_place` / `ifft_in_place`: preserve ordinary FFT's nondestructive/AD behavior, reject incompatible recording/ownership/layout states, and respect compact slice offsets and bounds via the existing write guard.
- Preserve the approved managed/Apple staging-copy boundary. No new synchronization or device-transfer API.

**No small-transform/locality optimization is included.** Tiling trials were rejected; the later move-capture experiment was removed. The maintainer explicitly requested stopping that expansion and submitting only the necessary changes.

Commits separate binary preparation, storage/pool lifecycle, FFT integration and documentation. Please preserve the commit structure with a **non-squash merge**.

## Work log

[Curated decisions, scope ledger, verification and limitations](docs/worklogs/1765-1766-cpu-performance.md)

[Ownership and execution contract](docs/design/cpu-fft-output-reuse.md)

## Verification

- Final-head `check-pr-fast.sh --coverage-reviewed` passed: formatting, snippet sync, workspace/standalone CI-parity clippy, consuming-FFT/FFT-allocation and binary-allocation tests.
- Deterministic committed-head repository-rules review passed; external LLM review skipped per repository policy.
- Full FFT/autodiff package tests and doctests passed; optimized release tests passed for all seven consuming-FFT cases plus allocation reuse.
- Runtime integration: 146 passing tests. Binary commit independently passed allocation regression and 24 session_ops tests.
- Recycler commit independently passed 60 kernel tests, 25 doctests and 36 storage tests.
- Guide dependency smoke checks and new API/helper doctests passed.
- Tests cover live-output separation, ordinary drop, explicit and cross-backend reclaim, backend-first drop, incomplete initialization, alias/AD saved values/capture, layout rejection and compact-slice bounds. Source review followed the shared typed/default backend paths and checked neighboring wrappers and skill mirrors.

Measured at explicit backend 1T: F64 mul (4096 elements) public 12 allocations / 32952 requested bytes versus direct backend 11 / 32944; both have one payload-sized allocation. C64 FFT (64x64) ordinary-drop reuse, explicit-reclaim reuse and consuming execution have **zero payload-sized allocations**, not zero total allocations. Consuming execution retains 22 small allocations / 6505 requested bytes.

## Limitations / CI follow-up

- The exploratory broad timing suite was **inconclusive**, not a passed speedup/non-regression gate. CPU contention and allocation-position correlation were observed; environment and implementation effects were not fully separated. No universal speedup claim or favorable subset promotion is made. Further small-size tuning is outside this PR by maintainer instruction.
- Focused coverage remains below 90% in some FFT files (CPU 84.32%, eager in-place 82.5%, backend 68.85%, eager extension 85%; lanes 93.57%, lib 90.97%). No coverage thresholds or exclusions were changed. Complete hosted coverage remains a merge requirement.
- CUDA/Apple hardware validation was not run locally. Existing required CI, backend matrix and review requirements are not bypassed.

## Checklist

- [x] I read `CONTRIBUTING.md` and the repository/remediation/performance rules.
- [x] I added or updated tests/docs as needed.
- [x] I ran deterministic repository-rules review and resolved or documented findings.
- [x] Implementation scope and added ownership/in-place contracts were approved by the maintainer.
- [x] I applied the scope gate and removed the unaccepted optimization trial.
- [x] I added and linked the required curated work log.
